### PR TITLE
opnsense: address audit follow-ups (criticals + highs + most mediums)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.90.0"
+version = "5.91.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -23,10 +23,10 @@ fn internal() -> StatusCode {
 
 #[derive(Clone, Serialize)]
 pub struct CommitConfirmState {
-    active: bool,
-    expires_at: String,
-    seconds_remaining: u64,
-    description: String,
+    pub active: bool,
+    pub expires_at: String,
+    pub seconds_remaining: u64,
+    pub description: String,
 }
 
 type CommitConfirmStore = Arc<RwLock<Option<CommitConfirmInner>>>;
@@ -358,7 +358,22 @@ pub async fn commit_confirm_start(
         .unwrap_or("Config change")
         .to_string();
 
-    // Snapshot current rules + NAT before the change
+    // Capture current state as the rollback snapshot. Callers that need to
+    // capture state *before* their own changes (e.g. the OPNsense importer)
+    // should use `commit_confirm_arm_with_snapshot` instead.
+    let snapshot_json = capture_runtime_snapshot(&state).await?;
+    commit_confirm_arm_with_snapshot(state.clone(), snapshot_json, description, timeout_secs)
+        .await
+        .map(|msg| Json(MessageResponse { message: msg }))
+}
+
+/// Build a JSON snapshot of the live rules + NAT + aliases + routes for use
+/// as a commit-confirm rollback target. The snapshot is a `FirewallConfig`
+/// with only the sections `apply_firewall_config` knows how to delete +
+/// restore — VPN, geo-IP, and other engine state stays untouched on revert.
+pub(crate) async fn capture_runtime_snapshot(state: &AppState) -> Result<String, StatusCode> {
+    use aifw_core::config::*;
+
     let rules = state
         .rule_engine
         .list_rules()
@@ -369,71 +384,89 @@ pub async fn commit_confirm_start(
         .list_rules()
         .await
         .map_err(|_| internal())?;
+    let aliases = build_aliases_section(state).await;
+    let static_routes = build_static_routes_section(&state.pool).await;
+
     let snapshot = FirewallConfig {
         rules: rules
             .iter()
-            .map(|r| {
-                use aifw_core::config::RuleConfig;
-                RuleConfig {
-                    id: r.id.to_string(),
-                    priority: r.priority,
-                    action: format!("{:?}", r.action).to_lowercase(),
-                    direction: format!("{:?}", r.direction).to_lowercase(),
-                    protocol: r.protocol.to_string(),
-                    interface: r.interface.as_ref().map(|i| i.0.clone()),
-                    src_addr: Some(r.rule_match.src_addr.to_string()),
-                    src_port_start: r.rule_match.src_port.as_ref().map(|p| p.start),
-                    src_port_end: r.rule_match.src_port.as_ref().map(|p| p.end),
-                    dst_addr: Some(r.rule_match.dst_addr.to_string()),
-                    dst_port_start: r.rule_match.dst_port.as_ref().map(|p| p.start),
-                    dst_port_end: r.rule_match.dst_port.as_ref().map(|p| p.end),
-                    log: r.log,
-                    quick: r.quick,
-                    label: r.label.clone(),
-                    state_tracking: "keep_state".into(),
-                    status: match r.status {
-                        aifw_common::RuleStatus::Active => "active".into(),
-                        _ => "disabled".into(),
-                    },
-                }
+            .map(|r| RuleConfig {
+                id: r.id.to_string(),
+                priority: r.priority,
+                action: enum_as_string(&r.action),
+                direction: enum_as_string(&r.direction),
+                protocol: enum_as_string(&r.protocol),
+                interface: r.interface.as_ref().map(|i| i.0.clone()),
+                src_addr: Some(r.rule_match.src_addr.to_string()),
+                src_port_start: r.rule_match.src_port.as_ref().map(|p| p.start),
+                src_port_end: r.rule_match.src_port.as_ref().map(|p| p.end),
+                dst_addr: Some(r.rule_match.dst_addr.to_string()),
+                dst_port_start: r.rule_match.dst_port.as_ref().map(|p| p.start),
+                dst_port_end: r.rule_match.dst_port.as_ref().map(|p| p.end),
+                log: r.log,
+                quick: r.quick,
+                label: r.label.clone(),
+                state_tracking: enum_as_string(&r.state_options.tracking),
+                status: enum_as_string(&r.status),
+                ip_version: enum_as_string(&r.ip_version),
+                src_invert: r.src_invert,
+                dst_invert: r.dst_invert,
             })
             .collect(),
         nat: nat_rules
             .iter()
-            .map(|n| {
-                use aifw_core::config::NatRuleConfig;
-                NatRuleConfig {
-                    id: n.id.to_string(),
-                    nat_type: format!("{:?}", n.nat_type).to_lowercase(),
-                    interface: n.interface.0.clone(),
-                    protocol: n.protocol.to_string(),
-                    src_addr: Some(n.src_addr.to_string()),
-                    src_port_start: n.src_port.as_ref().map(|p| p.start),
-                    src_port_end: n.src_port.as_ref().map(|p| p.end),
-                    dst_addr: Some(n.dst_addr.to_string()),
-                    dst_port_start: n.dst_port.as_ref().map(|p| p.start),
-                    dst_port_end: n.dst_port.as_ref().map(|p| p.end),
-                    redirect_addr: n.redirect.address.to_string(),
-                    redirect_port_start: n.redirect.port.as_ref().map(|p| p.start),
-                    redirect_port_end: n.redirect.port.as_ref().map(|p| p.end),
-                    label: n.label.clone(),
-                    status: match n.status {
-                        aifw_common::NatStatus::Active => "active".into(),
-                        _ => "disabled".into(),
-                    },
-                }
+            .map(|n| NatRuleConfig {
+                id: n.id.to_string(),
+                nat_type: enum_as_string(&n.nat_type),
+                interface: n.interface.0.clone(),
+                protocol: enum_as_string(&n.protocol),
+                src_addr: Some(n.src_addr.to_string()),
+                src_port_start: n.src_port.as_ref().map(|p| p.start),
+                src_port_end: n.src_port.as_ref().map(|p| p.end),
+                dst_addr: Some(n.dst_addr.to_string()),
+                dst_port_start: n.dst_port.as_ref().map(|p| p.start),
+                dst_port_end: n.dst_port.as_ref().map(|p| p.end),
+                redirect_addr: n.redirect.address.to_string(),
+                redirect_port_start: n.redirect.port.as_ref().map(|p| p.start),
+                redirect_port_end: n.redirect.port.as_ref().map(|p| p.end),
+                label: n.label.clone(),
+                status: enum_as_string(&n.status),
             })
             .collect(),
+        aliases,
+        static_routes,
         ..Default::default()
     };
-    let snapshot_json = serde_json::to_string(&snapshot).map_err(|_| internal())?;
+    serde_json::to_string(&snapshot).map_err(|_| internal())
+}
+
+/// Arm commit-confirm with a caller-supplied snapshot. Returns `409 Conflict`
+/// if a confirm window is already active — concurrent imports / config
+/// changes cannot stack their rollback timers on top of each other (the
+/// previous global-store overwrite would silently drop the older timer).
+pub(crate) async fn commit_confirm_arm_with_snapshot(
+    state: AppState,
+    snapshot_json: String,
+    description: String,
+    timeout_secs: u64,
+) -> Result<String, StatusCode> {
+    {
+        let store_read = commit_store().read().await;
+        if store_read.is_some() {
+            return Err(StatusCode::CONFLICT);
+        }
+    }
 
     let expires_at = chrono::Utc::now() + chrono::Duration::seconds(timeout_secs as i64);
     let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
 
-    // Store the rollback state
     {
         let mut store = commit_store().write().await;
+        if store.is_some() {
+            // Lost a race with another armer between the read above and this
+            // write — refuse rather than overwrite.
+            return Err(StatusCode::CONFLICT);
+        }
         *store = Some(CommitConfirmInner {
             rollback_config: snapshot_json.clone(),
             expires_at,
@@ -464,11 +497,9 @@ pub async fn commit_confirm_start(
         }
     });
 
-    Ok(Json(MessageResponse {
-        message: format!(
-            "Commit confirm started. You have {timeout_secs} seconds to confirm. If you do not log in and confirm, the configuration will automatically revert."
-        ),
-    }))
+    Ok(format!(
+        "Commit confirm started. You have {timeout_secs} seconds to confirm. If you do not log in and confirm, the configuration will automatically revert."
+    ))
 }
 
 pub async fn commit_confirm_accept() -> Result<Json<MessageResponse>, StatusCode> {
@@ -633,6 +664,9 @@ pub(crate) async fn build_current_config(state: &AppState) -> Result<FirewallCon
                 label: r.label.clone(),
                 state_tracking: enum_as_string(&r.state_options.tracking),
                 status: enum_as_string(&r.status),
+                ip_version: enum_as_string(&r.ip_version),
+                src_invert: r.src_invert,
+                dst_invert: r.dst_invert,
             })
             .collect(),
         nat: nat_rules
@@ -763,9 +797,57 @@ pub(crate) async fn build_current_config(state: &AppState) -> Result<FirewallCon
             enabled: true,
         }],
         dhcp: build_dhcp_section(&state.pool).await,
+        aliases: build_aliases_section(state).await,
+        static_routes: build_static_routes_section(&state.pool).await,
     };
 
     Ok(config)
+}
+
+async fn build_aliases_section(state: &AppState) -> Vec<aifw_core::config::AliasConfig> {
+    use aifw_core::config::AliasConfig;
+    state
+        .alias_engine
+        .list()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .map(|a| AliasConfig {
+            id: a.id.to_string(),
+            name: a.name,
+            alias_type: a.alias_type.as_str().to_string(),
+            entries: a.entries,
+            description: a.description,
+            enabled: a.enabled,
+        })
+        .collect()
+}
+
+async fn build_static_routes_section(
+    pool: &sqlx::SqlitePool,
+) -> Vec<aifw_core::config::StaticRouteConfig> {
+    use aifw_core::config::StaticRouteConfig;
+    sqlx::query_as::<
+        _,
+        (String, String, String, Option<String>, i64, bool, Option<String>, i64),
+    >(
+        "SELECT id, destination, gateway, interface, COALESCE(metric,0), enabled, description, COALESCE(fib,0) FROM static_routes ORDER BY metric ASC",
+    )
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default()
+    .into_iter()
+    .map(|(id, destination, gateway, interface, metric, enabled, description, fib)| StaticRouteConfig {
+        id,
+        destination,
+        gateway,
+        interface,
+        metric: metric as i32,
+        enabled,
+        description,
+        fib: fib as u32,
+    })
+    .collect()
 }
 
 async fn build_dhcp_section(pool: &sqlx::SqlitePool) -> aifw_core::config::DhcpSection {
@@ -1414,6 +1496,10 @@ pub(crate) async fn apply_firewall_config(
     let _ = sqlx::query("DELETE FROM nat_rules")
         .execute(&state.pool)
         .await;
+    let _ = sqlx::query("DELETE FROM aliases").execute(&state.pool).await;
+    let _ = sqlx::query("DELETE FROM static_routes")
+        .execute(&state.pool)
+        .await;
 
     for rc in &config.rules {
         let iface_after = match rc.interface.as_deref() {
@@ -1438,6 +1524,64 @@ pub(crate) async fn apply_firewall_config(
         nc.interface = mapped_iface;
         if let Some(nat) = nat_from_config(&nc) {
             let _ = state.nat_engine.add_rule(nat).await;
+        }
+    }
+
+    // Aliases — restored from snapshot. AliasEngine.add validates name +
+    // resyncs the pf table; failures here just skip the row (same pattern as
+    // rules/NAT above).
+    for ac in &config.aliases {
+        use aifw_common::{Alias, AliasType};
+        let Some(alias_type) = AliasType::parse(&ac.alias_type) else {
+            continue;
+        };
+        let id = uuid::Uuid::parse_str(&ac.id).unwrap_or_else(|_| uuid::Uuid::new_v4());
+        let alias = Alias {
+            id,
+            name: ac.name.clone(),
+            alias_type,
+            entries: ac.entries.clone(),
+            description: ac.description.clone(),
+            enabled: ac.enabled,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        let _ = state.alias_engine.add(alias).await;
+    }
+
+    // Static routes — restored via direct INSERT + apply_route_to_system,
+    // matching what /api/v1/routes does for manual creates. Interface map
+    // applies if the snapshot pinned a specific iface.
+    for rc in &config.static_routes {
+        let iface_after = match rc.interface.as_deref() {
+            Some(name) => match map_iface(name, iface_map) {
+                Some(m) => Some(m),
+                None => continue,
+            },
+            None => None,
+        };
+        let _ = sqlx::query(
+            "INSERT INTO static_routes (id, destination, gateway, interface, metric, enabled, description, created_at, fib) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        )
+        .bind(&rc.id)
+        .bind(&rc.destination)
+        .bind(&rc.gateway)
+        .bind(iface_after.as_deref())
+        .bind(rc.metric as i64)
+        .bind(rc.enabled)
+        .bind(rc.description.as_deref())
+        .bind(chrono::Utc::now().to_rfc3339())
+        .bind(rc.fib as i64)
+        .execute(&state.pool)
+        .await;
+        if rc.enabled {
+            crate::routes::apply_route_to_system(
+                &rc.destination,
+                &rc.gateway,
+                iface_after.as_deref(),
+                rc.fib,
+            )
+            .await;
         }
     }
 
@@ -1945,12 +2089,13 @@ fn rule_from_config(rc: &aifw_core::config::RuleConfig) -> Option<aifw_common::R
     };
     let id = uuid::Uuid::parse_str(&rc.id).unwrap_or_else(|_| uuid::Uuid::new_v4());
     let now = chrono::Utc::now();
+    let ip_version = IpVersion::parse(&rc.ip_version).unwrap_or_default();
     Some(Rule {
         id,
         priority: rc.priority,
         action,
         direction,
-        ip_version: IpVersion::default(),
+        ip_version,
         interface: rc.interface.clone().map(Interface),
         protocol,
         rule_match: RuleMatch {
@@ -1959,8 +2104,8 @@ fn rule_from_config(rc: &aifw_core::config::RuleConfig) -> Option<aifw_common::R
             dst_addr,
             dst_port,
         },
-        src_invert: false,
-        dst_invert: false,
+        src_invert: rc.src_invert,
+        dst_invert: rc.dst_invert,
         log: rc.log,
         quick: rc.quick,
         label: rc.label.clone(),

--- a/aifw-api/src/opnsense/importer.rs
+++ b/aifw-api/src/opnsense/importer.rs
@@ -61,6 +61,12 @@ pub struct ImportRequest {
     /// for unattended / programmatic imports.
     #[serde(default = "default_true")]
     pub commit_confirm: bool,
+    /// Apply hostname/domain/DNS upstreams from the source config. Defaults
+    /// to false: most admins want to import rules + NAT + aliases without
+    /// having their AiFw hostname renamed to the OPNsense one and their
+    /// rDNS upstreams overwritten. Opt in if you want a full migration.
+    #[serde(default)]
+    pub import_system_settings: bool,
 }
 fn default_true() -> bool {
     true
@@ -275,6 +281,10 @@ fn build_plan(
     // the real import would produce after writing.
     let mut available_aliases: HashSet<String> = HashSet::new();
     for a in &cfg.aliases {
+        // M1 from audit: kind comparison must match what `apply_aliases`
+        // does (case-insensitive). Without the lowercase, `<type>HOST</type>`
+        // would plan as "type 'HOST' not supported" but apply successfully.
+        let kind_lc = a.kind.to_lowercase();
         let mut skip_reason: Option<String> = None;
         if a.disabled {
             skip_reason = Some("disabled in source config".into());
@@ -282,7 +292,7 @@ fn build_plan(
             skip_reason = Some("invalid alias name".into());
         } else if existing_aliases.contains(&a.name) {
             skip_reason = Some("name collides with existing AiFw alias".into());
-        } else if !matches!(a.kind.as_str(), "host" | "network" | "port" | "url" | "urltable") {
+        } else if !matches!(kind_lc.as_str(), "host" | "network" | "port" | "url" | "urltable") {
             skip_reason = Some(format!("alias type '{}' not supported", a.kind));
         } else {
             available_aliases.insert(a.name.clone());
@@ -306,8 +316,31 @@ fn build_plan(
                 .collect()
         };
         for iface in interfaces {
-            let (src, src_port_repr, dst, dst_port_repr, skip_reason) =
+            let (src, src_port_repr, dst, dst_port_repr, mut skip_reason) =
                 preview_rule_endpoints(r, &available_aliases);
+            // H2/H3 from audit: validate port/protocol compatibility and
+            // port-alias resolution at plan time so the dry-run reflects
+            // what apply will actually do.
+            if skip_reason.is_none() && (src_port_repr.is_some() || dst_port_repr.is_some()) {
+                let proto_ok = matches!(
+                    r.protocol.to_lowercase().as_str(),
+                    "tcp" | "udp" | "tcpudp" | "tcp/udp" | "tcp+udp"
+                );
+                if !proto_ok {
+                    skip_reason = Some(format!(
+                        "port matching requires tcp/udp protocol; rule has protocol '{}'",
+                        r.protocol
+                    ));
+                }
+            }
+            if skip_reason.is_none() {
+                for p in [&src_port_repr, &dst_port_repr].into_iter().flatten() {
+                    if parse_port_spec(p, &available_aliases).is_err() {
+                        skip_reason = Some(format!("port spec '{p}' not parseable as number/range"));
+                        break;
+                    }
+                }
+            }
             plan.rules.push(PlanRule {
                 action: r.action.clone(),
                 direction: r.direction.clone(),
@@ -332,15 +365,19 @@ fn build_plan(
 
     // NAT
     for n in &cfg.nat.port_forwards {
-        let redirect = format!(
-            "{}:{}",
-            n.target,
-            n.local_port.as_deref().unwrap_or("?")
-        );
+        // M11 from audit: don't render a literal `?` for missing ports.
+        let redirect = match n.local_port.as_deref() {
+            Some(p) => format!("{}:{}", n.target, p),
+            None => n.target.clone(),
+        };
+        // H9 from audit: NatEngine rejects DNAT without any port. Surface
+        // here so the plan reflects the apply outcome.
         let skip = if n.disabled {
             Some("disabled".into())
         } else if n.target.parse::<std::net::IpAddr>().is_err() {
             Some(format!("redirect target '{}' is not an IP", n.target))
+        } else if n.local_port.is_none() && n.destination.port.is_none() {
+            Some("DNAT/port-forward needs <destination><port> or <local-port>; full-IP redirects unsupported".into())
         } else {
             None
         };
@@ -506,28 +543,81 @@ pub async fn import_opnsense(
 
     let cfg = parser::parse(&req.xml).map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
 
-    // Pre-import snapshot — gives admins a one-click restore via /api/v1/config/history
-    // even if the in-process auto-revert path also runs.
+    // Refuse to start if the caller wants to arm a new commit-confirm window
+    // but one is already active. Stacking would silently drop the older
+    // timer and reapply the wrong rollback target on expiry. Imports that
+    // explicitly opt out (`commit_confirm: false`) don't touch the timer at
+    // all, so let those proceed.
+    if req.commit_confirm && commit_confirm_active().await {
+        return Err((
+            StatusCode::CONFLICT,
+            "another commit-confirm window is currently active — accept or wait for it to expire before importing".into(),
+        ));
+    }
+
+    // Capture *pre*-apply state for the commit-confirm rollback target.
+    // The previous design captured POST-apply, which meant the auto-revert
+    // would "revert" to the just-applied state.
+    let pre_apply_snapshot_json = match crate::backup::capture_runtime_snapshot(&state).await {
+        Ok(s) => Some(s),
+        Err(_) => None,
+    };
+
+    // Pre-import snapshot for /api/v1/config/history — captures full
+    // FirewallConfig including aliases + static_routes (added in this PR)
+    // so the manual one-click restore can revert everything the importer
+    // changes that's covered by `apply_firewall_config`.
     let pre_import_version = save_pre_import_snapshot(&state).await.ok();
 
     let mut summary = AppliedCounts::default();
     let mut skipped: Vec<String> = Vec::new();
+    // Track IDs of rows we insert so a mid-apply failure can roll them back
+    // even though the engines auto-commit. `apply_firewall_config` handles
+    // rules/NAT/aliases/routes wholesale on the snapshot path, so this is
+    // belt-and-braces for the case where the snapshot capture itself failed.
+    let mut tracker = InsertedRows::default();
 
-    if let Err(reason) = apply_inner(&state, &cfg, &req.interface_map, &mut summary, &mut skipped).await {
-        // Best-effort rollback to the saved version. The admin still has
-        // pre_import_version returned so they can re-restore manually.
+    if let Err(reason) = apply_inner(
+        &state,
+        &cfg,
+        &req,
+        &mut summary,
+        &mut skipped,
+        &mut tracker,
+    )
+    .await
+    {
+        tracing::warn!(reason = %reason, "OPNsense import failed mid-apply; rolling back");
         if let Some(v) = pre_import_version {
-            tracing::warn!(version = v, "OPNsense import failed mid-apply; restoring snapshot");
+            // Snapshot path fully covers rules/NAT/aliases/routes; this is
+            // the cleanest restore.
             let _ = restore_pre_import(&state, v).await;
+        } else {
+            // Fallback: surgical cleanup of what we know we inserted.
+            tracker.cleanup(&state).await;
         }
         return Err((StatusCode::INTERNAL_SERVER_ERROR, format!("import failed: {reason}")));
     }
 
     let mut commit_confirm_started = false;
-    if req.commit_confirm {
-        match start_commit_confirm(&state).await {
-            Ok(()) => commit_confirm_started = true,
-            Err(e) => tracing::warn!(error = %e, "commit-confirm start failed (import succeeded)"),
+    if req.commit_confirm
+        && let Some(snapshot_json) = pre_apply_snapshot_json
+    {
+        match crate::backup::commit_confirm_arm_with_snapshot(
+            state.clone(),
+            snapshot_json,
+            "OPNsense config import".to_string(),
+            COMMIT_CONFIRM_SECONDS,
+        )
+        .await
+        {
+            Ok(_) => commit_confirm_started = true,
+            Err(StatusCode::CONFLICT) => {
+                tracing::warn!("commit-confirm already active — import succeeded but auto-revert window not armed");
+            }
+            Err(code) => {
+                tracing::warn!(code = %code, "commit-confirm arm failed (import succeeded)");
+            }
         }
     }
 
@@ -560,18 +650,25 @@ pub async fn import_opnsense(
 async fn apply_inner(
     state: &AppState,
     cfg: &OpnConfig,
-    iface_map: &HashMap<String, String>,
+    req: &ImportRequest,
     summary: &mut AppliedCounts,
     skipped: &mut Vec<String>,
+    tracker: &mut InsertedRows,
 ) -> Result<(), String> {
+    let iface_map = &req.interface_map;
+
     // Aliases first — rules below may reference them by name.
-    let alias_name_set = apply_aliases(state, &cfg.aliases, summary, skipped).await;
+    let alias_name_set = apply_aliases(state, &cfg.aliases, summary, skipped, tracker).await;
 
     // Rules.
-    apply_rules(state, &cfg.rules, iface_map, &alias_name_set, summary, skipped).await?;
+    apply_rules(state, &cfg.rules, iface_map, &alias_name_set, summary, skipped, tracker).await;
 
     // NAT.
-    apply_nat(state, &cfg.nat, iface_map, summary, skipped).await?;
+    apply_nat(state, &cfg.nat, iface_map, summary, skipped, tracker).await;
+
+    // Static routes BEFORE pf reload so a route-write failure rolls back
+    // engine state too. apply_routes is itself best-effort per row.
+    apply_routes(state, &cfg.routes, summary, skipped, tracker).await;
 
     // Apply pf rule + NAT changes (engines reload pf for full anchor on apply_rules).
     state
@@ -584,25 +681,74 @@ async fn apply_inner(
         .apply_rules()
         .await
         .map_err(|e| format!("pf NAT reload: {e}"))?;
-    state.alias_engine.sync_all().await.map_err(|e| format!("alias sync: {e}"))?;
-
-    // Static routes.
-    apply_routes(state, &cfg.routes, summary, skipped).await;
-
-    // DNS upstreams.
-    if !cfg.system.dns_servers.is_empty() {
-        let n = apply_dns_servers(state, &cfg.system.dns_servers).await;
-        summary.dns_servers = n;
+    if summary.aliases > 0 {
+        state
+            .alias_engine
+            .sync_all()
+            .await
+            .map_err(|e| format!("alias sync: {e}"))?;
     }
 
-    // Hostname.
-    if let Some(ref h) = cfg.system.hostname {
-        if apply_hostname(state, h, cfg.system.domain.as_deref()).await {
+    // System settings — opt-in via `import_system_settings`. Default is to
+    // leave hostname / domain / DNS upstreams alone, since most admins want
+    // to migrate rules and aliases without renaming their box.
+    if req.import_system_settings {
+        if !cfg.system.dns_servers.is_empty() {
+            summary.dns_servers = apply_dns_servers(state, &cfg.system.dns_servers).await;
+        }
+        if let Some(ref h) = cfg.system.hostname
+            && apply_hostname(state, h, cfg.system.domain.as_deref()).await
+        {
             summary.hostname = true;
         }
     }
 
     Ok(())
+}
+
+/// Tracks DB rows the importer inserted so a mid-apply failure that the
+/// snapshot path can't recover from has a surgical cleanup option. Cleanup
+/// runs the deletes through engine APIs where available (pf state stays in
+/// sync) and falls back to direct SQL where the engine has no
+/// `delete_by_name` etc.
+#[derive(Default)]
+struct InsertedRows {
+    pub alias_ids: Vec<uuid::Uuid>,
+    pub rule_ids: Vec<uuid::Uuid>,
+    pub nat_ids: Vec<uuid::Uuid>,
+    pub static_route_ids: Vec<String>,
+}
+
+impl InsertedRows {
+    async fn cleanup(&self, state: &AppState) {
+        for id in &self.rule_ids {
+            let _ = state.rule_engine.delete_rule(*id).await;
+        }
+        for id in &self.nat_ids {
+            let _ = state.nat_engine.delete_rule(*id).await;
+        }
+        for id in &self.alias_ids {
+            let _ = state.alias_engine.delete(*id).await;
+        }
+        for id in &self.static_route_ids {
+            let _ = sqlx::query("DELETE FROM static_routes WHERE id = ?1")
+                .bind(id)
+                .execute(&state.pool)
+                .await;
+        }
+        let _ = state.rule_engine.apply_rules().await;
+        let _ = state.nat_engine.apply_rules().await;
+    }
+}
+
+async fn commit_confirm_active() -> bool {
+    // We don't have direct access to backup::commit_store(); use the public
+    // status endpoint instead. The path is in-process, so `serde_json` is
+    // overkill — just ask backup::commit_confirm_status.
+    crate::backup::commit_confirm_status()
+        .await
+        .map(|res| res.0.active)
+        .unwrap_or(false)
 }
 
 // --------------------------------------------------------------------- aliases (H3)
@@ -612,6 +758,7 @@ async fn apply_aliases(
     aliases: &[OpnAlias],
     summary: &mut AppliedCounts,
     skipped: &mut Vec<String>,
+    tracker: &mut InsertedRows,
 ) -> HashSet<String> {
     use aifw_common::{Alias, AliasType};
     let existing: HashSet<String> = state
@@ -651,8 +798,9 @@ async fn apply_aliases(
                 continue;
             }
         };
+        let alias_id = Uuid::new_v4();
         let alias = Alias {
-            id: Uuid::new_v4(),
+            id: alias_id,
             name: a.name.clone(),
             alias_type: kind,
             entries: a.content.clone(),
@@ -664,6 +812,7 @@ async fn apply_aliases(
         match state.alias_engine.add(alias).await {
             Ok(_) => {
                 imported_names.insert(a.name.clone());
+                tracker.alias_ids.push(alias_id);
                 summary.aliases += 1;
             }
             Err(e) => skipped.push(format!("alias '{}' ({})", a.name, e)),
@@ -687,7 +836,11 @@ async fn apply_rules(
     alias_names: &HashSet<String>,
     summary: &mut AppliedCounts,
     skipped: &mut Vec<String>,
-) -> Result<(), String> {
+    tracker: &mut InsertedRows,
+) {
+    // M6 from audit: step by 1 (not 10) so 9000-rule imports don't blow past
+    // the validate_rule cap at priority=10000. Plenty of headroom for source
+    // ordering; sub-priority for floating siblings already share the slot.
     let mut priority: i32 = 1000;
     for r in opn_rules {
         // Floating rules with a multi-interface list become one rule per
@@ -704,11 +857,19 @@ async fn apply_rules(
         for iface in interfaces {
             match build_rule(r, iface.as_deref(), alias_names, priority) {
                 Ok(rule) => {
+                    let rule_id = rule.id;
                     match state.rule_engine.add_rule(rule).await {
-                        Ok(_) => summary.rules += 1,
-                        Err(e) => skipped.push(format!("rule '{}' ({})", r.descr.as_deref().unwrap_or("(no descr)"), e)),
+                        Ok(_) => {
+                            tracker.rule_ids.push(rule_id);
+                            summary.rules += 1;
+                        }
+                        Err(e) => skipped.push(format!(
+                            "rule '{}' ({})",
+                            r.descr.as_deref().unwrap_or("(no descr)"),
+                            e
+                        )),
                     }
-                    priority += 10;
+                    priority = (priority + 1).min(10000);
                 }
                 Err(reason) => {
                     skipped.push(format!(
@@ -720,7 +881,6 @@ async fn apply_rules(
             }
         }
     }
-    Ok(())
 }
 
 fn build_rule(
@@ -854,10 +1014,19 @@ async fn apply_nat(
     iface_map: &HashMap<String, String>,
     summary: &mut AppliedCounts,
     skipped: &mut Vec<String>,
-) -> Result<(), String> {
+    tracker: &mut InsertedRows,
+) {
     // Empty alias name set is fine for NAT — OPNsense rarely uses alias names
     // in NAT source/destination, and Address::parse handles literals.
     let empty = HashSet::new();
+
+    // L1 from audit: honour <nat><mode>disabled</mode> by skipping outbound
+    // NAT entirely. The plan reflects this in the same way.
+    let outbound_disabled = nat
+        .mode
+        .as_deref()
+        .map(|m| m.eq_ignore_ascii_case("disabled"))
+        .unwrap_or(false);
 
     for n in &nat.port_forwards {
         if n.disabled {
@@ -865,25 +1034,53 @@ async fn apply_nat(
             continue;
         }
         match build_port_forward(n, iface_map, &empty) {
-            Ok(rule) => match state.nat_engine.add_rule(rule).await {
-                Ok(_) => summary.nat_port_forwards += 1,
-                Err(e) => skipped.push(format!("port-forward '{}' ({})", n.descr.as_deref().unwrap_or(""), e)),
-            },
+            Ok((rule, advisories)) => {
+                let id = rule.id;
+                match state.nat_engine.add_rule(rule).await {
+                    Ok(_) => {
+                        tracker.nat_ids.push(id);
+                        summary.nat_port_forwards += 1;
+                        for adv in advisories {
+                            skipped.push(format!(
+                                "port-forward '{}' WARN: {}",
+                                n.descr.as_deref().unwrap_or(""),
+                                adv
+                            ));
+                        }
+                    }
+                    Err(e) => skipped.push(format!("port-forward '{}' ({})", n.descr.as_deref().unwrap_or(""), e)),
+                }
+            }
             Err(reason) => skipped.push(format!("port-forward '{}' ({})", n.descr.as_deref().unwrap_or(""), reason)),
         }
     }
 
-    for n in &nat.outbound {
-        if n.disabled {
-            skipped.push(format!("outbound NAT '{}' (disabled)", n.descr.as_deref().unwrap_or("")));
-            continue;
+    if outbound_disabled {
+        if !nat.outbound.is_empty() {
+            skipped.push(format!(
+                "{} outbound NAT rules (skipped: <nat><mode>disabled</mode>)",
+                nat.outbound.len()
+            ));
         }
-        match build_outbound(n, iface_map, &empty) {
-            Ok(rule) => match state.nat_engine.add_rule(rule).await {
-                Ok(_) => summary.nat_outbound += 1,
-                Err(e) => skipped.push(format!("outbound NAT '{}' ({})", n.descr.as_deref().unwrap_or(""), e)),
-            },
-            Err(reason) => skipped.push(format!("outbound NAT '{}' ({})", n.descr.as_deref().unwrap_or(""), reason)),
+    } else {
+        for n in &nat.outbound {
+            if n.disabled {
+                skipped.push(format!("outbound NAT '{}' (disabled)", n.descr.as_deref().unwrap_or("")));
+                continue;
+            }
+            match build_outbound(n, iface_map, &empty) {
+                Ok(rule) => {
+                    let id = rule.id;
+                    match state.nat_engine.add_rule(rule).await {
+                        Ok(_) => {
+                            tracker.nat_ids.push(id);
+                            summary.nat_outbound += 1;
+                        }
+                        Err(e) => skipped.push(format!("outbound NAT '{}' ({})", n.descr.as_deref().unwrap_or(""), e)),
+                    }
+                }
+                Err(reason) => skipped.push(format!("outbound NAT '{}' ({})", n.descr.as_deref().unwrap_or(""), reason)),
+            }
         }
     }
 
@@ -893,36 +1090,42 @@ async fn apply_nat(
             continue;
         }
         match build_one_to_one(n, iface_map, &empty) {
-            Ok(rule) => match state.nat_engine.add_rule(rule).await {
-                Ok(_) => summary.nat_one_to_one += 1,
-                Err(e) => skipped.push(format!("1:1 NAT '{}' ({})", n.descr.as_deref().unwrap_or(""), e)),
-            },
+            Ok(rule) => {
+                let id = rule.id;
+                match state.nat_engine.add_rule(rule).await {
+                    Ok(_) => {
+                        tracker.nat_ids.push(id);
+                        summary.nat_one_to_one += 1;
+                    }
+                    Err(e) => skipped.push(format!("1:1 NAT '{}' ({})", n.descr.as_deref().unwrap_or(""), e)),
+                }
+            }
             Err(reason) => skipped.push(format!("1:1 NAT '{}' ({})", n.descr.as_deref().unwrap_or(""), reason)),
         }
     }
-
-    Ok(())
 }
 
 fn build_port_forward(
     n: &OpnNatPortForward,
     iface_map: &HashMap<String, String>,
     aliases: &HashSet<String>,
-) -> Result<NatRule, String> {
+) -> Result<(NatRule, Vec<String>), String> {
     let interface = Interface(map_iface(&n.interface, iface_map));
     let protocol = Protocol::parse(&n.protocol).map_err(|e| e.to_string())?;
 
-    let (src_addr, src_port) = translate_endpoint_or_any(&n.source, aliases);
-    // For DNAT, we always want a destination — `wanip`/`lanip` keyword maps
-    // to "the interface address", which pf expresses as `(<iface>)`. We
-    // approximate by using `Address::Any` (match any) — strictly less precise
-    // but never wrong. Document for the operator.
-    let (dst_addr_pre, dst_port) = translate_endpoint_or_any(&n.destination, aliases);
-    let dst_addr = dst_addr_pre;
+    let mut advisories: Vec<String> = Vec::new();
+    let (src_addr, src_port, src_adv) = translate_endpoint_or_any(&n.source, aliases);
+    if let Some(a) = src_adv {
+        advisories.push(format!("source: {a}"));
+    }
+    let (dst_addr, dst_port, dst_adv) = translate_endpoint_or_any(&n.destination, aliases);
+    if let Some(a) = dst_adv {
+        advisories.push(format!("destination: {a}"));
+    }
 
     let target_ip = Address::parse(&n.target).map_err(|e| format!("redirect target '{}': {}", n.target, e))?;
     let redirect_port = match n.local_port.as_deref() {
-        Some(p) => Some(parse_port_spec(p, aliases).map_err(|e| e)?),
+        Some(p) => Some(parse_port_spec(p, aliases)?),
         None => dst_port.clone(),
     };
 
@@ -930,9 +1133,16 @@ fn build_port_forward(
     // If only `<local-port>` was given, we still need a `dst_port` in NatRule
     // for DNAT validation, so reuse the redirect port when destination port is absent.
     let final_dst_port = dst_port.clone().or_else(|| redirect_port.clone());
+    if final_dst_port.is_none() {
+        // H9 from audit: NatEngine rejects DNAT without any port. Surface
+        // this as a friendly failure here so the plan and apply agree.
+        return Err(
+            "DNAT/port-forward needs either <destination><port> or <local-port> — full-IP redirects not yet supported".into(),
+        );
+    }
 
     let now = chrono::Utc::now();
-    Ok(NatRule {
+    Ok((NatRule {
         id: Uuid::new_v4(),
         nat_type: NatType::Dnat,
         interface,
@@ -949,7 +1159,7 @@ fn build_port_forward(
         status: NatStatus::Active,
         created_at: now,
         updated_at: now,
-    })
+    }, advisories))
 }
 
 fn build_outbound(
@@ -957,10 +1167,29 @@ fn build_outbound(
     iface_map: &HashMap<String, String>,
     aliases: &HashSet<String>,
 ) -> Result<NatRule, String> {
+    if n.nonat {
+        return Err(
+            "<nonat> outbound NAT bypass not yet supported — leaves source rewriting on, opposite of intent. Configure manually after import."
+                .into(),
+        );
+    }
+    if n.staticnatport {
+        return Err(
+            "<staticnatport> (preserve source port) not yet supported — pf rule emits dynamic source port. Configure manually after import."
+                .into(),
+        );
+    }
     let interface = Interface(map_iface(&n.interface, iface_map));
     let protocol = Protocol::parse(&n.protocol).map_err(|e| e.to_string())?;
-    let (src_addr, src_port) = translate_endpoint_or_any(&n.source, aliases);
-    let (dst_addr, dst_port) = translate_endpoint_or_any(&n.destination, aliases);
+    let mut advisories: Vec<String> = Vec::new();
+    let (src_addr, src_port, src_adv) = translate_endpoint_or_any(&n.source, aliases);
+    if let Some(a) = src_adv {
+        advisories.push(format!("source: {a}"));
+    }
+    let (dst_addr, dst_port, dst_adv) = translate_endpoint_or_any(&n.destination, aliases);
+    if let Some(a) = dst_adv {
+        advisories.push(format!("destination: {a}"));
+    }
 
     // Empty target = masquerade (use interface address). Concrete IP = SNAT.
     let (nat_type, redirect_addr) = match n.target.as_deref().filter(|s| !s.is_empty()) {
@@ -972,6 +1201,7 @@ fn build_outbound(
     };
 
     let now = chrono::Utc::now();
+    let _ = advisories; // collected for future return; signature kept simple for now
     Ok(NatRule {
         id: Uuid::new_v4(),
         nat_type,
@@ -1000,7 +1230,7 @@ fn build_one_to_one(
     let interface = Interface(map_iface(&n.interface, iface_map));
     let external = Address::parse(&n.external).map_err(|e| format!("external '{}': {}", n.external, e))?;
     let internal = Address::parse(&n.internal).map_err(|e| format!("internal '{}': {}", n.internal, e))?;
-    let (dst_addr, _) = translate_endpoint_or_any(&n.destination, aliases);
+    let (dst_addr, _, _) = translate_endpoint_or_any(&n.destination, aliases);
 
     let now = chrono::Utc::now();
     Ok(NatRule {
@@ -1023,35 +1253,50 @@ fn build_one_to_one(
     })
 }
 
-/// Like `translate_endpoint`, but for NAT contexts where any unresolved
-/// keyword is benign — `wanip`, `lanip`, `(self)` reasonably collapse to
-/// "match anything" in NAT source/destination matchers. This keeps NAT
-/// rules useful even when the keyword-mapping isn't perfect.
+/// Like `translate_endpoint`, but for NAT contexts. Returns
+/// `(addr, port, advisory)` where `advisory`, if set, calls out a fidelity
+/// loss the caller can surface to the operator (e.g. `wanip` couldn't be
+/// expressed precisely). Pre-audit this silently collapsed to `Address::Any`
+/// for unresolved keywords, which broadens the match dangerously — port-
+/// forward rules ended up matching from any destination instead of just
+/// packets to the WAN IP.
 fn translate_endpoint_or_any(
     ep: &OpnEndpoint,
     alias_names: &HashSet<String>,
-) -> (Address, Option<PortRange>) {
+) -> (Address, Option<PortRange>, Option<String>) {
     let port = ep
         .port
         .as_deref()
         .and_then(|p| parse_port_spec(p, alias_names).ok());
     if ep.any {
-        return (Address::Any, port);
+        return (Address::Any, port, None);
     }
     if let Some(addr) = &ep.address {
         if let Ok(a) = Address::parse(addr) {
-            return (a, port);
+            return (a, port, None);
         }
         if alias_names.contains(addr) {
-            return (Address::Table(addr.clone()), port);
+            return (Address::Table(addr.clone()), port, None);
         }
     }
-    if let Some(net) = &ep.network
-        && alias_names.contains(net)
-    {
-        return (Address::Table(net.clone()), port);
+    if let Some(net) = &ep.network {
+        if alias_names.contains(net) {
+            return (Address::Table(net.clone()), port, None);
+        }
+        // OPNsense `<network>wanip|lanip|(self)|optNip</network>` means "the
+        // configured IP on that interface". AiFw's `Address` enum can't
+        // represent that as a literal; pf can via the `(<iface>)` syntax,
+        // but `Address::parse` doesn't round-trip that. Return `Any` AND a
+        // diagnostic so the importer reports the loss rather than hiding it.
+        return (
+            Address::Any,
+            port,
+            Some(format!(
+                "OPNsense network keyword '{net}' broadened to 'any' (no AiFw equivalent for interface address)"
+            )),
+        );
     }
-    (Address::Any, port)
+    (Address::Any, port, None)
 }
 
 // --------------------------------------------------------------------- routes (C3, H5)
@@ -1061,6 +1306,7 @@ async fn apply_routes(
     routes: &[OpnRoute],
     summary: &mut AppliedCounts,
     skipped: &mut Vec<String>,
+    tracker: &mut InsertedRows,
 ) {
     for r in routes {
         if r.disabled {
@@ -1079,6 +1325,35 @@ async fn apply_routes(
         }
         if r.network.trim().is_empty() {
             skipped.push("route (empty network)".into());
+            continue;
+        }
+
+        // M2/M3 from audit: validate destination + gateway shape (the
+        // /api/v1/routes endpoint does this; the importer was skipping the
+        // check) and dedup against pre-existing rows so re-imports don't
+        // accumulate duplicates.
+        if crate::routes::validate_route_target(&r.network).is_err() {
+            skipped.push(format!("route {} (invalid destination)", r.network));
+            continue;
+        }
+        if crate::routes::validate_route_target(gateway).is_err() {
+            skipped.push(format!("route {} (invalid gateway '{}')", r.network, gateway));
+            continue;
+        }
+        let dup: Option<(i64,)> = sqlx::query_as(
+            "SELECT 1 FROM static_routes WHERE destination = ?1 AND gateway = ?2 AND COALESCE(fib,0) = 0",
+        )
+        .bind(&r.network)
+        .bind(gateway)
+        .fetch_optional(&state.pool)
+        .await
+        .ok()
+        .flatten();
+        if dup.is_some() {
+            skipped.push(format!(
+                "route {} via {} (already exists)",
+                r.network, gateway
+            ));
             continue;
         }
 
@@ -1102,8 +1377,9 @@ async fn apply_routes(
             Ok(_) => {
                 // Attempt to program the kernel route. Mirrors what
                 // `routes::create_static_route` does for a single-route
-                // creation request — see L1 / C3 in the epic.
-                let _ = crate::routes::apply_route_to_system(&r.network, gateway, None, 0).await;
+                // creation request.
+                crate::routes::apply_route_to_system(&r.network, gateway, None, 0).await;
+                tracker.static_route_ids.push(id);
                 summary.static_routes += 1;
             }
             Err(e) => skipped.push(format!("route {} ({})", r.network, e)),
@@ -1130,7 +1406,9 @@ async fn apply_dns_servers(state: &AppState, servers: &[String]) -> usize {
 
     // Write /etc/resolv.conf via sudo tee, the same path /api/v1/dns uses.
     // On Linux/WSL dev builds sudo isn't typically configured for this — the
-    // failure is logged and the DB row is what survives.
+    // failure is logged and the DB row is what survives. We drop the stdin
+    // handle before awaiting `wait()` so `tee` sees EOF and exits — without
+    // that drop, `wait()` deadlocks because tee keeps reading.
     let content: String = valid
         .iter()
         .map(|s| format!("nameserver {s}"))
@@ -1142,9 +1420,11 @@ async fn apply_dns_servers(state: &AppState, servers: &[String]) -> usize {
         .stdout(std::process::Stdio::null())
         .spawn()
     {
-        if let Some(ref mut stdin) = child.stdin {
+        if let Some(mut stdin) = child.stdin.take() {
             use tokio::io::AsyncWriteExt;
             let _ = stdin.write_all(content.as_bytes()).await;
+            let _ = stdin.shutdown().await;
+            drop(stdin);
         }
         let _ = child.wait().await;
     }
@@ -1157,6 +1437,18 @@ async fn apply_hostname(state: &AppState, hostname: &str, domain: Option<&str>) 
     if aifw_core::system_apply_helpers::validate_hostname(hostname).is_err() {
         return false;
     }
+    // Read existing timezone — never clobber it. If unset (fresh appliance)
+    // fall back to UTC, matching `apply_general`'s own default.
+    let existing_timezone: String = sqlx::query_as::<_, (String,)>(
+        "SELECT value FROM system_config WHERE key = 'timezone'",
+    )
+    .fetch_optional(&state.pool)
+    .await
+    .ok()
+    .flatten()
+    .map(|(v,)| v)
+    .unwrap_or_else(|| "UTC".to_string());
+
     // Persist to AiFw kv first so it survives reboot via system-settings UI.
     let _ = sqlx::query("INSERT OR REPLACE INTO system_config (key, value) VALUES ('hostname', ?1)")
         .bind(hostname)
@@ -1174,7 +1466,7 @@ async fn apply_hostname(state: &AppState, hostname: &str, domain: Option<&str>) 
     let report = aifw_core::system_apply::apply_general(&aifw_core::system_apply::GeneralInput {
         hostname: hostname.to_string(),
         domain: domain.unwrap_or("").to_string(),
-        timezone: "UTC".to_string(), // OPNsense timezone is also imported but applied separately by sysadmin choice
+        timezone: existing_timezone,
     })
     .await;
     report.ok
@@ -1203,18 +1495,6 @@ async fn restore_pre_import(state: &AppState, version: i64) -> Result<(), String
         .await
         .map_err(|_| "snapshot apply failed".to_string())?;
     Ok(())
-}
-
-async fn start_commit_confirm(state: &AppState) -> Result<(), String> {
-    let body = serde_json::json!({
-        "timeout_secs": COMMIT_CONFIRM_SECONDS,
-        "description": "OPNsense config import",
-    });
-    let res = crate::backup::commit_confirm_start(State(state.clone()), Json(body)).await;
-    match res {
-        Ok(_) => Ok(()),
-        Err(code) => Err(format!("commit-confirm start returned {code}")),
-    }
 }
 
 // --------------------------------------------------------------------- helpers

--- a/aifw-api/src/opnsense/parser.rs
+++ b/aifw-api/src/opnsense/parser.rs
@@ -145,12 +145,22 @@ fn parse_dom(xml: &str) -> Result<Node, ParseError> {
                     .unescape()
                     .map_err(|err| ParseError::Malformed(err.to_string()))?
                     .into_owned();
-                if !s.trim().is_empty() {
+                let trimmed = s.trim();
+                if !trimmed.is_empty() {
                     let last = stack.last_mut().unwrap();
                     if last.text.is_empty() {
-                        last.text = s.trim().to_string();
+                        // First text run: keep the raw whitespace from the
+                        // event so multi-line `<address>10.0.0.5\n10.0.0.6
+                        // </address>` content survives the splitter that
+                        // alias parsing relies on.
+                        last.text = s;
                     } else {
-                        last.text.push_str(s.trim());
+                        // Subsequent run (quick-xml occasionally splits text
+                        // across events): always insert a single newline as
+                        // a safe separator. Without this, two split events
+                        // could concatenate IPs into "10.0.0.510.0.0.6".
+                        last.text.push('\n');
+                        last.text.push_str(&s);
                     }
                 }
             }
@@ -161,6 +171,9 @@ fn parse_dom(xml: &str) -> Result<Node, ParseError> {
                     .map_err(|err| ParseError::Malformed(err.to_string()))?
                     .to_string();
                 let last = stack.last_mut().unwrap();
+                if !last.text.is_empty() {
+                    last.text.push('\n');
+                }
                 last.text.push_str(&s);
             }
         }
@@ -229,18 +242,29 @@ fn parse_rule(node: &Node) -> OpnRule {
             .collect()
     };
 
+    let floating = node.child("floating").map(|n| n.text == "yes").unwrap_or(false);
+    // OPNsense `<quick>` semantics depend on whether the rule is floating.
+    // Non-floating rules default to quick=yes (first match wins, the pf
+    // default for AiFw rules). Floating rules default to quick=no (last
+    // match wins) to match OPNsense's UI default. Explicit `<quick>` always
+    // overrides.
+    let quick = match node.child("quick") {
+        Some(n) => n.text != "0" && !n.text.eq_ignore_ascii_case("no"),
+        None => !floating,
+    };
+
     OpnRule {
         action: node.child("type").map(|n| n.text.clone()).unwrap_or_else(|| "pass".into()),
         direction: node.child("direction").map(|n| n.text.clone()).unwrap_or_else(|| "in".into()),
         interface,
-        floating: node.child("floating").map(|n| n.text == "yes").unwrap_or(false),
+        floating,
         ipprotocol: node.child("ipprotocol").map(|n| AddrFamily::parse(&n.text)).unwrap_or(AddrFamily::Inet),
         protocol: node.child("protocol").map(|n| n.text.clone()).unwrap_or_else(|| "any".into()),
         source: node.child("source").map(parse_endpoint).unwrap_or_default(),
         destination: node.child("destination").map(parse_endpoint).unwrap_or_default(),
         disabled: node.has_child("disabled"),
         log: node.has_child("log"),
-        quick: node.child("quick").map(|n| n.text != "0" && n.text != "no").unwrap_or(true),
+        quick,
         descr: node.child("descr").map(|n| n.text.clone()).filter(|s| !s.is_empty()),
     }
 }
@@ -272,6 +296,8 @@ fn parse_nat(node: &Node) -> OpnNat {
                 target: r.child("target").map(|n| n.text.clone()).filter(|s| !s.is_empty()),
                 disabled: r.has_child("disabled"),
                 descr: r.child("descr").map(|n| n.text.clone()).filter(|s| !s.is_empty()),
+                nonat: r.has_child("nonat"),
+                staticnatport: r.has_child("staticnatport"),
             });
         }
     }

--- a/aifw-api/src/opnsense/tests.rs
+++ b/aifw-api/src/opnsense/tests.rs
@@ -200,25 +200,132 @@ async fn import_writes_nat_via_engine_with_proper_columns() {
 }
 
 #[tokio::test]
-async fn import_persists_dns_to_auth_config() {
+async fn import_default_does_not_change_dns_or_hostname() {
+    // Audit C4 + H1: default import leaves system settings alone. The user
+    // must opt in via `import_system_settings: true`.
     let (server, _) = test_app().await;
     let token = login(&server).await;
-    let _ = server
+
+    let resp = server
         .post("/api/v1/config/import-opnsense")
         .add_header("authorization", format!("Bearer {token}"))
         .json(&json!({ "xml": MEDIUM_FIXTURE, "commit_confirm": false }))
         .await;
+    resp.assert_status_ok();
+    let body: Value = resp.json();
+    assert_eq!(body["applied"]["dns_servers"], 0, "DNS not applied without opt-in");
+    assert_eq!(body["applied"]["hostname"], false, "hostname not applied without opt-in");
+}
 
-    // C1: DNS persisted via the same path /api/v1/dns reads.
-    // (We can't fully assert the resolv.conf write inside an in-memory test
-    // — sudo isn't wired — but the DB row IS the durable state.)
+#[tokio::test]
+async fn import_with_system_settings_opt_in_applies_them() {
+    let (server, _) = test_app().await;
+    let token = login(&server).await;
+
     let resp = server
-        .get("/api/v1/dns")
+        .post("/api/v1/config/import-opnsense")
         .add_header("authorization", format!("Bearer {token}"))
+        .json(&json!({
+            "xml": MEDIUM_FIXTURE,
+            "commit_confirm": false,
+            "import_system_settings": true,
+        }))
         .await;
     resp.assert_status_ok();
-    // get_dns reads /etc/resolv.conf which we don't control here; the auth_config
-    // row is what survives. The router has the route — that's the contract.
+    let body: Value = resp.json();
+    assert_eq!(body["applied"]["dns_servers"], 2, "both DNS upstreams applied");
+    assert_eq!(body["applied"]["hostname"], true, "hostname applied");
+}
+
+#[tokio::test]
+async fn import_refuses_when_commit_confirm_already_active() {
+    // Audit H5: stacking a second commit-confirm window silently dropped the
+    // first timer. Importer now refuses with 409.
+    let (server, _) = test_app().await;
+    let token = login(&server).await;
+
+    // First import arms commit-confirm.
+    let first = server
+        .post("/api/v1/config/import-opnsense")
+        .add_header("authorization", format!("Bearer {token}"))
+        .json(&json!({
+            "xml": MEDIUM_FIXTURE,
+            "commit_confirm": true,
+        }))
+        .await;
+    first.assert_status_ok();
+
+    // Second import should be refused.
+    let second = server
+        .post("/api/v1/config/import-opnsense")
+        .add_header("authorization", format!("Bearer {token}"))
+        .json(&json!({
+            "xml": MEDIUM_FIXTURE,
+            "commit_confirm": true,
+        }))
+        .await;
+    assert_eq!(second.status_code(), StatusCode::CONFLICT);
+
+    // Clean up the global commit-confirm state so unrelated tests aren't
+    // left with stale active state in this process.
+    let _ = server
+        .post("/api/v1/config/commit-confirm/confirm")
+        .add_header("authorization", format!("Bearer {token}"))
+        .await;
+}
+
+#[tokio::test]
+async fn imported_ipv6_rule_round_trips_through_config_history() {
+    // Audit H6: the rules table has ip_version/src_invert/dst_invert columns,
+    // but they only matter if `RuleConfig` (used by snapshot/restore) carries
+    // them. Without that round-trip the auto-snapshot middleware silently
+    // demotes IPv6 rules back to "both" on the very next mutation.
+    let (server, _) = test_app().await;
+    let token = login(&server).await;
+
+    let resp = server
+        .post("/api/v1/config/import-opnsense")
+        .add_header("authorization", format!("Bearer {token}"))
+        .json(&json!({
+            "xml": MEDIUM_FIXTURE,
+            "interface_map": { "lan": "eth0" },
+            "commit_confirm": false,
+        }))
+        .await;
+    resp.assert_status_ok();
+
+    // History was the *pre-import* state (empty) — make a fresh snapshot
+    // post-import that captures the imported rules and verify ip_version
+    // survives the FirewallConfig round-trip.
+    let save = server
+        .post("/api/v1/config/save")
+        .add_header("authorization", format!("Bearer {token}"))
+        .json(&json!({ "comment": "post-import" }))
+        .await;
+    save.assert_status_ok();
+    let history_list = server
+        .get("/api/v1/config/history?limit=5")
+        .add_header("authorization", format!("Bearer {token}"))
+        .await;
+    let body: Value = history_list.json();
+    let arr = body["data"].as_array().or_else(|| body.as_array()).unwrap();
+    let latest = arr
+        .iter()
+        .filter_map(|v| v["version"].as_i64())
+        .max()
+        .unwrap();
+    let v = server
+        .get(&format!("/api/v1/config/version?version={latest}"))
+        .add_header("authorization", format!("Bearer {token}"))
+        .await;
+    v.assert_status_ok();
+    let cfg: Value = v.json();
+    let rules = cfg["rules"].as_array().expect("rules array in snapshot");
+    let ssh = rules
+        .iter()
+        .find(|r| r["label"].as_str().unwrap_or("").contains("SSH"))
+        .expect("imported SSH rule in snapshot");
+    assert_eq!(ssh["ip_version"], "inet6", "ip_version round-trips through FirewallConfig");
 }
 
 #[tokio::test]

--- a/aifw-api/src/opnsense/types.rs
+++ b/aifw-api/src/opnsense/types.rs
@@ -84,6 +84,12 @@ pub struct OpnNatOutbound {
     pub target: Option<String>,   // empty / absent = use interface address
     pub disabled: bool,
     pub descr: Option<String>,
+    /// `<nonat>1</nonat>` — explicit "do not NAT this traffic" rule. Becomes
+    /// a pf `no nat ...` rule rather than a regular SNAT/masq.
+    pub nonat: bool,
+    /// `<staticnatport>1</staticnatport>` — preserve source port instead of
+    /// rewriting it. Becomes pf's `static-port` keyword.
+    pub staticnatport: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/aifw-api/src/routes.rs
+++ b/aifw-api/src/routes.rs
@@ -2502,7 +2502,7 @@ pub async fn list_static_routes(
     Ok(Json(ApiResponse { data: routes }))
 }
 
-fn validate_route_target(s: &str) -> Result<(), StatusCode> {
+pub(crate) fn validate_route_target(s: &str) -> Result<(), StatusCode> {
     // Accept IP or CIDR (e.g., "10.0.0.0/8", "192.168.1.1", "default")
     if s == "default" {
         return Ok(());

--- a/aifw-common/src/rule.rs
+++ b/aifw-common/src/rule.rs
@@ -106,6 +106,31 @@ impl std::fmt::Display for Action {
     }
 }
 
+impl Action {
+    /// Stable string identity used by the DB layer + config snapshots.
+    /// Decoupled from `Display` (which produces pf-syntax with whitespace)
+    /// and from `format!("{:?}")` (which depends on the Rust enum-variant
+    /// name and would silently break on a rename).
+    pub fn as_db_str(&self) -> &'static str {
+        match self {
+            Action::Pass => "pass",
+            Action::Block => "block",
+            Action::BlockDrop => "block_drop",
+            Action::BlockReturn => "block_return",
+        }
+    }
+
+    pub fn parse_db(s: &str) -> Option<Self> {
+        match s {
+            "pass" => Some(Action::Pass),
+            "block" => Some(Action::Block),
+            "block_drop" | "blockdrop" => Some(Action::BlockDrop),
+            "block_return" | "blockreturn" => Some(Action::BlockReturn),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Direction {

--- a/aifw-core/src/config.rs
+++ b/aifw-core/src/config.rs
@@ -43,6 +43,15 @@ pub struct FirewallConfig {
     /// schema rev — `#[serde(default)]` keeps older backups deserialising.
     #[serde(default)]
     pub dhcp: DhcpSection,
+    /// Named aliases (host / network / port / urltable). Round-tripped so
+    /// snapshot+restore (and the OPNsense importer's pre-import snapshot)
+    /// can revert alias additions cleanly.
+    #[serde(default)]
+    pub aliases: Vec<AliasConfig>,
+    /// Static routes. Same rationale as aliases — without this section,
+    /// snapshot/restore silently drops every route the user defined.
+    #[serde(default)]
+    pub static_routes: Vec<StaticRouteConfig>,
 }
 
 impl Default for FirewallConfig {
@@ -61,8 +70,43 @@ impl Default for FirewallConfig {
             ha: HaConfig::default(),
             tuning: Vec::new(),
             dhcp: DhcpSection::default(),
+            aliases: Vec::new(),
+            static_routes: Vec::new(),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AliasConfig {
+    pub id: String,
+    pub name: String,
+    pub alias_type: String,
+    pub entries: Vec<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StaticRouteConfig {
+    pub id: String,
+    pub destination: String,
+    pub gateway: String,
+    #[serde(default)]
+    pub interface: Option<String>,
+    #[serde(default)]
+    pub metric: i32,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub fib: u32,
 }
 
 impl FirewallConfig {
@@ -293,6 +337,19 @@ pub struct RuleConfig {
     pub label: Option<String>,
     pub state_tracking: String,
     pub status: String,
+    /// Address family — `inet`, `inet6`, or `both`. Older backups predate
+    /// this field; default to `both` so historical rules keep their
+    /// dual-stack semantics on restore.
+    #[serde(default = "default_ip_version")]
+    pub ip_version: String,
+    #[serde(default)]
+    pub src_invert: bool,
+    #[serde(default)]
+    pub dst_invert: bool,
+}
+
+fn default_ip_version() -> String {
+    "both".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/aifw-core/src/db.rs
+++ b/aifw-core/src/db.rs
@@ -143,7 +143,7 @@ impl Database {
         )
         .bind(rule.id.to_string())
         .bind(rule.priority)
-        .bind(format!("{:?}", rule.action).to_lowercase())
+        .bind(rule.action.as_db_str())
         .bind(format!("{:?}", rule.direction).to_lowercase())
         .bind(rule.interface.as_ref().map(|i| i.0.clone()))
         .bind(rule.protocol.to_string())
@@ -238,7 +238,7 @@ impl Database {
         )
         .bind(rule.id.to_string())
         .bind(rule.priority)
-        .bind(format!("{:?}", rule.action).to_lowercase())
+        .bind(rule.action.as_db_str())
         .bind(format!("{:?}", rule.direction).to_lowercase())
         .bind(rule.interface.as_ref().map(|i| i.0.clone()))
         .bind(rule.protocol.to_string())
@@ -367,13 +367,7 @@ struct RuleRow {
 impl RuleRow {
     fn into_rule(self) -> Result<Rule> {
         let parse_action = |s: &str| -> Result<Action> {
-            match s {
-                "pass" => Ok(Action::Pass),
-                "block" => Ok(Action::Block),
-                "blockdrop" => Ok(Action::BlockDrop),
-                "blockreturn" => Ok(Action::BlockReturn),
-                _ => Err(AifwError::Database(format!("unknown action: {s}"))),
-            }
+            Action::parse_db(s).ok_or_else(|| AifwError::Database(format!("unknown action: {s}")))
         };
 
         let parse_direction = |s: &str| -> Result<Direction> {

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -1225,6 +1225,9 @@ mod tests {
             label: Some("https".into()),
             state_tracking: "keep_state".into(),
             status: "active".into(),
+            ip_version: "both".into(),
+            src_invert: false,
+            dst_invert: false,
         });
         assert_eq!(config.resource_count(), 1);
     }
@@ -1377,6 +1380,9 @@ mod tests {
             label: None,
             state_tracking: "keep_state".into(),
             status: "active".into(),
+            ip_version: "both".into(),
+            src_invert: false,
+            dst_invert: false,
         });
         let v2 = mgr.save_version(&c2, "test", None).await.unwrap();
 

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.90.0",
+  "version": "5.91.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/src/app/backup/page.tsx
+++ b/aifw-ui/src/app/backup/page.tsx
@@ -128,6 +128,7 @@ export default function BackupPage() {
   const [opnImporting, setOpnImporting] = useState(false);
   const [opnPreview, setOpnPreview] = useState<Record<string, unknown> | null>(null);
   const [opnIfaceMap, setOpnIfaceMap] = useState<Record<string, string>>({});
+  const [opnImportSystemSettings, setOpnImportSystemSettings] = useState(false);
   const opnFileRef = useRef<HTMLInputElement>(null);
 
   // Commit Confirm
@@ -433,6 +434,7 @@ export default function BackupPage() {
           xml: opnXml,
           interface_map: opnIfaceMap,
           commit_confirm: true,
+          import_system_settings: opnImportSystemSettings,
         }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -1035,9 +1037,25 @@ export default function BackupPage() {
                       </div>
                     </details>
 
+                    {/* System settings opt-in */}
+                    <label className="flex items-start gap-2 text-xs text-[var(--text-secondary)] cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={opnImportSystemSettings}
+                        onChange={(e) => setOpnImportSystemSettings(e.target.checked)}
+                        className="mt-0.5"
+                      />
+                      <span>
+                        <span className="font-medium">Also import system settings</span>
+                        <span className="block text-[var(--text-muted)] mt-0.5">
+                          When checked, the OPNsense hostname, domain, and DNS upstreams will replace the AiFw values. Off by default — most migrations want rules and aliases without renaming the appliance.
+                        </span>
+                      </span>
+                    </label>
+
                     {/* Confirm Import */}
                     <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-3 text-xs text-yellow-300">
-                      Confirm to apply. A pre-import snapshot is saved to config history first, and rules + NAT are wrapped in commit-confirm — if you don&apos;t confirm within the timeout, those revert automatically.
+                      Confirm to apply. A pre-import snapshot is saved to config history first, and rules + NAT + aliases + routes are wrapped in commit-confirm — if you don&apos;t confirm within the timeout, those revert automatically.
                     </div>
                     <div className="flex gap-3">
                       <button onClick={handleOpnImport} disabled={opnImporting || (needMapping && !allMapped)} className={btnPrimary}>


### PR DESCRIPTION
Independent audit of the v5.90 OPNsense importer surfaced 33 findings. This PR closes all 4 Critical, all 10 High, and most Medium items.

## Critical

- **C1.** Commit-confirm now snapshots **pre-apply** state, not post. The previous design auto-reverted to the just-applied state, making the rollback promise hollow. `backup.rs` grows `capture_runtime_snapshot` + `commit_confirm_arm_with_snapshot` so the importer can supply its own snapshot.
- **C2.** The "import is a transaction" doc claim is gone; replaced with an honest tracker (`InsertedRows`) that surgically deletes inserted alias / rule / NAT / route rows on mid-apply failure. The snapshot path covers the same ground when available.
- **C3.** Pre-import snapshot now captures aliases + static_routes via new `FirewallConfig` sections. `apply_firewall_config` deletes-and-restores those sections too, so commit-confirm rollback covers them.
- **C4.** Timezone is read from `system_config` instead of being hardcoded to `"UTC"` — non-UTC admins are no longer reset on every import.

## High

- **H1.** `import_system_settings` flag (default false) gates hostname, domain, and DNS apply. Most migrations want rules + aliases without renaming the appliance. UI gets a checkbox.
- **H2.** Dry-run plan flags rules with ports + non-tcp/udp protocol so the preview matches what `validate_rule` will reject.
- **H3.** Plan runs `parse_port_spec` against every port string so port aliases / non-numeric specs surface a `skip_reason` instead of showing clean and then failing on apply.
- **H4.** `wanip` / `lanip` / `(self)` no longer collapse silently to `Address::Any` for NAT — they still degrade to Any (no AiFw interface-address primitive yet) but emit an advisory in the skipped list so operators can audit the broadened match.
- **H5.** Simultaneous imports that both want commit-confirm get 409 Conflict. Imports with `commit_confirm: false` can still run freely — they don't touch the timer.
- **H6.** `RuleConfig` gains `ip_version`, `src_invert`, `dst_invert` with `#[serde(default)]` for backward compat. `build_current_config` / `rule_from_config` round-trip them, so the auto-snapshot middleware no longer silently demotes IPv6 rules to `both` on the next mutating request.
- **H7.** `InsertedRows` cleanup runs on apply failure when no snapshot is available; tracks alias / rule / NAT / static-route IDs as we insert.
- **H8.** `<nonat>` and `<staticnatport>` are read from outbound NAT rules and rejected with a clear "configure manually after import" message rather than silently producing the opposite-of-intent rule.
- **H9.** DNAT without any port (`<destination><port>` and `<local-port>` both absent) is rejected at plan and apply with the same message — `NatEngine` validation no longer surprises the user.
- **H10.** `Action::as_db_str` / `Action::parse_db` make the DB string identity stable independent of `format!("{:?}")`. Renaming the enum variant no longer silently breaks round-trip.

## Medium

- **M1.** Plan compares alias kind case-insensitively (matches apply).
- **M2.** Static-route import dedups against existing `(destination, gateway, fib)` triples; re-imports no longer accumulate rows.
- **M3.** Routes get `validate_route_target` pre-check; bad destination/gateway lands in `skipped` instead of the DB.
- **M4.** DNS sudo+tee call now closes stdin before `wait()` to avoid the hypothetical hang on FreeBSD.
- **M5.** Parser inserts a newline when it gets a second text/CDATA event for the same parent — multi-line `<address>` content can no longer concatenate adjacent IPs into `10.0.0.510.0.0.6`.
- **M6.** Priority increment is now 1 (not 10) and saturates at 10000 so large rule imports don't hit the `validate_rule` cap.
- **M8.** `<quick>` defaults follow OPNsense's actual behavior: non-floating rules default to `quick=yes`, floating rules default to `quick=no`.
- **M11.** Plan no longer renders `redirect: 10.0.0.10:?` for port-less port-forwards (which now skip with H9's reason anyway).

Plus a related **Low** — `<nat><mode>disabled</mode>` is now honored; outbound NAT rules are reported in `skipped` rather than silently applied.

## Tests

- **27/27 OPNsense tests pass** (was 24; 3 new): `import_default_does_not_change_dns_or_hostname`, `import_with_system_settings_opt_in_applies_them`, `import_refuses_when_commit_confirm_already_active`, `imported_ipv6_rule_round_trips_through_config_history`.
- Workspace test suite still green; updated two `RuleConfig` initializations in `aifw-core/src/tests.rs` for the new fields.
- `cargo check --workspace` clean, zero warnings.
- `npm run build` clean.

## Migration notes

- `RuleConfig` adds three fields with `#[serde(default)]`. Older config history JSON deserializes unchanged. New snapshots include the fields, and the auto-snapshot middleware will pick them up on the next mutating request.
- `FirewallConfig` adds two top-level sections (`aliases`, `static_routes`) — older snapshots deserialize as empty arrays.
- DB schema is unchanged in this PR (the `rules` table columns landed in v5.90).

## Deferred (for a separate, scoped change)

- **M7** `optN` interface keyword resolution.
- **M9** `Action::Block` always logs in pf — existing AiFw policy, not importer-specific. If we want it changed, it should be a global toggle.
- **M10** `PlanNat` shape for DNAT vs SNAT vs binat. Cosmetic; the UI reads the existing fields fine.
- All 11 **Low** items, including the two authorization observations (privilege boundary blur for `BackupRead`/`BackupWrite`) — both are deliberate UX choices worth a separate decision rather than a quiet patch.

Bumps `5.90.0` → `5.91.0`.