### PR TITLE
opnsense audit follow-ups + multi-WAN one-click enable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ai"
-version = "5.90.0"
+version = "5.92.0"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-api"
-version = "5.90.0"
+version = "5.92.0"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-cli"
-version = "5.90.0"
+version = "5.92.0"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-common"
-version = "5.90.0"
+version = "5.92.0"
 dependencies = [
  "chrono",
  "nix 0.31.2",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-conntrack"
-version = "5.90.0"
+version = "5.92.0"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-core"
-version = "5.90.0"
+version = "5.92.0"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-daemon"
-version = "5.90.0"
+version = "5.92.0"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids"
-version = "5.90.0"
+version = "5.92.0"
 dependencies = [
  "aho-corasick",
  "aifw-common",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-bin"
-version = "5.90.0"
+version = "5.92.0"
 dependencies = [
  "aifw-common",
  "aifw-ids",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-ipc"
-version = "5.90.0"
+version = "5.92.0"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-metrics"
-version = "5.90.0"
+version = "5.92.0"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-pf"
-version = "5.90.0"
+version = "5.92.0"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-plugins"
-version = "5.90.0"
+version = "5.92.0"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-setup"
-version = "5.90.0"
+version = "5.92.0"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-tui"
-version = "5.90.0"
+version = "5.92.0"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.91.0"
+version = "5.92.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -1032,6 +1032,10 @@ pub fn build_router(
     let system_reboot = Router::new()
         .route("/api/v1/updates/reboot", post(updates::reboot_system))
         .route("/api/v1/updates/shutdown", post(updates::shutdown_system))
+        .route(
+            "/api/v1/multiwan/enable-fibs",
+            post(multiwan::enable_fibs),
+        )
         .layer(middleware::from_fn(perm_check!(Permission::SystemReboot)));
 
     // proxy:read

--- a/aifw-api/src/multiwan.rs
+++ b/aifw-api/src/multiwan.rs
@@ -211,6 +211,98 @@ pub async fn list_fibs(
     }))
 }
 
+#[derive(Debug, Deserialize, Default)]
+pub struct EnableFibsRequest {
+    /// If true, schedule a reboot in 10s after writing loader.conf.
+    #[serde(default)]
+    pub reboot: bool,
+    /// Override fib count (default 16). Must be a power of two between 2 and 65536.
+    #[serde(default)]
+    pub fibs: Option<u32>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EnableFibsResponse {
+    pub message: String,
+    pub net_fibs: u32,
+    pub already_enabled: bool,
+    pub reboot_scheduled: bool,
+}
+
+/// POST /api/v1/multiwan/enable-fibs
+///
+/// Idempotently writes `net.fibs="<n>"` to `/boot/loader.conf` so that the
+/// kernel allocates multiple forwarding tables on next boot. If the user
+/// passes `reboot=true`, schedules a reboot in 10 seconds. Requires the
+/// `system:reboot` permission since it touches boot config + reboots.
+pub async fn enable_fibs(
+    Json(req): Json<EnableFibsRequest>,
+) -> Result<Json<ApiResponse<EnableFibsResponse>>, StatusCode> {
+    let target_fibs = req.fibs.unwrap_or(16);
+    if target_fibs < 2 || target_fibs > 65536 || !target_fibs.is_power_of_two() {
+        return Err(bad_request());
+    }
+
+    #[cfg(target_os = "freebsd")]
+    let already_enabled = {
+        let path = "/boot/loader.conf";
+        let existing = std::fs::read_to_string(path).unwrap_or_default();
+        let has_line = existing.lines().any(|line| {
+            let trimmed = line.trim_start();
+            !trimmed.starts_with('#')
+                && trimmed.split('=').next().map(str::trim) == Some("net.fibs")
+        });
+        if has_line {
+            true
+        } else {
+            let mut new_content = existing;
+            if !new_content.is_empty() && !new_content.ends_with('\n') {
+                new_content.push('\n');
+            }
+            new_content
+                .push_str("\n# AiFw — multi-WAN forwarding tables (added via UI)\n");
+            new_content.push_str(&format!("net.fibs=\"{target_fibs}\"\n"));
+            std::fs::write(path, new_content).map_err(|_| internal())?;
+            false
+        }
+    };
+
+    #[cfg(not(target_os = "freebsd"))]
+    let already_enabled = false;
+
+    let reboot_scheduled = if req.reboot && !already_enabled {
+        let _ = tokio::process::Command::new("/usr/local/bin/sudo")
+            .args([
+                "/sbin/shutdown",
+                "-r",
+                "+10s",
+                "AiFw enabling multi-WAN forwarding tables",
+            ])
+            .output()
+            .await;
+        true
+    } else {
+        false
+    };
+
+    let message = if already_enabled {
+        "net.fibs is already configured in /boot/loader.conf — reboot to apply if not already".into()
+    } else if reboot_scheduled {
+        format!("net.fibs={target_fibs} written to /boot/loader.conf — system rebooting in 10 seconds")
+    } else {
+        format!("net.fibs={target_fibs} written to /boot/loader.conf — reboot required to take effect")
+    };
+
+    Ok(Json(ApiResponse {
+        data: EnableFibsResponse {
+            message,
+            net_fibs: target_fibs,
+            already_enabled,
+            reboot_scheduled,
+        },
+    }))
+}
+
 // ============================================================
 // Gateways (Phase 2)
 // ============================================================

--- a/aifw-setup/src/tuning.rs
+++ b/aifw-setup/src/tuning.rs
@@ -67,6 +67,18 @@ pub fn generate_recommendations(profile: &SystemProfile) -> Vec<TuningItem> {
         enabled: true,
     });
 
+    // ── Multi-WAN FIBs ───────────────────────────────────────
+    // Allocate 16 forwarding tables so the multi-WAN feature is usable
+    // out of the box. Cost is negligible (a few KB of kernel memory) and
+    // changing this later requires a reboot, so set it at install time.
+    items.push(TuningItem {
+        key: "net.fibs".into(),
+        value: "16".into(),
+        target: TuningTarget::LoaderConf,
+        reason: "Forwarding tables for multi-WAN routing instances (16 = up to 15 WAN uplinks)".into(),
+        enabled: true,
+    });
+
     // ── pf State Table (scale with RAM) ──────────────────────
     let states_hashsize = match profile.memory.total_mb {
         0..=1024 => 32768,

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.91.0",
+  "version": "5.92.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/src/app/multi-wan/page.tsx
+++ b/aifw-ui/src/app/multi-wan/page.tsx
@@ -35,6 +35,7 @@ export default function MultiWanPage() {
 
   const [memberInputs, setMemberInputs] = useState<Record<string, string>>({});
   const [memberErrs, setMemberErrs] = useState<Record<string, string>>({});
+  const [enabling, setEnabling] = useState(false);
 
   const clearFeedback = useCallback(() => {
     setTimeout(() => setFeedback(null), 4000);
@@ -155,6 +156,31 @@ export default function MultiWanPage() {
     }
   }
 
+  async function enableFibs() {
+    if (
+      !confirm(
+        "This will write net.fibs=16 to /boot/loader.conf and reboot the system in 10 seconds. Continue?",
+      )
+    )
+      return;
+    setEnabling(true);
+    try {
+      const r = await api<{
+        data: { message: string; reboot_scheduled: boolean };
+      }>("POST", "/api/v1/multiwan/enable-fibs", { reboot: true });
+      setFeedback({ type: "success", message: r.data.message });
+      clearFeedback();
+    } catch (err) {
+      setFeedback({
+        type: "error",
+        message: err instanceof Error ? err.message : "enable failed",
+      });
+      clearFeedback();
+    } finally {
+      setEnabling(false);
+    }
+  }
+
   async function detachMember(instId: string, iface: string) {
     try {
       await api(
@@ -222,9 +248,10 @@ export default function MultiWanPage() {
             <code>ifconfig &lt;if&gt; fib N</code> for you.
           </li>
           <li>
-            <b>Prerequisite:</b> set <code>net.fibs=16</code> in
-            <code> /boot/loader.conf</code> and reboot. The
-            card below shows how many FIBs the kernel currently offers.
+            <b>Prerequisite:</b> the kernel must be built with multiple FIBs.
+            New AiFw installs ship with <code>net.fibs=16</code> by default;
+            older installs can flip it on with the <i>Enable multi-WAN</i>{" "}
+            button below (writes <code>/boot/loader.conf</code> and reboots).
           </li>
         </ul>
       </HelpBanner>
@@ -320,10 +347,22 @@ export default function MultiWanPage() {
           </div>
         </div>
         {fibs && fibs.net_fibs <= 1 && (
-          <p className="text-xs text-yellow-400">
-            Only 1 FIB available. To enable multi-WAN, set{" "}
-            <code>net.fibs=16</code> in <code>/boot/loader.conf</code> and reboot.
-          </p>
+          <div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3 space-y-2">
+            <p className="text-xs text-yellow-300">
+              Only 1 FIB available. Multi-WAN needs the kernel to allocate
+              extra forwarding tables, which requires a one-time reboot.
+            </p>
+            <button
+              type="button"
+              onClick={enableFibs}
+              disabled={enabling}
+              className="px-3 py-2 rounded bg-yellow-600 hover:bg-yellow-700 text-white text-xs disabled:opacity-50"
+            >
+              {enabling
+                ? "Writing loader.conf…"
+                : "Enable multi-WAN (writes loader.conf + reboots)"}
+            </button>
+          </div>
         )}
         <button
           type="submit"


### PR DESCRIPTION
## Summary

- **OPNsense importer audit follow-ups** (9719269): addresses the criticals, highs, and most mediums from the post-rewrite audit.
- **Multi-WAN one-click enable** (c1f0208, closes #251): users no longer need to drop to a shell to set `net.fibs=16` in `/boot/loader.conf`. New installs ship with it baked into the default tuning bundle, and existing installs get an "Enable multi-WAN" button on `/multi-wan/` that writes loader.conf and reboots.

## Test plan

- [x] `cargo check` — zero warnings
- [x] `cargo test` — 122 api + 28 setup tests pass
- [x] `npm run build` — static export succeeds
- [ ] Smoke-test the new "Enable multi-WAN" button on the test VM after deploy
- [ ] Verify net.fibs persists across reboot