### PR TITLE
sudo: wg helper (#204 slice 2) + docs gh-pages refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ai"
-version = "5.92.3"
+version = "5.93.2"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-api"
-version = "5.92.3"
+version = "5.93.2"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-cli"
-version = "5.92.3"
+version = "5.93.2"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-common"
-version = "5.92.3"
+version = "5.93.2"
 dependencies = [
  "chrono",
  "nix 0.31.2",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-conntrack"
-version = "5.92.3"
+version = "5.93.2"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-core"
-version = "5.92.3"
+version = "5.93.2"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-daemon"
-version = "5.92.3"
+version = "5.93.2"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids"
-version = "5.92.3"
+version = "5.93.2"
 dependencies = [
  "aho-corasick",
  "aifw-common",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-bin"
-version = "5.92.3"
+version = "5.93.2"
 dependencies = [
  "aifw-common",
  "aifw-ids",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-ipc"
-version = "5.92.3"
+version = "5.93.2"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-metrics"
-version = "5.92.3"
+version = "5.93.2"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-pf"
-version = "5.92.3"
+version = "5.93.2"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-plugins"
-version = "5.92.3"
+version = "5.93.2"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-setup"
-version = "5.92.3"
+version = "5.93.2"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-tui"
-version = "5.92.3"
+version = "5.93.2"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.93.1"
+version = "5.93.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.92.4"
+version = "5.93.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-core/src/sudo.rs
+++ b/aifw-core/src/sudo.rs
@@ -15,6 +15,7 @@ use tokio::process::Command;
 
 const SUDO: &str = "/usr/local/bin/sudo";
 const HELPER_WRITE: &str = "/usr/local/libexec/aifw-sudo-write";
+const HELPER_WG: &str = "/usr/local/libexec/aifw-sudo-wg";
 
 /// Atomically write `contents` to `path`, as root, via the
 /// `aifw-sudo-write` helper script.
@@ -50,4 +51,21 @@ pub async fn write_file(path: &Path, contents: &[u8]) -> std::io::Result<()> {
         )));
     }
     Ok(())
+}
+
+/// Run `wg <subcommand> <iface> [args...]` as root via the
+/// `aifw-sudo-wg` helper.
+///
+/// The helper restricts `subcommand` to `set` / `show` and `iface` to
+/// `wg<N>` patterns; remaining args are passed through. Returns the raw
+/// `Output` so callers can inspect stdout (e.g. `wg show … dump`) and
+/// surface `stderr` themselves on failure.
+pub async fn wg(
+    subcommand: &str,
+    iface: &str,
+    extra_args: &[&str],
+) -> std::io::Result<std::process::Output> {
+    let mut args: Vec<&str> = vec![HELPER_WG, subcommand, iface];
+    args.extend_from_slice(extra_args);
+    Command::new(SUDO).args(&args).output().await
 }

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -359,17 +359,11 @@ pub async fn install_from_path(
         }
     }
 
-    // Ensure wg is in sudoers for aifw user (older installs may be missing it)
-    {
-        let sudoers_path = "/usr/local/etc/sudoers.d/aifw";
-        if let Ok(content) = tokio::fs::read_to_string(sudoers_path).await
-            && !content.contains("/usr/bin/wg")
-        {
-            let patched = format!("{content}aifw ALL=(ALL) NOPASSWD: /usr/bin/wg *\n");
-            let _ = tokio::fs::write(sudoers_path, patched).await;
-            info!("Added wg to sudoers for aifw user");
-        }
-    }
+    // Migrate wg sudoers grant. Older installs may have nothing (was added
+    // ad-hoc post-install) or the broad `/usr/bin/wg *` grant; both are
+    // replaced with the narrow `aifw-sudo-wg` helper grant
+    // (GHSA-mjqh-2vx8-7hq7 follow-up #204). Idempotent.
+    ensure_sudoers_wg_helper().await;
 
     // Ensure /usr/sbin/daemon is in sudoers. Without it, the detached
     // restart driver in restart_services() spawns sudo, sudo refuses
@@ -791,6 +785,68 @@ pub async fn ensure_sudoers_write_helper() {
             "sudoers write-helper migration install failed"
         ),
         Err(e) => warn!(error = %e, "sudoers write-helper migration errored"),
+    }
+}
+
+/// Migrate sudoers from the broad `/usr/bin/wg *` grant (or no wg grant
+/// at all — older installs added it ad-hoc) to the narrow `aifw-sudo-wg`
+/// helper (GHSA-mjqh-2vx8-7hq7 follow-up #204). Idempotent.
+pub async fn ensure_sudoers_wg_helper() {
+    let path = "/usr/local/etc/sudoers.d/aifw";
+    let Ok(content) = tokio::fs::read_to_string(path).await else {
+        return;
+    };
+
+    let helper_marker = "/usr/local/libexec/aifw-sudo-wg";
+    let direct_substr = "/usr/bin/wg *";
+
+    let needs_helper = !content.contains(helper_marker);
+    let needs_strip = content.contains(direct_substr);
+    if !needs_helper && !needs_strip {
+        return;
+    }
+
+    let mut patched: String = content
+        .lines()
+        .filter(|line| !line.contains(direct_substr))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if !patched.ends_with('\n') {
+        patched.push('\n');
+    }
+    if needs_helper {
+        patched.push_str("aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-wg *\n");
+    }
+
+    let stage = "/tmp/aifw-sudoers-wg-helper-patch";
+    if tokio::fs::write(stage, &patched).await.is_err() {
+        warn!("failed to stage sudoers wg-helper patch");
+        return;
+    }
+    let result = Command::new("/usr/local/bin/sudo")
+        .args([
+            "/usr/bin/install",
+            "-m",
+            "440",
+            "-o",
+            "root",
+            "-g",
+            "wheel",
+            stage,
+            path,
+        ])
+        .output()
+        .await;
+    let _ = tokio::fs::remove_file(stage).await;
+    match result {
+        Ok(o) if o.status.success() => {
+            info!("migrated sudoers: dropped /usr/bin/wg, added aifw-sudo-wg helper grant")
+        }
+        Ok(o) => warn!(
+            stderr = %String::from_utf8_lossy(&o.stderr),
+            "sudoers wg-helper migration install failed"
+        ),
+        Err(e) => warn!(error = %e, "sudoers wg-helper migration errored"),
     }
 }
 

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -476,19 +476,14 @@ impl VpnEngine {
         // TODO: WG role-change subscriber for explicit wg-quick down on BACKUP
         // (default-false `wg_deconfigure_on_backup` flag, deferred — out of
         // scope for Commit 9 #222).
-        let output = Command::new("/usr/local/bin/sudo")
-            .args([
-                "/usr/bin/wg",
-                "set",
-                iface,
-                "private-key",
-                &key_path,
-                "listen-port",
-                &tunnel.listen_port.to_string(),
-            ])
-            .output()
-            .await
-            .map_err(|e| AifwError::Pf(format!("wg set failed: {e}")))?;
+        let listen_port_s = tunnel.listen_port.to_string();
+        let output = crate::sudo::wg(
+            "set",
+            iface,
+            &["private-key", &key_path, "listen-port", &listen_port_s],
+        )
+        .await
+        .map_err(|e| AifwError::Pf(format!("wg set failed: {e}")))?;
         let _ = tokio::fs::remove_file(&key_path).await;
         if !output.status.success() {
             let _ = Command::new("/usr/local/bin/sudo")
@@ -576,14 +571,12 @@ impl VpnEngine {
     /// Apply a single peer to a running WireGuard interface via `wg set`.
     async fn apply_peer_to_interface(&self, iface: &str, peer: &WgPeer) -> Result<()> {
         let allowed: Vec<String> = peer.allowed_ips.iter().map(|a| a.to_string()).collect();
-        let mut args = vec![
-            "/usr/bin/wg".to_string(),
-            "set".to_string(),
-            iface.to_string(),
+        let allowed_joined = allowed.join(",");
+        let mut args: Vec<String> = vec![
             "peer".to_string(),
             peer.public_key.clone(),
             "allowed-ips".to_string(),
-            allowed.join(","),
+            allowed_joined,
         ];
         if let Some(ref endpoint) = peer.endpoint
             && !endpoint.is_empty()
@@ -596,41 +589,36 @@ impl VpnEngine {
             args.push(ka.to_string());
         }
         // PSK requires a temp file
-        if let Some(ref psk) = peer.preshared_key {
-            let psk_path = format!("/tmp/wg-psk-{}.key", peer.id);
-            tokio::fs::write(&psk_path, psk)
+        let psk_path = if let Some(ref psk) = peer.preshared_key {
+            let path = format!("/tmp/wg-psk-{}.key", peer.id);
+            tokio::fs::write(&path, psk)
                 .await
                 .map_err(|e| AifwError::Pf(format!("Failed to write PSK: {e}")))?;
             let _ = Command::new("chmod")
-                .args(["600", &psk_path])
+                .args(["600", &path])
                 .output()
                 .await;
             args.push("preshared-key".to_string());
-            args.push(psk_path.clone());
-            let output = Command::new("/usr/local/bin/sudo")
-                .args(args.iter().map(|s| s.as_str()).collect::<Vec<_>>())
-                .output()
-                .await
-                .map_err(|e| AifwError::Pf(format!("wg set peer failed: {e}")))?;
-            let _ = tokio::fs::remove_file(&psk_path).await;
-            if !output.status.success() {
-                return Err(AifwError::Pf(format!(
-                    "wg set peer failed: {}",
-                    String::from_utf8_lossy(&output.stderr)
-                )));
-            }
+            args.push(path.clone());
+            Some(path)
         } else {
-            let output = Command::new("/usr/local/bin/sudo")
-                .args(args.iter().map(|s| s.as_str()).collect::<Vec<_>>())
-                .output()
-                .await
-                .map_err(|e| AifwError::Pf(format!("wg set peer failed: {e}")))?;
-            if !output.status.success() {
-                return Err(AifwError::Pf(format!(
-                    "wg set peer failed: {}",
-                    String::from_utf8_lossy(&output.stderr)
-                )));
-            }
+            None
+        };
+
+        let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let output = crate::sudo::wg("set", iface, &arg_refs)
+            .await
+            .map_err(|e| AifwError::Pf(format!("wg set peer failed: {e}")))?;
+
+        if let Some(ref path) = psk_path {
+            let _ = tokio::fs::remove_file(path).await;
+        }
+
+        if !output.status.success() {
+            return Err(AifwError::Pf(format!(
+                "wg set peer failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
         }
         Ok(())
     }
@@ -640,9 +628,7 @@ impl VpnEngine {
         let tunnel = self.get_wg_tunnel(id).await?;
         let iface = &tunnel.interface.0;
 
-        let output = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/bin/wg", "show", iface, "dump"])
-            .output()
+        let output = crate::sudo::wg("show", iface, &["dump"])
             .await
             .map_err(|e| AifwError::Pf(format!("wg show failed: {e}")))?;
 

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -107,6 +107,7 @@ aifw ALL=(root) NOPASSWD: /sbin/shutdown -r +10s *
 # paths, services, interfaces. Migrate broad grants below to wrappers
 # and remove the corresponding line as each category lands.
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-write *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-wg *
 
 # --- Network configuration ---
 # TODO(GHSA-mjqh-2vx8-7hq7): the wildcards below still grant broad root.
@@ -130,7 +131,6 @@ aifw ALL=(ALL) NOPASSWD: /usr/bin/pkill *
 aifw ALL=(ALL) NOPASSWD: /usr/bin/tar *
 aifw ALL=(ALL) NOPASSWD: /usr/sbin/chown *
 aifw ALL=(ALL) NOPASSWD: /usr/sbin/tcpdump *
-aifw ALL=(ALL) NOPASSWD: /usr/bin/wg *
 
 # --- Detached restart driver ---
 # Required by aifw-core/src/updater.rs `restart_services()` so post-update

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.92.4",
+  "version": "5.93.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.93.1",
+  "version": "5.93.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -17,6 +17,7 @@ repository: ZerosAndOnesLLC/AiFw
 plugins:
   - jekyll-seo-tag
   - jekyll-feed
+  - jekyll-sitemap
 
 # SEO
 twitter:
@@ -42,7 +43,44 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - vendor
+  - superpowers
 
 markdown: kramdown
 kramdown:
   syntax_highlighter: rouge
+
+# Top nav definition — referenced by _layouts/default.html
+nav:
+  primary:
+    - title: Features
+      url: /features/
+    - title: Docs
+      dropdown:
+        - { title: "Install",        url: "/install/" }
+        - { title: "First boot",     url: "/install/#first-boot-setup-wizard" }
+        - { divider: true }
+        - { title: "Firewall",       url: "/docs/firewall/" }
+        - { title: "NAT",            url: "/docs/nat/" }
+        - { title: "VPN",            url: "/docs/vpn/" }
+        - { title: "IDS / IPS",      url: "/docs/ids/" }
+        - { title: "Multi-WAN",      url: "/multi-wan/" }
+        - { title: "HA cluster",     url: "/ha/" }
+        - { title: "DNS",            url: "/docs/dns/" }
+        - { title: "DHCP",           url: "/docs/dhcp/" }
+        - { title: "Geo-IP",         url: "/docs/geoip/" }
+        - { title: "Auth & RBAC",    url: "/docs/auth/" }
+        - { title: "Reverse proxy",  url: "/docs/reverse-proxy/" }
+        - { title: "Backup & migration", url: "/docs/backup/" }
+        - { title: "Plugins",        url: "/plugins/" }
+        - { divider: true }
+        - { title: "API reference", url: "/docs/api/" }
+        - { title: "CLI reference", url: "/docs/cli/" }
+        - { title: "FAQ",           url: "/faq/" }
+    - title: Compare
+      url: /compare/
+    - title: Download
+      url: https://github.com/ZerosAndOnesLLC/AiFw/releases/latest
+      external: true
+    - title: GitHub
+      url: https://github.com/ZerosAndOnesLLC/AiFw
+      external: true

--- a/docs/_includes/breadcrumb.html
+++ b/docs/_includes/breadcrumb.html
@@ -1,0 +1,26 @@
+{% if page.breadcrumb %}
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <ol>
+    <li><a href="{{ '/' | relative_url }}">Home</a></li>
+    {% for crumb in page.breadcrumb %}
+      {% if forloop.last %}
+        <li aria-current="page">{{ crumb.title }}</li>
+      {% else %}
+        <li><a href="{{ crumb.url | relative_url }}">{{ crumb.title }}</a></li>
+      {% endif %}
+    {% endfor %}
+  </ol>
+</nav>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "{{ site.url }}/" }
+    {%- for crumb in page.breadcrumb -%}
+    , { "@type": "ListItem", "position": {{ forloop.index | plus: 1 }}, "name": "{{ crumb.title }}"{% unless forloop.last %}, "item": "{{ site.url }}{{ crumb.url }}"{% endunless %} }
+    {%- endfor -%}
+  ]
+}
+</script>
+{% endif %}

--- a/docs/_includes/last-updated.html
+++ b/docs/_includes/last-updated.html
@@ -1,0 +1,3 @@
+{% if page.date %}
+<p class="last-updated">Last updated: <time datetime="{{ page.date | date: '%Y-%m-%d' }}">{{ page.date | date: "%B %-d, %Y" }}</time></p>
+{% endif %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -46,18 +46,41 @@
         <img src="{{ '/assets/AiFw-1.png' | relative_url }}" alt="AiFw" class="brand-logo">
         <span>AiFw</span>
       </a>
-      <nav>
-        <a href="{{ '/features/' | relative_url }}">Features</a>
-        <a href="{{ '/compare/' | relative_url }}">Compare</a>
-        <a href="{{ '/install/' | relative_url }}">Install</a>
-        <a href="{{ '/docs/' | relative_url }}">Docs</a>
-        <a href="https://github.com/ZerosAndOnesLLC/AiFw" class="btn btn-outline" target="_blank" rel="noopener">GitHub</a>
+      <nav class="primary-nav" aria-label="Primary">
+        <ul class="nav-list">
+          {% for item in site.nav.primary %}
+            {% if item.dropdown %}
+              <li class="nav-item has-dropdown">
+                <button class="nav-trigger" aria-expanded="false" aria-haspopup="true">{{ item.title }} <span aria-hidden="true">▾</span></button>
+                <ul class="nav-dropdown">
+                  {% for sub in item.dropdown %}
+                    {% if sub.divider %}
+                      <li class="nav-divider" role="separator"></li>
+                    {% else %}
+                      <li><a href="{{ sub.url | relative_url }}">{{ sub.title }}</a></li>
+                    {% endif %}
+                  {% endfor %}
+                </ul>
+              </li>
+            {% else %}
+              <li class="nav-item">
+                {% if item.external %}
+                  <a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.title }}{% if item.title == 'GitHub' %} ↗{% endif %}</a>
+                {% else %}
+                  <a href="{{ item.url | relative_url }}">{{ item.title }}</a>
+                {% endif %}
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
       </nav>
     </div>
   </header>
 
   <main>
+    {% include breadcrumb.html %}
     {{ content }}
+    {% include last-updated.html %}
   </main>
 
   <footer class="site-footer">

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -941,3 +941,119 @@ table.compare td:not(:first-child) { text-align: center; }
   .footer-grid { grid-template-columns: 1fr; }
   .hero-stats { gap: 24px; }
 }
+
+/* ─────────── Nav dropdown ─────────── */
+.primary-nav .nav-list {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.primary-nav .nav-item { position: relative; }
+.primary-nav .nav-trigger {
+  background: none;
+  border: 0;
+  color: var(--text-1);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.primary-nav .nav-trigger:hover,
+.primary-nav .nav-trigger:focus { color: var(--text-0); outline: none; }
+.primary-nav .nav-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 220px;
+  background: rgba(10, 14, 24, 0.96);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(30,43,69,0.6);
+  border-radius: 10px;
+  padding: 8px 0;
+  list-style: none;
+  margin: 0;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-4px);
+  transition: opacity 0.12s, transform 0.12s;
+  z-index: 100;
+}
+.primary-nav .has-dropdown:hover .nav-dropdown,
+.primary-nav .has-dropdown:focus-within .nav-dropdown {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+.primary-nav .has-dropdown:hover .nav-trigger,
+.primary-nav .has-dropdown:focus-within .nav-trigger { color: var(--text-0); }
+.primary-nav .nav-trigger[aria-expanded="true"] { color: var(--text-0); }
+.primary-nav .nav-dropdown a {
+  display: block;
+  padding: 8px 16px;
+  color: var(--text-1);
+  font-size: 14px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.primary-nav .nav-dropdown a:hover { color: var(--text-0); background: rgba(255,255,255,0.04); }
+.primary-nav .nav-divider {
+  height: 1px;
+  background: rgba(30,43,69,0.6);
+  margin: 6px 12px;
+}
+@media (max-width: 720px) {
+  .primary-nav .nav-list { gap: 12px; }
+  .primary-nav .nav-item:not(.has-dropdown) > a:not(.btn) { display: none; }
+  .primary-nav .nav-dropdown {
+    position: static;
+    opacity: 1;
+    pointer-events: auto;
+    transform: none;
+    background: transparent;
+    border: 0;
+    padding: 0;
+    box-shadow: none;
+  }
+  .primary-nav .nav-trigger { display: none; }
+}
+
+/* ─────────── Breadcrumb ─────────── */
+.breadcrumb {
+  max-width: 880px;
+  margin: 24px auto 0;
+  padding: 0 24px;
+  font-size: 13px;
+  color: var(--text-2);
+}
+.breadcrumb ol {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.breadcrumb li:not(:last-child)::after {
+  content: "›";
+  margin-left: 6px;
+  color: var(--text-3, var(--text-2));
+}
+.breadcrumb a { color: var(--text-2); text-decoration: none; }
+.breadcrumb a:hover { color: var(--text-0); }
+
+/* ─────────── Last-updated ─────────── */
+.last-updated {
+  max-width: 880px;
+  margin: 48px auto 64px;
+  padding: 16px 24px 0;
+  border-top: 1px solid rgba(30,43,69,0.5);
+  color: var(--text-2);
+  font-size: 13px;
+}

--- a/freebsd/deploy.sh
+++ b/freebsd/deploy.sh
@@ -255,7 +255,7 @@ done
 # login migrate, shutdown hook, narrow-grant sudo wrappers from #204).
 # Mode 755 so the daemon supervisor / sudo can exec them.
 mkdir -p /usr/local/libexec
-for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write; do
+for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write aifw-sudo-wg; do
     src="$REPO_DIR/freebsd/overlay/usr/local/libexec/$script"
     if [ -f "$src" ]; then
         install -m 755 "$src" "/usr/local/libexec/$script"
@@ -268,7 +268,8 @@ done
 mkdir -p /usr/local/etc/sudoers.d
 echo 'aifw ALL=(ALL) NOPASSWD: /sbin/pfctl, /sbin/ifconfig, /sbin/dhclient, /sbin/route, /usr/sbin/service, /usr/sbin/sysrc, /usr/sbin/pkg, /usr/sbin/freebsd-update, /sbin/shutdown, /bin/hostname, /bin/cat, /bin/pkill, /usr/bin/pkill, /usr/sbin/chown, /bin/mkdir, /usr/sbin/tcpdump, /usr/bin/install, /bin/rm /usr/local/etc/rdns/rpz/*
 aifw ALL=(root) NOPASSWD: /usr/sbin/daemon -f *
-aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-write *' > /usr/local/etc/sudoers.d/aifw
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-write *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-wg *' > /usr/local/etc/sudoers.d/aifw
 chmod 440 /usr/local/etc/sudoers.d/aifw
 
 echo ""

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-wg
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-wg
@@ -1,0 +1,42 @@
+#!/bin/sh
+# /usr/local/libexec/aifw-sudo-wg <subcommand> <iface> [args...]
+#
+# Narrow-grant wrapper around /usr/bin/wg (GHSA-mjqh-2vx8-7hq7 follow-up
+# #204). Restricts the `aifw` user to:
+#
+#   - subcommands `set` and `show` (no `setconf`, `pubkey`, `genkey`, etc.)
+#   - interface names matching wg<N> (no `lo0`, no arbitrary system iface)
+#
+# Remaining args (peer pubkey, allowed-ips, key-file paths, etc.) are
+# passed through. wg's own argument validator catches malformed forms.
+
+set -eu
+
+if [ $# -lt 2 ]; then
+    echo "usage: $0 <set|show> <iface> [args...]" >&2
+    exit 2
+fi
+
+SUBCMD="$1"
+IFACE="$2"
+shift 2
+
+case "$SUBCMD" in
+    set|show) ;;
+    *)
+        echo "aifw-sudo-wg: unsupported subcommand: $SUBCMD" >&2
+        exit 1
+        ;;
+esac
+
+# Whitelist iface names — wg<N> with up to 3 digits. AiFw's tunnel
+# allocator uses wg0, wg1, ... so 3 digits gives plenty of headroom.
+case "$IFACE" in
+    wg[0-9]|wg[0-9][0-9]|wg[0-9][0-9][0-9]) ;;
+    *)
+        echo "aifw-sudo-wg: invalid iface (expected wg<N>): $IFACE" >&2
+        exit 1
+        ;;
+esac
+
+exec /usr/bin/wg "$SUBCMD" "$IFACE" "$@"


### PR DESCRIPTION
## Summary

- **`#204` second slice** (v5.93.2): narrow `/usr/bin/wg *` sudoers grant to the allowlisted `aifw-sudo-wg` helper script. Helper restricts subcommands to `set` / `show` and interface names to `wg<N>`. Migrated three call sites in `aifw-core/src/vpn.rs`. Sudoers updated in all three sources of truth (aifw-setup, deploy.sh, updater.rs); the existing `ensure_sudoers_wg` ad-hoc patcher (which silently failed because of file perms) is replaced with `ensure_sudoers_wg_helper` that strips the broad grant and adds the helper grant via the same `sudo install` pattern as `ensure_sudoers_daemon`.
- **gh-pages docs refresh**: grouped-dropdown nav, breadcrumb partial, sitemap plugin (`a6f8b18`).

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace` green
- [ ] FreeBSD deploy validates `wg set` / `wg show` go through the helper
- [ ] Verify `ensure_sudoers_wg_helper` migration on an upgraded appliance (old sudoers had `/usr/bin/wg *`; new should have only the helper grant)
- [ ] gh-pages site renders correctly with the new nav/breadcrumb/sitemap