### PR TITLE
sudo: freebsd-update helper (#204 slice 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ai"
-version = "5.93.2"
+version = "5.93.3"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-api"
-version = "5.93.2"
+version = "5.93.3"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-cli"
-version = "5.93.2"
+version = "5.93.3"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-common"
-version = "5.93.2"
+version = "5.93.3"
 dependencies = [
  "chrono",
  "nix 0.31.2",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-conntrack"
-version = "5.93.2"
+version = "5.93.3"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-core"
-version = "5.93.2"
+version = "5.93.3"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-daemon"
-version = "5.93.2"
+version = "5.93.3"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids"
-version = "5.93.2"
+version = "5.93.3"
 dependencies = [
  "aho-corasick",
  "aifw-common",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-bin"
-version = "5.93.2"
+version = "5.93.3"
 dependencies = [
  "aifw-common",
  "aifw-ids",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-ipc"
-version = "5.93.2"
+version = "5.93.3"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-metrics"
-version = "5.93.2"
+version = "5.93.3"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-pf"
-version = "5.93.2"
+version = "5.93.3"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-plugins"
-version = "5.93.2"
+version = "5.93.3"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-setup"
-version = "5.93.2"
+version = "5.93.3"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-tui"
-version = "5.93.2"
+version = "5.93.3"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.93.2"
+version = "5.93.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/updates.rs
+++ b/aifw-api/src/updates.rs
@@ -198,17 +198,13 @@ pub async fn update_status(
         }
     }
 
-    let pending_os = Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/freebsd-update", "updatesready"])
-        .output()
+    let pending_os = aifw_core::sudo::freebsd_update("updatesready", &[])
         .await
         .map(|o| o.status.success())
         .unwrap_or(false);
 
     let needs_reboot = std::path::Path::new("/var/run/reboot-required").exists()
-        || Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/freebsd-update", "updatesready"])
-            .output()
+        || aifw_core::sudo::freebsd_update("updatesready", &[])
             .await
             .map(|o| o.status.success())
             .unwrap_or(false);
@@ -255,14 +251,7 @@ pub async fn check_updates(
     };
 
     // Check OS updates
-    let os_result = Command::new("/usr/local/bin/sudo")
-        .args([
-            "/usr/sbin/freebsd-update",
-            "fetch",
-            "--not-running-from-cron",
-        ])
-        .output()
-        .await;
+    let os_result = aifw_core::sudo::freebsd_update("fetch", &["--not-running-from-cron"]).await;
     let os_msg = match os_result {
         Ok(o) => {
             if o.status.success() {
@@ -309,10 +298,7 @@ pub async fn install_updates(
     }
 
     // Install OS updates
-    let os_result = Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/freebsd-update", "install"])
-        .output()
-        .await;
+    let os_result = aifw_core::sudo::freebsd_update("install", &[]).await;
     match os_result {
         Ok(o) => {
             if o.status.success() {

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -1934,14 +1934,7 @@ pub async fn update_os_check() -> anyhow::Result<()> {
         );
     }
 
-    let os = tokio::process::Command::new("/usr/local/bin/sudo")
-        .args([
-            "/usr/sbin/freebsd-update",
-            "fetch",
-            "--not-running-from-cron",
-        ])
-        .output()
-        .await?;
+    let os = aifw_core::sudo::freebsd_update("fetch", &["--not-running-from-cron"]).await?;
     if os.status.success() {
         println!("  OS update check complete.");
     } else {
@@ -1987,10 +1980,7 @@ pub async fn update_os_install() -> anyhow::Result<()> {
         .count();
     println!("  {} package(s) updated.", count);
 
-    let os = tokio::process::Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/freebsd-update", "install"])
-        .output()
-        .await?;
+    let os = aifw_core::sudo::freebsd_update("install", &[]).await?;
     if os.status.success() {
         println!("  OS updates installed.");
     } else {

--- a/aifw-core/src/sudo.rs
+++ b/aifw-core/src/sudo.rs
@@ -16,6 +16,7 @@ use tokio::process::Command;
 const SUDO: &str = "/usr/local/bin/sudo";
 const HELPER_WRITE: &str = "/usr/local/libexec/aifw-sudo-write";
 const HELPER_WG: &str = "/usr/local/libexec/aifw-sudo-wg";
+const HELPER_FREEBSD_UPDATE: &str = "/usr/local/libexec/aifw-sudo-freebsd-update";
 
 /// Atomically write `contents` to `path`, as root, via the
 /// `aifw-sudo-write` helper script.
@@ -66,6 +67,23 @@ pub async fn wg(
     extra_args: &[&str],
 ) -> std::io::Result<std::process::Output> {
     let mut args: Vec<&str> = vec![HELPER_WG, subcommand, iface];
+    args.extend_from_slice(extra_args);
+    Command::new(SUDO).args(&args).output().await
+}
+
+/// Run `freebsd-update <action> [args...]` as root via the
+/// `aifw-sudo-freebsd-update` helper.
+///
+/// The helper restricts `action` to `updatesready` / `fetch` / `install`
+/// and validates the small set of allowed args per action (currently
+/// just `--not-running-from-cron` for `fetch`). Returns the raw
+/// `Output` so callers can branch on `status.success()` and surface
+/// `stderr`/`stdout` themselves.
+pub async fn freebsd_update(
+    action: &str,
+    extra_args: &[&str],
+) -> std::io::Result<std::process::Output> {
+    let mut args: Vec<&str> = vec![HELPER_FREEBSD_UPDATE, action];
     args.extend_from_slice(extra_args);
     Command::new(SUDO).args(&args).output().await
 }

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -365,6 +365,11 @@ pub async fn install_from_path(
     // (GHSA-mjqh-2vx8-7hq7 follow-up #204). Idempotent.
     ensure_sudoers_wg_helper().await;
 
+    // Migrate freebsd-update sudoers grant from the broad
+    // `/usr/sbin/freebsd-update *` to the narrow
+    // `aifw-sudo-freebsd-update *` helper (#204). Idempotent.
+    ensure_sudoers_freebsd_update_helper().await;
+
     // Ensure /usr/sbin/daemon is in sudoers. Without it, the detached
     // restart driver in restart_services() spawns sudo, sudo refuses
     // for lack of NOPASSWD, and we silently skip the bounce — leaving
@@ -847,6 +852,72 @@ pub async fn ensure_sudoers_wg_helper() {
             "sudoers wg-helper migration install failed"
         ),
         Err(e) => warn!(error = %e, "sudoers wg-helper migration errored"),
+    }
+}
+
+/// Migrate sudoers from the broad `/usr/sbin/freebsd-update *` grant to
+/// the narrow `aifw-sudo-freebsd-update` helper
+/// (GHSA-mjqh-2vx8-7hq7 follow-up #204). Idempotent.
+pub async fn ensure_sudoers_freebsd_update_helper() {
+    let path = "/usr/local/etc/sudoers.d/aifw";
+    let Ok(content) = tokio::fs::read_to_string(path).await else {
+        return;
+    };
+
+    let helper_marker = "/usr/local/libexec/aifw-sudo-freebsd-update";
+    let direct_substr = "/usr/sbin/freebsd-update *";
+
+    let needs_helper = !content.contains(helper_marker);
+    let needs_strip = content.contains(direct_substr);
+    if !needs_helper && !needs_strip {
+        return;
+    }
+
+    let mut patched: String = content
+        .lines()
+        .filter(|line| !line.contains(direct_substr))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if !patched.ends_with('\n') {
+        patched.push('\n');
+    }
+    if needs_helper {
+        patched.push_str(
+            "aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-freebsd-update *\n",
+        );
+    }
+
+    let stage = "/tmp/aifw-sudoers-freebsd-update-helper-patch";
+    if tokio::fs::write(stage, &patched).await.is_err() {
+        warn!("failed to stage sudoers freebsd-update-helper patch");
+        return;
+    }
+    let result = Command::new("/usr/local/bin/sudo")
+        .args([
+            "/usr/bin/install",
+            "-m",
+            "440",
+            "-o",
+            "root",
+            "-g",
+            "wheel",
+            stage,
+            path,
+        ])
+        .output()
+        .await;
+    let _ = tokio::fs::remove_file(stage).await;
+    match result {
+        Ok(o) if o.status.success() => {
+            info!(
+                "migrated sudoers: dropped /usr/sbin/freebsd-update, added aifw-sudo-freebsd-update helper grant"
+            )
+        }
+        Ok(o) => warn!(
+            stderr = %String::from_utf8_lossy(&o.stderr),
+            "sudoers freebsd-update-helper migration install failed"
+        ),
+        Err(e) => warn!(error = %e, "sudoers freebsd-update-helper migration errored"),
     }
 }
 

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -108,6 +108,7 @@ aifw ALL=(root) NOPASSWD: /sbin/shutdown -r +10s *
 # and remove the corresponding line as each category lands.
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-write *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-wg *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-freebsd-update *
 
 # --- Network configuration ---
 # TODO(GHSA-mjqh-2vx8-7hq7): the wildcards below still grant broad root.
@@ -119,7 +120,6 @@ aifw ALL=(ALL) NOPASSWD: /sbin/route *
 aifw ALL=(ALL) NOPASSWD: /usr/sbin/service *
 aifw ALL=(ALL) NOPASSWD: /usr/sbin/sysrc *
 aifw ALL=(ALL) NOPASSWD: /usr/sbin/pkg *
-aifw ALL=(ALL) NOPASSWD: /usr/sbin/freebsd-update *
 aifw ALL=(ALL) NOPASSWD: /bin/cat *
 aifw ALL=(ALL) NOPASSWD: /bin/cp *
 aifw ALL=(ALL) NOPASSWD: /bin/rm *

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.93.2",
+  "version": "5.93.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/freebsd/deploy.sh
+++ b/freebsd/deploy.sh
@@ -255,7 +255,7 @@ done
 # login migrate, shutdown hook, narrow-grant sudo wrappers from #204).
 # Mode 755 so the daemon supervisor / sudo can exec them.
 mkdir -p /usr/local/libexec
-for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write aifw-sudo-wg; do
+for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write aifw-sudo-wg aifw-sudo-freebsd-update; do
     src="$REPO_DIR/freebsd/overlay/usr/local/libexec/$script"
     if [ -f "$src" ]; then
         install -m 755 "$src" "/usr/local/libexec/$script"
@@ -266,10 +266,11 @@ done
 # favor of /usr/local/libexec/aifw-sudo-write, which enforces a closed
 # allowlist of write paths (#204).
 mkdir -p /usr/local/etc/sudoers.d
-echo 'aifw ALL=(ALL) NOPASSWD: /sbin/pfctl, /sbin/ifconfig, /sbin/dhclient, /sbin/route, /usr/sbin/service, /usr/sbin/sysrc, /usr/sbin/pkg, /usr/sbin/freebsd-update, /sbin/shutdown, /bin/hostname, /bin/cat, /bin/pkill, /usr/bin/pkill, /usr/sbin/chown, /bin/mkdir, /usr/sbin/tcpdump, /usr/bin/install, /bin/rm /usr/local/etc/rdns/rpz/*
+echo 'aifw ALL=(ALL) NOPASSWD: /sbin/pfctl, /sbin/ifconfig, /sbin/dhclient, /sbin/route, /usr/sbin/service, /usr/sbin/sysrc, /usr/sbin/pkg, /sbin/shutdown, /bin/hostname, /bin/cat, /bin/pkill, /usr/bin/pkill, /usr/sbin/chown, /bin/mkdir, /usr/sbin/tcpdump, /usr/bin/install, /bin/rm /usr/local/etc/rdns/rpz/*
 aifw ALL=(root) NOPASSWD: /usr/sbin/daemon -f *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-write *
-aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-wg *' > /usr/local/etc/sudoers.d/aifw
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-wg *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-freebsd-update *' > /usr/local/etc/sudoers.d/aifw
 chmod 440 /usr/local/etc/sudoers.d/aifw
 
 echo ""

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-freebsd-update
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-freebsd-update
@@ -1,0 +1,63 @@
+#!/bin/sh
+# /usr/local/libexec/aifw-sudo-freebsd-update <action>
+#
+# Narrow-grant wrapper around /usr/sbin/freebsd-update (#204).
+# Restricts the `aifw` user to:
+#
+#   - updatesready             — exit code reflects whether updates pending
+#   - fetch [--not-running-from-cron]
+#   - install                  — apply downloaded updates
+#
+# Other subcommands (cron, IDS, rollback, upgrade) are denied so a
+# compromised daemon can't, for example, `freebsd-update rollback` to
+# uninstall security patches or `freebsd-update IDS` to spam the system
+# with checksumming load.
+
+set -eu
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <updatesready|fetch|install>" >&2
+    exit 2
+fi
+
+ACTION="$1"
+shift
+
+case "$ACTION" in
+    updatesready)
+        if [ $# -ne 0 ]; then
+            echo "aifw-sudo-freebsd-update: 'updatesready' takes no extra args" >&2
+            exit 1
+        fi
+        exec /usr/sbin/freebsd-update updatesready
+        ;;
+    fetch)
+        case $# in
+            0)
+                exec /usr/sbin/freebsd-update fetch
+                ;;
+            1)
+                if [ "$1" = "--not-running-from-cron" ]; then
+                    exec /usr/sbin/freebsd-update fetch --not-running-from-cron
+                fi
+                echo "aifw-sudo-freebsd-update: only --not-running-from-cron is allowed for fetch" >&2
+                exit 1
+                ;;
+            *)
+                echo "aifw-sudo-freebsd-update: too many args for fetch" >&2
+                exit 1
+                ;;
+        esac
+        ;;
+    install)
+        if [ $# -ne 0 ]; then
+            echo "aifw-sudo-freebsd-update: 'install' takes no extra args" >&2
+            exit 1
+        fi
+        exec /usr/sbin/freebsd-update install
+        ;;
+    *)
+        echo "aifw-sudo-freebsd-update: unsupported action: $ACTION" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Third slice of the GHSA-mjqh-2vx8-7hq7 follow-up. Replaces the broad `/usr/sbin/freebsd-update *` sudoers grant with the narrow `aifw-sudo-freebsd-update` helper.

The helper restricts the `aifw` user to a closed set of subcommands:
- `updatesready` — exit code reflects whether updates pending
- `fetch [--not-running-from-cron]`
- `install` — apply downloaded updates

Other subcommands (`cron`, `IDS`, `rollback`, `upgrade`) are denied. A compromised daemon can no longer `freebsd-update rollback` to uninstall security patches or `freebsd-update IDS` to spam the system with checksumming load.

## Migrated

- 6 call sites — `aifw-api/src/updates.rs` (3) and `aifw-cli/src/commands.rs` (2: fetch + install). Plus `updates.rs:202` and `:210` (duplicate `updatesready` checks).
- Sudoers in all three sources of truth — `aifw-setup/apply.rs`, `freebsd/deploy.sh`, `aifw-core/updater.rs::ensure_sudoers_freebsd_update_helper` (idempotent migrator).

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace` green (all 700+ tests)
- [ ] FreeBSD deploy validates `freebsd-update updatesready` / `fetch` / `install` go through the helper
- [ ] Verify `ensure_sudoers_freebsd_update_helper` strips the broad grant on an upgraded appliance