### PR TITLE
sudo: pkg helper (#204 slice 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ai"
-version = "5.93.3"
+version = "5.93.4"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-api"
-version = "5.93.3"
+version = "5.93.4"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-cli"
-version = "5.93.3"
+version = "5.93.4"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-common"
-version = "5.93.3"
+version = "5.93.4"
 dependencies = [
  "chrono",
  "nix 0.31.2",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-conntrack"
-version = "5.93.3"
+version = "5.93.4"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-core"
-version = "5.93.3"
+version = "5.93.4"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-daemon"
-version = "5.93.3"
+version = "5.93.4"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids"
-version = "5.93.3"
+version = "5.93.4"
 dependencies = [
  "aho-corasick",
  "aifw-common",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-bin"
-version = "5.93.3"
+version = "5.93.4"
 dependencies = [
  "aifw-common",
  "aifw-ids",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-ipc"
-version = "5.93.3"
+version = "5.93.4"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-metrics"
-version = "5.93.3"
+version = "5.93.4"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-pf"
-version = "5.93.3"
+version = "5.93.4"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-plugins"
-version = "5.93.3"
+version = "5.93.4"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-setup"
-version = "5.93.3"
+version = "5.93.4"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-tui"
-version = "5.93.3"
+version = "5.93.4"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.93.3"
+version = "5.93.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/updates.rs
+++ b/aifw-api/src/updates.rs
@@ -173,9 +173,7 @@ pub async fn update_status(
             .map(|r| r.0);
 
     // Check for pending pkg updates
-    let pkg_out = Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/pkg", "upgrade", "-n"])
-        .output()
+    let pkg_out = aifw_core::sudo::pkg("upgrade", &["-n"])
         .await
         .map(|o| String::from_utf8_lossy(&o.stdout).to_string())
         .unwrap_or_default();
@@ -228,10 +226,7 @@ pub async fn check_updates(
     save_config(&state.pool, "last_check", &now).await;
 
     // Check pkg updates
-    let pkg_result = Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/pkg", "update"])
-        .output()
-        .await;
+    let pkg_result = aifw_core::sudo::pkg("update", &[]).await;
     let pkg_msg = match pkg_result {
         Ok(o) => {
             let stdout = String::from_utf8_lossy(&o.stdout);
@@ -281,10 +276,7 @@ pub async fn install_updates(
     let mut results = Vec::new();
 
     // Install pkg updates
-    let pkg_result = Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/pkg", "upgrade", "-y"])
-        .output()
-        .await;
+    let pkg_result = aifw_core::sudo::pkg("upgrade", &["-y"]).await;
     match pkg_result {
         Ok(o) => {
             let stdout = String::from_utf8_lossy(&o.stdout);

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -1921,10 +1921,7 @@ fn prompt_restart_yes() -> anyhow::Result<bool> {
 pub async fn update_os_check() -> anyhow::Result<()> {
     println!("Checking for OS and package updates...");
 
-    let pkg = tokio::process::Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/pkg", "update"])
-        .output()
-        .await?;
+    let pkg = aifw_core::sudo::pkg("update", &[]).await?;
     if pkg.status.success() {
         println!("  Package catalog updated.");
     } else {
@@ -1948,10 +1945,7 @@ pub async fn update_os_check() -> anyhow::Result<()> {
     }
 
     // Show pending
-    let pending = tokio::process::Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/pkg", "upgrade", "-n"])
-        .output()
-        .await?;
+    let pending = aifw_core::sudo::pkg("upgrade", &["-n"]).await?;
     let stdout = String::from_utf8_lossy(&pending.stdout);
     let count = stdout
         .lines()
@@ -1969,10 +1963,7 @@ pub async fn update_os_check() -> anyhow::Result<()> {
 pub async fn update_os_install() -> anyhow::Result<()> {
     println!("Installing OS and package updates...");
 
-    let pkg = tokio::process::Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/pkg", "upgrade", "-y"])
-        .output()
-        .await?;
+    let pkg = aifw_core::sudo::pkg("upgrade", &["-y"]).await?;
     let stdout = String::from_utf8_lossy(&pkg.stdout);
     let count = stdout
         .lines()

--- a/aifw-core/src/sudo.rs
+++ b/aifw-core/src/sudo.rs
@@ -17,6 +17,7 @@ const SUDO: &str = "/usr/local/bin/sudo";
 const HELPER_WRITE: &str = "/usr/local/libexec/aifw-sudo-write";
 const HELPER_WG: &str = "/usr/local/libexec/aifw-sudo-wg";
 const HELPER_FREEBSD_UPDATE: &str = "/usr/local/libexec/aifw-sudo-freebsd-update";
+const HELPER_PKG: &str = "/usr/local/libexec/aifw-sudo-pkg";
 
 /// Atomically write `contents` to `path`, as root, via the
 /// `aifw-sudo-write` helper script.
@@ -84,6 +85,18 @@ pub async fn freebsd_update(
     extra_args: &[&str],
 ) -> std::io::Result<std::process::Output> {
     let mut args: Vec<&str> = vec![HELPER_FREEBSD_UPDATE, action];
+    args.extend_from_slice(extra_args);
+    Command::new(SUDO).args(&args).output().await
+}
+
+/// Run `pkg <action> [args...]` as root via the `aifw-sudo-pkg` helper.
+///
+/// The helper restricts `action` to `update` / `install` / `upgrade`
+/// and validates each form (`install -y <pkg>...` requires alnum/dot/
+/// underscore/plus/hyphen-only package names; `upgrade` must be `-y`
+/// or `-n`). Other subcommands and arbitrary flags are denied.
+pub async fn pkg(action: &str, extra_args: &[&str]) -> std::io::Result<std::process::Output> {
+    let mut args: Vec<&str> = vec![HELPER_PKG, action];
     args.extend_from_slice(extra_args);
     Command::new(SUDO).args(&args).output().await
 }

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -370,6 +370,10 @@ pub async fn install_from_path(
     // `aifw-sudo-freebsd-update *` helper (#204). Idempotent.
     ensure_sudoers_freebsd_update_helper().await;
 
+    // Migrate pkg sudoers grant from the broad `/usr/sbin/pkg *` to the
+    // narrow `aifw-sudo-pkg *` helper (#204). Idempotent.
+    ensure_sudoers_pkg_helper().await;
+
     // Ensure /usr/sbin/daemon is in sudoers. Without it, the detached
     // restart driver in restart_services() spawns sudo, sudo refuses
     // for lack of NOPASSWD, and we silently skip the bounce — leaving
@@ -388,10 +392,7 @@ pub async fn install_from_path(
         let pkg_installed = check.map(|o| o.status.success()).unwrap_or(false);
         if !pkg_installed {
             info!(package = pkg, "Installing missing dependency");
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args(["pkg", "install", "-y", pkg])
-                .output()
-                .await;
+            let _ = crate::sudo::pkg("install", &["-y", pkg]).await;
         }
     }
 
@@ -918,6 +919,67 @@ pub async fn ensure_sudoers_freebsd_update_helper() {
             "sudoers freebsd-update-helper migration install failed"
         ),
         Err(e) => warn!(error = %e, "sudoers freebsd-update-helper migration errored"),
+    }
+}
+
+/// Migrate sudoers from the broad `/usr/sbin/pkg *` grant to the
+/// narrow `aifw-sudo-pkg` helper (#204). Idempotent.
+pub async fn ensure_sudoers_pkg_helper() {
+    let path = "/usr/local/etc/sudoers.d/aifw";
+    let Ok(content) = tokio::fs::read_to_string(path).await else {
+        return;
+    };
+
+    let helper_marker = "/usr/local/libexec/aifw-sudo-pkg";
+    let direct_substr = "/usr/sbin/pkg *";
+
+    let needs_helper = !content.contains(helper_marker);
+    let needs_strip = content.contains(direct_substr);
+    if !needs_helper && !needs_strip {
+        return;
+    }
+
+    let mut patched: String = content
+        .lines()
+        .filter(|line| !line.contains(direct_substr))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if !patched.ends_with('\n') {
+        patched.push('\n');
+    }
+    if needs_helper {
+        patched.push_str("aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-pkg *\n");
+    }
+
+    let stage = "/tmp/aifw-sudoers-pkg-helper-patch";
+    if tokio::fs::write(stage, &patched).await.is_err() {
+        warn!("failed to stage sudoers pkg-helper patch");
+        return;
+    }
+    let result = Command::new("/usr/local/bin/sudo")
+        .args([
+            "/usr/bin/install",
+            "-m",
+            "440",
+            "-o",
+            "root",
+            "-g",
+            "wheel",
+            stage,
+            path,
+        ])
+        .output()
+        .await;
+    let _ = tokio::fs::remove_file(stage).await;
+    match result {
+        Ok(o) if o.status.success() => {
+            info!("migrated sudoers: dropped /usr/sbin/pkg, added aifw-sudo-pkg helper grant")
+        }
+        Ok(o) => warn!(
+            stderr = %String::from_utf8_lossy(&o.stderr),
+            "sudoers pkg-helper migration install failed"
+        ),
+        Err(e) => warn!(error = %e, "sudoers pkg-helper migration errored"),
     }
 }
 

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -109,6 +109,7 @@ aifw ALL=(root) NOPASSWD: /sbin/shutdown -r +10s *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-write *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-wg *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-freebsd-update *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-pkg *
 
 # --- Network configuration ---
 # TODO(GHSA-mjqh-2vx8-7hq7): the wildcards below still grant broad root.
@@ -119,7 +120,6 @@ aifw ALL=(ALL) NOPASSWD: /sbin/dhclient *
 aifw ALL=(ALL) NOPASSWD: /sbin/route *
 aifw ALL=(ALL) NOPASSWD: /usr/sbin/service *
 aifw ALL=(ALL) NOPASSWD: /usr/sbin/sysrc *
-aifw ALL=(ALL) NOPASSWD: /usr/sbin/pkg *
 aifw ALL=(ALL) NOPASSWD: /bin/cat *
 aifw ALL=(ALL) NOPASSWD: /bin/cp *
 aifw ALL=(ALL) NOPASSWD: /bin/rm *

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.93.3",
+  "version": "5.93.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/freebsd/deploy.sh
+++ b/freebsd/deploy.sh
@@ -255,7 +255,7 @@ done
 # login migrate, shutdown hook, narrow-grant sudo wrappers from #204).
 # Mode 755 so the daemon supervisor / sudo can exec them.
 mkdir -p /usr/local/libexec
-for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write aifw-sudo-wg aifw-sudo-freebsd-update; do
+for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write aifw-sudo-wg aifw-sudo-freebsd-update aifw-sudo-pkg; do
     src="$REPO_DIR/freebsd/overlay/usr/local/libexec/$script"
     if [ -f "$src" ]; then
         install -m 755 "$src" "/usr/local/libexec/$script"
@@ -266,11 +266,12 @@ done
 # favor of /usr/local/libexec/aifw-sudo-write, which enforces a closed
 # allowlist of write paths (#204).
 mkdir -p /usr/local/etc/sudoers.d
-echo 'aifw ALL=(ALL) NOPASSWD: /sbin/pfctl, /sbin/ifconfig, /sbin/dhclient, /sbin/route, /usr/sbin/service, /usr/sbin/sysrc, /usr/sbin/pkg, /sbin/shutdown, /bin/hostname, /bin/cat, /bin/pkill, /usr/bin/pkill, /usr/sbin/chown, /bin/mkdir, /usr/sbin/tcpdump, /usr/bin/install, /bin/rm /usr/local/etc/rdns/rpz/*
+echo 'aifw ALL=(ALL) NOPASSWD: /sbin/pfctl, /sbin/ifconfig, /sbin/dhclient, /sbin/route, /usr/sbin/service, /usr/sbin/sysrc, /sbin/shutdown, /bin/hostname, /bin/cat, /bin/pkill, /usr/bin/pkill, /usr/sbin/chown, /bin/mkdir, /usr/sbin/tcpdump, /usr/bin/install, /bin/rm /usr/local/etc/rdns/rpz/*
 aifw ALL=(root) NOPASSWD: /usr/sbin/daemon -f *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-write *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-wg *
-aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-freebsd-update *' > /usr/local/etc/sudoers.d/aifw
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-freebsd-update *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-pkg *' > /usr/local/etc/sudoers.d/aifw
 chmod 440 /usr/local/etc/sudoers.d/aifw
 
 echo ""

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-pkg
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-pkg
@@ -1,0 +1,83 @@
+#!/bin/sh
+# /usr/local/libexec/aifw-sudo-pkg <action> [args...]
+#
+# Narrow-grant wrapper around /usr/sbin/pkg (#204). Restricts the
+# `aifw` user to:
+#
+#   - update                    — refresh package catalog
+#   - install -y <pkg> [<pkg>...]  — install packages (no scripts/repos)
+#   - upgrade -y                — apply all pending upgrades
+#   - upgrade -n                — dry-run pending upgrades
+#
+# Other subcommands (delete, set, lock, unlock, autoremove, audit
+# fetch-from-arbitrary-URL, install with `-r reponame`, install of
+# absolute paths, etc.) are denied. Package names are validated
+# character-class-wise so a compromised daemon can't smuggle shell
+# metacharacters or `-r` flags through.
+
+set -eu
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <update|install|upgrade> [args...]" >&2
+    exit 2
+fi
+
+ACTION="$1"
+shift
+
+# Validate a single package name: alnum, dot, underscore, plus, hyphen.
+# Reject empty and anything starting with `-` (which would smuggle a flag).
+valid_pkg_name() {
+    case "$1" in
+        ""|-*)
+            return 1
+            ;;
+        *[^A-Za-z0-9._+-]*)
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+case "$ACTION" in
+    update)
+        if [ $# -ne 0 ]; then
+            echo "aifw-sudo-pkg: 'update' takes no extra args" >&2
+            exit 1
+        fi
+        exec /usr/sbin/pkg update
+        ;;
+    install)
+        if [ $# -lt 2 ] || [ "$1" != "-y" ]; then
+            echo "aifw-sudo-pkg: only 'install -y <pkg>...' supported" >&2
+            exit 1
+        fi
+        shift  # drop -y
+        for p; do
+            if ! valid_pkg_name "$p"; then
+                echo "aifw-sudo-pkg: invalid package name: $p" >&2
+                exit 1
+            fi
+        done
+        exec /usr/sbin/pkg install -y "$@"
+        ;;
+    upgrade)
+        if [ $# -ne 1 ]; then
+            echo "aifw-sudo-pkg: 'upgrade' takes exactly one of -y or -n" >&2
+            exit 1
+        fi
+        case "$1" in
+            -y|-n)
+                exec /usr/sbin/pkg upgrade "$1"
+                ;;
+            *)
+                echo "aifw-sudo-pkg: unsupported upgrade flag: $1" >&2
+                exit 1
+                ;;
+        esac
+        ;;
+    *)
+        echo "aifw-sudo-pkg: unsupported action: $ACTION" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Fourth slice of the GHSA-mjqh-2vx8-7hq7 follow-up. Replaces the broad `/usr/sbin/pkg *` sudoers grant with the narrow `aifw-sudo-pkg` helper.

The helper restricts the `aifw` user to:
- `update` — refresh package catalog
- `install -y <pkg> [<pkg>...]` — install packages (names validated character-class-wise: alnum/dot/underscore/plus/hyphen, no shell metacharacters or smuggled flags)
- `upgrade -y` — apply pending upgrades
- `upgrade -n` — dry-run pending upgrades

Denied: `delete`, `set`, `lock`, `unlock`, `autoremove`, `repo` from URL, install of absolute paths, install with `-r reponame`, and any other subcommand.

## Migrated

- 7 call sites — `aifw-core/updater.rs` (1: first-boot curl install), `aifw-cli/commands.rs` (3: update, upgrade -n, upgrade -y), `aifw-api/updates.rs` (3: pending check, update, upgrade -y).
- Sudoers in all three sources of truth — `aifw-setup/apply.rs`, `freebsd/deploy.sh`, `aifw-core/updater.rs::ensure_sudoers_pkg_helper` (idempotent migrator).

The lone non-sudo `pkg info -q curl` check stays as-is — read-only, doesn't need root, not in scope for #204.

## Test plan

- [x] `cargo check --workspace` clean
- [ ] FreeBSD deploy: `pkg update`, `pkg upgrade -n`, `pkg install -y curl` go through the helper; `pkg delete` denied
- [ ] Verify `ensure_sudoers_pkg_helper` strips broad grant on upgraded appliance