### PR TITLE
sudo: service helper (#204 slice 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ai"
-version = "5.93.4"
+version = "5.93.5"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-api"
-version = "5.93.4"
+version = "5.93.5"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-cli"
-version = "5.93.4"
+version = "5.93.5"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-common"
-version = "5.93.4"
+version = "5.93.5"
 dependencies = [
  "chrono",
  "nix 0.31.2",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-conntrack"
-version = "5.93.4"
+version = "5.93.5"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-core"
-version = "5.93.4"
+version = "5.93.5"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-daemon"
-version = "5.93.4"
+version = "5.93.5"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids"
-version = "5.93.4"
+version = "5.93.5"
 dependencies = [
  "aho-corasick",
  "aifw-common",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-bin"
-version = "5.93.4"
+version = "5.93.5"
 dependencies = [
  "aifw-common",
  "aifw-ids",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-ipc"
-version = "5.93.4"
+version = "5.93.5"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-metrics"
-version = "5.93.4"
+version = "5.93.5"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-pf"
-version = "5.93.4"
+version = "5.93.5"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-plugins"
-version = "5.93.4"
+version = "5.93.5"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-setup"
-version = "5.93.4"
+version = "5.93.5"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-tui"
-version = "5.93.4"
+version = "5.93.5"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.93.4"
+version = "5.93.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/dhcp.rs
+++ b/aifw-api/src/dhcp.rs
@@ -1148,9 +1148,7 @@ async fn rdhcp_api_delete(path: &str, api_port: u16) -> Result<(), String> {
 pub async fn dhcp_status(State(state): State<AppState>) -> Result<Json<DhcpStatus>, StatusCode> {
     let config = load_global_config(&state.pool).await;
 
-    let running = Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/service", "rdhcpd", "status"])
-        .output()
+    let running = aifw_core::sudo::service("rdhcpd", "status")
         .await
         .map(|o| o.status.success())
         .unwrap_or(false);
@@ -1218,10 +1216,7 @@ async fn run_rdhcp_service(action: &str) -> Json<MessageResponse> {
             .output()
             .await;
     }
-    let output = Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/service", "rdhcpd", action])
-        .output()
-        .await;
+    let output = aifw_core::sudo::service("rdhcpd", action).await;
     match output {
         Ok(o) => {
             let stdout = String::from_utf8_lossy(&o.stdout).to_string();
@@ -2003,10 +1998,7 @@ pub async fn apply_config(
             .args(["/usr/sbin/sysrc", "rdhcpd_enable=YES"])
             .output()
             .await;
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/service", "rdhcpd", "restart"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::service("rdhcpd", "restart").await;
 
         // Reload all aifw anchor rules (includes user rules + service rules)
         // This preserves existing firewall rules while adding DHCP pass rules
@@ -2016,10 +2008,7 @@ pub async fn apply_config(
             message: "DHCP config applied and rDHCP restarted".to_string(),
         }))
     } else {
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/service", "rdhcpd", "stop"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::service("rdhcpd", "stop").await;
         let _ = Command::new("/usr/local/bin/sudo")
             .args(["/usr/sbin/sysrc", "rdhcpd_enable=NO"])
             .output()
@@ -2051,10 +2040,7 @@ pub(crate) async fn auto_apply(state: &AppState) {
             .args(["chown", "-R", "aifw:aifw", "/usr/local/etc/rdhcpd"])
             .output()
             .await;
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/service", "rdhcpd", "restart"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::service("rdhcpd", "restart").await;
         tracing::info!("DHCP config auto-applied");
     }
 

--- a/aifw-api/src/dns_resolver.rs
+++ b/aifw-api/src/dns_resolver.rs
@@ -131,11 +131,13 @@ async fn run_cmd_timeout(program: &str, args: &[&str]) -> std::io::Result<std::p
     })
 }
 
-/// Run a service command with timeout (no shell interpolation).
+/// Run a service command with timeout (no shell interpolation). Routes
+/// through the `aifw-sudo-service` allowlist helper rather than the
+/// broad `/usr/sbin/service *` grant (#204).
 async fn service_cmd(service: &str, action: &str) {
     let _ = run_cmd_timeout(
         "/usr/local/bin/sudo",
-        &["/usr/sbin/service", service, action],
+        &["/usr/local/libexec/aifw-sudo-service", service, action],
     )
     .await;
 }
@@ -1326,10 +1328,7 @@ pub async fn resolver_status(
     let is_rdns = config.backend == "rdns";
 
     let service_name = if is_rdns { "rdns" } else { "local_unbound" };
-    let running = Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/service", service_name, "status"])
-        .output()
-        .await
+    let running = aifw_core::sudo::service(service_name, "status").await
         .map(|o| o.status.success())
         .unwrap_or(false);
 
@@ -1710,7 +1709,7 @@ async fn start_backend(backend: &str) -> Result<String, String> {
     sysrc_set_if_different(key, "YES").await;
     match run_cmd_timeout(
         "/usr/local/bin/sudo",
-        &["/usr/sbin/service", svc, "restart"],
+        &["/usr/local/libexec/aifw-sudo-service", svc, "restart"],
     )
     .await
     {

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -1930,10 +1930,7 @@ async fn ensure_rc_services_enabled() {
         if already_running {
             continue;
         }
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["service", svc, "start"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::service(svc, "start").await;
         info!(service = svc, "started by aifw-api startup migration");
     }
 }

--- a/aifw-api/src/reverse_proxy.rs
+++ b/aifw-api/src/reverse_proxy.rs
@@ -1062,10 +1062,7 @@ pub async fn generate_trafficcop_config(pool: &SqlitePool) -> Result<String, sql
 // ============================================================
 
 async fn run_trafficcop_service(action: &str) -> Json<MessageResponse> {
-    let output = Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/service", "trafficcop", action])
-        .output()
-        .await;
+    let output = aifw_core::sudo::service("trafficcop", action).await;
     match output {
         Ok(o) => {
             let stdout = String::from_utf8_lossy(&o.stdout).to_string();
@@ -1091,9 +1088,7 @@ async fn run_trafficcop_service(action: &str) -> Json<MessageResponse> {
 pub async fn rp_status(
     State(state): State<AppState>,
 ) -> Result<Json<ReverseProxyStatus>, StatusCode> {
-    let running = Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/service", "trafficcop", "status"])
-        .output()
+    let running = aifw_core::sudo::service("trafficcop", "status")
         .await
         .map(|o| o.status.success())
         .unwrap_or(false);
@@ -1255,18 +1250,12 @@ pub async fn apply_config(
             .args(["/usr/sbin/sysrc", "trafficcop_enable=YES"])
             .output()
             .await;
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/service", "trafficcop", "restart"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::service("trafficcop", "restart").await;
         Ok(Json(MessageResponse {
             message: "TrafficCop config applied and service restarted".to_string(),
         }))
     } else {
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/service", "trafficcop", "stop"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::service("trafficcop", "stop").await;
         let _ = Command::new("/usr/local/bin/sudo")
             .args(["/usr/sbin/sysrc", "trafficcop_enable=NO"])
             .output()

--- a/aifw-api/src/time_service.rs
+++ b/aifw-api/src/time_service.rs
@@ -446,10 +446,7 @@ async fn run_service(action: &str) -> Json<MessageResponse> {
             .output()
             .await;
     }
-    let output = Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/service", "rtime", action])
-        .output()
-        .await;
+    let output = aifw_core::sudo::service("rtime", action).await;
     match output {
         Ok(o) => {
             let stdout = String::from_utf8_lossy(&o.stdout).to_string();
@@ -473,9 +470,7 @@ async fn run_service(action: &str) -> Json<MessageResponse> {
 }
 
 pub async fn time_status(State(state): State<AppState>) -> Result<Json<TimeStatus>, StatusCode> {
-    let running = Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/service", "rtime", "status"])
-        .output()
+    let running = aifw_core::sudo::service("rtime", "status")
         .await
         .map(|o| o.status.success())
         .unwrap_or(false);
@@ -557,19 +552,13 @@ pub async fn apply_config(
             .args(["/usr/sbin/sysrc", "rtime_enable=YES"])
             .output()
             .await;
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/service", "rtime", "restart"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::service("rtime", "restart").await;
 
         Ok(Json(MessageResponse {
             message: "Time config applied and rTime restarted".to_string(),
         }))
     } else {
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/service", "rtime", "stop"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::service("rtime", "stop").await;
         let _ = Command::new("/usr/local/bin/sudo")
             .args(["/usr/sbin/sysrc", "rtime_enable=NO"])
             .output()

--- a/aifw-api/src/ws.rs
+++ b/aifw-api/src/ws.rs
@@ -1458,9 +1458,7 @@ async fn collect_services() -> Vec<ServiceStatusPayload> {
             ("rTIME", "rtime"),
             ("TrafficCop", "trafficcop"),
         ] {
-            let running = tokio::process::Command::new("/usr/local/bin/sudo")
-                .args(["/usr/sbin/service", svc_name, "status"])
-                .output()
+            let running = aifw_core::sudo::service(svc_name, "status")
                 .await
                 .map(|o| o.status.success())
                 .unwrap_or(false);

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -1994,10 +1994,7 @@ pub async fn rp_status(db_path: &Path) -> anyhow::Result<()> {
     let pool = db.pool();
 
     // Check service status
-    let output = tokio::process::Command::new("/usr/local/bin/sudo")
-        .args(["service", "trafficcop", "status"])
-        .output()
-        .await;
+    let output = aifw_core::sudo::service("trafficcop", "status").await;
     let running = output.map(|o| o.status.success()).unwrap_or(false);
 
     println!("Reverse Proxy (TrafficCop)");
@@ -2039,10 +2036,7 @@ pub async fn rp_status(db_path: &Path) -> anyhow::Result<()> {
 }
 
 pub async fn rp_start() -> anyhow::Result<()> {
-    let output = tokio::process::Command::new("/usr/local/bin/sudo")
-        .args(["service", "trafficcop", "start"])
-        .output()
-        .await?;
+    let output = aifw_core::sudo::service("trafficcop", "start").await?;
     println!("{}", String::from_utf8_lossy(&output.stdout).trim());
     if !output.stderr.is_empty() {
         eprintln!("{}", String::from_utf8_lossy(&output.stderr).trim());
@@ -2051,19 +2045,13 @@ pub async fn rp_start() -> anyhow::Result<()> {
 }
 
 pub async fn rp_stop() -> anyhow::Result<()> {
-    let output = tokio::process::Command::new("/usr/local/bin/sudo")
-        .args(["service", "trafficcop", "stop"])
-        .output()
-        .await?;
+    let output = aifw_core::sudo::service("trafficcop", "stop").await?;
     println!("{}", String::from_utf8_lossy(&output.stdout).trim());
     Ok(())
 }
 
 pub async fn rp_restart() -> anyhow::Result<()> {
-    let output = tokio::process::Command::new("/usr/local/bin/sudo")
-        .args(["service", "trafficcop", "restart"])
-        .output()
-        .await?;
+    let output = aifw_core::sudo::service("trafficcop", "restart").await?;
     println!("{}", String::from_utf8_lossy(&output.stdout).trim());
     Ok(())
 }
@@ -2110,10 +2098,7 @@ pub async fn rp_apply(db_path: &Path) -> anyhow::Result<()> {
     .await?;
 
     println!("Config written. Restarting service...");
-    let output = tokio::process::Command::new("/usr/local/bin/sudo")
-        .args(["service", "trafficcop", "restart"])
-        .output()
-        .await?;
+    let output = aifw_core::sudo::service("trafficcop", "restart").await?;
     println!("{}", String::from_utf8_lossy(&output.stdout).trim());
     Ok(())
 }

--- a/aifw-core/src/acme_export.rs
+++ b/aifw-core/src/acme_export.rs
@@ -231,10 +231,10 @@ async fn run_local_tls_store(cert: &AcmeCert, cfg: &serde_json::Value) -> Result
     .await?;
     sudo_install_string(key, &format!("{dir}/key.pem"), "0640", Some("root:rdns")).await?;
 
-    // Reload the configured service so it picks up the new cert.
-    let _ = Command::new(SUDO)
-        .args(["/usr/sbin/service", reload_service, "restart"])
-        .output()
-        .await;
+    // Reload the configured service so it picks up the new cert. The
+    // helper enforces an allowlist on `reload_service` — operators
+    // setting an arbitrary service name in the cert export config will
+    // see the call fail loudly rather than escalate via service(8).
+    let _ = crate::sudo::service(reload_service, "restart").await;
     Ok(())
 }

--- a/aifw-core/src/sudo.rs
+++ b/aifw-core/src/sudo.rs
@@ -18,6 +18,7 @@ const HELPER_WRITE: &str = "/usr/local/libexec/aifw-sudo-write";
 const HELPER_WG: &str = "/usr/local/libexec/aifw-sudo-wg";
 const HELPER_FREEBSD_UPDATE: &str = "/usr/local/libexec/aifw-sudo-freebsd-update";
 const HELPER_PKG: &str = "/usr/local/libexec/aifw-sudo-pkg";
+const HELPER_SERVICE: &str = "/usr/local/libexec/aifw-sudo-service";
 
 /// Atomically write `contents` to `path`, as root, via the
 /// `aifw-sudo-write` helper script.
@@ -99,4 +100,19 @@ pub async fn pkg(action: &str, extra_args: &[&str]) -> std::io::Result<std::proc
     let mut args: Vec<&str> = vec![HELPER_PKG, action];
     args.extend_from_slice(extra_args);
     Command::new(SUDO).args(&args).output().await
+}
+
+/// Run `service <name> <action>` as root via the `aifw-sudo-service`
+/// helper.
+///
+/// The helper restricts both the service name (closed allowlist of
+/// AiFw-managed services + `unbound`/`sshd`) and the action verb
+/// (`start` / `stop` / `restart` / `reload` / `status`, plus the
+/// `one*` force variants). Adding a new managed service requires
+/// updating the helper script's case block.
+pub async fn service(name: &str, action: &str) -> std::io::Result<std::process::Output> {
+    Command::new(SUDO)
+        .args([HELPER_SERVICE, name, action])
+        .output()
+        .await
 }

--- a/aifw-core/src/system_apply/freebsd_impl.rs
+++ b/aifw-core/src/system_apply/freebsd_impl.rs
@@ -121,13 +121,23 @@ pub async fn apply_ssh(i: &SshInput) -> ApplyReport {
 
     // --- service action ---
     let service_action = if i.enabled { "start" } else { "stop" };
-    if let Err(e) = sudo_run("/usr/sbin/service", &["sshd", service_action]).await {
+    if let Err(e) = crate::sudo::service("sshd", service_action)
+        .await
+        .map_err(|e| e.to_string())
+        .and_then(|o| {
+            if o.status.success() {
+                Ok(())
+            } else {
+                Err(String::from_utf8_lossy(&o.stderr).trim().to_string())
+            }
+        })
+    {
         // Ignore "already running" / "not running" style non-zero exits — surface them as hints, not errors.
         warnings.push(format!("service sshd {} failed: {}", service_action, e));
     }
     if i.enabled {
         // Reload after starting so the config changes take effect without dropping connections unnecessarily.
-        let _ = sudo_run("/usr/sbin/service", &["sshd", "reload"]).await;
+        let _ = crate::sudo::service("sshd", "reload").await;
     }
 
     let mut r = ApplyReport::ok_requires_restart("sshd");

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -374,6 +374,10 @@ pub async fn install_from_path(
     // narrow `aifw-sudo-pkg *` helper (#204). Idempotent.
     ensure_sudoers_pkg_helper().await;
 
+    // Migrate service sudoers grant from the broad `/usr/sbin/service *`
+    // to the narrow `aifw-sudo-service *` helper (#204). Idempotent.
+    ensure_sudoers_service_helper().await;
+
     // Ensure /usr/sbin/daemon is in sudoers. Without it, the detached
     // restart driver in restart_services() spawns sudo, sudo refuses
     // for lack of NOPASSWD, and we silently skip the bounce — leaving
@@ -983,6 +987,69 @@ pub async fn ensure_sudoers_pkg_helper() {
     }
 }
 
+/// Migrate sudoers from the broad `/usr/sbin/service *` grant to the
+/// narrow `aifw-sudo-service` helper (#204). Idempotent.
+pub async fn ensure_sudoers_service_helper() {
+    let path = "/usr/local/etc/sudoers.d/aifw";
+    let Ok(content) = tokio::fs::read_to_string(path).await else {
+        return;
+    };
+
+    let helper_marker = "/usr/local/libexec/aifw-sudo-service";
+    let direct_substr = "/usr/sbin/service *";
+
+    let needs_helper = !content.contains(helper_marker);
+    let needs_strip = content.contains(direct_substr);
+    if !needs_helper && !needs_strip {
+        return;
+    }
+
+    let mut patched: String = content
+        .lines()
+        .filter(|line| !line.contains(direct_substr))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if !patched.ends_with('\n') {
+        patched.push('\n');
+    }
+    if needs_helper {
+        patched.push_str("aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-service *\n");
+    }
+
+    let stage = "/tmp/aifw-sudoers-service-helper-patch";
+    if tokio::fs::write(stage, &patched).await.is_err() {
+        warn!("failed to stage sudoers service-helper patch");
+        return;
+    }
+    let result = Command::new("/usr/local/bin/sudo")
+        .args([
+            "/usr/bin/install",
+            "-m",
+            "440",
+            "-o",
+            "root",
+            "-g",
+            "wheel",
+            stage,
+            path,
+        ])
+        .output()
+        .await;
+    let _ = tokio::fs::remove_file(stage).await;
+    match result {
+        Ok(o) if o.status.success() => {
+            info!(
+                "migrated sudoers: dropped /usr/sbin/service, added aifw-sudo-service helper grant"
+            )
+        }
+        Ok(o) => warn!(
+            stderr = %String::from_utf8_lossy(&o.stderr),
+            "sudoers service-helper migration install failed"
+        ),
+        Err(e) => warn!(error = %e, "sudoers service-helper migration errored"),
+    }
+}
+
 /// Ensure each AiFw service has its rcvar set to YES in /etc/rc.conf.
 ///
 /// Appliances upgraded from versions predating a service (notably aifw_ids
@@ -1113,9 +1180,7 @@ pub async fn schedule_reboot() -> Result<(), UpdaterError> {
 /// wedge the entire upgrade. The next restart cycle's `start_precmd` pkill
 /// will reap any orphans we leave behind.
 async fn restart_one(svc: &str) {
-    let cmd = Command::new("/usr/local/bin/sudo")
-        .args(["service", svc, "restart"])
-        .output();
+    let cmd = crate::sudo::service(svc, "restart");
     match tokio::time::timeout(std::time::Duration::from_secs(60), cmd).await {
         Ok(Ok(_)) => {}
         Ok(Err(e)) => warn!(service = svc, error = %e, "service restart errored"),

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -110,6 +110,7 @@ aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-write *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-wg *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-freebsd-update *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-pkg *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-service *
 
 # --- Network configuration ---
 # TODO(GHSA-mjqh-2vx8-7hq7): the wildcards below still grant broad root.
@@ -118,7 +119,6 @@ aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-pkg *
 aifw ALL=(ALL) NOPASSWD: /sbin/ifconfig *
 aifw ALL=(ALL) NOPASSWD: /sbin/dhclient *
 aifw ALL=(ALL) NOPASSWD: /sbin/route *
-aifw ALL=(ALL) NOPASSWD: /usr/sbin/service *
 aifw ALL=(ALL) NOPASSWD: /usr/sbin/sysrc *
 aifw ALL=(ALL) NOPASSWD: /bin/cat *
 aifw ALL=(ALL) NOPASSWD: /bin/cp *

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.93.4",
+  "version": "5.93.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,7 @@
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+vendor/
+.bundle/
+Gemfile.lock

--- a/freebsd/deploy.sh
+++ b/freebsd/deploy.sh
@@ -255,7 +255,7 @@ done
 # login migrate, shutdown hook, narrow-grant sudo wrappers from #204).
 # Mode 755 so the daemon supervisor / sudo can exec them.
 mkdir -p /usr/local/libexec
-for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write aifw-sudo-wg aifw-sudo-freebsd-update aifw-sudo-pkg; do
+for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write aifw-sudo-wg aifw-sudo-freebsd-update aifw-sudo-pkg aifw-sudo-service; do
     src="$REPO_DIR/freebsd/overlay/usr/local/libexec/$script"
     if [ -f "$src" ]; then
         install -m 755 "$src" "/usr/local/libexec/$script"
@@ -266,12 +266,13 @@ done
 # favor of /usr/local/libexec/aifw-sudo-write, which enforces a closed
 # allowlist of write paths (#204).
 mkdir -p /usr/local/etc/sudoers.d
-echo 'aifw ALL=(ALL) NOPASSWD: /sbin/pfctl, /sbin/ifconfig, /sbin/dhclient, /sbin/route, /usr/sbin/service, /usr/sbin/sysrc, /sbin/shutdown, /bin/hostname, /bin/cat, /bin/pkill, /usr/bin/pkill, /usr/sbin/chown, /bin/mkdir, /usr/sbin/tcpdump, /usr/bin/install, /bin/rm /usr/local/etc/rdns/rpz/*
+echo 'aifw ALL=(ALL) NOPASSWD: /sbin/pfctl, /sbin/ifconfig, /sbin/dhclient, /sbin/route, /usr/sbin/sysrc, /sbin/shutdown, /bin/hostname, /bin/cat, /bin/pkill, /usr/bin/pkill, /usr/sbin/chown, /bin/mkdir, /usr/sbin/tcpdump, /usr/bin/install, /bin/rm /usr/local/etc/rdns/rpz/*
 aifw ALL=(root) NOPASSWD: /usr/sbin/daemon -f *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-write *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-wg *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-freebsd-update *
-aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-pkg *' > /usr/local/etc/sudoers.d/aifw
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-pkg *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-service *' > /usr/local/etc/sudoers.d/aifw
 chmod 440 /usr/local/etc/sudoers.d/aifw
 
 echo ""

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-service
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-service
@@ -1,0 +1,46 @@
+#!/bin/sh
+# /usr/local/libexec/aifw-sudo-service <service> <action>
+#
+# Narrow-grant wrapper around /usr/sbin/service (#204). Restricts the
+# `aifw` user to a closed allowlist of AiFw-managed services and the
+# standard rc.d action verbs.
+#
+# Allowlist must be kept in sync with `aifw_sudo_service_allowed`
+# in aifw-core/src/sudo.rs and the OWNED_RCVARS list in updater.rs —
+# adding a new managed service requires updating all three.
+
+set -eu
+
+if [ $# -ne 2 ]; then
+    echo "usage: $0 <service> <action>" >&2
+    exit 2
+fi
+
+SERVICE="$1"
+ACTION="$2"
+
+case "$SERVICE" in
+    aifw_daemon|aifw_api|aifw_ids|aifw_watchdog|aifw_carp_demote|aifw_demote_on_shutdown)
+        ;;
+    rdhcpd|rdns|rtime|trafficcop)
+        ;;
+    unbound|local_unbound|sshd)
+        ;;
+    *)
+        echo "aifw-sudo-service: service not in allowlist: $SERVICE" >&2
+        exit 1
+        ;;
+esac
+
+case "$ACTION" in
+    start|stop|restart|reload|status)
+        ;;
+    onestart|onestop|onerestart|onestatus)
+        ;;
+    *)
+        echo "aifw-sudo-service: action not allowed: $ACTION" >&2
+        exit 1
+        ;;
+esac
+
+exec /usr/sbin/service "$SERVICE" "$ACTION"


### PR DESCRIPTION
## Summary

Fifth slice of the GHSA-mjqh-2vx8-7hq7 follow-up. Replaces the broad `/usr/sbin/service *` sudoers grant with the narrow `aifw-sudo-service` helper.

**Service allowlist:** AiFw services (`aifw_daemon`, `aifw_api`, `aifw_ids`, `aifw_watchdog`, `aifw_carp_demote`, `aifw_demote_on_shutdown`), companions (`rdhcpd`, `rdns`, `rtime`, `trafficcop`), and system (`unbound`, `local_unbound`, `sshd`).

**Action allowlist:** `start` / `stop` / `restart` / `reload` / `status` plus the `one*` force-run variants.

## Migrated

27 call sites across `aifw-api/{dhcp,dns_resolver,main,reverse_proxy,time_service,ws}.rs`, `aifw-cli/commands.rs`, and `aifw-core/{acme_export,updater,system_apply/freebsd_impl}.rs`.

**Notable security improvement:** `acme_export` previously took an arbitrary service name from operator-supplied cert export config and ran `sudo service <name> restart`. Now that name has to be in the allowlist or the call fails loudly — closes the most user-controlled escalation path in the service category.

Sudoers updated in all three sources of truth — `aifw-setup/apply.rs`, `freebsd/deploy.sh`, `aifw-core/updater.rs::ensure_sudoers_service_helper` (idempotent migrator).

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace` green (all tests pass)
- [ ] FreeBSD deploy: `service rdhcpd restart`, `service rdns status`, `service trafficcop reload` go through the helper
- [ ] Verify `service evil_service restart` is denied
- [ ] Verify `ensure_sudoers_service_helper` strips the broad grant on an upgraded appliance