### PR TITLE
sudo: chown helper (#204 slice 6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ai"
-version = "5.94.1"
+version = "5.94.3"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-api"
-version = "5.94.1"
+version = "5.94.3"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-cli"
-version = "5.94.1"
+version = "5.94.3"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-common"
-version = "5.94.1"
+version = "5.94.3"
 dependencies = [
  "chrono",
  "nix 0.31.2",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-conntrack"
-version = "5.94.1"
+version = "5.94.3"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-core"
-version = "5.94.1"
+version = "5.94.3"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-daemon"
-version = "5.94.1"
+version = "5.94.3"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids"
-version = "5.94.1"
+version = "5.94.3"
 dependencies = [
  "aho-corasick",
  "aifw-common",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-bin"
-version = "5.94.1"
+version = "5.94.3"
 dependencies = [
  "aifw-common",
  "aifw-ids",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-ipc"
-version = "5.94.1"
+version = "5.94.3"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-metrics"
-version = "5.94.1"
+version = "5.94.3"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-pf"
-version = "5.94.1"
+version = "5.94.3"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-plugins"
-version = "5.94.1"
+version = "5.94.3"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-setup"
-version = "5.94.1"
+version = "5.94.3"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-tui"
-version = "5.94.1"
+version = "5.94.3"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.94.2"
+version = "5.94.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/dhcp.rs
+++ b/aifw-api/src/dhcp.rs
@@ -1980,18 +1980,9 @@ pub async fn apply_config(
         .map_err(|_| internal())?;
 
     // Fix ownership
-    let _ = Command::new("/usr/local/bin/sudo")
-        .args(["chown", "-R", "aifw:aifw", "/usr/local/etc/rdhcpd"])
-        .output()
-        .await;
-    let _ = Command::new("/usr/local/bin/sudo")
-        .args(["chown", "-R", "aifw:aifw", RDHCP_LEASE_DB])
-        .output()
-        .await;
-    let _ = Command::new("/usr/local/bin/sudo")
-        .args(["chown", "-R", "aifw:aifw", "/var/log/rdhcpd"])
-        .output()
-        .await;
+    let _ = aifw_core::sudo::chown_r("aifw:aifw", "/usr/local/etc/rdhcpd").await;
+    let _ = aifw_core::sudo::chown_r("aifw:aifw", RDHCP_LEASE_DB).await;
+    let _ = aifw_core::sudo::chown_r("aifw:aifw", "/var/log/rdhcpd").await;
 
     if config.enabled {
         let _ = Command::new("/usr/local/bin/sudo")
@@ -2036,10 +2027,7 @@ pub(crate) async fn auto_apply(state: &AppState) {
         .await
         .is_ok()
     {
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["chown", "-R", "aifw:aifw", "/usr/local/etc/rdhcpd"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::chown_r("aifw:aifw", "/usr/local/etc/rdhcpd").await;
         let _ = aifw_core::sudo::service("rdhcpd", "restart").await;
         tracing::info!("DHCP config auto-applied");
     }

--- a/aifw-api/src/dns_resolver.rs
+++ b/aifw-api/src/dns_resolver.rs
@@ -1612,10 +1612,7 @@ async fn write_backend_config_files(state: &AppState, backend: &str) -> Result<(
                 .map_err(|_| internal())?;
             sudo_copy(tmp_path, "/var/unbound/unbound.conf").await;
             let _ = tokio::fs::remove_file(tmp_path).await;
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args(["/usr/sbin/chown", "-R", "unbound:unbound", "/var/unbound"])
-                .output()
-                .await;
+            let _ = aifw_core::sudo::chown_r("unbound:unbound", "/var/unbound").await;
             Ok(())
         }
         "rdns" => {

--- a/aifw-api/src/time_service.rs
+++ b/aifw-api/src/time_service.rs
@@ -538,14 +538,8 @@ pub async fn apply_config(
         .await
         .map_err(|_| internal())?;
 
-    let _ = Command::new("/usr/local/bin/sudo")
-        .args(["chown", "-R", "aifw:aifw", "/usr/local/etc/rtime"])
-        .output()
-        .await;
-    let _ = Command::new("/usr/local/bin/sudo")
-        .args(["chown", "-R", "aifw:aifw", "/var/log/rtime"])
-        .output()
-        .await;
+    let _ = aifw_core::sudo::chown_r("aifw:aifw", "/usr/local/etc/rtime").await;
+    let _ = aifw_core::sudo::chown_r("aifw:aifw", "/var/log/rtime").await;
 
     if config.enabled {
         let _ = Command::new("/usr/local/bin/sudo")

--- a/aifw-core/src/sudo.rs
+++ b/aifw-core/src/sudo.rs
@@ -19,6 +19,7 @@ const HELPER_WG: &str = "/usr/local/libexec/aifw-sudo-wg";
 const HELPER_FREEBSD_UPDATE: &str = "/usr/local/libexec/aifw-sudo-freebsd-update";
 const HELPER_PKG: &str = "/usr/local/libexec/aifw-sudo-pkg";
 const HELPER_SERVICE: &str = "/usr/local/libexec/aifw-sudo-service";
+const HELPER_CHOWN: &str = "/usr/local/libexec/aifw-sudo-chown";
 
 /// Atomically write `contents` to `path`, as root, via the
 /// `aifw-sudo-write` helper script.
@@ -113,6 +114,19 @@ pub async fn pkg(action: &str, extra_args: &[&str]) -> std::io::Result<std::proc
 pub async fn service(name: &str, action: &str) -> std::io::Result<std::process::Output> {
     Command::new(SUDO)
         .args([HELPER_SERVICE, name, action])
+        .output()
+        .await
+}
+
+/// Recursively change ownership of `path` to `owner_group` (e.g.
+/// `"aifw:aifw"`), as root, via the `aifw-sudo-chown` helper.
+///
+/// The helper enforces closed allowlists for both `owner_group` and
+/// `path`. Only the `-R` form is exposed; adding a new managed
+/// directory requires editing the helper script.
+pub async fn chown_r(owner_group: &str, path: &str) -> std::io::Result<std::process::Output> {
+    Command::new(SUDO)
+        .args([HELPER_CHOWN, "-R", owner_group, path])
         .output()
         .await
 }

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -378,6 +378,10 @@ pub async fn install_from_path(
     // to the narrow `aifw-sudo-service *` helper (#204). Idempotent.
     ensure_sudoers_service_helper().await;
 
+    // Migrate chown sudoers grant from the broad `/usr/sbin/chown *` to
+    // the narrow `aifw-sudo-chown *` helper (#204). Idempotent.
+    ensure_sudoers_chown_helper().await;
+
     // Ensure /usr/sbin/daemon is in sudoers. Without it, the detached
     // restart driver in restart_services() spawns sudo, sudo refuses
     // for lack of NOPASSWD, and we silently skip the bounce — leaving
@@ -1047,6 +1051,67 @@ pub async fn ensure_sudoers_service_helper() {
             "sudoers service-helper migration install failed"
         ),
         Err(e) => warn!(error = %e, "sudoers service-helper migration errored"),
+    }
+}
+
+/// Migrate sudoers from the broad `/usr/sbin/chown *` grant to the
+/// narrow `aifw-sudo-chown` helper (#204). Idempotent.
+pub async fn ensure_sudoers_chown_helper() {
+    let path = "/usr/local/etc/sudoers.d/aifw";
+    let Ok(content) = tokio::fs::read_to_string(path).await else {
+        return;
+    };
+
+    let helper_marker = "/usr/local/libexec/aifw-sudo-chown";
+    let direct_substr = "/usr/sbin/chown *";
+
+    let needs_helper = !content.contains(helper_marker);
+    let needs_strip = content.contains(direct_substr);
+    if !needs_helper && !needs_strip {
+        return;
+    }
+
+    let mut patched: String = content
+        .lines()
+        .filter(|line| !line.contains(direct_substr))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if !patched.ends_with('\n') {
+        patched.push('\n');
+    }
+    if needs_helper {
+        patched.push_str("aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-chown *\n");
+    }
+
+    let stage = "/tmp/aifw-sudoers-chown-helper-patch";
+    if tokio::fs::write(stage, &patched).await.is_err() {
+        warn!("failed to stage sudoers chown-helper patch");
+        return;
+    }
+    let result = Command::new("/usr/local/bin/sudo")
+        .args([
+            "/usr/bin/install",
+            "-m",
+            "440",
+            "-o",
+            "root",
+            "-g",
+            "wheel",
+            stage,
+            path,
+        ])
+        .output()
+        .await;
+    let _ = tokio::fs::remove_file(stage).await;
+    match result {
+        Ok(o) if o.status.success() => {
+            info!("migrated sudoers: dropped /usr/sbin/chown, added aifw-sudo-chown helper grant")
+        }
+        Ok(o) => warn!(
+            stderr = %String::from_utf8_lossy(&o.stderr),
+            "sudoers chown-helper migration install failed"
+        ),
+        Err(e) => warn!(error = %e, "sudoers chown-helper migration errored"),
     }
 }
 

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -111,6 +111,7 @@ aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-wg *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-freebsd-update *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-pkg *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-service *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-chown *
 
 # --- Network configuration ---
 # TODO(GHSA-mjqh-2vx8-7hq7): the wildcards below still grant broad root.
@@ -129,7 +130,6 @@ aifw ALL=(ALL) NOPASSWD: /bin/pkill *
 aifw ALL=(ALL) NOPASSWD: /usr/bin/install *
 aifw ALL=(ALL) NOPASSWD: /usr/bin/pkill *
 aifw ALL=(ALL) NOPASSWD: /usr/bin/tar *
-aifw ALL=(ALL) NOPASSWD: /usr/sbin/chown *
 aifw ALL=(ALL) NOPASSWD: /usr/sbin/tcpdump *
 
 # --- Detached restart driver ---

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.94.2",
+  "version": "5.94.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/freebsd/deploy.sh
+++ b/freebsd/deploy.sh
@@ -255,7 +255,7 @@ done
 # login migrate, shutdown hook, narrow-grant sudo wrappers from #204).
 # Mode 755 so the daemon supervisor / sudo can exec them.
 mkdir -p /usr/local/libexec
-for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write aifw-sudo-wg aifw-sudo-freebsd-update aifw-sudo-pkg aifw-sudo-service; do
+for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write aifw-sudo-wg aifw-sudo-freebsd-update aifw-sudo-pkg aifw-sudo-service aifw-sudo-chown; do
     src="$REPO_DIR/freebsd/overlay/usr/local/libexec/$script"
     if [ -f "$src" ]; then
         install -m 755 "$src" "/usr/local/libexec/$script"
@@ -266,13 +266,14 @@ done
 # favor of /usr/local/libexec/aifw-sudo-write, which enforces a closed
 # allowlist of write paths (#204).
 mkdir -p /usr/local/etc/sudoers.d
-echo 'aifw ALL=(ALL) NOPASSWD: /sbin/pfctl, /sbin/ifconfig, /sbin/dhclient, /sbin/route, /usr/sbin/sysrc, /sbin/shutdown, /bin/hostname, /bin/cat, /bin/pkill, /usr/bin/pkill, /usr/sbin/chown, /bin/mkdir, /usr/sbin/tcpdump, /usr/bin/install, /bin/rm /usr/local/etc/rdns/rpz/*
+echo 'aifw ALL=(ALL) NOPASSWD: /sbin/pfctl, /sbin/ifconfig, /sbin/dhclient, /sbin/route, /usr/sbin/sysrc, /sbin/shutdown, /bin/hostname, /bin/cat, /bin/pkill, /usr/bin/pkill, /bin/mkdir, /usr/sbin/tcpdump, /usr/bin/install, /bin/rm /usr/local/etc/rdns/rpz/*
 aifw ALL=(root) NOPASSWD: /usr/sbin/daemon -f *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-write *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-wg *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-freebsd-update *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-pkg *
-aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-service *' > /usr/local/etc/sudoers.d/aifw
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-service *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-chown *' > /usr/local/etc/sudoers.d/aifw
 chmod 440 /usr/local/etc/sudoers.d/aifw
 
 echo ""

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-chown
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-chown
@@ -1,0 +1,59 @@
+#!/bin/sh
+# /usr/local/libexec/aifw-sudo-chown -R <owner:group> <path>
+#
+# Narrow-grant wrapper around /usr/sbin/chown (#204). Restricts the
+# `aifw` user to recursive ownership changes on AiFw-managed companion
+# service directories, with a closed allowlist of valid owner:group
+# pairs.
+#
+# Only the `-R` form is exposed — single-file chown is never needed by
+# AiFw and a non-recursive variant would just be more surface to
+# defend.
+
+set -eu
+
+if [ $# -ne 3 ]; then
+    echo "usage: $0 -R <owner:group> <path>" >&2
+    exit 2
+fi
+
+FLAG="$1"
+OWNER_GROUP="$2"
+TARGET="$3"
+
+if [ "$FLAG" != "-R" ]; then
+    echo "aifw-sudo-chown: only -R is supported" >&2
+    exit 1
+fi
+
+# Closed allowlist of owner:group pairs. The companion services run as
+# the `aifw` user (rdhcpd, rtime) or their own user (unbound).
+case "$OWNER_GROUP" in
+    aifw:aifw|unbound:unbound)
+        ;;
+    *)
+        echo "aifw-sudo-chown: owner:group not in allowlist: $OWNER_GROUP" >&2
+        exit 1
+        ;;
+esac
+
+# Closed allowlist of target paths. Add a path here when adding a new
+# managed companion service directory — do NOT widen the pattern to
+# `/usr/local/etc/*` or `/var/log/*`, which would let an `aifw`-process
+# compromise hand /etc/sudoers.d/ or /var/log/auth.log to itself.
+case "$TARGET" in
+    /usr/local/etc/rdhcpd|/usr/local/etc/rtime|/usr/local/etc/rdns)
+        ;;
+    /var/db/rdhcpd|/var/db/rdhcpd/leases)
+        ;;
+    /var/log/rdhcpd|/var/log/rtime|/var/log/rdns)
+        ;;
+    /var/unbound|/var/run/rdns)
+        ;;
+    *)
+        echo "aifw-sudo-chown: path not in allowlist: $TARGET" >&2
+        exit 1
+        ;;
+esac
+
+exec /usr/sbin/chown -R "$OWNER_GROUP" "$TARGET"


### PR DESCRIPTION
## Summary

Sixth slice of the GHSA-mjqh-2vx8-7hq7 follow-up. Replaces the broad `/usr/sbin/chown *` sudoers grant with the narrow `aifw-sudo-chown` helper.

**owner:group allowlist:** `aifw:aifw`, `unbound:unbound`
**path allowlist:** `/usr/local/etc/{rdhcpd,rtime,rdns}`, `/var/db/rdhcpd[/leases]`, `/var/log/{rdhcpd,rtime,rdns}`, `/var/unbound`, `/var/run/rdns`

Only `-R` is exposed — AiFw never needs single-file chown.

## Migrated

7 call sites — `aifw-api/time_service.rs` (rtime config + log), `aifw-api/dhcp.rs` (4: rdhcpd config + leases + log + auto-apply), `aifw-api/dns_resolver.rs` (`/var/unbound` on backend switch).

Sudoers updated in all three sources of truth (`aifw-setup/apply.rs`, `freebsd/deploy.sh`, `aifw-core/updater.rs::ensure_sudoers_chown_helper`).

## Test plan

- [x] `cargo check --workspace` clean
- [ ] FreeBSD deploy: rdhcpd config/lease/log dirs chown'd correctly
- [ ] Verify `chown -R aifw:wheel /etc` denied
- [ ] Verify `ensure_sudoers_chown_helper` strips broad grant on upgrade