### PR TITLE
sudo: ifconfig helper (#204 slice 7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ai"
-version = "5.94.3"
+version = "5.94.4"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-api"
-version = "5.94.3"
+version = "5.94.4"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-cli"
-version = "5.94.3"
+version = "5.94.4"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-common"
-version = "5.94.3"
+version = "5.94.4"
 dependencies = [
  "chrono",
  "nix 0.31.2",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-conntrack"
-version = "5.94.3"
+version = "5.94.4"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-core"
-version = "5.94.3"
+version = "5.94.4"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-daemon"
-version = "5.94.3"
+version = "5.94.4"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids"
-version = "5.94.3"
+version = "5.94.4"
 dependencies = [
  "aho-corasick",
  "aifw-common",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-bin"
-version = "5.94.3"
+version = "5.94.4"
 dependencies = [
  "aifw-common",
  "aifw-ids",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-ipc"
-version = "5.94.3"
+version = "5.94.4"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-metrics"
-version = "5.94.3"
+version = "5.94.4"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-pf"
-version = "5.94.3"
+version = "5.94.4"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-plugins"
-version = "5.94.3"
+version = "5.94.4"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-setup"
-version = "5.94.3"
+version = "5.94.4"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-tui"
-version = "5.94.3"
+version = "5.94.4"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.94.3"
+version = "5.94.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/iface.rs
+++ b/aifw-api/src/iface.rs
@@ -489,16 +489,13 @@ pub async fn configure_interface(
 
     // Handle enable/disable
     if let Some(enabled) = req.enabled {
-        if enabled {
-            let _ = sudo_cmd(&["/sbin/ifconfig", &name, "up"]).await;
-        } else {
-            let _ = sudo_cmd(&["/sbin/ifconfig", &name, "down"]).await;
-        }
+        let _ = aifw_core::sudo::ifconfig(&name, if enabled { "up" } else { "down" }, &[]).await;
     }
 
     // Handle MTU
     if let Some(mtu) = req.mtu {
-        let _ = sudo_cmd(&["/sbin/ifconfig", &name, "mtu", &mtu.to_string()]).await;
+        let mtu_s = mtu.to_string();
+        let _ = aifw_core::sudo::ifconfig(&name, "mtu", &[&mtu_s]).await;
     }
 
     // Handle IPv4 mode change
@@ -507,7 +504,7 @@ pub async fn configure_interface(
             "dhcp" => {
                 // Kill any existing dhclient, remove static address, then start dhclient
                 let _ = sudo_cmd(&["/usr/bin/pkill", "-f", &format!("dhclient {}", name)]).await;
-                let _ = sudo_cmd(&["/sbin/ifconfig", &name, "delete"]).await;
+                let _ = aifw_core::sudo::ifconfig(&name, "delete", &[]).await;
                 let _ = sudo_cmd(&["/sbin/dhclient", &name]).await;
                 // Persist
                 let _ = Command::new("/usr/local/bin/sudo")
@@ -528,20 +525,11 @@ pub async fn configure_interface(
                     // FreeBSD ifconfig won't replace — it adds aliases. Must delete first.
                     let current = get_iface_ipv4s(&name).await;
                     for old_ip in &current {
-                        let _ = Command::new("/usr/local/bin/sudo")
-                            .args(["/sbin/ifconfig", &name, "inet", old_ip, "-alias"])
-                            .output()
-                            .await;
+                        let _ = aifw_core::sudo::ifconfig(&name, "inet", &[old_ip, "-alias"]).await;
                     }
                     // Set the new static IP
-                    let _ = Command::new("/usr/local/bin/sudo")
-                        .args(["/sbin/ifconfig", &name, "inet", addr])
-                        .output()
-                        .await;
-                    let _ = Command::new("/usr/local/bin/sudo")
-                        .args(["/sbin/ifconfig", &name, "up"])
-                        .output()
-                        .await;
+                    let _ = aifw_core::sudo::ifconfig(&name, "inet", &[addr]).await;
+                    let _ = aifw_core::sudo::ifconfig(&name, "up", &[]).await;
 
                     // Persist in rc.conf
                     let _ = Command::new("/usr/local/bin/sudo")
@@ -595,7 +583,7 @@ pub async fn configure_interface(
             }
             "none" => {
                 let _ = sudo_cmd(&["/usr/bin/pkill", "-f", &format!("dhclient {}", name)]).await;
-                let _ = sudo_cmd(&["/sbin/ifconfig", &name, "delete"]).await;
+                let _ = aifw_core::sudo::ifconfig(&name, "delete", &[]).await;
                 let _ = Command::new("/usr/local/bin/sudo")
                     .args(["/usr/sbin/sysrc", "-x", &format!("ifconfig_{}", name)])
                     .output()
@@ -638,11 +626,11 @@ pub async fn configure_interface(
     if let Some(ref ipv6) = req.ipv6_address
         && !ipv6.is_empty()
     {
-        let _ = sudo_cmd(&["/sbin/ifconfig", &name, "inet6", ipv6]).await;
+        let _ = aifw_core::sudo::ifconfig(&name, "inet6", &[ipv6]).await;
     }
 
     if let Some(ref desc) = req.description {
-        let _ = sudo_cmd(&["/sbin/ifconfig", &name, "description", desc]).await;
+        let _ = aifw_core::sudo::ifconfig(&name, "description", &[desc]).await;
     }
 
     let summary = if msgs.is_empty() {
@@ -753,32 +741,20 @@ pub async fn apply_vlans(pool: &SqlitePool) -> Result<(), String> {
 
         if *enabled {
             // Create if not exists
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args(["/sbin/ifconfig", &vlan_name, "create"])
-                .output()
-                .await;
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args([
-                    "/sbin/ifconfig",
-                    &vlan_name,
-                    "vlan",
-                    &vid.to_string(),
-                    "vlandev",
-                    parent,
-                ])
-                .output()
-                .await;
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args(["/sbin/ifconfig", &vlan_name, "mtu", &mtu.to_string()])
-                .output()
-                .await;
+            let _ = aifw_core::sudo::ifconfig(&vlan_name, "create", &[]).await;
+            let vid_s = vid.to_string();
+            let _ = aifw_core::sudo::ifconfig(
+                &vlan_name,
+                "vlan",
+                &[&vid_s, "vlandev", parent],
+            )
+            .await;
+            let mtu_s = mtu.to_string();
+            let _ = aifw_core::sudo::ifconfig(&vlan_name, "mtu", &[&mtu_s]).await;
 
             if mode == "static" {
                 if let Some(addr) = ip_addr {
-                    let _ = Command::new("/usr/local/bin/sudo")
-                        .args(["/sbin/ifconfig", &vlan_name, "inet", addr])
-                        .output()
-                        .await;
+                    let _ = aifw_core::sudo::ifconfig(&vlan_name, "inet", &[addr]).await;
                 }
             } else if mode == "dhcp" {
                 let _ = Command::new("/usr/local/bin/sudo")
@@ -786,10 +762,7 @@ pub async fn apply_vlans(pool: &SqlitePool) -> Result<(), String> {
                     .output()
                     .await;
             }
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args(["/sbin/ifconfig", &vlan_name, "up"])
-                .output()
-                .await;
+            let _ = aifw_core::sudo::ifconfig(&vlan_name, "up", &[]).await;
 
             // Persist in rc.conf
             let _ = Command::new("/usr/local/bin/sudo")
@@ -809,10 +782,7 @@ pub async fn apply_vlans(pool: &SqlitePool) -> Result<(), String> {
                 .output()
                 .await;
         } else {
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args(["/sbin/ifconfig", &vlan_name, "down"])
-                .output()
-                .await;
+            let _ = aifw_core::sudo::ifconfig(&vlan_name, "down", &[]).await;
         }
     }
 
@@ -829,10 +799,7 @@ pub async fn apply_vlans(pool: &SqlitePool) -> Result<(), String> {
         .collect();
     for iface in iface_list.split_whitespace() {
         if iface.starts_with("vlan") && !db_vlan_names.contains(&iface.to_string()) {
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args(["/sbin/ifconfig", iface, "destroy"])
-                .output()
-                .await;
+            let _ = aifw_core::sudo::ifconfig(iface, "destroy", &[]).await;
             let _ = Command::new("/usr/local/bin/sudo")
                 .args(["/usr/sbin/sysrc", "-x", &format!("ifconfig_{}", iface)])
                 .output()

--- a/aifw-core/src/sudo.rs
+++ b/aifw-core/src/sudo.rs
@@ -20,6 +20,7 @@ const HELPER_FREEBSD_UPDATE: &str = "/usr/local/libexec/aifw-sudo-freebsd-update
 const HELPER_PKG: &str = "/usr/local/libexec/aifw-sudo-pkg";
 const HELPER_SERVICE: &str = "/usr/local/libexec/aifw-sudo-service";
 const HELPER_CHOWN: &str = "/usr/local/libexec/aifw-sudo-chown";
+const HELPER_IFCONFIG: &str = "/usr/local/libexec/aifw-sudo-ifconfig";
 
 /// Atomically write `contents` to `path`, as root, via the
 /// `aifw-sudo-write` helper script.
@@ -129,4 +130,22 @@ pub async fn chown_r(owner_group: &str, path: &str) -> std::io::Result<std::proc
         .args([HELPER_CHOWN, "-R", owner_group, path])
         .output()
         .await
+}
+
+/// Run `ifconfig <iface> <action> [args...]` as root via the
+/// `aifw-sudo-ifconfig` helper.
+///
+/// The helper validates the iface name (alnum/dot/underscore, ≤16
+/// chars, no flag-shape) and constrains `action` to a closed set:
+/// `up`/`down`/`delete`/`destroy`/`create` (no-arg), `mtu`/`fib`
+/// (numeric arg), `inet` (1–2 args), `inet6` (one arg), `description`
+/// (≤128 chars), and `vlan <id> vlandev <parent>`.
+pub async fn ifconfig(
+    iface: &str,
+    action: &str,
+    extra_args: &[&str],
+) -> std::io::Result<std::process::Output> {
+    let mut args: Vec<&str> = vec![HELPER_IFCONFIG, iface, action];
+    args.extend_from_slice(extra_args);
+    Command::new(SUDO).args(&args).output().await
 }

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -382,6 +382,10 @@ pub async fn install_from_path(
     // the narrow `aifw-sudo-chown *` helper (#204). Idempotent.
     ensure_sudoers_chown_helper().await;
 
+    // Migrate ifconfig sudoers grant from the broad `/sbin/ifconfig *`
+    // to the narrow `aifw-sudo-ifconfig *` helper (#204). Idempotent.
+    ensure_sudoers_ifconfig_helper().await;
+
     // Ensure /usr/sbin/daemon is in sudoers. Without it, the detached
     // restart driver in restart_services() spawns sudo, sudo refuses
     // for lack of NOPASSWD, and we silently skip the bounce — leaving
@@ -1112,6 +1116,67 @@ pub async fn ensure_sudoers_chown_helper() {
             "sudoers chown-helper migration install failed"
         ),
         Err(e) => warn!(error = %e, "sudoers chown-helper migration errored"),
+    }
+}
+
+/// Migrate sudoers from the broad `/sbin/ifconfig *` grant to the
+/// narrow `aifw-sudo-ifconfig` helper (#204). Idempotent.
+pub async fn ensure_sudoers_ifconfig_helper() {
+    let path = "/usr/local/etc/sudoers.d/aifw";
+    let Ok(content) = tokio::fs::read_to_string(path).await else {
+        return;
+    };
+
+    let helper_marker = "/usr/local/libexec/aifw-sudo-ifconfig";
+    let direct_substr = "/sbin/ifconfig *";
+
+    let needs_helper = !content.contains(helper_marker);
+    let needs_strip = content.contains(direct_substr);
+    if !needs_helper && !needs_strip {
+        return;
+    }
+
+    let mut patched: String = content
+        .lines()
+        .filter(|line| !line.contains(direct_substr))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if !patched.ends_with('\n') {
+        patched.push('\n');
+    }
+    if needs_helper {
+        patched.push_str("aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-ifconfig *\n");
+    }
+
+    let stage = "/tmp/aifw-sudoers-ifconfig-helper-patch";
+    if tokio::fs::write(stage, &patched).await.is_err() {
+        warn!("failed to stage sudoers ifconfig-helper patch");
+        return;
+    }
+    let result = Command::new("/usr/local/bin/sudo")
+        .args([
+            "/usr/bin/install",
+            "-m",
+            "440",
+            "-o",
+            "root",
+            "-g",
+            "wheel",
+            stage,
+            path,
+        ])
+        .output()
+        .await;
+    let _ = tokio::fs::remove_file(stage).await;
+    match result {
+        Ok(o) if o.status.success() => {
+            info!("migrated sudoers: dropped /sbin/ifconfig, added aifw-sudo-ifconfig helper grant")
+        }
+        Ok(o) => warn!(
+            stderr = %String::from_utf8_lossy(&o.stderr),
+            "sudoers ifconfig-helper migration install failed"
+        ),
+        Err(e) => warn!(error = %e, "sudoers ifconfig-helper migration errored"),
     }
 }
 

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -432,13 +432,8 @@ impl VpnEngine {
             .await;
 
         // Create the WireGuard interface
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["ifconfig", iface, "destroy"])
-            .output()
-            .await; // clean up if exists
-        let output = Command::new("/usr/local/bin/sudo")
-            .args(["ifconfig", iface, "create"])
-            .output()
+        let _ = crate::sudo::ifconfig(iface, "destroy", &[]).await; // clean up if exists
+        let output = crate::sudo::ifconfig(iface, "create", &[])
             .await
             .map_err(|e| AifwError::Pf(format!("ifconfig create failed: {e}")))?;
         if !output.status.success() {
@@ -452,17 +447,12 @@ impl VpnEngine {
 
         // Set address and bring up
         let addr = tunnel.address.to_string();
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["ifconfig", iface, "inet", &addr, "up"])
-            .output()
-            .await;
+        let _ = crate::sudo::ifconfig(iface, "inet", &[&addr, "up"]).await;
 
         // Set MTU if specified
         if let Some(mtu) = tunnel.mtu {
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args(["ifconfig", iface, "mtu", &mtu.to_string()])
-                .output()
-                .await;
+            let mtu_s = mtu.to_string();
+            let _ = crate::sudo::ifconfig(iface, "mtu", &[&mtu_s]).await;
         }
 
         // Configure WireGuard private key and listen port.
@@ -486,10 +476,7 @@ impl VpnEngine {
         .map_err(|e| AifwError::Pf(format!("wg set failed: {e}")))?;
         let _ = tokio::fs::remove_file(&key_path).await;
         if !output.status.success() {
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args(["ifconfig", iface, "destroy"])
-                .output()
-                .await;
+            let _ = crate::sudo::ifconfig(iface, "destroy", &[]).await;
             return Err(AifwError::Pf(format!(
                 "wg set failed: {}",
                 String::from_utf8_lossy(&output.stderr)
@@ -522,10 +509,7 @@ impl VpnEngine {
         let tunnel = self.get_wg_tunnel(id).await?;
         let iface = &tunnel.interface.0;
 
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["ifconfig", iface, "destroy"])
-            .output()
-            .await;
+        let _ = crate::sudo::ifconfig(iface, "destroy", &[]).await;
 
         let _ = sqlx::query("UPDATE wg_tunnels SET status = 'down', updated_at = ?1 WHERE id = ?2")
             .bind(Utc::now().to_rfc3339())

--- a/aifw-pf/src/ioctl.rs
+++ b/aifw-pf/src/ioctl.rs
@@ -443,8 +443,18 @@ impl PfBackend for PfIoctl {
     }
 
     async fn set_interface_fib(&self, iface: &str, fib: u32) -> Result<(), PfError> {
+        // Route through the narrow `aifw-sudo-ifconfig` helper rather
+        // than the broad `/sbin/ifconfig *` grant (#204). `aifw-pf`
+        // can't depend on `aifw-core::sudo`, so the helper path is
+        // inlined here.
+        let fib_s = fib.to_string();
         let output = Command::new("/usr/local/bin/sudo")
-            .args(["/sbin/ifconfig", iface, "fib", &fib.to_string()])
+            .args([
+                "/usr/local/libexec/aifw-sudo-ifconfig",
+                iface,
+                "fib",
+                &fib_s,
+            ])
             .output()
             .await
             .map_err(|e| PfError::Other(format!("ifconfig fib exec failed: {e}")))?;

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -112,12 +112,12 @@ aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-freebsd-update *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-pkg *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-service *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-chown *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-ifconfig *
 
 # --- Network configuration ---
 # TODO(GHSA-mjqh-2vx8-7hq7): the wildcards below still grant broad root.
 # Migrate each call site to a narrow wrapper script and replace these
 # lines with the wrapper path.
-aifw ALL=(ALL) NOPASSWD: /sbin/ifconfig *
 aifw ALL=(ALL) NOPASSWD: /sbin/dhclient *
 aifw ALL=(ALL) NOPASSWD: /sbin/route *
 aifw ALL=(ALL) NOPASSWD: /usr/sbin/sysrc *

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.94.3",
+  "version": "5.94.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/freebsd/deploy.sh
+++ b/freebsd/deploy.sh
@@ -255,7 +255,7 @@ done
 # login migrate, shutdown hook, narrow-grant sudo wrappers from #204).
 # Mode 755 so the daemon supervisor / sudo can exec them.
 mkdir -p /usr/local/libexec
-for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write aifw-sudo-wg aifw-sudo-freebsd-update aifw-sudo-pkg aifw-sudo-service aifw-sudo-chown; do
+for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write aifw-sudo-wg aifw-sudo-freebsd-update aifw-sudo-pkg aifw-sudo-service aifw-sudo-chown aifw-sudo-ifconfig; do
     src="$REPO_DIR/freebsd/overlay/usr/local/libexec/$script"
     if [ -f "$src" ]; then
         install -m 755 "$src" "/usr/local/libexec/$script"
@@ -266,14 +266,15 @@ done
 # favor of /usr/local/libexec/aifw-sudo-write, which enforces a closed
 # allowlist of write paths (#204).
 mkdir -p /usr/local/etc/sudoers.d
-echo 'aifw ALL=(ALL) NOPASSWD: /sbin/pfctl, /sbin/ifconfig, /sbin/dhclient, /sbin/route, /usr/sbin/sysrc, /sbin/shutdown, /bin/hostname, /bin/cat, /bin/pkill, /usr/bin/pkill, /bin/mkdir, /usr/sbin/tcpdump, /usr/bin/install, /bin/rm /usr/local/etc/rdns/rpz/*
+echo 'aifw ALL=(ALL) NOPASSWD: /sbin/pfctl, /sbin/dhclient, /sbin/route, /usr/sbin/sysrc, /sbin/shutdown, /bin/hostname, /bin/cat, /bin/pkill, /usr/bin/pkill, /bin/mkdir, /usr/sbin/tcpdump, /usr/bin/install, /bin/rm /usr/local/etc/rdns/rpz/*
 aifw ALL=(root) NOPASSWD: /usr/sbin/daemon -f *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-write *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-wg *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-freebsd-update *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-pkg *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-service *
-aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-chown *' > /usr/local/etc/sudoers.d/aifw
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-chown *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-ifconfig *' > /usr/local/etc/sudoers.d/aifw
 chmod 440 /usr/local/etc/sudoers.d/aifw
 
 echo ""

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-ifconfig
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-ifconfig
@@ -1,0 +1,131 @@
+#!/bin/sh
+# /usr/local/libexec/aifw-sudo-ifconfig <iface> <action> [args...]
+#
+# Narrow-grant wrapper around /sbin/ifconfig (#204). Restricts the
+# `aifw` user to the small set of subcommands AiFw legitimately needs
+# (bring an interface up/down, set address, set MTU, create/destroy a
+# cloned interface, set FIB, configure a VLAN child), with iface name
+# validation that rejects shell metacharacters and flag-shaped values.
+#
+# Read-only `ifconfig` invocations (status/info, listing) don't need
+# root and don't go through this wrapper — call ifconfig directly.
+
+set -eu
+
+if [ $# -lt 2 ]; then
+    echo "usage: $0 <iface> <action> [args...]" >&2
+    exit 2
+fi
+
+IFACE="$1"
+ACTION="$2"
+shift 2
+
+# Interface name: alnum, dot, underscore. No paths, no flags, max
+# IFNAMSIZ (FreeBSD = 16).
+if [ -z "$IFACE" ] || [ ${#IFACE} -gt 16 ]; then
+    echo "aifw-sudo-ifconfig: invalid iface name length: $IFACE" >&2
+    exit 1
+fi
+case "$IFACE" in
+    -*|*[^A-Za-z0-9._]*)
+        echo "aifw-sudo-ifconfig: invalid iface name: $IFACE" >&2
+        exit 1
+        ;;
+esac
+
+# Helper: validate a single argument as numeric (no leading -, no
+# embedded chars).
+is_numeric() {
+    case "$1" in
+        ''|*[!0-9]*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# Helper: validate a parent iface name (same rules as the top-level
+# IFACE arg).
+is_valid_iface_name() {
+    [ -n "$1" ] && [ ${#1} -le 16 ] || return 1
+    case "$1" in
+        -*|*[^A-Za-z0-9._]*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+case "$ACTION" in
+    up|down|delete|destroy|create)
+        if [ $# -ne 0 ]; then
+            echo "aifw-sudo-ifconfig: '$ACTION' takes no extra args" >&2
+            exit 1
+        fi
+        exec /sbin/ifconfig "$IFACE" "$ACTION"
+        ;;
+    mtu|fib)
+        if [ $# -ne 1 ]; then
+            echo "aifw-sudo-ifconfig: '$ACTION' takes one numeric arg" >&2
+            exit 1
+        fi
+        if ! is_numeric "$1"; then
+            echo "aifw-sudo-ifconfig: '$ACTION' arg must be numeric: $1" >&2
+            exit 1
+        fi
+        exec /sbin/ifconfig "$IFACE" "$ACTION" "$1"
+        ;;
+    inet)
+        # inet <addr>           — set IPv4
+        # inet <addr> -alias    — remove IPv4 alias
+        # inet <addr> up        — set + bring up
+        case $# in
+            1)
+                exec /sbin/ifconfig "$IFACE" inet "$1"
+                ;;
+            2)
+                if [ "$2" = "-alias" ] || [ "$2" = "up" ]; then
+                    exec /sbin/ifconfig "$IFACE" inet "$1" "$2"
+                fi
+                echo "aifw-sudo-ifconfig: inet second arg must be -alias or up" >&2
+                exit 1
+                ;;
+            *)
+                echo "aifw-sudo-ifconfig: inet takes 1 or 2 args" >&2
+                exit 1
+                ;;
+        esac
+        ;;
+    inet6)
+        if [ $# -ne 1 ]; then
+            echo "aifw-sudo-ifconfig: inet6 takes one address arg" >&2
+            exit 1
+        fi
+        exec /sbin/ifconfig "$IFACE" inet6 "$1"
+        ;;
+    description)
+        # Bounded length so a 1 MB body can't go into syslog.
+        if [ $# -ne 1 ] || [ ${#1} -gt 128 ]; then
+            echo "aifw-sudo-ifconfig: description takes one arg <=128 chars" >&2
+            exit 1
+        fi
+        exec /sbin/ifconfig "$IFACE" description "$1"
+        ;;
+    vlan)
+        # Form: vlan <id> vlandev <parent>
+        if [ $# -ne 3 ] || [ "$2" != "vlandev" ]; then
+            echo "aifw-sudo-ifconfig: vlan form is 'vlan <id> vlandev <parent>'" >&2
+            exit 1
+        fi
+        if ! is_numeric "$1"; then
+            echo "aifw-sudo-ifconfig: vlan id must be numeric: $1" >&2
+            exit 1
+        fi
+        if ! is_valid_iface_name "$3"; then
+            echo "aifw-sudo-ifconfig: invalid vlan parent: $3" >&2
+            exit 1
+        fi
+        exec /sbin/ifconfig "$IFACE" vlan "$1" vlandev "$3"
+        ;;
+    *)
+        echo "aifw-sudo-ifconfig: unsupported action: $ACTION" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Seventh slice of the GHSA-mjqh-2vx8-7hq7 follow-up. Replaces the broad `/sbin/ifconfig *` sudoers grant with the narrow `aifw-sudo-ifconfig` helper.

The helper validates the iface name (alnum/dot/underscore, ≤16 chars, no leading `-`) and restricts the action verb to a closed set:
- `up`/`down`/`delete`/`destroy`/`create` (no-arg)
- `mtu`/`fib` (numeric arg)
- `inet` (1–2 args, with `-alias`/`up` modifier only)
- `inet6` (one arg)
- `description` (≤128 chars)
- `vlan <id> vlandev <parent>` (numeric id, parent name validated)

## Migrated

~20 sudo'd ifconfig sites across `aifw-core/vpn.rs` (WG tunnels), `aifw-api/iface.rs` (physical + VLAN), and `aifw-pf/ioctl.rs` (FIB). Read-only `ifconfig` reads stay direct.

Sudoers updated in all three sources of truth (`aifw-setup/apply.rs`, `freebsd/deploy.sh`, `aifw-core/updater.rs::ensure_sudoers_ifconfig_helper`).

## Test plan

- [x] `cargo check --workspace` clean
- [ ] FreeBSD: `ifconfig wg0 create`, `ifconfig em0 up`, `ifconfig vlan100 vlan 100 vlandev em0` all work through helper
- [ ] Verify `ifconfig lo0 destroy` denied (or whatever the goal is)
- [ ] Verify `ifconfig em0 inet 1.2.3.4 rm` (bogus modifier) denied
- [ ] `ensure_sudoers_ifconfig_helper` strips broad grant on upgrade