### PR TITLE
sudo: install helper (#204 slice 8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ai"
-version = "5.94.4"
+version = "5.94.5"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-api"
-version = "5.94.4"
+version = "5.94.5"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-cli"
-version = "5.94.4"
+version = "5.94.5"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-common"
-version = "5.94.4"
+version = "5.94.5"
 dependencies = [
  "chrono",
  "nix 0.31.2",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-conntrack"
-version = "5.94.4"
+version = "5.94.5"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-core"
-version = "5.94.4"
+version = "5.94.5"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-daemon"
-version = "5.94.4"
+version = "5.94.5"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids"
-version = "5.94.4"
+version = "5.94.5"
 dependencies = [
  "aho-corasick",
  "aifw-common",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-bin"
-version = "5.94.4"
+version = "5.94.5"
 dependencies = [
  "aifw-common",
  "aifw-ids",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-ipc"
-version = "5.94.4"
+version = "5.94.5"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-metrics"
-version = "5.94.4"
+version = "5.94.5"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-pf"
-version = "5.94.4"
+version = "5.94.5"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-plugins"
-version = "5.94.4"
+version = "5.94.5"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-setup"
-version = "5.94.4"
+version = "5.94.5"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-tui"
-version = "5.94.4"
+version = "5.94.5"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.94.4"
+version = "5.94.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/dns_resolver.rs
+++ b/aifw-api/src/dns_resolver.rs
@@ -171,12 +171,10 @@ async fn sysrc_set_if_different(key: &str, value: &str) {
     sysrc(&format!("{key}={value}")).await;
 }
 
-/// Copy a file to a destination using sudo tee — no shell interpolation.
+/// Copy a file to a destination via the `aifw-sudo-install` helper —
+/// no shell interpolation (#204).
 async fn sudo_copy(src: &str, dest: &str) {
-    let _ = Command::new("/usr/local/bin/sudo")
-        .args(["/usr/bin/install", "-m", "0644", src, dest])
-        .output()
-        .await;
+    let _ = aifw_core::sudo::install(Some("0644"), None, None, src, dest).await;
 }
 
 /// Validate a domain name — alphanumeric, hyphens, dots only.

--- a/aifw-core/src/acme_export.rs
+++ b/aifw-core/src/acme_export.rs
@@ -138,27 +138,19 @@ async fn sudo_install_string(
         .await
         .map_err(|e| format!("stage tmp: {e}"))?;
 
-    let mut args: Vec<String> = vec!["/usr/bin/install".into(), "-m".into(), mode.into()];
-    if let Some(o) = owner {
-        // install(1): -o user, -g group. Accept "user:group" by splitting.
-        let mut parts = o.splitn(2, ':');
-        let u = parts.next().unwrap_or("").to_string();
-        let g = parts.next().map(|s| s.to_string());
-        if !u.is_empty() {
-            args.push("-o".into());
-            args.push(u);
+    // Parse "user:group" form into separate owner/group args. The
+    // `aifw-sudo-install` helper enforces allowlists on both (#204).
+    let (owner_user, owner_group) = match owner {
+        Some(o) => {
+            let mut parts = o.splitn(2, ':');
+            let u = parts.next().filter(|s| !s.is_empty());
+            let g = parts.next();
+            (u, g)
         }
-        if let Some(g) = g {
-            args.push("-g".into());
-            args.push(g);
-        }
-    }
-    args.push(tmp.clone());
-    args.push(dest.to_string());
+        None => (None, None),
+    };
 
-    let out = Command::new(SUDO)
-        .args(&args)
-        .output()
+    let out = crate::sudo::install(Some(mode), owner_user, owner_group, &tmp, dest)
         .await
         .map_err(|e| format!("spawn sudo install: {e}"))?;
     let _ = tokio::fs::remove_file(&tmp).await;

--- a/aifw-core/src/dns_blocklists.rs
+++ b/aifw-core/src/dns_blocklists.rs
@@ -822,10 +822,7 @@ async fn atomic_write(path: &std::path::Path, body: &str) -> std::io::Result<()>
     let dest = path
         .to_str()
         .ok_or_else(|| std::io::Error::other("non-utf8 path"))?;
-    let out = Command::new("/usr/local/bin/sudo")
-        .args(["/usr/bin/install", "-m", "0644", &tmp, dest])
-        .output()
-        .await?;
+    let out = crate::sudo::install(Some("0644"), None, None, &tmp, dest).await?;
     let _ = tokio::fs::remove_file(&tmp).await;
     if !out.status.success() {
         return Err(std::io::Error::other(format!(

--- a/aifw-core/src/pf_tuning.rs
+++ b/aifw-core/src/pf_tuning.rs
@@ -93,9 +93,7 @@ pub async fn apply_to_pf(value: u64) -> Result<(), String> {
         .args(["/bin/mkdir", "-p", "/usr/local/etc/aifw"])
         .output()
         .await;
-    let install = Command::new(SUDO)
-        .args(["/usr/bin/install", "-m", "0644", tmp, TUNING_FILE])
-        .output()
+    let install = crate::sudo::install(Some("0644"), None, None, tmp, TUNING_FILE)
         .await
         .map_err(|e| format!("spawn install: {e}"))?;
     let _ = tokio::fs::remove_file(tmp).await;

--- a/aifw-core/src/sudo.rs
+++ b/aifw-core/src/sudo.rs
@@ -21,6 +21,7 @@ const HELPER_PKG: &str = "/usr/local/libexec/aifw-sudo-pkg";
 const HELPER_SERVICE: &str = "/usr/local/libexec/aifw-sudo-service";
 const HELPER_CHOWN: &str = "/usr/local/libexec/aifw-sudo-chown";
 const HELPER_IFCONFIG: &str = "/usr/local/libexec/aifw-sudo-ifconfig";
+const HELPER_INSTALL: &str = "/usr/local/libexec/aifw-sudo-install";
 
 /// Atomically write `contents` to `path`, as root, via the
 /// `aifw-sudo-write` helper script.
@@ -147,5 +148,38 @@ pub async fn ifconfig(
 ) -> std::io::Result<std::process::Output> {
     let mut args: Vec<&str> = vec![HELPER_IFCONFIG, iface, action];
     args.extend_from_slice(extra_args);
+    Command::new(SUDO).args(&args).output().await
+}
+
+/// Run `install -m MODE [-o OWNER] [-g GROUP] SRC DEST` as root via the
+/// `aifw-sudo-install` helper.
+///
+/// The helper enforces closed allowlists for SRC (must be under
+/// `/tmp/` or `/usr/share/zoneinfo/`), DEST (specific files +
+/// AiFw-managed prefixes), MODE (`0440`/`0600`/`0644`/`0755`), and
+/// OWNER/GROUP (root, aifw, rdns, unbound, nginx, www / wheel, aifw,
+/// rdns, unbound, nginx, www). Pass `None` for any unwanted field.
+pub async fn install(
+    mode: Option<&str>,
+    owner: Option<&str>,
+    group: Option<&str>,
+    src: &str,
+    dest: &str,
+) -> std::io::Result<std::process::Output> {
+    let mut args: Vec<&str> = vec![HELPER_INSTALL];
+    if let Some(m) = mode {
+        args.push("-m");
+        args.push(m);
+    }
+    if let Some(o) = owner {
+        args.push("-o");
+        args.push(o);
+    }
+    if let Some(g) = group {
+        args.push("-g");
+        args.push(g);
+    }
+    args.push(src);
+    args.push(dest);
     Command::new(SUDO).args(&args).output().await
 }

--- a/aifw-core/src/system_apply/freebsd_impl.rs
+++ b/aifw-core/src/system_apply/freebsd_impl.rs
@@ -343,16 +343,33 @@ async fn sudo_install_content(path: &str, data: &[u8], mode: &str) -> Result<(),
     tokio::fs::write(&tmp, data)
         .await
         .map_err(|e| format!("tmp write: {}", e))?;
-    let result = sudo_run("/usr/bin/install", &["-m", mode, &tmp, path]).await;
+    let result = run_install_helper(mode, &tmp, path).await;
     // Best-effort cleanup regardless of install result.
     let _ = tokio::fs::remove_file(&tmp).await;
     result
 }
 
-/// Atomically place an existing file at `path` via `sudo install`.
-/// The source must already exist and be readable.
+/// Atomically place an existing file at `path` via the
+/// `aifw-sudo-install` helper. The source must already exist and be
+/// readable.
 async fn sudo_install_from(src: &str, path: &str, mode: &str) -> Result<(), String> {
-    sudo_run("/usr/bin/install", &["-m", mode, src, path]).await
+    run_install_helper(mode, src, path).await
+}
+
+/// Route through the narrow `aifw-sudo-install` helper (#204). The
+/// helper enforces closed allowlists on src/dest/mode/owner/group.
+async fn run_install_helper(mode: &str, src: &str, dest: &str) -> Result<(), String> {
+    let output = crate::sudo::install(Some(mode), None, None, src, dest)
+        .await
+        .map_err(|e| format!("aifw-sudo-install spawn failed: {e}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "aifw-sudo-install {src} -> {dest}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+    }
 }
 
 /// Create `/var/db/aifw/motd.user-edited` (mode 0644, root-owned).

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -316,9 +316,7 @@ pub async fn install_from_path(
                 None => continue,
             };
             let dst = format!("{}/{}", BIN_DIR, name);
-            let output = Command::new("/usr/local/bin/sudo")
-                .args(["/usr/bin/install", "-m", "755", src.to_str().unwrap(), &dst])
-                .output()
+            let output = crate::sudo::install(Some("755"), None, None, src.to_str().unwrap(), &dst)
                 .await
                 .map_err(|e| UpdaterError::Install(format!("Failed to install {}: {}", name, e)))?;
             if !output.status.success() {
@@ -358,6 +356,16 @@ pub async fn install_from_path(
             )));
         }
     }
+
+    // Migrate install sudoers grant from the broad `/usr/bin/install *`
+    // to the narrow `aifw-sudo-install *` helper (#204). MUST run before
+    // the other helper migrators because they use `crate::sudo::install`
+    // (which goes through the helper) to write their patched sudoers.
+    // The install migrator itself bootstraps via raw `sudo install`
+    // because it can't depend on the helper grant it's adding.
+    // Two-phase: first run adds the helper grant (broad grant stays),
+    // second run strips the broad grant.
+    ensure_sudoers_install_helper().await;
 
     // Migrate wg sudoers grant. Older installs may have nothing (was added
     // ad-hoc post-install) or the broad `/usr/bin/wg *` grant; both are
@@ -428,9 +436,7 @@ pub async fn install_from_path(
                     None => continue,
                 };
                 let dst = format!("/usr/local/etc/rc.d/{}", name);
-                let _ = Command::new("/usr/local/bin/sudo")
-                    .args(["/usr/bin/install", "-m", "755", src.to_str().unwrap(), &dst])
-                    .output()
+                let _ = crate::sudo::install(Some("755"), None, None, src.to_str().unwrap(), &dst)
                     .await;
             }
         }
@@ -458,9 +464,7 @@ pub async fn install_from_path(
                     None => continue,
                 };
                 let dst = format!("/usr/local/libexec/{}", name);
-                let _ = Command::new("/usr/local/bin/sudo")
-                    .args(["/usr/bin/install", "-m", "755", src.to_str().unwrap(), &dst])
-                    .output()
+                let _ = crate::sudo::install(Some("755"), None, None, src.to_str().unwrap(), &dst)
                     .await;
             }
         }
@@ -482,9 +486,7 @@ pub async fn install_from_path(
                     None => continue,
                 };
                 let dst = format!("{}/{}", BIN_DIR, name);
-                let _ = Command::new("/usr/local/bin/sudo")
-                    .args(["/usr/bin/install", "-m", "755", src.to_str().unwrap(), &dst])
-                    .output()
+                let _ = crate::sudo::install(Some("755"), None, None, src.to_str().unwrap(), &dst)
                     .await;
             }
         }
@@ -664,10 +666,7 @@ async fn write_embedded_script(name: &str, content: &str) {
         .args(["/bin/mkdir", "-p", "/usr/local/libexec"])
         .output()
         .await;
-    let result = Command::new("/usr/local/bin/sudo")
-        .args(["/usr/bin/install", "-m", "755", &tmp, &path])
-        .output()
-        .await;
+    let result = crate::sudo::install(Some("755"), None, None, &tmp, &path).await;
     let _ = tokio::fs::remove_file(&tmp).await;
     match result {
         Ok(o) if o.status.success() => info!(name, "libexec script bootstrapped"),
@@ -686,7 +685,7 @@ async fn write_embedded_script(name: &str, content: &str) {
 /// The sudoers file is `r--r----- root:wheel`, so a direct `fs::write`
 /// from the aifw user (under whom aifw-api runs) silently fails. We
 /// stage the new content in /tmp and re-install via `sudo install` —
-/// /usr/bin/install is already in the existing sudoers entries.
+/// `aifw-sudo-install` is already in the sudoers entries (#204).
 pub async fn ensure_sudoers_daemon() {
     let path = "/usr/local/etc/sudoers.d/aifw";
     let Ok(content) = tokio::fs::read_to_string(path).await else {
@@ -706,20 +705,7 @@ pub async fn ensure_sudoers_daemon() {
         warn!("failed to stage sudoers patch");
         return;
     }
-    let result = Command::new("/usr/local/bin/sudo")
-        .args([
-            "/usr/bin/install",
-            "-m",
-            "440",
-            "-o",
-            "root",
-            "-g",
-            "wheel",
-            stage,
-            path,
-        ])
-        .output()
-        .await;
+    let result = crate::sudo::install(Some("440"), Some("root"), Some("wheel"), stage, path).await;
     let _ = tokio::fs::remove_file(stage).await;
     match result {
         Ok(o) if o.status.success() => {
@@ -777,20 +763,7 @@ pub async fn ensure_sudoers_write_helper() {
         warn!("failed to stage sudoers write-helper patch");
         return;
     }
-    let result = Command::new("/usr/local/bin/sudo")
-        .args([
-            "/usr/bin/install",
-            "-m",
-            "440",
-            "-o",
-            "root",
-            "-g",
-            "wheel",
-            stage,
-            path,
-        ])
-        .output()
-        .await;
+    let result = crate::sudo::install(Some("440"), Some("root"), Some("wheel"), stage, path).await;
     let _ = tokio::fs::remove_file(stage).await;
     match result {
         Ok(o) if o.status.success() => {
@@ -841,20 +814,7 @@ pub async fn ensure_sudoers_wg_helper() {
         warn!("failed to stage sudoers wg-helper patch");
         return;
     }
-    let result = Command::new("/usr/local/bin/sudo")
-        .args([
-            "/usr/bin/install",
-            "-m",
-            "440",
-            "-o",
-            "root",
-            "-g",
-            "wheel",
-            stage,
-            path,
-        ])
-        .output()
-        .await;
+    let result = crate::sudo::install(Some("440"), Some("root"), Some("wheel"), stage, path).await;
     let _ = tokio::fs::remove_file(stage).await;
     match result {
         Ok(o) if o.status.success() => {
@@ -905,20 +865,7 @@ pub async fn ensure_sudoers_freebsd_update_helper() {
         warn!("failed to stage sudoers freebsd-update-helper patch");
         return;
     }
-    let result = Command::new("/usr/local/bin/sudo")
-        .args([
-            "/usr/bin/install",
-            "-m",
-            "440",
-            "-o",
-            "root",
-            "-g",
-            "wheel",
-            stage,
-            path,
-        ])
-        .output()
-        .await;
+    let result = crate::sudo::install(Some("440"), Some("root"), Some("wheel"), stage, path).await;
     let _ = tokio::fs::remove_file(stage).await;
     match result {
         Ok(o) if o.status.success() => {
@@ -968,20 +915,7 @@ pub async fn ensure_sudoers_pkg_helper() {
         warn!("failed to stage sudoers pkg-helper patch");
         return;
     }
-    let result = Command::new("/usr/local/bin/sudo")
-        .args([
-            "/usr/bin/install",
-            "-m",
-            "440",
-            "-o",
-            "root",
-            "-g",
-            "wheel",
-            stage,
-            path,
-        ])
-        .output()
-        .await;
+    let result = crate::sudo::install(Some("440"), Some("root"), Some("wheel"), stage, path).await;
     let _ = tokio::fs::remove_file(stage).await;
     match result {
         Ok(o) if o.status.success() => {
@@ -1029,20 +963,7 @@ pub async fn ensure_sudoers_service_helper() {
         warn!("failed to stage sudoers service-helper patch");
         return;
     }
-    let result = Command::new("/usr/local/bin/sudo")
-        .args([
-            "/usr/bin/install",
-            "-m",
-            "440",
-            "-o",
-            "root",
-            "-g",
-            "wheel",
-            stage,
-            path,
-        ])
-        .output()
-        .await;
+    let result = crate::sudo::install(Some("440"), Some("root"), Some("wheel"), stage, path).await;
     let _ = tokio::fs::remove_file(stage).await;
     match result {
         Ok(o) if o.status.success() => {
@@ -1092,20 +1013,7 @@ pub async fn ensure_sudoers_chown_helper() {
         warn!("failed to stage sudoers chown-helper patch");
         return;
     }
-    let result = Command::new("/usr/local/bin/sudo")
-        .args([
-            "/usr/bin/install",
-            "-m",
-            "440",
-            "-o",
-            "root",
-            "-g",
-            "wheel",
-            stage,
-            path,
-        ])
-        .output()
-        .await;
+    let result = crate::sudo::install(Some("440"), Some("root"), Some("wheel"), stage, path).await;
     let _ = tokio::fs::remove_file(stage).await;
     match result {
         Ok(o) if o.status.success() => {
@@ -1153,6 +1061,71 @@ pub async fn ensure_sudoers_ifconfig_helper() {
         warn!("failed to stage sudoers ifconfig-helper patch");
         return;
     }
+    let result = crate::sudo::install(Some("440"), Some("root"), Some("wheel"), stage, path).await;
+    let _ = tokio::fs::remove_file(stage).await;
+    match result {
+        Ok(o) if o.status.success() => {
+            info!("migrated sudoers: dropped /sbin/ifconfig, added aifw-sudo-ifconfig helper grant")
+        }
+        Ok(o) => warn!(
+            stderr = %String::from_utf8_lossy(&o.stderr),
+            "sudoers ifconfig-helper migration install failed"
+        ),
+        Err(e) => warn!(error = %e, "sudoers ifconfig-helper migration errored"),
+    }
+}
+
+/// Migrate sudoers from the broad `/usr/bin/install *` grant to the
+/// narrow `aifw-sudo-install` helper (#204). Idempotent.
+///
+/// Special care: this migrator itself uses `sudo install` to update
+/// `/usr/local/etc/sudoers.d/aifw`. It writes a sudoers patch that
+/// includes BOTH the old `/usr/bin/install *` grant AND the new helper
+/// grant first, then on the *next* call (or update cycle) strips the
+/// old grant. Trying to drop both in one shot would brick the very
+/// command used to write the file.
+pub async fn ensure_sudoers_install_helper() {
+    let path = "/usr/local/etc/sudoers.d/aifw";
+    let Ok(content) = tokio::fs::read_to_string(path).await else {
+        return;
+    };
+
+    let helper_marker = "/usr/local/libexec/aifw-sudo-install";
+    let direct_substr = "/usr/bin/install *";
+
+    let needs_helper = !content.contains(helper_marker);
+    let needs_strip = content.contains(direct_substr);
+    if !needs_helper && !needs_strip {
+        return;
+    }
+
+    // Two-phase migration so the install grant we depend on stays
+    // available until the helper grant is in place.
+    let mut patched: String;
+    if needs_helper {
+        // Phase 1: add helper grant; KEEP `/usr/bin/install *` for now.
+        patched = content.clone();
+        if !patched.ends_with('\n') {
+            patched.push('\n');
+        }
+        patched.push_str("aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-install *\n");
+    } else {
+        // Phase 2: helper grant exists, strip the broad install grant.
+        patched = content
+            .lines()
+            .filter(|line| !line.contains(direct_substr))
+            .collect::<Vec<_>>()
+            .join("\n");
+        if !patched.ends_with('\n') {
+            patched.push('\n');
+        }
+    }
+
+    let stage = "/tmp/aifw-sudoers-install-helper-patch";
+    if tokio::fs::write(stage, &patched).await.is_err() {
+        warn!("failed to stage sudoers install-helper patch");
+        return;
+    }
     let result = Command::new("/usr/local/bin/sudo")
         .args([
             "/usr/bin/install",
@@ -1170,13 +1143,17 @@ pub async fn ensure_sudoers_ifconfig_helper() {
     let _ = tokio::fs::remove_file(stage).await;
     match result {
         Ok(o) if o.status.success() => {
-            info!("migrated sudoers: dropped /sbin/ifconfig, added aifw-sudo-ifconfig helper grant")
+            if needs_helper {
+                info!("migrated sudoers (phase 1/2): added aifw-sudo-install helper grant");
+            } else {
+                info!("migrated sudoers (phase 2/2): dropped /usr/bin/install");
+            }
         }
         Ok(o) => warn!(
             stderr = %String::from_utf8_lossy(&o.stderr),
-            "sudoers ifconfig-helper migration install failed"
+            "sudoers install-helper migration install failed"
         ),
-        Err(e) => warn!(error = %e, "sudoers ifconfig-helper migration errored"),
+        Err(e) => warn!(error = %e, "sudoers install-helper migration errored"),
     }
 }
 
@@ -1341,10 +1318,7 @@ pub async fn rollback() -> Result<String, UpdaterError> {
         let src = format!("{}/bin/{}", BACKUP_DIR, bin);
         if std::path::Path::new(&src).exists() {
             let dst = format!("{}/{}", BIN_DIR, bin);
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args(["/usr/bin/install", "-m", "755", &src, &dst])
-                .output()
-                .await;
+            let _ = crate::sudo::install(Some("755"), None, None, &src, &dst).await;
         }
     }
 
@@ -1354,10 +1328,7 @@ pub async fn rollback() -> Result<String, UpdaterError> {
         let src = format!("{}/rc.d/{}", BACKUP_DIR, script);
         if std::path::Path::new(&src).exists() {
             let dst = format!("/usr/local/etc/rc.d/{}", script);
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args(["/usr/bin/install", "-m", "755", &src, &dst])
-                .output()
-                .await;
+            let _ = crate::sudo::install(Some("755"), None, None, &src, &dst).await;
         }
     }
 

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -113,6 +113,7 @@ aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-pkg *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-service *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-chown *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-ifconfig *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-install *
 
 # --- Network configuration ---
 # TODO(GHSA-mjqh-2vx8-7hq7): the wildcards below still grant broad root.
@@ -127,7 +128,6 @@ aifw ALL=(ALL) NOPASSWD: /bin/rm *
 aifw ALL=(ALL) NOPASSWD: /bin/mkdir *
 aifw ALL=(ALL) NOPASSWD: /bin/chmod *
 aifw ALL=(ALL) NOPASSWD: /bin/pkill *
-aifw ALL=(ALL) NOPASSWD: /usr/bin/install *
 aifw ALL=(ALL) NOPASSWD: /usr/bin/pkill *
 aifw ALL=(ALL) NOPASSWD: /usr/bin/tar *
 aifw ALL=(ALL) NOPASSWD: /usr/sbin/tcpdump *

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.94.4",
+  "version": "5.94.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/freebsd/deploy.sh
+++ b/freebsd/deploy.sh
@@ -255,7 +255,7 @@ done
 # login migrate, shutdown hook, narrow-grant sudo wrappers from #204).
 # Mode 755 so the daemon supervisor / sudo can exec them.
 mkdir -p /usr/local/libexec
-for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write aifw-sudo-wg aifw-sudo-freebsd-update aifw-sudo-pkg aifw-sudo-service aifw-sudo-chown aifw-sudo-ifconfig; do
+for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write aifw-sudo-wg aifw-sudo-freebsd-update aifw-sudo-pkg aifw-sudo-service aifw-sudo-chown aifw-sudo-ifconfig aifw-sudo-install; do
     src="$REPO_DIR/freebsd/overlay/usr/local/libexec/$script"
     if [ -f "$src" ]; then
         install -m 755 "$src" "/usr/local/libexec/$script"
@@ -266,7 +266,7 @@ done
 # favor of /usr/local/libexec/aifw-sudo-write, which enforces a closed
 # allowlist of write paths (#204).
 mkdir -p /usr/local/etc/sudoers.d
-echo 'aifw ALL=(ALL) NOPASSWD: /sbin/pfctl, /sbin/dhclient, /sbin/route, /usr/sbin/sysrc, /sbin/shutdown, /bin/hostname, /bin/cat, /bin/pkill, /usr/bin/pkill, /bin/mkdir, /usr/sbin/tcpdump, /usr/bin/install, /bin/rm /usr/local/etc/rdns/rpz/*
+echo 'aifw ALL=(ALL) NOPASSWD: /sbin/pfctl, /sbin/dhclient, /sbin/route, /usr/sbin/sysrc, /sbin/shutdown, /bin/hostname, /bin/cat, /bin/pkill, /usr/bin/pkill, /bin/mkdir, /usr/sbin/tcpdump, /bin/rm /usr/local/etc/rdns/rpz/*
 aifw ALL=(root) NOPASSWD: /usr/sbin/daemon -f *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-write *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-wg *
@@ -274,7 +274,8 @@ aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-freebsd-update *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-pkg *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-service *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-chown *
-aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-ifconfig *' > /usr/local/etc/sudoers.d/aifw
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-ifconfig *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-install *' > /usr/local/etc/sudoers.d/aifw
 chmod 440 /usr/local/etc/sudoers.d/aifw
 
 echo ""

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-install
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-install
@@ -1,0 +1,159 @@
+#!/bin/sh
+# /usr/local/libexec/aifw-sudo-install [-m MODE] [-o OWNER] [-g GROUP] SRC DEST
+#
+# Narrow-grant wrapper around /usr/bin/install (#204). Replaces the
+# broad `/usr/bin/install *` sudoers grant so a compromised `aifw`
+# daemon can't `sudo install /tmp/cert.pem /root/.ssh/authorized_keys`
+# itself into a root shell.
+#
+# Enforcement:
+#  - SRC must be in /tmp or /usr/share/zoneinfo (staging dirs aifw owns).
+#  - DEST must be on the closed allowlist (specific files + prefix
+#    patterns for AiFw-managed paths).
+#  - MODE must be a standard install mode (0440/0600/0644/0755).
+#  - OWNER/GROUP must be a known AiFw-managed identity.
+#  - Only -m / -o / -g flags are supported; everything else is denied.
+#
+# Adding a new managed destination requires editing this script.
+
+set -eu
+
+MODE=""
+OWNER=""
+GROUP=""
+SRC=""
+DEST=""
+
+# Parse args.
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -m)
+            [ $# -lt 2 ] && { echo "aifw-sudo-install: -m needs a value" >&2; exit 1; }
+            MODE="$2"; shift 2 ;;
+        -o)
+            [ $# -lt 2 ] && { echo "aifw-sudo-install: -o needs a value" >&2; exit 1; }
+            OWNER="$2"; shift 2 ;;
+        -g)
+            [ $# -lt 2 ] && { echo "aifw-sudo-install: -g needs a value" >&2; exit 1; }
+            GROUP="$2"; shift 2 ;;
+        -*)
+            echo "aifw-sudo-install: unsupported flag: $1" >&2
+            exit 1 ;;
+        *)
+            if [ -z "$SRC" ]; then SRC="$1"
+            elif [ -z "$DEST" ]; then DEST="$1"
+            else
+                echo "aifw-sudo-install: too many positional args" >&2
+                exit 1
+            fi
+            shift ;;
+    esac
+done
+
+if [ -z "$SRC" ] || [ -z "$DEST" ]; then
+    echo "usage: $0 [-m MODE] [-o OWNER] [-g GROUP] SRC DEST" >&2
+    exit 2
+fi
+
+# Mode allowlist (only standard install modes).
+case "$MODE" in
+    ""|0440|440|0600|600|0644|644|0755|755) ;;
+    *)
+        echo "aifw-sudo-install: mode not allowed: $MODE" >&2
+        exit 1 ;;
+esac
+
+# Owner allowlist.
+case "$OWNER" in
+    ""|root|aifw|rdns|unbound|nginx|www) ;;
+    *)
+        echo "aifw-sudo-install: owner not allowed: $OWNER" >&2
+        exit 1 ;;
+esac
+
+# Group allowlist.
+case "$GROUP" in
+    ""|wheel|aifw|rdns|unbound|nginx|www) ;;
+    *)
+        echo "aifw-sudo-install: group not allowed: $GROUP" >&2
+        exit 1 ;;
+esac
+
+# Reject path traversal in either side.
+case "$SRC$DEST" in
+    *..*|*//*)
+        echo "aifw-sudo-install: '..' or '//' not allowed" >&2
+        exit 1 ;;
+esac
+
+# Source must be under one of: /tmp (staging), /usr/share/zoneinfo
+# (timezone files installed into /etc/localtime), or
+# /usr/local/share/aifw/backup (rollback path that restores from the
+# pre-upgrade snapshot).
+case "$SRC" in
+    /tmp/*) ;;
+    /usr/share/zoneinfo/*) ;;
+    /usr/local/share/aifw/backup/*) ;;
+    *)
+        echo "aifw-sudo-install: source not allowed: $SRC" >&2
+        exit 1 ;;
+esac
+
+# Destination: closed allowlist. Keep these tightly scoped — any pattern
+# wider than `path/*` is the difference between this helper and the old
+# `sudo install *` grant.
+case "$DEST" in
+    # AiFw-managed configuration files
+    /usr/local/etc/sudoers.d/aifw) ;;
+    /usr/local/etc/aifw/pf-tuning.conf) ;;
+    /usr/local/etc/aifw/anchors/aifw|/usr/local/etc/aifw/anchors/aifw*) ;;
+    /usr/local/etc/aifw/tls/*) ;;
+    /usr/local/etc/aifw/*) ;;
+
+    # AiFw binaries (root-owned)
+    /usr/local/sbin/aifw|/usr/local/sbin/aifw-*) ;;
+    /usr/local/sbin/rdhcpd|/usr/local/sbin/rdns|/usr/local/sbin/rdns-control) ;;
+    /usr/local/sbin/rtime|/usr/local/sbin/trafficcop) ;;
+
+    # rc.d scripts
+    /usr/local/etc/rc.d/aifw_*) ;;
+    /usr/local/etc/rc.d/rdhcpd|/usr/local/etc/rc.d/rdns) ;;
+    /usr/local/etc/rc.d/rtime|/usr/local/etc/rc.d/trafficcop) ;;
+
+    # libexec helper scripts (including the aifw-sudo-* wrappers themselves)
+    /usr/local/libexec/aifw-*) ;;
+
+    # Companion service config + data
+    /usr/local/etc/rdns/zones/*|/usr/local/etc/rdns/rpz/*) ;;
+    /usr/local/etc/rdhcpd/*) ;;
+    /usr/local/etc/rtime/*) ;;
+    /usr/local/etc/trafficcop/*) ;;
+    /usr/local/etc/nginx/*) ;;
+    /usr/local/etc/traefik/*) ;;
+    /usr/local/etc/haproxy/*) ;;
+    /usr/local/etc/ssl/*) ;;
+    /etc/ssl/*) ;;
+    /var/unbound/*) ;;
+
+    # System-settings opt-in writes (system_apply path)
+    /etc/hosts) ;;
+    /etc/resolv.conf) ;;
+    /etc/localtime) ;;
+    /var/db/zoneinfo) ;;
+    /etc/issue) ;;
+    /etc/motd.template) ;;
+    /etc/ssh/sshd_config) ;;
+    /boot/loader.conf) ;;
+
+    *)
+        echo "aifw-sudo-install: destination not allowed: $DEST" >&2
+        exit 1 ;;
+esac
+
+# Rebuild the install argv (now validated) and exec.
+set -- "$SRC" "$DEST"
+[ -n "$GROUP" ] && set -- -g "$GROUP" "$@"
+[ -n "$OWNER" ] && set -- -o "$OWNER" "$@"
+[ -n "$MODE" ] && set -- -m "$MODE" "$@"
+
+exec /usr/bin/install "$@"


### PR DESCRIPTION
## Summary

Eighth slice of the GHSA-mjqh-2vx8-7hq7 follow-up — the **most dangerous** remaining grant. `sudo install /tmp/x /root/.ssh/authorized_keys` was a one-liner to root for any compromise of the `aifw` user. This commit narrows `/usr/bin/install *` to the allowlisted `aifw-sudo-install` helper.

Helper enforces closed allowlists for:
- **src**: `/tmp/*`, `/usr/share/zoneinfo/*`, `/usr/local/share/aifw/backup/*`
- **dest**: AiFw-managed configs (`sudoers.d/aifw`, `pf-tuning.conf`, `tls/*`, `anchors/*`), binaries (`/usr/local/sbin/aifw*` + companion services), rc.d scripts, libexec scripts (`aifw-*`), companion service config dirs, and system-settings opt-in targets (`/etc/hosts`, `/etc/resolv.conf`, etc.)
- **mode**: `0440`/`0600`/`0644`/`0755`
- **owner/group**: known AiFw-managed identities only

## Migrated

~25 call sites across `aifw-core/system_apply/freebsd_impl.rs` (factored into a `run_install_helper`), `aifw-core/updater.rs` (binary + rc.d + libexec + sbin install + rollback + all 8 sudoers migrators), `aifw-core/acme_export.rs`, `aifw-core/dns_blocklists.rs`, `aifw-core/pf_tuning.rs`, `aifw-api/dns_resolver.rs`.

## Bootstrapping note

`ensure_sudoers_install_helper` uses a **two-phase** migration: phase 1 adds the helper grant while keeping the broad grant (so the raw `sudo install` it uses for its own sudoers write still works), phase 2 strips the broad grant on the next update cycle. The other sudoers migrators were reordered to run **after** install-helper so the helper grant is in place by the time they call `crate::sudo::install` to write their own sudoers patches.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace` green
- [ ] FreeBSD: binary install + rollback work via helper
- [ ] Verify `sudo install /tmp/x /root/.ssh/authorized_keys` denied
- [ ] Verify two-phase migration: phase 1 adds helper, phase 2 strips broad