### PR TITLE
sudo: sysrc helper (#204 slice 9 — final category)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ai"
-version = "5.94.5"
+version = "5.94.6"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-api"
-version = "5.94.5"
+version = "5.94.6"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-cli"
-version = "5.94.5"
+version = "5.94.6"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-common"
-version = "5.94.5"
+version = "5.94.6"
 dependencies = [
  "chrono",
  "nix 0.31.2",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-conntrack"
-version = "5.94.5"
+version = "5.94.6"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-core"
-version = "5.94.5"
+version = "5.94.6"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-daemon"
-version = "5.94.5"
+version = "5.94.6"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids"
-version = "5.94.5"
+version = "5.94.6"
 dependencies = [
  "aho-corasick",
  "aifw-common",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-bin"
-version = "5.94.5"
+version = "5.94.6"
 dependencies = [
  "aifw-common",
  "aifw-ids",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-ipc"
-version = "5.94.5"
+version = "5.94.6"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-metrics"
-version = "5.94.5"
+version = "5.94.6"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-pf"
-version = "5.94.5"
+version = "5.94.6"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-plugins"
-version = "5.94.5"
+version = "5.94.6"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-setup"
-version = "5.94.5"
+version = "5.94.6"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-tui"
-version = "5.94.5"
+version = "5.94.6"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.94.5"
+version = "5.94.6"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/dhcp.rs
+++ b/aifw-api/src/dhcp.rs
@@ -1211,10 +1211,7 @@ pub async fn dhcp_status(State(state): State<AppState>) -> Result<Json<DhcpStatu
 async fn run_rdhcp_service(action: &str) -> Json<MessageResponse> {
     // Ensure rdhcpd is enabled in rc.conf before start/restart
     if action == "start" || action == "restart" {
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/sysrc", "rdhcpd_enable=YES"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::sysrc(&["rdhcpd_enable=YES"]).await;
     }
     let output = aifw_core::sudo::service("rdhcpd", action).await;
     match output {
@@ -1985,10 +1982,7 @@ pub async fn apply_config(
     let _ = aifw_core::sudo::chown_r("aifw:aifw", "/var/log/rdhcpd").await;
 
     if config.enabled {
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/sysrc", "rdhcpd_enable=YES"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::sysrc(&["rdhcpd_enable=YES"]).await;
         let _ = aifw_core::sudo::service("rdhcpd", "restart").await;
 
         // Reload all aifw anchor rules (includes user rules + service rules)
@@ -2000,10 +1994,7 @@ pub async fn apply_config(
         }))
     } else {
         let _ = aifw_core::sudo::service("rdhcpd", "stop").await;
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/sysrc", "rdhcpd_enable=NO"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::sysrc(&["rdhcpd_enable=NO"]).await;
         // Reload anchor to remove DHCP rules
         reload_aifw_anchor(&state).await;
         Ok(Json(MessageResponse {

--- a/aifw-api/src/dns_resolver.rs
+++ b/aifw-api/src/dns_resolver.rs
@@ -142,9 +142,14 @@ async fn service_cmd(service: &str, action: &str) {
     .await;
 }
 
-/// Run sysrc safely without shell interpolation.
+/// Run sysrc safely without shell interpolation. Routes through the
+/// narrow `aifw-sudo-sysrc` helper (#204).
 async fn sysrc(setting: &str) {
-    let _ = run_cmd_timeout("/usr/local/bin/sudo", &["/usr/sbin/sysrc", setting]).await;
+    let _ = run_cmd_timeout(
+        "/usr/local/bin/sudo",
+        &["/usr/local/libexec/aifw-sudo-sysrc", setting],
+    )
+    .await;
 }
 
 /// Read a sysrc value — returns the raw value without the "key: " prefix.

--- a/aifw-api/src/iface.rs
+++ b/aifw-api/src/iface.rs
@@ -507,10 +507,8 @@ pub async fn configure_interface(
                 let _ = aifw_core::sudo::ifconfig(&name, "delete", &[]).await;
                 let _ = sudo_cmd(&["/sbin/dhclient", &name]).await;
                 // Persist
-                let _ = Command::new("/usr/local/bin/sudo")
-                    .args(["/usr/sbin/sysrc", &format!("ifconfig_{}=DHCP", name)])
-                    .output()
-                    .await;
+                let kv = format!("ifconfig_{}=DHCP", name);
+                let _ = aifw_core::sudo::sysrc(&[&kv]).await;
                 // Remove static defaultrouter if we're switching to DHCP (DHCP will set it)
                 msgs.push("Set to DHCP".to_string());
             }
@@ -532,13 +530,8 @@ pub async fn configure_interface(
                     let _ = aifw_core::sudo::ifconfig(&name, "up", &[]).await;
 
                     // Persist in rc.conf
-                    let _ = Command::new("/usr/local/bin/sudo")
-                        .args([
-                            "/usr/sbin/sysrc",
-                            &format!("ifconfig_{}=inet {}", name, addr),
-                        ])
-                        .output()
-                        .await;
+                    let kv = format!("ifconfig_{}=inet {}", name, addr);
+                    let _ = aifw_core::sudo::sysrc(&[&kv]).await;
                     msgs.push(format!("Set static IP {}", addr));
                 }
 
@@ -553,10 +546,8 @@ pub async fn configure_interface(
                         if owns_default {
                             let _ = sudo_cmd(&["/sbin/route", "delete", "default"]).await;
                             let _ = sudo_cmd(&["/sbin/route", "add", "default", gw]).await;
-                            let _ = Command::new("/usr/local/bin/sudo")
-                                .args(["/usr/sbin/sysrc", &format!("defaultrouter={}", gw)])
-                                .output()
-                                .await;
+                            let kv = format!("defaultrouter={}", gw);
+                            let _ = aifw_core::sudo::sysrc(&[&kv]).await;
                             msgs.push(format!("Gateway set to {}", gw));
                         } else {
                             msgs.push(format!(
@@ -572,10 +563,7 @@ pub async fn configure_interface(
                         let (_, cur_gw_iface) = get_default_gateway().await;
                         if cur_gw_iface.as_deref() == Some(&name) {
                             let _ = sudo_cmd(&["/sbin/route", "delete", "default"]).await;
-                            let _ = Command::new("/usr/local/bin/sudo")
-                                .args(["/usr/sbin/sysrc", "-x", "defaultrouter"])
-                                .output()
-                                .await;
+                            let _ = aifw_core::sudo::sysrc(&["-x", "defaultrouter"]).await;
                             msgs.push("Default gateway removed".to_string());
                         }
                     }
@@ -584,10 +572,8 @@ pub async fn configure_interface(
             "none" => {
                 let _ = sudo_cmd(&["/usr/bin/pkill", "-f", &format!("dhclient {}", name)]).await;
                 let _ = aifw_core::sudo::ifconfig(&name, "delete", &[]).await;
-                let _ = Command::new("/usr/local/bin/sudo")
-                    .args(["/usr/sbin/sysrc", "-x", &format!("ifconfig_{}", name)])
-                    .output()
-                    .await;
+                let key = format!("ifconfig_{}", name);
+                let _ = aifw_core::sudo::sysrc(&["-x", &key]).await;
                 msgs.push("Removed IP configuration".to_string());
             }
             _ => {}
@@ -601,10 +587,8 @@ pub async fn configure_interface(
             if owns_default {
                 let _ = sudo_cmd(&["/sbin/route", "delete", "default"]).await;
                 let _ = sudo_cmd(&["/sbin/route", "add", "default", gw]).await;
-                let _ = Command::new("/usr/local/bin/sudo")
-                    .args(["/usr/sbin/sysrc", &format!("defaultrouter={}", gw)])
-                    .output()
-                    .await;
+                let kv = format!("defaultrouter={}", gw);
+                let _ = aifw_core::sudo::sysrc(&[&kv]).await;
                 msgs.push(format!("Gateway set to {}", gw));
             } else {
                 msgs.push(format!(
@@ -615,10 +599,7 @@ pub async fn configure_interface(
             }
         } else if cur_gw_iface.as_deref() == Some(&name) {
             let _ = sudo_cmd(&["/sbin/route", "delete", "default"]).await;
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args(["/usr/sbin/sysrc", "-x", "defaultrouter"])
-                .output()
-                .await;
+            let _ = aifw_core::sudo::sysrc(&["-x", "defaultrouter"]).await;
             msgs.push("Default gateway removed".to_string());
         }
     }
@@ -765,22 +746,15 @@ pub async fn apply_vlans(pool: &SqlitePool) -> Result<(), String> {
             let _ = aifw_core::sudo::ifconfig(&vlan_name, "up", &[]).await;
 
             // Persist in rc.conf
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args(["/usr/sbin/sysrc", &format!("vlans_{}={}", parent, vid)])
-                .output()
-                .await;
+            let vlans_kv = format!("vlans_{}={}", parent, vid);
+            let _ = aifw_core::sudo::sysrc(&[&vlans_kv]).await;
             let rc_val = match mode.as_str() {
                 "dhcp" => "DHCP".to_string(),
                 "static" => format!("inet {}", ip_addr.as_deref().unwrap_or("")),
                 _ => "up".to_string(),
             };
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args([
-                    "/usr/sbin/sysrc",
-                    &format!("ifconfig_{}={}", vlan_name, rc_val),
-                ])
-                .output()
-                .await;
+            let ifconfig_kv = format!("ifconfig_{}={}", vlan_name, rc_val);
+            let _ = aifw_core::sudo::sysrc(&[&ifconfig_kv]).await;
         } else {
             let _ = aifw_core::sudo::ifconfig(&vlan_name, "down", &[]).await;
         }
@@ -800,10 +774,8 @@ pub async fn apply_vlans(pool: &SqlitePool) -> Result<(), String> {
     for iface in iface_list.split_whitespace() {
         if iface.starts_with("vlan") && !db_vlan_names.contains(&iface.to_string()) {
             let _ = aifw_core::sudo::ifconfig(iface, "destroy", &[]).await;
-            let _ = Command::new("/usr/local/bin/sudo")
-                .args(["/usr/sbin/sysrc", "-x", &format!("ifconfig_{}", iface)])
-                .output()
-                .await;
+            let key = format!("ifconfig_{}", iface);
+            let _ = aifw_core::sudo::sysrc(&["-x", &key]).await;
         }
     }
 

--- a/aifw-api/src/reverse_proxy.rs
+++ b/aifw-api/src/reverse_proxy.rs
@@ -1246,20 +1246,14 @@ pub async fn apply_config(
         .map_err(|_| internal())?;
 
     if global.enabled {
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/sysrc", "trafficcop_enable=YES"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::sysrc(&["trafficcop_enable=YES"]).await;
         let _ = aifw_core::sudo::service("trafficcop", "restart").await;
         Ok(Json(MessageResponse {
             message: "TrafficCop config applied and service restarted".to_string(),
         }))
     } else {
         let _ = aifw_core::sudo::service("trafficcop", "stop").await;
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/sysrc", "trafficcop_enable=NO"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::sysrc(&["trafficcop_enable=NO"]).await;
         Ok(Json(MessageResponse {
             message: "TrafficCop config saved, service stopped".to_string(),
         }))

--- a/aifw-api/src/time_service.rs
+++ b/aifw-api/src/time_service.rs
@@ -5,7 +5,6 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use sqlx::sqlite::SqlitePool;
-use tokio::process::Command;
 use uuid::Uuid;
 
 use crate::AppState;
@@ -441,10 +440,7 @@ pub async fn delete_source(
 
 async fn run_service(action: &str) -> Json<MessageResponse> {
     if action == "start" || action == "restart" {
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/sysrc", "rtime_enable=YES"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::sysrc(&["rtime_enable=YES"]).await;
     }
     let output = aifw_core::sudo::service("rtime", action).await;
     match output {
@@ -542,10 +538,7 @@ pub async fn apply_config(
     let _ = aifw_core::sudo::chown_r("aifw:aifw", "/var/log/rtime").await;
 
     if config.enabled {
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/sysrc", "rtime_enable=YES"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::sysrc(&["rtime_enable=YES"]).await;
         let _ = aifw_core::sudo::service("rtime", "restart").await;
 
         Ok(Json(MessageResponse {
@@ -553,10 +546,7 @@ pub async fn apply_config(
         }))
     } else {
         let _ = aifw_core::sudo::service("rtime", "stop").await;
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/sysrc", "rtime_enable=NO"])
-            .output()
-            .await;
+        let _ = aifw_core::sudo::sysrc(&["rtime_enable=NO"]).await;
         Ok(Json(MessageResponse {
             message: "Time config saved, rTime stopped".to_string(),
         }))

--- a/aifw-api/src/ws.rs
+++ b/aifw-api/src/ws.rs
@@ -1462,8 +1462,12 @@ async fn collect_services() -> Vec<ServiceStatusPayload> {
                 .await
                 .map(|o| o.status.success())
                 .unwrap_or(false);
-            let enabled = tokio::process::Command::new("/usr/local/bin/sudo")
-                .args(["/usr/sbin/sysrc", "-n", &format!("{svc_name}_enable")])
+            // `sysrc -n` is a read; doesn't need root. Calling
+            // `/usr/sbin/sysrc` directly avoids the helper allowlist
+            // round-trip for what should be a status check.
+            let enable_key = format!("{svc_name}_enable");
+            let enabled = tokio::process::Command::new("/usr/sbin/sysrc")
+                .args(["-n", &enable_key])
                 .output()
                 .await
                 .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "YES")

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -389,10 +389,8 @@ pub async fn reconcile(db_path: &Path) -> anyhow::Result<()> {
 }
 
 async fn sudo_sysrc_set(key: &str, value: &str) -> anyhow::Result<()> {
-    let out = tokio::process::Command::new("/usr/local/bin/sudo")
-        .args(["/usr/sbin/sysrc", &format!("{key}={value}")])
-        .output()
-        .await?;
+    let kv = format!("{key}={value}");
+    let out = aifw_core::sudo::sysrc(&[&kv]).await?;
     if !out.status.success() {
         anyhow::bail!(
             "sysrc {key}={value} failed: {}",

--- a/aifw-core/src/sudo.rs
+++ b/aifw-core/src/sudo.rs
@@ -22,6 +22,7 @@ const HELPER_SERVICE: &str = "/usr/local/libexec/aifw-sudo-service";
 const HELPER_CHOWN: &str = "/usr/local/libexec/aifw-sudo-chown";
 const HELPER_IFCONFIG: &str = "/usr/local/libexec/aifw-sudo-ifconfig";
 const HELPER_INSTALL: &str = "/usr/local/libexec/aifw-sudo-install";
+const HELPER_SYSRC: &str = "/usr/local/libexec/aifw-sudo-sysrc";
 
 /// Atomically write `contents` to `path`, as root, via the
 /// `aifw-sudo-write` helper script.
@@ -159,6 +160,20 @@ pub async fn ifconfig(
 /// AiFw-managed prefixes), MODE (`0440`/`0600`/`0644`/`0755`), and
 /// OWNER/GROUP (root, aifw, rdns, unbound, nginx, www / wheel, aifw,
 /// rdns, unbound, nginx, www). Pass `None` for any unwanted field.
+/// Set or unset an `/etc/rc.conf` variable as root via the
+/// `aifw-sudo-sysrc` helper.
+///
+/// The helper restricts which rcvars `aifw` may touch (AiFw service
+/// `*_enable` rcvars, `ifconfig_*`, `vlans_*`, `hostname`,
+/// `defaultrouter`, etc.) and rejects keys with shell metacharacters.
+/// Pass `["KEY=VALUE"]` to set, `["-x", "KEY"]` to unset, `["-n",
+/// "KEY"]` to read (though reads don't actually need root).
+pub async fn sysrc(args: &[&str]) -> std::io::Result<std::process::Output> {
+    let mut full: Vec<&str> = vec![HELPER_SYSRC];
+    full.extend_from_slice(args);
+    Command::new(SUDO).args(&full).output().await
+}
+
 pub async fn install(
     mode: Option<&str>,
     owner: Option<&str>,

--- a/aifw-core/src/system_apply/freebsd_impl.rs
+++ b/aifw-core/src/system_apply/freebsd_impl.rs
@@ -9,7 +9,8 @@ pub async fn apply_general(i: &GeneralInput) -> ApplyReport {
     let mut warnings: Vec<String> = Vec::new();
 
     // --- hostname: sysrc (persistent) + live ---
-    if let Err(e) = sudo_run("/usr/sbin/sysrc", &[&format!("hostname={}", i.hostname)]).await {
+    let hostname_kv = format!("hostname={}", i.hostname);
+    if let Err(e) = run_sysrc_helper(&[&hostname_kv]).await {
         warnings.push(format!("sysrc hostname failed: {}", e));
     }
     if let Err(e) = sudo_run("/bin/hostname", &[&i.hostname]).await {
@@ -93,15 +94,11 @@ pub async fn apply_ssh(i: &SshInput) -> ApplyReport {
     let mut warnings: Vec<String> = Vec::new();
 
     // --- sysrc sshd_enable=YES|NO ---
-    if let Err(e) = sudo_run(
-        "/usr/sbin/sysrc",
-        &[&format!(
-            "sshd_enable={}",
-            if i.enabled { "YES" } else { "NO" }
-        )],
-    )
-    .await
-    {
+    let sshd_kv = format!(
+        "sshd_enable={}",
+        if i.enabled { "YES" } else { "NO" }
+    );
+    if let Err(e) = run_sysrc_helper(&[&sshd_kv]).await {
         warnings.push(format!("sysrc sshd_enable failed: {}", e));
     }
 
@@ -354,6 +351,22 @@ async fn sudo_install_content(path: &str, data: &[u8], mode: &str) -> Result<(),
 /// readable.
 async fn sudo_install_from(src: &str, path: &str, mode: &str) -> Result<(), String> {
     run_install_helper(mode, src, path).await
+}
+
+/// Route through the narrow `aifw-sudo-sysrc` helper (#204). The
+/// helper enforces a closed allowlist of rcvar keys.
+async fn run_sysrc_helper(args: &[&str]) -> Result<(), String> {
+    let output = crate::sudo::sysrc(args)
+        .await
+        .map_err(|e| format!("aifw-sudo-sysrc spawn failed: {e}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "aifw-sudo-sysrc {args:?}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+    }
 }
 
 /// Route through the narrow `aifw-sudo-install` helper (#204). The

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -394,6 +394,10 @@ pub async fn install_from_path(
     // to the narrow `aifw-sudo-ifconfig *` helper (#204). Idempotent.
     ensure_sudoers_ifconfig_helper().await;
 
+    // Migrate sysrc sudoers grant from the broad `/usr/sbin/sysrc *` to
+    // the narrow `aifw-sudo-sysrc *` helper (#204). Idempotent.
+    ensure_sudoers_sysrc_helper().await;
+
     // Ensure /usr/sbin/daemon is in sudoers. Without it, the detached
     // restart driver in restart_services() spawns sudo, sudo refuses
     // for lack of NOPASSWD, and we silently skip the bounce — leaving
@@ -1157,6 +1161,54 @@ pub async fn ensure_sudoers_install_helper() {
     }
 }
 
+/// Migrate sudoers from the broad `/usr/sbin/sysrc *` grant to the
+/// narrow `aifw-sudo-sysrc` helper (#204). Idempotent.
+pub async fn ensure_sudoers_sysrc_helper() {
+    let path = "/usr/local/etc/sudoers.d/aifw";
+    let Ok(content) = tokio::fs::read_to_string(path).await else {
+        return;
+    };
+
+    let helper_marker = "/usr/local/libexec/aifw-sudo-sysrc";
+    let direct_substr = "/usr/sbin/sysrc *";
+
+    let needs_helper = !content.contains(helper_marker);
+    let needs_strip = content.contains(direct_substr);
+    if !needs_helper && !needs_strip {
+        return;
+    }
+
+    let mut patched: String = content
+        .lines()
+        .filter(|line| !line.contains(direct_substr))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if !patched.ends_with('\n') {
+        patched.push('\n');
+    }
+    if needs_helper {
+        patched.push_str("aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-sysrc *\n");
+    }
+
+    let stage = "/tmp/aifw-sudoers-sysrc-helper-patch";
+    if tokio::fs::write(stage, &patched).await.is_err() {
+        warn!("failed to stage sudoers sysrc-helper patch");
+        return;
+    }
+    let result = crate::sudo::install(Some("440"), Some("root"), Some("wheel"), stage, path).await;
+    let _ = tokio::fs::remove_file(stage).await;
+    match result {
+        Ok(o) if o.status.success() => {
+            info!("migrated sudoers: dropped /usr/sbin/sysrc, added aifw-sudo-sysrc helper grant")
+        }
+        Ok(o) => warn!(
+            stderr = %String::from_utf8_lossy(&o.stderr),
+            "sudoers sysrc-helper migration install failed"
+        ),
+        Err(e) => warn!(error = %e, "sudoers sysrc-helper migration errored"),
+    }
+}
+
 /// Ensure each AiFw service has its rcvar set to YES in /etc/rc.conf.
 ///
 /// Appliances upgraded from versions predating a service (notably aifw_ids
@@ -1167,10 +1219,7 @@ pub async fn ensure_sudoers_install_helper() {
 pub async fn ensure_rcvars() {
     for var in OWNED_RCVARS {
         let arg = format!("{}=YES", var);
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/usr/sbin/sysrc", &arg])
-            .output()
-            .await;
+        let _ = crate::sudo::sysrc(&[&arg]).await;
     }
 }
 

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -114,6 +114,7 @@ aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-service *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-chown *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-ifconfig *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-install *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-sysrc *
 
 # --- Network configuration ---
 # TODO(GHSA-mjqh-2vx8-7hq7): the wildcards below still grant broad root.
@@ -121,7 +122,6 @@ aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-install *
 # lines with the wrapper path.
 aifw ALL=(ALL) NOPASSWD: /sbin/dhclient *
 aifw ALL=(ALL) NOPASSWD: /sbin/route *
-aifw ALL=(ALL) NOPASSWD: /usr/sbin/sysrc *
 aifw ALL=(ALL) NOPASSWD: /bin/cat *
 aifw ALL=(ALL) NOPASSWD: /bin/cp *
 aifw ALL=(ALL) NOPASSWD: /bin/rm *

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.94.5",
+  "version": "5.94.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/freebsd/deploy.sh
+++ b/freebsd/deploy.sh
@@ -255,7 +255,7 @@ done
 # login migrate, shutdown hook, narrow-grant sudo wrappers from #204).
 # Mode 755 so the daemon supervisor / sudo can exec them.
 mkdir -p /usr/local/libexec
-for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write aifw-sudo-wg aifw-sudo-freebsd-update aifw-sudo-pkg aifw-sudo-service aifw-sudo-chown aifw-sudo-ifconfig aifw-sudo-install; do
+for script in aifw-restart.sh aifw-watchdog.sh aifw-motd-cleanup.sh aifw-login-migrate.sh aifw-shutdown-hook.sh aifw-sudo-write aifw-sudo-wg aifw-sudo-freebsd-update aifw-sudo-pkg aifw-sudo-service aifw-sudo-chown aifw-sudo-ifconfig aifw-sudo-install aifw-sudo-sysrc; do
     src="$REPO_DIR/freebsd/overlay/usr/local/libexec/$script"
     if [ -f "$src" ]; then
         install -m 755 "$src" "/usr/local/libexec/$script"
@@ -266,7 +266,7 @@ done
 # favor of /usr/local/libexec/aifw-sudo-write, which enforces a closed
 # allowlist of write paths (#204).
 mkdir -p /usr/local/etc/sudoers.d
-echo 'aifw ALL=(ALL) NOPASSWD: /sbin/pfctl, /sbin/dhclient, /sbin/route, /usr/sbin/sysrc, /sbin/shutdown, /bin/hostname, /bin/cat, /bin/pkill, /usr/bin/pkill, /bin/mkdir, /usr/sbin/tcpdump, /bin/rm /usr/local/etc/rdns/rpz/*
+echo 'aifw ALL=(ALL) NOPASSWD: /sbin/pfctl, /sbin/dhclient, /sbin/route, /sbin/shutdown, /bin/hostname, /bin/cat, /bin/pkill, /usr/bin/pkill, /bin/mkdir, /usr/sbin/tcpdump, /bin/rm /usr/local/etc/rdns/rpz/*
 aifw ALL=(root) NOPASSWD: /usr/sbin/daemon -f *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-write *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-wg *
@@ -275,7 +275,8 @@ aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-pkg *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-service *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-chown *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-ifconfig *
-aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-install *' > /usr/local/etc/sudoers.d/aifw
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-install *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-sysrc *' > /usr/local/etc/sudoers.d/aifw
 chmod 440 /usr/local/etc/sudoers.d/aifw
 
 echo ""

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-sysrc
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-sysrc
@@ -1,0 +1,82 @@
+#!/bin/sh
+# /usr/local/libexec/aifw-sudo-sysrc [-x|-n] <key[=value]>
+#
+# Narrow-grant wrapper around /usr/sbin/sysrc (#204). Restricts the
+# `aifw` user to writing only AiFw-managed rcvars, with key-name
+# validation that rejects shell metacharacters.
+#
+# Supported forms:
+#   aifw-sudo-sysrc <key>=<value>    — set rcvar
+#   aifw-sudo-sysrc -x <key>         — unset rcvar
+#   aifw-sudo-sysrc -n <key>         — print value (read-only)
+#
+# Pre-fix `sysrc` had a broad sudoers grant that let a compromised
+# daemon write arbitrary rcvars, e.g. `sudo sysrc ifconfig_em0=...` to
+# hijack network configuration outside the AiFw-managed set.
+
+set -eu
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+    echo "usage: $0 [-x|-n] <key[=value]>" >&2
+    exit 2
+fi
+
+FLAG=""
+ARG=""
+if [ $# -eq 2 ]; then
+    case "$1" in
+        -x|-n) FLAG="$1"; ARG="$2" ;;
+        *)
+            echo "aifw-sudo-sysrc: first arg must be -x or -n: $1" >&2
+            exit 1 ;;
+    esac
+else
+    ARG="$1"
+fi
+
+# Extract KEY from KEY[=VALUE].
+KEY="${ARG%%=*}"
+
+# -x and -n take a bare key — no =value.
+if [ -n "$FLAG" ] && [ "${ARG#*=}" != "$ARG" ]; then
+    echo "aifw-sudo-sysrc: -x and -n take a bare key, no =value: $ARG" >&2
+    exit 1
+fi
+
+# Key character validation: alphanumeric + underscore only.
+case "$KEY" in
+    ""|*[^A-Za-z0-9_]*)
+        echo "aifw-sudo-sysrc: invalid key (alnum + underscore only): $KEY" >&2
+        exit 1 ;;
+esac
+
+# Key allowlist — only rcvars AiFw legitimately manages.
+case "$KEY" in
+    # System basics AiFw sets via system-settings UI
+    hostname|defaultrouter|sshd_enable) ;;
+
+    # AiFw service rcvars (aifw_daemon_enable, aifw_api_enable, etc.)
+    aifw_cluster_enabled) ;;
+    aifw_daemon_enable|aifw_api_enable|aifw_ids_enable|aifw_watchdog_enable) ;;
+    aifw_carp_demote_enable|aifw_demote_on_shutdown_enable) ;;
+
+    # Companion service rcvars
+    rdhcpd_enable|rdns_enable|rtime_enable|trafficcop_enable) ;;
+    local_unbound_enable|unbound_enable) ;;
+
+    # Interface configuration (ifconfig_<iface>, ifconfig_<iface>_<n>)
+    ifconfig_*) ;;
+
+    # VLAN child list per parent interface (vlans_<parent>)
+    vlans_*) ;;
+
+    *)
+        echo "aifw-sudo-sysrc: key not in allowlist: $KEY" >&2
+        exit 1 ;;
+esac
+
+if [ -n "$FLAG" ]; then
+    exec /usr/sbin/sysrc "$FLAG" "$KEY"
+else
+    exec /usr/sbin/sysrc "$ARG"
+fi


### PR DESCRIPTION
## Summary

**Final** slice of the GHSA-mjqh-2vx8-7hq7 follow-up. Replaces the broad `/usr/sbin/sysrc *` sudoers grant with the narrow `aifw-sudo-sysrc` helper.

The helper:
- validates the rcvar key character set (alnum + underscore only)
- restricts the key to AiFw-managed rcvars:
  - AiFw services: `aifw_{daemon,api,ids,watchdog,carp_demote,demote_on_shutdown}_enable`, `aifw_cluster_enabled`
  - Companion services: `{rdhcpd,rdns,rtime,trafficcop,unbound,local_unbound}_enable`
  - Network: `ifconfig_*`, `vlans_*`, `defaultrouter`
  - System basics: `hostname`, `sshd_enable`
- supports the three forms AiFw uses: `KEY=VALUE` (set), `-x KEY` (unset), `-n KEY` (read)

## Migrated

22 sudo'd sysrc call sites across `aifw-core/{system_apply/freebsd_impl,updater}.rs`, `aifw-api/{iface,dhcp,time_service,reverse_proxy,dns_resolver}.rs`, `aifw-cli/commands.rs`. Read-only `sysrc -n` calls in `ws.rs` switched to direct (no sudo) since reads don't need root.

Sudoers updated in all three sources of truth (`aifw-setup/apply.rs`, `freebsd/deploy.sh`, `aifw-core/updater.rs::ensure_sudoers_sysrc_helper`).

## Final state of #204

All nine broad sudoers grants are now narrow-helper-only:

| Category | Helper | Status |
|---|---|---|
| `tee` | `aifw-sudo-write` | ✅ v5.92.4 |
| `wg` | `aifw-sudo-wg` | ✅ v5.93.2 |
| `freebsd-update` | `aifw-sudo-freebsd-update` | ✅ v5.93.3 |
| `pkg` | `aifw-sudo-pkg` | ✅ v5.93.4 |
| `service` | `aifw-sudo-service` | ✅ v5.93.5 |
| `chown` | `aifw-sudo-chown` | ✅ v5.94.3 |
| `ifconfig` | `aifw-sudo-ifconfig` | ✅ v5.94.4 |
| `install` | `aifw-sudo-install` | ✅ v5.94.5 |
| `sysrc` | `aifw-sudo-sysrc` | ✅ v5.94.6 (this PR) |

Remaining cleanup (`visudo -cf` CI gate + dropping the GHSA TODO block in `apply.rs`) is a separate small commit.

## Test plan

- [x] `cargo check --workspace` clean (warnings fixed)
- [x] `cargo test --workspace` green
- [ ] FreeBSD: `sysrc trafficcop_enable=YES` works, `sysrc nginx_enable=YES` denied
- [ ] `ensure_sudoers_sysrc_helper` strips the broad grant on upgrade