### PR TITLE
vpn: auto-NAT WireGuard subnets, family-aware AllowedIPs, VPN page help (#469)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ai"
-version = "5.97.1"
+version = "5.97.2"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-api"
-version = "5.97.1"
+version = "5.97.2"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-cli"
-version = "5.97.1"
+version = "5.97.2"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-common"
-version = "5.97.1"
+version = "5.97.2"
 dependencies = [
  "chrono",
  "nix 0.31.3",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-conntrack"
-version = "5.97.1"
+version = "5.97.2"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-core"
-version = "5.97.1"
+version = "5.97.2"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-daemon"
-version = "5.97.1"
+version = "5.97.2"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids"
-version = "5.97.1"
+version = "5.97.2"
 dependencies = [
  "aho-corasick",
  "aifw-common",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-bin"
-version = "5.97.1"
+version = "5.97.2"
 dependencies = [
  "aifw-common",
  "aifw-ids",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-ipc"
-version = "5.97.1"
+version = "5.97.2"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-metrics"
-version = "5.97.1"
+version = "5.97.2"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-pf"
-version = "5.97.1"
+version = "5.97.2"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-plugins"
-version = "5.97.1"
+version = "5.97.2"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-setup"
-version = "5.97.1"
+version = "5.97.2"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-tui"
-version = "5.97.1"
+version = "5.97.2"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ai"
-version = "5.97.2"
+version = "5.97.3"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-api"
-version = "5.97.2"
+version = "5.97.3"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-cli"
-version = "5.97.2"
+version = "5.97.3"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-common"
-version = "5.97.2"
+version = "5.97.3"
 dependencies = [
  "chrono",
  "nix 0.31.3",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-conntrack"
-version = "5.97.2"
+version = "5.97.3"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-core"
-version = "5.97.2"
+version = "5.97.3"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-daemon"
-version = "5.97.2"
+version = "5.97.3"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids"
-version = "5.97.2"
+version = "5.97.3"
 dependencies = [
  "aho-corasick",
  "aifw-common",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-bin"
-version = "5.97.2"
+version = "5.97.3"
 dependencies = [
  "aifw-common",
  "aifw-ids",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-ids-ipc"
-version = "5.97.2"
+version = "5.97.3"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-metrics"
-version = "5.97.2"
+version = "5.97.3"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-pf"
-version = "5.97.2"
+version = "5.97.3"
 dependencies = [
  "aifw-common",
  "async-trait",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-plugins"
-version = "5.97.2"
+version = "5.97.3"
 dependencies = [
  "aifw-common",
  "aifw-pf",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-setup"
-version = "5.97.2"
+version = "5.97.3"
 dependencies = [
  "aifw-common",
  "aifw-core",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "aifw-tui"
-version = "5.97.2"
+version = "5.97.3"
 dependencies = [
  "aifw-common",
  "aifw-conntrack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.2"
+version = "5.97.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.1"
+version = "5.97.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/routes/mod.rs
+++ b/aifw-api/src/routes/mod.rs
@@ -1354,8 +1354,8 @@ pub async fn start_wg_tunnel(
         tracing::error!("Failed to start tunnel: {e}");
         internal()
     })?;
-    // Apply VPN pf rules and re-inject into the aifw anchor
-    let _ = state.vpn_engine.apply_vpn_rules().await;
+    // start_tunnel refreshed the aifw-vpn anchor (pass + NAT); also
+    // re-inject the pass rules into the aifw anchor ahead of its block rule
     if let Ok(vpn_rules) = state.vpn_engine.collect_vpn_rules().await {
         state.rule_engine.set_extra_rules(vpn_rules).await;
         let _ = state.rule_engine.apply_rules().await;
@@ -1375,6 +1375,11 @@ pub async fn stop_wg_tunnel(
         .stop_tunnel(uuid)
         .await
         .map_err(|_| internal())?;
+    // Drop this tunnel's pass rules from the aifw anchor extras too
+    if let Ok(vpn_rules) = state.vpn_engine.collect_vpn_rules().await {
+        state.rule_engine.set_extra_rules(vpn_rules).await;
+        let _ = state.rule_engine.apply_rules().await;
+    }
     Ok(Json(MessageResponse {
         message: "Tunnel stopped".to_string(),
     }))

--- a/aifw-common/src/vpn.rs
+++ b/aifw-common/src/vpn.rs
@@ -84,6 +84,37 @@ impl WgTunnel {
             ),
         ]
     }
+
+    /// Network CIDR of the tunnel subnet, masked to the network boundary
+    /// (e.g. address 10.10.0.1/24 → "10.10.0.0/24").
+    pub fn network_cidr(&self) -> String {
+        address_network_cidr(&self.address)
+    }
+
+    /// Outbound NAT rule so tunnel clients reach the internet through the
+    /// WAN (#469). Only IPv4 tunnel subnets are NAT'd — returns None for
+    /// IPv6 / alias / any addresses so we never masquerade 0.0.0.0/0.
+    pub fn to_nat_rule(&self, wan_if: &str) -> Option<String> {
+        use std::net::IpAddr;
+        match &self.address {
+            Address::Single(IpAddr::V4(_)) | Address::Network(IpAddr::V4(_), _) => Some(format!(
+                "nat on {wan_if} from {} to any -> ({wan_if})",
+                self.network_cidr()
+            )),
+            _ => None,
+        }
+    }
+}
+
+/// AllowedIPs for a full-tunnel client config, scoped to the address
+/// families the tunnel's inner network can carry.
+fn full_tunnel_allowed_ips(addr: &Address) -> &'static str {
+    use std::net::IpAddr;
+    match addr {
+        Address::Single(IpAddr::V4(_)) | Address::Network(IpAddr::V4(_), _) => "0.0.0.0/0",
+        Address::Single(IpAddr::V6(_)) | Address::Network(IpAddr::V6(_), _) => "::/0",
+        _ => "0.0.0.0/0, ::/0",
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -180,8 +211,14 @@ impl WgPeer {
                 .unwrap_or_else(|| address_network_cidr(&tunnel.address));
             conf.push_str(&format!("AllowedIPs = {routes}\n"));
         } else {
-            // Route all traffic through the VPN
-            conf.push_str("AllowedIPs = 0.0.0.0/0, ::/0\n");
+            // Route all traffic through the VPN — but only the address
+            // families the tunnel's inner network actually carries. Emitting
+            // ::/0 for a v4-only tunnel blackholes all IPv6 traffic on
+            // dual-stack clients (#469).
+            conf.push_str(&format!(
+                "AllowedIPs = {}\n",
+                full_tunnel_allowed_ips(&tunnel.address)
+            ));
         }
         if let Some(ka) = self.persistent_keepalive {
             conf.push_str(&format!("PersistentKeepalive = {ka}\n"));
@@ -705,5 +742,73 @@ mod split_tunnel_tests {
         let cfg = peer.to_client_config(&tunnel, "1.2.3.4", true);
         assert!(cfg.contains("AllowedIPs = 172.29.240.0/24"));
         assert!(!cfg.contains("172.29.240.1/24"));
+    }
+
+    fn test_tunnel(address: Address) -> WgTunnel {
+        WgTunnel {
+            id: Uuid::new_v4(),
+            name: "wg0".into(),
+            interface: crate::types::Interface("wg0".into()),
+            private_key: "x".into(),
+            public_key: "y".into(),
+            listen_port: 51820,
+            address,
+            dns: None,
+            mtu: None,
+            listen_interface: None,
+            split_routes: None,
+            status: VpnStatus::Down,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn test_peer(tunnel_id: Uuid) -> WgPeer {
+        WgPeer {
+            id: Uuid::new_v4(),
+            tunnel_id,
+            name: "peer1".into(),
+            public_key: "pk".into(),
+            preshared_key: None,
+            client_private_key: Some("cpk".into()),
+            endpoint: None,
+            allowed_ips: vec![Address::Network("10.10.0.2".parse().unwrap(), 32)],
+            persistent_keepalive: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn full_tunnel_v4_omits_v6_route() {
+        let tunnel = test_tunnel(Address::Network("10.10.0.1".parse().unwrap(), 24));
+        let cfg = test_peer(tunnel.id).to_client_config(&tunnel, "vpn.example.com", false);
+        assert!(cfg.contains("AllowedIPs = 0.0.0.0/0\n"));
+        assert!(!cfg.contains("::/0"));
+    }
+
+    #[test]
+    fn full_tunnel_v6_emits_v6_route_only() {
+        let tunnel = test_tunnel(Address::Network("fd00:a1f0::1".parse().unwrap(), 64));
+        let cfg = test_peer(tunnel.id).to_client_config(&tunnel, "vpn.example.com", false);
+        assert!(cfg.contains("AllowedIPs = ::/0\n"));
+        assert!(!cfg.contains("0.0.0.0/0"));
+    }
+
+    #[test]
+    fn nat_rule_masks_to_network_boundary() {
+        let tunnel = test_tunnel(Address::Network("10.10.0.1".parse().unwrap(), 24));
+        assert_eq!(
+            tunnel.to_nat_rule("em0").as_deref(),
+            Some("nat on em0 from 10.10.0.0/24 to any -> (em0)")
+        );
+    }
+
+    #[test]
+    fn nat_rule_skipped_for_non_v4_addresses() {
+        let v6 = test_tunnel(Address::Network("fd00:a1f0::1".parse().unwrap(), 64));
+        assert_eq!(v6.to_nat_rule("em0"), None);
+        let any = test_tunnel(Address::Any);
+        assert_eq!(any.to_nat_rule("em0"), None);
     }
 }

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -781,18 +781,25 @@ mod tests {
         let engine = crate::vpn::VpnEngine::new(db.pool().clone(), pf);
         engine.migrate().await.unwrap();
 
-        engine
-            .add_wg_tunnel(WgTunnel::new(
-                "wg0".to_string(),
-                Interface("wg0".to_string()),
-                51820,
-                Address::Network(
-                    std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)),
-                    24,
-                ),
-            ))
-            .await
-            .unwrap();
+        // WAN role drives the auto-generated WireGuard outbound NAT rule
+        sqlx::query(
+            "INSERT INTO interface_roles (interface_name, role, updated_at) VALUES ('em0', 'WAN', '2026-01-01T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let mut tunnel = WgTunnel::new(
+            "wg0".to_string(),
+            Interface("wg0".to_string()),
+            51820,
+            Address::Network(
+                std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)),
+                24,
+            ),
+        );
+        tunnel.status = VpnStatus::Up;
+        engine.add_wg_tunnel(tunnel).await.unwrap();
 
         engine
             .add_ipsec_sa(IpsecSa::new(
@@ -808,11 +815,50 @@ mod tests {
         engine.apply_vpn_rules().await.unwrap();
 
         let pf_rules = mock.get_rules("aifw-vpn").await.unwrap();
-        // 2 WG rules + 5 IPsec rules (tunnel mode)
-        assert_eq!(pf_rules.len(), 7);
+        // 1 NAT rule + 2 WG rules + 5 IPsec rules (tunnel mode)
+        assert_eq!(pf_rules.len(), 8);
+        // NAT must precede filter rules or pfctl rejects the ruleset
+        assert_eq!(pf_rules[0], "nat on em0 from 10.0.0.0/24 to any -> (em0)");
         assert!(pf_rules.iter().any(|r| r.contains("port 51820")));
         assert!(pf_rules.iter().any(|r| r.contains("proto esp")));
         assert!(pf_rules.iter().any(|r| r.contains("on enc0")));
+    }
+
+    #[tokio::test]
+    async fn test_vpn_down_tunnel_emits_no_rules() {
+        let db = Database::new_in_memory().await.unwrap();
+        let mock = Arc::new(aifw_pf::PfMock::new());
+        let pf: Arc<dyn PfBackend> = mock.clone();
+        let engine = crate::vpn::VpnEngine::new(db.pool().clone(), pf);
+        engine.migrate().await.unwrap();
+
+        sqlx::query(
+            "INSERT INTO interface_roles (interface_name, role, updated_at) VALUES ('em0', 'WAN', '2026-01-01T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        // Status defaults to Down — must not open the listen port or NAT
+        engine
+            .add_wg_tunnel(WgTunnel::new(
+                "wg0".to_string(),
+                Interface("wg0".to_string()),
+                51820,
+                Address::Network(
+                    std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)),
+                    24,
+                ),
+            ))
+            .await
+            .unwrap();
+
+        engine.apply_vpn_rules().await.unwrap();
+        let pf_rules = mock.get_rules("aifw-vpn").await.unwrap();
+        assert!(
+            pf_rules.is_empty(),
+            "down tunnel leaked rules: {pf_rules:?}"
+        );
     }
 
     // --- Geo-IP engine tests ---

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -82,6 +82,12 @@ impl VpnEngine {
             .execute(&self.pool)
             .await;
 
+        // Shared with aifw-setup / aifw-api (QUAL-C5) — wan_interface() below
+        // reads it to build the WireGuard outbound NAT rule.
+        sqlx::query(aifw_common::schemas::INTERFACE_ROLES_CREATE)
+            .execute(&self.pool)
+            .await?;
+
         sqlx::query(
             r#"
             CREATE TABLE IF NOT EXISTS ipsec_sas (
@@ -496,9 +502,12 @@ impl VpnEngine {
             .execute(&self.pool)
             .await;
 
-        // Open WAN UDP for this tunnel's listen-port in the aifw-vpn anchor.
-        // Without this, handshake packets are dropped by the default block rule.
-        let _ = self.rebuild_vpn_pf_anchor().await;
+        // Refresh the aifw-vpn anchor: opens WAN UDP for this tunnel's
+        // listen-port (without it, handshakes are dropped by the default
+        // block rule) and adds outbound NAT so clients reach the internet.
+        if let Err(e) = self.apply_vpn_rules().await {
+            tracing::warn!(%id, error = %e, "failed to refresh aifw-vpn anchor after start");
+        }
 
         tracing::info!(%id, iface, "WireGuard tunnel started");
         Ok(())
@@ -517,38 +526,13 @@ impl VpnEngine {
             .execute(&self.pool)
             .await;
 
-        // Close the WAN pass rule for this tunnel by recomputing from remaining
+        // Close this tunnel's pass + NAT rules by recomputing from remaining
         // up tunnels only.
-        let _ = self.rebuild_vpn_pf_anchor().await;
+        if let Err(e) = self.apply_vpn_rules().await {
+            tracing::warn!(%id, error = %e, "failed to refresh aifw-vpn anchor after stop");
+        }
 
         tracing::info!(%id, iface, "WireGuard tunnel stopped");
-        Ok(())
-    }
-
-    /// Rebuild the `aifw-vpn` filter anchor from the set of currently-up
-    /// WireGuard tunnels. Emits one UDP pass rule per listen_port, optionally
-    /// scoped to the tunnel's listen_interface when set.
-    ///
-    /// Idempotent: replaces the anchor's contents, so stopped tunnels disappear
-    /// and started tunnels appear.
-    pub async fn rebuild_vpn_pf_anchor(&self) -> Result<()> {
-        let tunnels = self.list_wg_tunnels().await?;
-        let mut rules: Vec<String> = Vec::new();
-        for t in tunnels.iter().filter(|t| t.status == VpnStatus::Up) {
-            let iface_clause = match t.listen_interface.as_deref() {
-                Some(iface) if !iface.is_empty() && iface != "any" => format!(" on {iface}"),
-                _ => String::new(),
-            };
-            rules.push(format!(
-                "pass in quick{iface_clause} proto udp to any port {} keep state label \"wg-{}\"",
-                t.listen_port, t.name
-            ));
-        }
-        self.pf
-            .load_rules("aifw-vpn", &rules)
-            .await
-            .map_err(|e| AifwError::Pf(e.to_string()))?;
-        tracing::info!(count = rules.len(), "aifw-vpn anchor rebuilt");
         Ok(())
     }
 
@@ -715,11 +699,13 @@ impl VpnEngine {
     // Apply VPN pf rules
     // ============================================================
 
-    /// Collect all VPN pf rules without loading them.
+    /// Collect VPN pf filter (pass) rules without loading them. Only tunnels
+    /// marked up contribute rules — a stopped tunnel must not hold its
+    /// listen-port open. IPsec SAs are always included.
     pub async fn collect_vpn_rules(&self) -> Result<Vec<String>> {
         let mut pf_rules = Vec::new();
         let tunnels = self.list_wg_tunnels().await?;
-        for t in &tunnels {
+        for t in tunnels.iter().filter(|t| t.status == VpnStatus::Up) {
             pf_rules.extend(t.to_pf_rules());
         }
         let sas = self.list_ipsec_sas().await?;
@@ -729,8 +715,52 @@ impl VpnEngine {
         Ok(pf_rules)
     }
 
+    /// Collect outbound NAT rules for up WireGuard tunnels so clients reach
+    /// the internet through the WAN (#469). These load into the `aifw-vpn`
+    /// nat-anchor declared in pf.conf — do NOT mix them into the filter-rule
+    /// extras, pfctl requires translation rules before filter rules.
+    pub async fn collect_vpn_nat_rules(&self) -> Result<Vec<String>> {
+        let tunnels = self.list_wg_tunnels().await?;
+        let up: Vec<&WgTunnel> = tunnels
+            .iter()
+            .filter(|t| t.status == VpnStatus::Up)
+            .collect();
+        if up.is_empty() {
+            return Ok(Vec::new());
+        }
+        let Some(wan) = self.wan_interface().await else {
+            tracing::warn!(
+                "no WAN interface role assigned — WireGuard clients will not be NAT'd to the internet"
+            );
+            return Ok(Vec::new());
+        };
+        Ok(up.iter().filter_map(|t| t.to_nat_rule(&wan)).collect())
+    }
+
+    /// Resolve the WAN interface from the interface_roles table (seeded by
+    /// the setup wizard, editable via the Interfaces page).
+    async fn wan_interface(&self) -> Option<String> {
+        match sqlx::query_scalar::<_, String>(
+            "SELECT interface_name FROM interface_roles WHERE role = 'WAN' ORDER BY interface_name LIMIT 1",
+        )
+        .fetch_optional(&self.pool)
+        .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to look up WAN interface for VPN NAT");
+                None
+            }
+        }
+    }
+
+    /// Load the full VPN rule set (NAT + filter) into the `aifw-vpn` anchor.
+    /// Idempotent: replaces the anchor's contents, so stopped tunnels
+    /// disappear and started tunnels appear.
     pub async fn apply_vpn_rules(&self) -> Result<()> {
-        let pf_rules = self.collect_vpn_rules().await?;
+        // NAT rules must precede filter rules within a pfctl ruleset load.
+        let mut pf_rules = self.collect_vpn_nat_rules().await?;
+        pf_rules.extend(self.collect_vpn_rules().await?);
 
         tracing::info!(count = pf_rules.len(), "applying VPN pf rules");
         self.pf

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.2",
+  "version": "5.97.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.1",
+  "version": "5.97.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/src/app/vpn/Help.tsx
+++ b/aifw-ui/src/app/vpn/Help.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+
+/**
+ * Small contextual help button. Drops in next to section titles or field labels.
+ * Click the "?" to toggle a popover. Click outside or press Esc to close.
+ *
+ * Example:
+ *   <Help title="Hysteresis">
+ *     Number of consecutive passes/fails required before a state change.
+ *     Higher = more stable, slower to react.
+ *   </Help>
+ */
+export default function Help({
+  title,
+  size = "sm",
+  children,
+}: {
+  title?: string;
+  size?: "xs" | "sm" | "md";
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const sizeCls = {
+    xs: "w-4 h-4 text-[10px]",
+    sm: "w-5 h-5 text-xs",
+    md: "w-6 h-6 text-sm",
+  }[size];
+
+  return (
+    <div className="relative inline-block" ref={ref}>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setOpen((o) => !o);
+        }}
+        aria-label={title ? `Help: ${title}` : "Help"}
+        className={`${sizeCls} inline-flex items-center justify-center rounded-full border border-blue-500/40 bg-blue-500/10 text-blue-400 hover:bg-blue-500/20 hover:text-blue-300 transition-colors font-bold`}
+      >
+        ?
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          className="absolute z-50 mt-2 left-0 w-80 max-w-[90vw] p-3 rounded-lg border border-blue-500/40 bg-[var(--bg-card)] shadow-xl text-xs leading-relaxed text-[var(--text-primary)]"
+        >
+          {title && (
+            <div className="font-semibold text-white mb-1 flex items-center justify-between">
+              <span>{title}</span>
+              <button
+                onClick={() => setOpen(false)}
+                className="text-[var(--text-muted)] hover:text-white"
+                aria-label="Close help"
+              >
+                ✕
+              </button>
+            </div>
+          )}
+          <div className="space-y-2 text-[var(--text-muted)]">{children}</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Page-level help card — larger, always open, sits at the top of a page. */
+export function HelpBanner({
+  title,
+  children,
+  storageKey,
+}: {
+  title: string;
+  children: React.ReactNode;
+  storageKey?: string;
+}) {
+  const [dismissed, setDismissed] = useState(() => {
+    if (typeof window === "undefined" || !storageKey) return false;
+    return localStorage.getItem(`help:${storageKey}`) === "dismissed";
+  });
+
+  if (dismissed) return null;
+
+  return (
+    <div className="bg-blue-500/5 border border-blue-500/30 rounded-lg p-4 text-sm text-[var(--text-primary)] space-y-2">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2 text-blue-400 font-semibold">
+          <span className="inline-flex w-5 h-5 items-center justify-center rounded-full border border-blue-500/50 bg-blue-500/20 text-xs">
+            ?
+          </span>
+          {title}
+        </div>
+        {storageKey && (
+          <button
+            onClick={() => {
+              localStorage.setItem(`help:${storageKey}`, "dismissed");
+              setDismissed(true);
+            }}
+            className="text-xs text-[var(--text-muted)] hover:text-white"
+          >
+            Hide
+          </button>
+        )}
+      </div>
+      <div className="text-[var(--text-muted)] leading-relaxed space-y-2">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/aifw-ui/src/app/vpn/page.tsx
+++ b/aifw-ui/src/app/vpn/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useWs } from "@/context/WsContext";
+import Help, { HelpBanner } from "./Help";
 
 /* ────────────────────────── Types ────────────────────────── */
 
@@ -527,6 +528,28 @@ export default function VpnPage() {
         </p>
       </div>
 
+      <HelpBanner title="WireGuard in four steps" storageKey="vpn-overview">
+        <p>
+          <b>1.</b> Create a tunnel — pick a private subnet that doesn&apos;t
+          overlap your LAN (e.g. <code>10.10.0.1/24</code>).{" "}
+          <b>2.</b> Start it. <b>3.</b> Add a peer for each device.{" "}
+          <b>4.</b> Open the peer&apos;s config and import it in the WireGuard
+          app on the device.
+        </p>
+        <p>
+          Starting a tunnel handles the plumbing for you: the UDP listen port
+          is opened, traffic on the tunnel interface is allowed, and the
+          tunnel subnet is NAT&apos;d to the internet through the WAN — no
+          manual firewall or NAT rules needed. If the firewall sits behind
+          another router, forward the listen port (UDP) to it there.
+        </p>
+        <p>
+          Peers can <i>connect</i> to the firewall over IPv4 or IPv6, but
+          traffic <i>inside</i> the tunnel is IPv4-only for now — client
+          configs are generated accordingly.
+        </p>
+      </HelpBanner>
+
       {/* Summary cards */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
         <SummaryCard label="WG Tunnels" value={tunnels.length} color="cyan" />
@@ -614,7 +637,15 @@ export default function VpnPage() {
                     />
                   </div>
                   <div>
-                    <label className={labelCls}>Listen Port</label>
+                    <label className={labelCls}>
+                      Listen Port{" "}
+                      <Help title="Listen port" size="xs">
+                        UDP port peers connect to (51820 is the convention).
+                        It is opened in the firewall automatically when the
+                        tunnel starts. Behind another router? Forward this
+                        UDP port to the firewall there.
+                      </Help>
+                    </label>
                     <input
                       type="number"
                       value={wgForm.listen_port}
@@ -624,7 +655,16 @@ export default function VpnPage() {
                     />
                   </div>
                   <div>
-                    <label className={labelCls}>Address (CIDR)</label>
+                    <label className={labelCls}>
+                      Address (CIDR){" "}
+                      <Help title="Tunnel address" size="xs">
+                        The firewall&apos;s IP <i>inside</i> the VPN, plus the
+                        tunnel subnet size — e.g. <code>10.10.0.1/24</code>.
+                        Peers get other IPs from this subnet. Use a private
+                        range that doesn&apos;t overlap your LAN or any
+                        network you connect from. IPv4 only for now.
+                      </Help>
+                    </label>
                     <input
                       type="text"
                       value={wgForm.address}
@@ -634,7 +674,14 @@ export default function VpnPage() {
                     />
                   </div>
                   <div>
-                    <label className={labelCls}>Listen Interface</label>
+                    <label className={labelCls}>
+                      Listen Interface{" "}
+                      <Help title="Listen interface" size="xs">
+                        Restricts which interface accepts WireGuard
+                        handshakes. <b>Any</b> is fine for most setups; pick
+                        your WAN to be strict.
+                      </Help>
+                    </label>
                     <select
                       value={wgForm.listen_interface}
                       onChange={(e) => setWgForm((f) => ({ ...f, listen_interface: e.target.value }))}
@@ -651,7 +698,16 @@ export default function VpnPage() {
                 </div>
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-3">
                   <div>
-                    <label className={labelCls}>DNS Servers</label>
+                    <label className={labelCls}>
+                      DNS Servers{" "}
+                      <Help title="DNS for clients" size="xs">
+                        Pushed to devices while connected. Use the tunnel
+                        address (e.g. <code>10.10.0.1</code>) to resolve
+                        through this firewall&apos;s DNS — including any
+                        blocklists — or leave empty to keep each
+                        device&apos;s own DNS.
+                      </Help>
+                    </label>
                     <input
                       type="text"
                       value={wgForm.dns}
@@ -661,7 +717,14 @@ export default function VpnPage() {
                     />
                   </div>
                   <div>
-                    <label className={labelCls}>MTU</label>
+                    <label className={labelCls}>
+                      MTU{" "}
+                      <Help title="MTU" size="xs">
+                        Leave empty for the default (1420). Lower it (e.g.
+                        1380) only if large transfers stall while small
+                        pages load fine — common on PPPoE links.
+                      </Help>
+                    </label>
                     <input
                       type="number"
                       value={wgForm.mtu}
@@ -671,7 +734,14 @@ export default function VpnPage() {
                     />
                   </div>
                   <div>
-                    <label className={labelCls}>Private Key (optional)</label>
+                    <label className={labelCls}>
+                      Private Key (optional){" "}
+                      <Help title="Private key" size="xs">
+                        Leave empty — a keypair is generated for you. Only
+                        paste a key here when migrating an existing
+                        WireGuard server so peers keep working.
+                      </Help>
+                    </label>
                     <input
                       type="password"
                       value={wgForm.private_key}
@@ -720,7 +790,14 @@ export default function VpnPage() {
             {wgLoading ? (
               <div className="text-center py-12 text-gray-500">Loading tunnels...</div>
             ) : tunnels.length === 0 ? (
-              <div className="text-center py-12 text-gray-500">No WireGuard tunnels configured</div>
+              <div className="text-center py-12 text-gray-500">
+                <p>No WireGuard tunnels configured</p>
+                <p className="text-xs mt-2 max-w-md mx-auto">
+                  Click <b>Add Tunnel</b> to get started — firewall rules and
+                  NAT are set up automatically when the tunnel starts, so
+                  peers can reach the internet right away.
+                </p>
+              </div>
             ) : (
               <div className="divide-y divide-gray-700/50">
                 {tunnels.map((tunnel) => {
@@ -829,7 +906,16 @@ export default function VpnPage() {
                                   />
                                 </div>
                                 <div>
-                                  <label className={labelCls}>Client IP</label>
+                                  <label className={labelCls}>
+                                    Client IP{" "}
+                                    <Help title="Client IP" size="xs">
+                                      This device&apos;s address inside the
+                                      tunnel, e.g. <code>10.10.0.2/32</code>.
+                                      Every peer needs its own — <b>Auto</b>{" "}
+                                      picks the next free IP in the tunnel
+                                      subnet.
+                                    </Help>
+                                  </label>
                                   <div className="flex gap-1">
                                     <input
                                       type="text"
@@ -844,7 +930,16 @@ export default function VpnPage() {
                                   </div>
                                 </div>
                                 <div>
-                                  <label className={labelCls}>Keepalive (sec)</label>
+                                  <label className={labelCls}>
+                                    Keepalive (sec){" "}
+                                    <Help title="Persistent keepalive" size="xs">
+                                      Sends a packet every N seconds so NAT
+                                      routers along the way don&apos;t drop
+                                      the connection. Use <b>25</b> for
+                                      phones and laptops; leave empty for
+                                      site-to-site peers with public IPs.
+                                    </Help>
+                                  </label>
                                   <input
                                     type="number"
                                     value={peerForm.keepalive}
@@ -879,7 +974,16 @@ export default function VpnPage() {
                                   </div>
                                 )}
                                 <div>
-                                  <label className={labelCls}>Endpoint (optional)</label>
+                                  <label className={labelCls}>
+                                    Endpoint (optional){" "}
+                                    <Help title="Peer endpoint" size="xs">
+                                      Only for site-to-site links where the
+                                      firewall should dial <i>out</i> to a
+                                      peer at a fixed address. Leave empty
+                                      for roaming devices (phones, laptops)
+                                      — they connect in to this firewall.
+                                    </Help>
+                                  </label>
                                   <input
                                     type="text"
                                     value={peerForm.endpoint}
@@ -1267,12 +1371,19 @@ export default function VpnPage() {
               </div>
               <p className="text-xs text-gray-400 mb-3">
                 {configTab === "full"
-                  ? "Routes ALL traffic through the VPN. Your IP will appear as the firewall\u2019s WAN address."
-                  : "Only routes traffic destined for the VPN subnet. Internet traffic uses your normal connection."}
+                  ? "Everything goes through the VPN: the device reaches the internet via the firewall\u2019s WAN address. Use this on untrusted networks (public Wi-Fi) or to apply the firewall\u2019s filtering everywhere. IPv6 traffic stays on the device\u2019s normal connection \u2014 the tunnel carries IPv4 only for now."
+                  : "Only the VPN subnet (plus any split-tunnel routes configured on the tunnel) goes through the VPN \u2014 use this to reach home/office devices while everything else uses the device\u2019s normal connection. Faster, but internet traffic is not protected by the VPN."}
               </p>
               <pre className="bg-gray-900 border border-gray-700 rounded-lg p-4 text-sm font-mono text-green-400 whitespace-pre-wrap select-all overflow-x-auto">
                 {configTab === "full" ? configModal.fullTunnel : configModal.splitTunnel}
               </pre>
+              <p className="text-xs text-gray-500 mt-3">
+                To use it: copy the config, then in the WireGuard app on the
+                device choose <b>Add tunnel</b> and paste (or save it as a{" "}
+                <code>.conf</code> file and import). If the tunnel here
+                isn&apos;t started yet, start it first \u2014 nothing will connect
+                until it is.
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Addresses #469 — "peer connects but no internet."

## Root causes found

1. **No outbound NAT for WireGuard subnets.** The only masquerade AiFw ever wrote was the setup wizard's LAN rule, so WG client traffic left the WAN un-NAT'd and died at the ISP. pf.conf already declared a `nat-anchor "aifw-vpn"` but nothing populated it.
2. **Full-tunnel client configs always advertised `::/0`** while the tunnel interior is IPv4-only — on IPv6-capable networks (like the reporter's) all v6 traffic was routed into the tunnel and blackholed.
3. **Two writers disagreed about the `aifw-vpn` anchor**: boot recovery clobbered the full rule set with port-only rules, silently dropping tunnel pass + IPsec rules.

## Changes (v5.97.2)

- Auto-generate `nat on <wan> from <tunnel_net> to any -> (<wan>)` for **up** tunnels into the `aifw-vpn` nat-anchor. WAN resolved from `interface_roles` (seeded by setup, self-seeded from pf.conf on upgrades). IPv4 subnets only; `any`/table/v6 addresses never produce a NAT rule, and a missing WAN role logs a warning instead of failing silently.
- Full-tunnel `AllowedIPs` is now family-aware: `0.0.0.0/0` for v4 tunnels, `::/0` for v6, both only when indeterminate.
- Unified anchor writers: start/stop/boot all reload the full NAT + pass + IPsec set via `apply_vpn_rules`. Only up tunnels contribute rules (a stopped tunnel no longer holds its listen port open), and stopping a tunnel also removes its pass rules from the `aifw` anchor extras.

## UI (v5.97.3)

- Dismissible quick-start banner on the VPN page: setup steps, what's automatic on tunnel start (port, pass rules, NAT), double-NAT port-forward hint, and the IPv4-inner/IPv6-transport limitation.
- `?` help popovers on all non-obvious tunnel and peer fields (existing Help component pattern).
- Config modal explains full vs split tunnel trade-offs (incl. the IPv6 note) and how to import the config in the WireGuard app.

## Testing

- `cargo check` / clippy clean, zero warnings
- Full workspace suite green; 6 new tests: NAT rule format + v4-only guard, both AllowedIPs behaviors, up/down rule emission with NAT-before-filter ordering asserted
- `npm run lint` + `npm run build` (static export) clean
