### PR TITLE
auth: fix SEC-H7/H8/H9 — password_min_length, refresh DoS, OAuth CSRF state (#292 #293 #294)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.6"
+version = "5.97.7"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/auth/mod.rs
+++ b/aifw-api/src/auth/mod.rs
@@ -126,6 +126,20 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     .execute(pool)
     .await?;
 
+    // SEC-H8: a short, non-secret prefix of the raw token lets rotate/revoke
+    // do an O(1) indexed lookup instead of Argon2-verifying every row. Legacy
+    // rows (pre-upgrade) have NULL prefix and simply won't match a lookup —
+    // those refresh tokens become invalid on upgrade (services restart anyway),
+    // forcing a harmless re-login.
+    let _ = sqlx::query("ALTER TABLE refresh_tokens ADD COLUMN token_prefix TEXT")
+        .execute(pool)
+        .await;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_refresh_tokens_prefix ON refresh_tokens(token_prefix)",
+    )
+    .execute(pool)
+    .await?;
+
     sqlx::query(aifw_common::schemas::RECOVERY_CODES_CREATE)
         .execute(pool)
         .await?;
@@ -158,6 +172,19 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
             created_at TEXT NOT NULL,
             FOREIGN KEY (user_id) REFERENCES users(id),
             FOREIGN KEY (provider_id) REFERENCES oauth_providers(id)
+        )"#,
+    )
+    .execute(pool)
+    .await?;
+
+    // SEC-H9: short-lived CSRF state store. A `state` nonce is created at
+    // /oauth/{provider}/authorize and must be presented (and consumed) at the
+    // callback, binding the callback to a request this server initiated.
+    sqlx::query(
+        r#"CREATE TABLE IF NOT EXISTS oauth_states (
+            state TEXT PRIMARY KEY,
+            provider TEXT NOT NULL,
+            created_at TEXT NOT NULL
         )"#,
     )
     .execute(pool)
@@ -354,8 +381,13 @@ pub async fn cleanup_revoked_tokens(pool: &SqlitePool) {
 // ============================================================
 
 /// Validate password meets minimum security requirements.
-pub fn validate_password(password: &str) -> Result<(), StatusCode> {
-    if password.len() < 8 {
+///
+/// `min_length` is the operator-configured `password_min_length`
+/// (`AuthSettings`). We floor it at 8 so a misconfigured-low setting can
+/// never weaken the baseline below the historical hardcoded minimum.
+pub fn validate_password(password: &str, min_length: u32) -> Result<(), StatusCode> {
+    let min = (min_length as usize).max(8);
+    if password.len() < min {
         return Err(StatusCode::BAD_REQUEST);
     }
     if !password.chars().any(|c| c.is_uppercase()) {
@@ -370,8 +402,12 @@ pub fn validate_password(password: &str) -> Result<(), StatusCode> {
     Ok(())
 }
 
-pub async fn create_user(pool: &SqlitePool, req: &CreateUserRequest) -> Result<User, StatusCode> {
-    validate_password(&req.password)?;
+pub async fn create_user(
+    pool: &SqlitePool,
+    req: &CreateUserRequest,
+    min_length: u32,
+) -> Result<User, StatusCode> {
+    validate_password(&req.password, min_length)?;
     let pw_hash = hash_password(&req.password)?;
     let role = req.role.as_deref().unwrap_or("viewer").to_string();
     let role_id = match role.as_str() {
@@ -444,6 +480,7 @@ pub async fn update_user(
     pool: &SqlitePool,
     user_id: &str,
     req: &UpdateUserRequest,
+    min_length: u32,
 ) -> Result<User, StatusCode> {
     let mut user = get_user_by_id(pool, user_id)
         .await?
@@ -453,7 +490,7 @@ pub async fn update_user(
         user.username = username.clone();
     }
     if let Some(ref password) = req.password {
-        validate_password(password)?;
+        validate_password(password, min_length)?;
         user.password_hash = hash_password(password)?;
     }
     if let Some(ref role) = req.role {

--- a/aifw-api/src/auth/oauth.rs
+++ b/aifw-api/src/auth/oauth.rs
@@ -167,6 +167,60 @@ pub async fn delete_provider(pool: &SqlitePool, id: Uuid) -> Result<(), String> 
     Ok(())
 }
 
+// ============================================================
+// SEC-H9: OAuth CSRF state store
+// ============================================================
+
+/// How long an issued `state` nonce remains valid between authorize and
+/// callback. OAuth round-trips complete in seconds; 10 minutes is generous
+/// while keeping the store self-cleaning.
+const OAUTH_STATE_TTL_SECS: i64 = 600;
+
+/// Persist a freshly-issued `state` nonce bound to a provider.
+pub async fn save_state(pool: &SqlitePool, state: &str, provider: &str) -> Result<(), String> {
+    sqlx::query(
+        "INSERT OR REPLACE INTO oauth_states (state, provider, created_at) VALUES (?1, ?2, ?3)",
+    )
+    .bind(state)
+    .bind(provider)
+    .bind(Utc::now().to_rfc3339())
+    .execute(pool)
+    .await
+    .map_err(|e| format!("db error: {e}"))?;
+    Ok(())
+}
+
+/// Consume a `state` nonce at the callback: it must exist, match the
+/// provider, and be unexpired. The row is deleted so a nonce is single-use
+/// (replay-proof). Returns true iff the state was valid. Expired rows are
+/// swept opportunistically.
+pub async fn consume_state(pool: &SqlitePool, state: &str, provider: &str) -> bool {
+    // Best-effort GC of stale nonces.
+    let cutoff = (Utc::now() - chrono::Duration::seconds(OAUTH_STATE_TTL_SECS)).to_rfc3339();
+    let _ = sqlx::query("DELETE FROM oauth_states WHERE created_at < ?1")
+        .bind(&cutoff)
+        .execute(pool)
+        .await;
+
+    let row = sqlx::query_as::<_, (String, String)>(
+        "DELETE FROM oauth_states WHERE state = ?1 RETURNING provider, created_at",
+    )
+    .bind(state)
+    .fetch_optional(pool)
+    .await
+    .unwrap_or(None);
+
+    match row {
+        Some((row_provider, created_at)) => {
+            let fresh = chrono::DateTime::parse_from_rfc3339(&created_at)
+                .map(|c| (Utc::now() - c.with_timezone(&Utc)).num_seconds() <= OAUTH_STATE_TTL_SECS)
+                .unwrap_or(false);
+            fresh && row_provider.eq_ignore_ascii_case(provider)
+        }
+        None => false,
+    }
+}
+
 fn url_encode(s: &str) -> String {
     s.replace(' ', "+")
         .replace(':', "%3A")
@@ -199,7 +253,6 @@ pub struct AuthorizeResponse {
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 pub struct CallbackQuery {
     pub code: String,
     pub state: String,

--- a/aifw-api/src/auth/tokens.rs
+++ b/aifw-api/src/auth/tokens.rs
@@ -80,6 +80,35 @@ pub fn verify_access_token(
 // Refresh Tokens (DB-backed with rotation + family tracking)
 // ============================================================
 
+/// Length of the non-secret prefix stored alongside the Argon2 hash.
+/// The raw token is `rfx_<32 hex>` (36 chars); the first 12 (`rfx_` + 8 hex)
+/// are enough to index a lookup to at most a handful of rows. This is NOT a
+/// security boundary — the Argon2 hash still authenticates the token — it
+/// only bounds the number of `verify_password` calls per request (SEC-H8).
+const REFRESH_PREFIX_LEN: usize = 12;
+
+pub(crate) fn refresh_prefix(raw: &str) -> &str {
+    if raw.len() >= REFRESH_PREFIX_LEN {
+        &raw[..REFRESH_PREFIX_LEN]
+    } else {
+        raw
+    }
+}
+
+/// Delete revoked or expired refresh tokens. Called opportunistically on
+/// rotate so the table (and any same-prefix bucket) stays small. Best-effort:
+/// a failure here is non-fatal and must not block token issuance.
+async fn prune_refresh_tokens(pool: &SqlitePool) {
+    let now = Utc::now().to_rfc3339();
+    if let Err(e) = sqlx::query("DELETE FROM refresh_tokens WHERE revoked = 1 OR expires_at < ?1")
+        .bind(&now)
+        .execute(pool)
+        .await
+    {
+        tracing::warn!(error = %e, "failed to prune refresh_tokens");
+    }
+}
+
 pub async fn create_refresh_token(
     pool: &SqlitePool,
     user_id: &str,
@@ -87,17 +116,19 @@ pub async fn create_refresh_token(
 ) -> Result<(String, String), String> {
     let raw_token = format!("rfx_{}", Uuid::new_v4().to_string().replace('-', ""));
     let token_hash = hash_password(&raw_token).map_err(|_| "hash error".to_string())?;
+    let prefix = refresh_prefix(&raw_token).to_string();
     let family_id = Uuid::new_v4().to_string();
     let expires = Utc::now() + Duration::days(settings.refresh_token_expiry_days);
     let id = Uuid::new_v4().to_string();
 
     sqlx::query(
-        r#"INSERT INTO refresh_tokens (id, user_id, token_hash, family_id, expires_at, revoked, created_at)
-           VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6)"#,
+        r#"INSERT INTO refresh_tokens (id, user_id, token_hash, token_prefix, family_id, expires_at, revoked, created_at)
+           VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7)"#,
     )
     .bind(&id)
     .bind(user_id)
     .bind(&token_hash)
+    .bind(&prefix)
     .bind(&family_id)
     .bind(expires.to_rfc3339())
     .bind(Utc::now().to_rfc3339())
@@ -137,11 +168,15 @@ pub async fn rotate_refresh_token(
     old_token: &str,
     settings: &AuthSettings,
 ) -> Result<TokenPair, String> {
-    // Find the matching refresh token by checking hashes
+    // SEC-H8: look up by the non-secret prefix so we Argon2-verify at most a
+    // handful of rows, not the whole table. A random/forged token whose prefix
+    // matches nothing returns zero rows and costs no verify.
+    let prefix = refresh_prefix(old_token);
     let rows = sqlx::query_as::<_, (String, String, String, String, bool, String)>(
         r#"SELECT id, user_id, token_hash, family_id, revoked, expires_at
-           FROM refresh_tokens ORDER BY created_at DESC"#,
+           FROM refresh_tokens WHERE token_prefix = ?1 ORDER BY created_at DESC"#,
     )
+    .bind(prefix)
     .fetch_all(pool)
     .await
     .map_err(|e| format!("db error: {e}"))?;
@@ -193,22 +228,27 @@ pub async fn rotate_refresh_token(
     // Issue new refresh token in the same family
     let new_raw = format!("rfx_{}", Uuid::new_v4().to_string().replace('-', ""));
     let new_hash = hash_password(&new_raw).map_err(|_| "hash error".to_string())?;
+    let new_prefix = refresh_prefix(&new_raw).to_string();
     let new_expires = Utc::now() + Duration::days(settings.refresh_token_expiry_days);
     let new_id = Uuid::new_v4().to_string();
 
     sqlx::query(
-        r#"INSERT INTO refresh_tokens (id, user_id, token_hash, family_id, expires_at, revoked, created_at)
-           VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6)"#,
+        r#"INSERT INTO refresh_tokens (id, user_id, token_hash, token_prefix, family_id, expires_at, revoked, created_at)
+           VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7)"#,
     )
     .bind(&new_id)
     .bind(&user_id)
     .bind(&new_hash)
+    .bind(&new_prefix)
     .bind(&family_id) // same family
     .bind(new_expires.to_rfc3339())
     .bind(Utc::now().to_rfc3339())
     .execute(pool)
     .await
     .map_err(|e| format!("db error: {e}"))?;
+
+    // Opportunistic cleanup of revoked/expired rows keeps the table bounded.
+    prune_refresh_tokens(pool).await;
 
     // Get username, enabled, and role for permission resolution
     let (username, enabled, role, role_id) =
@@ -241,9 +281,12 @@ pub async fn rotate_refresh_token(
 
 /// Revoke a specific refresh token (logout)
 pub async fn revoke_refresh_token(pool: &SqlitePool, token: &str) -> Result<(), String> {
+    // SEC-H8: scope to the prefix so logout verifies at most a few hashes.
+    let prefix = refresh_prefix(token);
     let rows = sqlx::query_as::<_, (String, String)>(
-        "SELECT id, token_hash FROM refresh_tokens WHERE revoked = 0",
+        "SELECT id, token_hash FROM refresh_tokens WHERE token_prefix = ?1 AND revoked = 0",
     )
+    .bind(prefix)
     .fetch_all(pool)
     .await
     .map_err(|e| format!("db error: {e}"))?;

--- a/aifw-api/src/routes/mod.rs
+++ b/aifw-api/src/routes/mod.rs
@@ -280,13 +280,48 @@ pub async fn totp_login(
 
 pub async fn refresh_token(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(req): Json<auth::tokens::RefreshRequest>,
 ) -> Result<Json<auth::TokenPair>, StatusCode> {
-    let tokens =
-        auth::tokens::rotate_refresh_token(&state.pool, &req.refresh_token, &state.auth_settings)
-            .await
-            .map_err(|_| StatusCode::UNAUTHORIZED)?;
+    // SEC-H8: rate-limit refresh like login. Key on the client IP (best
+    // effort, spoofable without a trusted-proxy allow-list) and on the
+    // token prefix so a spray of forged tokens from one source is capped.
+    // Falling back to the prefix as the IP key when there's no XFF avoids a
+    // single shared global bucket that would block unrelated clients.
+    let token_prefix = auth::tokens::refresh_prefix(&req.refresh_token).to_string();
+    let client_ip = headers
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.split(',').next())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| format!("rfx:{token_prefix}"));
 
+    if state
+        .login_limiter
+        .is_blocked(&client_ip, &token_prefix)
+        .await
+    {
+        return Err(StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    let tokens = match auth::tokens::rotate_refresh_token(
+        &state.pool,
+        &req.refresh_token,
+        &state.auth_settings,
+    )
+    .await
+    {
+        Ok(t) => t,
+        Err(_) => {
+            state
+                .login_limiter
+                .record_failure(&client_ip, &token_prefix)
+                .await;
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    };
+
+    state.login_limiter.clear(&client_ip, &token_prefix).await;
     Ok(Json(tokens))
 }
 
@@ -529,6 +564,11 @@ pub async fn oauth_authorize(
         .ok_or(StatusCode::NOT_FOUND)?;
 
     let oauth_state = Uuid::new_v4().to_string();
+    // SEC-H9: bind this state nonce so the callback can prove it originated
+    // from an authorize request this server issued.
+    auth::oauth::save_state(&state.pool, &oauth_state, &provider_name)
+        .await
+        .map_err(|_| internal())?;
     let redirect_uri = format!("/api/v1/auth/oauth/{}/callback", provider_name);
     let url = provider.authorize_url(&redirect_uri, &oauth_state);
 
@@ -539,8 +579,8 @@ pub async fn oauth_authorize(
 }
 
 pub async fn oauth_callback(
-    State(_state): State<AppState>,
-    Path(_provider_name): Path<String>,
+    State(state): State<AppState>,
+    Path(provider_name): Path<String>,
     axum::extract::Query(query): axum::extract::Query<auth::oauth::CallbackQuery>,
 ) -> Result<Json<MessageResponse>, StatusCode> {
     // Validate required parameters are present
@@ -550,7 +590,14 @@ pub async fn oauth_callback(
     if query.state.is_empty() {
         return Err(bad_request());
     }
-    // OAuth token exchange is not yet implemented — return 501
+    // SEC-H9: the state nonce must match one we issued at /authorize for this
+    // provider and be unexpired. consume_state deletes it (single-use), so a
+    // replayed or forged callback is rejected before any token exchange.
+    if !auth::oauth::consume_state(&state.pool, &query.state, &provider_name).await {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    // State is valid, but the token exchange itself is not yet implemented
+    // (tracked in #170) — return 501 until that lands.
     Err(StatusCode::NOT_IMPLEMENTED)
 }
 
@@ -568,7 +615,7 @@ pub async fn register(
         password: req.password,
         role: Some("admin".to_string()),
     };
-    auth::validate_password(&admin_req.password)?;
+    auth::validate_password(&admin_req.password, state.auth_settings.password_min_length)?;
     let pw_hash = auth::hash_password(&admin_req.password)?;
     let user_id = uuid::Uuid::new_v4();
     let now = chrono::Utc::now().to_rfc3339();
@@ -611,7 +658,8 @@ pub async fn create_user(
     State(state): State<AppState>,
     Json(req): Json<auth::CreateUserRequest>,
 ) -> Result<(StatusCode, Json<ApiResponse<auth::User>>), StatusCode> {
-    let user = auth::create_user(&state.pool, &req).await?;
+    let user =
+        auth::create_user(&state.pool, &req, state.auth_settings.password_min_length).await?;
     Ok((StatusCode::CREATED, Json(ApiResponse { data: user })))
 }
 
@@ -671,7 +719,13 @@ pub async fn update_user(
     Json(req): Json<auth::UpdateUserRequest>,
 ) -> Result<Json<ApiResponse<auth::User>>, StatusCode> {
     let actor_id = extract_user_id(&headers, &state)?;
-    let user = auth::update_user(&state.pool, &id, &req).await?;
+    let user = auth::update_user(
+        &state.pool,
+        &id,
+        &req,
+        state.auth_settings.password_min_length,
+    )
+    .await?;
     // PERF-C12: invalidate the user cache so disable / role change takes
     // effect immediately instead of waiting out the TTL.
     state.auth_user_cache.remove(&id);

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -713,6 +713,155 @@ mod tests {
     // Security regression tests
     // ================================================================
 
+    /// Build a test server whose AuthSettings override `password_min_length`.
+    async fn test_app_min_len(min_length: u32) -> TestServer {
+        let auth_settings = AuthSettings {
+            jwt_secret: "test-secret-key".to_string(),
+            access_token_expiry_mins: 60,
+            refresh_token_expiry_days: 7,
+            require_totp: false,
+            require_totp_for_oauth: false,
+            auto_create_oauth_users: true,
+            max_login_attempts: 5,
+            lockout_duration_secs: 300,
+            allow_registration: true,
+            password_min_length: min_length,
+        };
+        let state = crate::create_app_state_in_memory(auth_settings)
+            .await
+            .unwrap();
+        TestServer::new(crate::build_router(state, None, "*", false))
+    }
+
+    /// SEC-H7 (#292): the configured `password_min_length` must be enforced,
+    /// not the hardcoded floor of 8.
+    #[tokio::test]
+    async fn test_password_min_length_enforced() {
+        let server = test_app_min_len(16).await;
+
+        // First-user bootstrap (register) must honor the 16-char minimum:
+        // a complexity-valid but 12-char password is rejected.
+        let resp = server
+            .post("/api/v1/auth/register")
+            .json(&json!({"username": "admin", "password": "ShortPass123"}))
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+
+        // A 16-char password satisfies it.
+        let resp = server
+            .post("/api/v1/auth/register")
+            .json(&json!({"username": "admin", "password": "LongEnoughPass12"}))
+            .await;
+        resp.assert_status(StatusCode::CREATED);
+
+        // Log in and exercise the admin create-user path too.
+        let login = server
+            .post("/api/v1/auth/login")
+            .json(&json!({"username": "admin", "password": "LongEnoughPass12"}))
+            .await;
+        let token = login.json::<Value>()["tokens"]["access_token"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let resp = server
+            .post("/api/v1/auth/users")
+            .authorization_bearer(&token)
+            .json(&json!({"username": "bob", "password": "ShortPass123", "role": "viewer"}))
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+
+        let resp = server
+            .post("/api/v1/auth/users")
+            .authorization_bearer(&token)
+            .json(&json!({"username": "bob", "password": "LongEnoughPass12", "role": "viewer"}))
+            .await;
+        resp.assert_status(StatusCode::CREATED);
+    }
+
+    /// SEC-H8 (#293): the refresh endpoint is rate-limited so a spray of
+    /// forged tokens can't tie up the CPU indefinitely.
+    #[tokio::test]
+    async fn test_refresh_endpoint_rate_limited() {
+        let (server, _) = test_app().await;
+        // max_login_attempts is 5. A forged token with a fixed prefix keeps
+        // the rate-limit key stable across attempts.
+        let forged = "rfx_deadbeefdeadbeefdeadbeefdeadbeef";
+
+        // First failure returns 401 (invalid token), not yet blocked.
+        let resp = server
+            .post("/api/v1/auth/refresh")
+            .json(&json!({"refresh_token": forged}))
+            .await;
+        resp.assert_status(StatusCode::UNAUTHORIZED);
+
+        // Exhaust the remaining attempts.
+        for _ in 0..4 {
+            server
+                .post("/api/v1/auth/refresh")
+                .json(&json!({"refresh_token": forged}))
+                .await;
+        }
+
+        // Now blocked.
+        let resp = server
+            .post("/api/v1/auth/refresh")
+            .json(&json!({"refresh_token": forged}))
+            .await;
+        resp.assert_status(StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    /// SEC-H9 (#294): the OAuth callback must reject a `state` it never
+    /// issued, and a valid state is single-use (replay-proof).
+    #[tokio::test]
+    async fn test_oauth_callback_state_binding() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        // A forged state is rejected before any token exchange.
+        let resp = server
+            .get("/api/v1/auth/oauth/Google/callback?code=abc&state=forged-nonce")
+            .await;
+        resp.assert_status(StatusCode::UNAUTHORIZED);
+
+        // Create the provider, then obtain a real state from /authorize.
+        server
+            .post("/api/v1/auth/oauth/providers")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "name": "Google",
+                "provider_type": "google",
+                "client_id": "test-client-id",
+                "client_secret": "test-secret"
+            }))
+            .await
+            .assert_status(StatusCode::CREATED);
+
+        let authorize = server.get("/api/v1/auth/oauth/Google/authorize").await;
+        authorize.assert_status_ok();
+        let state = authorize.json::<Value>()["state"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // A valid state passes the CSRF check — the 501 confirms it reached
+        // the (still-unimplemented, #170) token-exchange step.
+        let resp = server
+            .get(&format!(
+                "/api/v1/auth/oauth/Google/callback?code=abc&state={state}"
+            ))
+            .await;
+        resp.assert_status(StatusCode::NOT_IMPLEMENTED);
+
+        // Replaying the same (now-consumed) state is rejected.
+        let resp = server
+            .get(&format!(
+                "/api/v1/auth/oauth/Google/callback?code=abc&state={state}"
+            ))
+            .await;
+        resp.assert_status(StatusCode::UNAUTHORIZED);
+    }
+
     /// Helper: create admin + a viewer user, return (admin_token, viewer_token)
     async fn create_admin_and_viewer(server: &TestServer) -> (String, String) {
         let admin_token = create_user_and_login(server).await;

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.6",
+  "version": "5.97.7",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Fixes three **HIGH** auth findings from the security audit (EPIC #281). All exercised end-to-end via the in-memory `TestServer` suite (127 passed, 0 failed; `clippy -D warnings` clean).

## SEC-H7 — `validate_password` ignores `password_min_length` (#292)
`validate_password` now takes the configured `password_min_length` (floored at 8 so a misconfigured-low setting can't weaken the baseline) instead of a hardcoded `8`. Threaded through `create_user`, `update_user`, and `register`.

**Out of scope (intentional):** the audit also mentioned recovery-code generation and `cluster::generate_loopback_key`. Those are machine-generated fixed-format secrets, not user passwords, so a user-password length policy doesn't apply.

## SEC-H8 — Argon2 verify looped over every refresh token (#293)
- New indexed, non-secret `token_prefix` column on `refresh_tokens`. `rotate`/`revoke` look up by prefix (O(1), ≤ a handful of Argon2 verifies) instead of scanning + verifying every unrevoked row — closes the DoS amplifier where one `/auth/refresh` could pin a CPU for tens of seconds.
- Login-style **rate limiting** on `POST /auth/refresh` (keyed on client IP + token prefix).
- Opportunistic **pruning** of revoked/expired rows on rotate.
- Legacy pre-upgrade refresh tokens (NULL prefix) become invalid → one harmless re-login (services restart on upgrade anyway).

## SEC-H9 — OAuth callback had no state CSRF binding (#294)
- New short-lived (10 min), single-use `oauth_states` store. The `state` nonce is created at `/oauth/{provider}/authorize` and consumed (`DELETE … RETURNING`) at the callback.
- Forged / expired / replayed `state` → `401` before any token exchange. The exchange itself still returns `501` (tracked separately in #170).

## Tests
New regression tests: `test_password_min_length_enforced`, `test_refresh_endpoint_rate_limited`, `test_oauth_callback_state_binding`. Existing refresh/logout/oauth tests still green against the modified paths.

Version bumped to 5.97.7.

Closes #292
Closes #293
Closes #294