### PR TITLE
security: SSRF guard on IDS ruleset / alias URL-table / DNS blocklist downloaders (#286 #287 #288)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.7"
+version = "5.97.8"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"
@@ -64,6 +64,7 @@ rustls = "0.23"
 tokio-rustls = "0.26"
 rustls-pemfile = "2"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+url = "2"
 
 # Workspace-wide clippy lint posture. Stylistic-only lints are allowed —
 # documented engine constructors legitimately have many parameters, the

--- a/aifw-common/Cargo.toml
+++ b/aifw-common/Cargo.toml
@@ -11,7 +11,8 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 sqlx = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["sync", "net"] }
+url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true }

--- a/aifw-common/src/lib.rs
+++ b/aifw-common/src/lib.rs
@@ -19,6 +19,7 @@ pub mod ha;
 pub mod ids;
 pub mod multiwan;
 pub mod nat;
+pub mod net_safety;
 pub mod permission;
 pub mod ratelimit;
 pub mod rule;

--- a/aifw-common/src/net_safety.rs
+++ b/aifw-common/src/net_safety.rs
@@ -1,9 +1,10 @@
 //! SSRF guards for outbound HTTP from the daemon.
 //!
-//! Two classes of outbound request are operator-configurable and therefore
-//! reachable by anyone with admin API access: DDNS IP-echo URLs and ACME
-//! export webhooks. Without these checks, a compromised admin account can
-//! steer the daemon at 127.0.0.1, RFC1918, cloud metadata endpoints, etc.
+//! Several classes of outbound request are operator-configurable and therefore
+//! reachable by anyone with admin API access: DDNS IP-echo URLs, ACME export
+//! webhooks, IDS ruleset feeds, alias URL-tables, and DNS blocklists. Without
+//! these checks, a compromised admin account can steer the daemon at
+//! 127.0.0.1, RFC1918, cloud metadata endpoints, or `file://` local paths.
 //!
 //! DNS rebinding is partially mitigated: we resolve up front and check
 //! every returned address. For complete protection the caller would need
@@ -21,7 +22,7 @@ use std::net::IpAddr;
 /// - loopback, private (RFC1918), link-local, CGNAT, ULA, multicast,
 ///   reserved, unspecified, and IPv4-mapped-private addresses are refused
 pub async fn validate_outbound_url(url_str: &str) -> Result<(), String> {
-    let url = reqwest::Url::parse(url_str).map_err(|e| format!("invalid URL: {e}"))?;
+    let url = url::Url::parse(url_str).map_err(|e| format!("invalid URL: {e}"))?;
     if url.scheme() != "https" {
         return Err(format!(
             "only https:// URLs are allowed (got {})",
@@ -167,6 +168,14 @@ mod tests {
     #[tokio::test]
     async fn rejects_http_scheme() {
         let err = validate_outbound_url("http://example.com/")
+            .await
+            .unwrap_err();
+        assert!(err.contains("https"));
+    }
+
+    #[tokio::test]
+    async fn rejects_file_scheme() {
+        let err = validate_outbound_url("file:///etc/passwd")
             .await
             .unwrap_err();
         assert!(err.contains("https"));

--- a/aifw-core/src/alias.rs
+++ b/aifw-core/src/alias.rs
@@ -175,8 +175,25 @@ impl AliasEngine {
             AliasType::UrlTable => {
                 // Fetch URL and load IPs into table
                 for url in &alias.entries {
+                    let url = url.trim();
+                    // SEC-H2 (#287): reject SSRF / local-file targets before
+                    // fetching. https-only, no internal/metadata hosts; a bad
+                    // URL is skipped (not fatal) like any other fetch failure.
+                    if let Err(e) = crate::net_safety::validate_outbound_url(url).await {
+                        tracing::warn!(alias = %alias.name, url, error = %e, "skipping unsafe URL-table source");
+                        continue;
+                    }
                     if let Ok(output) = tokio::process::Command::new("curl")
-                        .args(["-sf", "--max-time", "30", url.trim()])
+                        .args([
+                            "-sf",
+                            "--proto",
+                            "=https",
+                            "--proto-redir",
+                            "=https",
+                            "--max-time",
+                            "30",
+                            url,
+                        ])
                         .output()
                         .await
                         && output.status.success()

--- a/aifw-core/src/dns_blocklists.rs
+++ b/aifw-core/src/dns_blocklists.rs
@@ -688,9 +688,17 @@ pub async fn delete_pattern(pool: &SqlitePool, table: &str, id: i64) -> Result<(
 // ============================================================================
 
 async fn fetch(url: &str) -> Result<Vec<u8>, String> {
+    // SEC-H3 (#288): block SSRF / local-file reads via operator-set blocklist
+    // URLs — https-only, no internal/metadata targets. Redirects stay enabled
+    // (--proto-redir =https) so http→internal redirects are refused.
+    crate::net_safety::validate_outbound_url(url).await?;
     let out = tokio::process::Command::new("curl")
         .args([
             "-sfL",
+            "--proto",
+            "=https",
+            "--proto-redir",
+            "=https",
             "--max-time",
             &HTTP_TIMEOUT_SECS.to_string(),
             "--max-filesize",
@@ -1147,6 +1155,22 @@ pub fn spawn_scheduler(pool: SqlitePool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// SEC-H3 (#288): fetch() must reject SSRF / local-file URLs before it
+    /// ever spawns curl. All cases below fail validation without a network or
+    /// DNS round-trip (bad scheme or literal internal IP).
+    #[tokio::test]
+    async fn fetch_rejects_unsafe_urls() {
+        for bad in [
+            "file:///etc/passwd",
+            "http://example.com/list.txt",
+            "https://127.0.0.1/list.txt",
+            "https://10.0.0.1/list.txt",
+            "https://169.254.169.254/latest/meta-data/",
+        ] {
+            assert!(fetch(bad).await.is_err(), "should reject {bad}");
+        }
+    }
 
     #[test]
     fn parses_hosts_format() {

--- a/aifw-core/src/lib.rs
+++ b/aifw-core/src/lib.rs
@@ -16,7 +16,10 @@ pub mod ha;
 pub mod migrations;
 pub mod multiwan;
 pub mod nat;
-pub mod net_safety;
+/// SSRF guard for operator-configurable outbound HTTP. Relocated to
+/// `aifw-common` so downloaders in sibling crates (aifw-ids) can share it;
+/// re-exported here so existing `crate::net_safety::…` call sites keep working.
+pub use aifw_common::net_safety;
 pub mod path_safety;
 pub mod pf_tuning;
 pub mod s3_backup;

--- a/aifw-ids/src/rules/manager.rs
+++ b/aifw-ids/src/rules/manager.rs
@@ -155,6 +155,14 @@ impl RulesetManager {
             .as_deref()
             .ok_or_else(|| crate::IdsError::Config("Ruleset has no source URL".into()))?;
 
+        // SEC-H1 (#286): reject SSRF / local-file targets before downloading a
+        // ruleset from an operator-set source_url. https-only, no
+        // internal/metadata hosts. Applies to both the `fetch` and `curl`
+        // paths below since it gates on the URL itself.
+        aifw_common::net_safety::validate_outbound_url(url)
+            .await
+            .map_err(|e| crate::IdsError::Config(format!("unsafe ruleset URL: {e}")))?;
+
         tracing::info!(url, ruleset = %ruleset.name, "downloading ruleset");
 
         // Download to temp file using fetch (FreeBSD) or curl
@@ -171,7 +179,16 @@ impl RulesetManager {
 
         if !downloaded {
             let output = Command::new("curl")
-                .args(["-sL", "-o", &tmp, url])
+                .args([
+                    "-sL",
+                    "--proto",
+                    "=https",
+                    "--proto-redir",
+                    "=https",
+                    "-o",
+                    &tmp,
+                    url,
+                ])
                 .output()
                 .await
                 .map_err(|e| crate::IdsError::Config(format!("download failed: {e}")))?;
@@ -449,6 +466,39 @@ mod tests {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         crate::IdsEngine::migrate(&pool).await.unwrap();
         pool
+    }
+
+    /// SEC-H1 (#286): download_and_store_rules must reject SSRF / local-file
+    /// source URLs before spawning fetch/curl. Every case fails validation
+    /// without a network or DNS round-trip (bad scheme or literal internal IP).
+    #[tokio::test]
+    async fn download_rejects_unsafe_urls() {
+        let pool = test_pool().await;
+        let mgr = RulesetManager::new(pool);
+
+        for bad in [
+            "file:///etc/passwd",
+            "http://example.com/emerging-all.rules",
+            "https://127.0.0.1/x.rules",
+            "https://169.254.169.254/x.rules",
+        ] {
+            let rs = IdsRuleset {
+                id: Uuid::new_v4(),
+                name: "bad".into(),
+                source_url: Some(bad.into()),
+                rule_format: RuleFormat::Suricata,
+                enabled: true,
+                auto_update: false,
+                update_interval_hours: 0,
+                last_updated: None,
+                rule_count: 0,
+                created_at: Utc::now(),
+            };
+            assert!(
+                mgr.download_and_store_rules(&rs).await.is_err(),
+                "should reject {bad}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.7",
+  "version": "5.97.8",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Fixes **SEC-H1/H2/H3** (#286 / #287 / #288). Three operator-configurable downloaders shelled out to `fetch`/`curl` with **no URL validation**, letting an admin-API-capable attacker steer the daemon at `127.0.0.1`, RFC1918 LAN hosts, cloud metadata (`169.254.169.254`), or `file://` local paths — SSRF + local file read.

## Approach
The `net_safety` SSRF guard already existed (https-only; rejects loopback/RFC1918/link-local/CGNAT/ULA/metadata) but lived in `aifw-core`, which `aifw-ids` doesn't depend on.

- **Relocated** `net_safety` → `aifw-common` (the shared base every crate depends on) so all three downloaders can call it. Re-exported from `aifw-core`, so existing `ddns`/`acme_export` call sites are unchanged.
- Swapped `reqwest::Url` → `url::Url` to avoid pulling `reqwest` into `aifw-common` (`url 2.5.8` was already in the tree — no new deps).
- Each downloader now calls `validate_outbound_url()` before fetching and passes `curl --proto =https --proto-redir =https`.

## Redirect policy
**Compatible** (per decision): redirects stay enabled, but `--proto-redir =https` refuses a redirect to `http://` or a non-https target. Residual same-scheme redirect-to-public-then-rebind is accepted as out of scope for a shell-out client.

## ⚠️ Behavior change
Enforces **https-only**. Any existing `http://` ruleset / alias URL-table / blocklist URL will now be **rejected** — operators must switch those to `https://`.

## Not included
**#289** (AI provider `curl -k`) is intentionally excluded: its endpoint is frequently a legitimate local LLM on loopback/RFC1918, so it needs a different policy. Tracked separately.

## Tests
- Guard-level: `file://`, `http://`, literal loopback, metadata IP (all network-free).
- Per-site wiring: `download_and_store_rules` (IDS) and `fetch` (DNS blocklist) reject unsafe URLs before spawning curl.
- Full suites green (aifw-common/core/ids), `clippy -D warnings` clean.

Version bumped to 5.97.8.

Closes #286
Closes #287
Closes #288