### PR TITLE
ai: TLS verified by default, per-provider opt-in skip for local endpoints (#289)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.8"
+version = "5.97.9"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/ai_analysis.rs
+++ b/aifw-api/src/ai_analysis.rs
@@ -40,6 +40,13 @@ pub async fn run_analysis(pool: &SqlitePool) -> Result<u32, String> {
     let model = get_config(pool, &format!("ai_{provider}_model"))
         .await
         .unwrap_or_default();
+    // SEC-H4 (#289): TLS verification is on by default. Operators running a
+    // local endpoint with a self-signed cert can opt into skip-verify per
+    // provider instead of it being forced on for everyone.
+    let tls_insecure = get_config(pool, &format!("ai_{provider}_tls_insecure"))
+        .await
+        .map(|v| v == "true")
+        .unwrap_or(false);
 
     if endpoint.is_empty() {
         return Err("AI provider endpoint not configured".into());
@@ -111,7 +118,15 @@ Respond with ONLY a JSON object, no markdown, no explanation outside the JSON:
 
         // 5. Call the AI provider
         let start = std::time::Instant::now();
-        let response = call_ai_provider(&provider, &endpoint, &api_key, &model, &prompt).await;
+        let response = call_ai_provider(
+            &provider,
+            &endpoint,
+            &api_key,
+            &model,
+            &prompt,
+            tls_insecure,
+        )
+        .await;
         let duration_ms = start.elapsed().as_millis() as i64;
 
         match response {
@@ -188,14 +203,33 @@ Respond with ONLY a JSON object, no markdown, no explanation outside the JSON:
     Ok(classified)
 }
 
+/// Reject an AI endpoint URL whose scheme isn't http/https (e.g. `file://`,
+/// `gopher://`). Unlike the strict outbound guard used for threat-intel
+/// downloaders, this deliberately allows loopback/RFC1918 hosts because a
+/// local LLM (Ollama, LM Studio) is the common, legitimate case for #289.
+pub(crate) fn require_http_url(url: &str) -> Result<(), String> {
+    let l = url.trim().to_ascii_lowercase();
+    if l.starts_with("http://") || l.starts_with("https://") {
+        Ok(())
+    } else {
+        Err(format!("AI endpoint must be http(s): {url}"))
+    }
+}
+
 /// Call the AI provider's chat completion API.
+///
+/// `tls_insecure` skips TLS certificate verification (`curl -k`). It is
+/// off by default and only enabled when the operator opts in per provider —
+/// intended for local endpoints with self-signed certs.
 async fn call_ai_provider(
     provider: &str,
     endpoint: &str,
     api_key: &str,
     model: &str,
     prompt: &str,
+    tls_insecure: bool,
 ) -> Result<String, String> {
+    require_http_url(endpoint)?;
     let (url, body) = match provider {
         "openai" | "lm_studio" => {
             let url = format!("{}/chat/completions", endpoint.trim_end_matches('/'));
@@ -230,8 +264,11 @@ async fn call_ai_provider(
 
     let body_str = serde_json::to_string(&body).map_err(|e| e.to_string())?;
 
-    let mut args = vec![
-        "-sk".to_string(),
+    let mut args = vec!["-s".to_string()];
+    if tls_insecure {
+        args.push("-k".to_string());
+    }
+    args.extend([
         "--connect-timeout".to_string(),
         "30".to_string(),
         "-m".to_string(),
@@ -240,7 +277,7 @@ async fn call_ai_provider(
         "POST".to_string(),
         "-H".to_string(),
         "Content-Type: application/json".to_string(),
-    ];
+    ]);
 
     match provider {
         "claude" => {
@@ -449,4 +486,35 @@ pub async fn get_audit_log(
         .collect();
 
     Ok(Json(serde_json::json!({ "entries": entries })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn require_http_url_allows_http_and_https_including_local() {
+        // SEC-H4 (#289): local LLM endpoints (loopback/RFC1918, http) are the
+        // legitimate case and must be allowed — only the scheme is gated.
+        for ok in [
+            "http://127.0.0.1:11434",
+            "http://192.168.1.50:1234",
+            "https://api.openai.com",
+            "HTTPS://Example.com/v1",
+        ] {
+            assert!(require_http_url(ok).is_ok(), "should allow {ok}");
+        }
+    }
+
+    #[test]
+    fn require_http_url_rejects_non_http_schemes() {
+        for bad in [
+            "file:///etc/passwd",
+            "gopher://internal/",
+            "ftp://host/x",
+            "/etc/passwd",
+        ] {
+            assert!(require_http_url(bad).is_err(), "should reject {bad}");
+        }
+    }
 }

--- a/aifw-api/src/routes/mod.rs
+++ b/aifw-api/src/routes/mod.rs
@@ -2263,6 +2263,10 @@ pub async fn get_ai_settings(
         let model = get_val(pool, &format!("ai_{p}_model"))
             .await
             .unwrap_or_default();
+        let tls_insecure = get_val(pool, &format!("ai_{p}_tls_insecure"))
+            .await
+            .map(|v| v == "true")
+            .unwrap_or(false);
 
         configs.push(serde_json::json!({
             "provider": p,
@@ -2270,6 +2274,7 @@ pub async fn get_ai_settings(
             "api_key_set": !api_key.is_empty(),
             "endpoint": endpoint,
             "model": model,
+            "tls_insecure": tls_insecure,
         }));
     }
 
@@ -2297,6 +2302,9 @@ pub struct UpdateAiSettingsRequest {
     pub endpoint: Option<String>,
     pub model: Option<String>,
     pub provider_enabled: Option<bool>,
+    /// SEC-H4 (#289): opt-in skip of TLS cert verification for a provider,
+    /// for local endpoints with self-signed certs. Off unless explicitly set.
+    pub tls_insecure: Option<bool>,
 }
 
 pub async fn update_ai_settings(
@@ -2334,6 +2342,14 @@ pub async fn update_ai_settings(
         if let Some(ref model) = req.model {
             save_val(pool, &format!("ai_{provider}_model"), model).await;
         }
+        if let Some(insecure) = req.tls_insecure {
+            save_val(
+                pool,
+                &format!("ai_{provider}_tls_insecure"),
+                if insecure { "true" } else { "false" },
+            )
+            .await;
+        }
         if let Some(enabled) = req.provider_enabled {
             save_val(
                 pool,
@@ -2349,9 +2365,17 @@ pub async fn update_ai_settings(
 
 // --- AI HTTP helpers (curl with fetch fallback for FreeBSD) ---
 
-async fn http_get_status(url: &str, auth: &str, provider: &str) -> Result<(String, bool), String> {
+async fn http_get_status(
+    url: &str,
+    auth: &str,
+    provider: &str,
+    tls_insecure: bool,
+) -> Result<(String, bool), String> {
+    // Reject non-http(s) schemes up front — gates both the curl and the
+    // fetch fallback (FreeBSD `fetch` honors file://).
+    crate::ai_analysis::require_http_url(url)?;
     // Try curl first, fall back to fetch (FreeBSD built-in)
-    let result = if let Ok(output) = build_curl_status(url, auth, provider).await {
+    let result = if let Ok(output) = build_curl_status(url, auth, provider, tls_insecure).await {
         output
     } else if let Ok(output) = build_fetch_status(url).await {
         output
@@ -2365,19 +2389,24 @@ async fn build_curl_status(
     url: &str,
     auth: &str,
     provider: &str,
+    tls_insecure: bool,
 ) -> Result<(String, bool), String> {
-    let mut args: Vec<String> = vec![
-        "-sk",
-        "--connect-timeout",
-        "5",
-        "-o",
-        "/dev/null",
-        "-w",
-        "%{http_code}",
-    ]
-    .into_iter()
-    .map(String::from)
-    .collect();
+    let mut args: Vec<String> = vec!["-s"].into_iter().map(String::from).collect();
+    if tls_insecure {
+        args.push("-k".to_string());
+    }
+    args.extend(
+        [
+            "--connect-timeout",
+            "5",
+            "-o",
+            "/dev/null",
+            "-w",
+            "%{http_code}",
+        ]
+        .into_iter()
+        .map(String::from),
+    );
     if !auth.is_empty() {
         if provider == "claude" {
             args.extend([
@@ -2422,9 +2451,16 @@ async fn build_fetch_status(url: &str) -> Result<(String, bool), String> {
     ))
 }
 
-async fn http_get_body(url: &str, auth: &str, provider: &str) -> Result<String, String> {
+async fn http_get_body(
+    url: &str,
+    auth: &str,
+    provider: &str,
+    tls_insecure: bool,
+) -> Result<String, String> {
+    // Reject non-http(s) schemes up front — gates the fetch fallback too.
+    crate::ai_analysis::require_http_url(url)?;
     // Try curl first
-    if let Ok(body) = build_curl_body(url, auth, provider).await {
+    if let Ok(body) = build_curl_body(url, auth, provider, tls_insecure).await {
         return Ok(body);
     }
     // Fallback to fetch
@@ -2436,11 +2472,17 @@ async fn http_get_body(url: &str, auth: &str, provider: &str) -> Result<String, 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-async fn build_curl_body(url: &str, auth: &str, provider: &str) -> Result<String, String> {
-    let mut args: Vec<String> = vec!["-sk", "--connect-timeout", "5"]
-        .into_iter()
-        .map(String::from)
-        .collect();
+async fn build_curl_body(
+    url: &str,
+    auth: &str,
+    provider: &str,
+    tls_insecure: bool,
+) -> Result<String, String> {
+    let mut args: Vec<String> = vec!["-s"].into_iter().map(String::from).collect();
+    if tls_insecure {
+        args.push("-k".to_string());
+    }
+    args.extend(["--connect-timeout", "5"].into_iter().map(String::from));
     if !auth.is_empty() {
         if provider == "claude" {
             args.extend([
@@ -2492,6 +2534,7 @@ pub async fn test_ai_provider(
     let api_key = get_val(pool, &format!("ai_{provider}_api_key")).await;
     let endpoint = get_val(pool, &format!("ai_{provider}_endpoint")).await;
     let model = get_val(pool, &format!("ai_{provider}_model")).await;
+    let stored_insecure = get_val(pool, &format!("ai_{provider}_tls_insecure")).await == "true";
 
     // Allow request overrides for testing before saving
     let endpoint = req
@@ -2504,6 +2547,10 @@ pub async fn test_ai_provider(
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
         .unwrap_or(api_key);
+    let tls_insecure = req
+        .get("tls_insecure")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(stored_insecure);
 
     if endpoint.is_empty() {
         return Ok(Json(
@@ -2536,10 +2583,11 @@ pub async fn test_ai_provider(
     };
 
     // Test connectivity — try curl, fall back to fetch (FreeBSD built-in)
-    let (status_code, success) = match http_get_status(&models_url, &auth_header, provider).await {
-        Ok((code, ok)) => (code, ok),
-        Err(_) => return Err(internal()),
-    };
+    let (status_code, success) =
+        match http_get_status(&models_url, &auth_header, provider, tls_insecure).await {
+            Ok((code, ok)) => (code, ok),
+            Err(_) => return Err(internal()),
+        };
 
     Ok(Json(serde_json::json!({
         "success": success,
@@ -2569,6 +2617,7 @@ pub async fn list_ai_models(
 
     let api_key = get_val(pool, &format!("ai_{provider}_api_key")).await;
     let endpoint = get_val(pool, &format!("ai_{provider}_endpoint")).await;
+    let tls_insecure = get_val(pool, &format!("ai_{provider}_tls_insecure")).await == "true";
 
     if endpoint.is_empty() {
         return Ok(Json(
@@ -2610,7 +2659,7 @@ pub async fn list_ai_models(
     } else {
         String::new()
     };
-    let body = http_get_body(&url, &auth, provider.as_str())
+    let body = http_get_body(&url, &auth, provider.as_str(), tls_insecure)
         .await
         .unwrap_or_default();
 

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -862,6 +862,65 @@ mod tests {
         resp.assert_status(StatusCode::UNAUTHORIZED);
     }
 
+    /// SEC-H4 (#289): the per-provider `tls_insecure` opt-in must persist and
+    /// round-trip through GET /settings/ai (default false).
+    #[tokio::test]
+    async fn test_ai_tls_insecure_roundtrip() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        let ollama = |body: &Value| -> Value {
+            body["providers"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|p| p["provider"] == "ollama")
+                .unwrap()
+                .clone()
+        };
+
+        // Default: not configured → tls_insecure false.
+        let resp = server
+            .get("/api/v1/settings/ai")
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        assert_eq!(ollama(&resp.json::<Value>())["tls_insecure"], false);
+
+        // Opt in.
+        server
+            .put("/api/v1/settings/ai")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "provider": "ollama",
+                "endpoint": "http://127.0.0.1:11434",
+                "tls_insecure": true
+            }))
+            .await
+            .assert_status_ok();
+
+        let resp = server
+            .get("/api/v1/settings/ai")
+            .authorization_bearer(&token)
+            .await;
+        let cfg = ollama(&resp.json::<Value>());
+        assert_eq!(cfg["tls_insecure"], true);
+        assert_eq!(cfg["endpoint"], "http://127.0.0.1:11434");
+
+        // Opt back out.
+        server
+            .put("/api/v1/settings/ai")
+            .authorization_bearer(&token)
+            .json(&json!({"provider": "ollama", "tls_insecure": false}))
+            .await
+            .assert_status_ok();
+        let resp = server
+            .get("/api/v1/settings/ai")
+            .authorization_bearer(&token)
+            .await;
+        assert_eq!(ollama(&resp.json::<Value>())["tls_insecure"], false);
+    }
+
     /// Helper: create admin + a viewer user, return (admin_token, viewer_token)
     async fn create_admin_and_viewer(server: &TestServer) -> (String, String) {
         let admin_token = create_user_and_login(server).await;

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.8",
+  "version": "5.97.9",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/src/app/settings/page.tsx
+++ b/aifw-ui/src/app/settings/page.tsx
@@ -203,7 +203,7 @@ export default function SettingsPage() {
   // --- AI Providers ---
   const [aiEnabled, setAiEnabled] = useState(false);
   const [aiActiveProvider, setAiActiveProvider] = useState("");
-  const [aiProviders, setAiProviders] = useState<{ provider: string; enabled: boolean; api_key_set: boolean; endpoint: string; model: string }[]>([]);
+  const [aiProviders, setAiProviders] = useState<{ provider: string; enabled: boolean; api_key_set: boolean; endpoint: string; model: string; tls_insecure?: boolean }[]>([]);
   const [aiFeedback, setAiFeedback] = useState<SectionFeedback | null>(null);
   const [aiSaving, setAiSaving] = useState(false);
   const [aiLoading, setAiLoading] = useState(true);
@@ -211,6 +211,7 @@ export default function SettingsPage() {
   const [aiEditKey, setAiEditKey] = useState("");
   const [aiEditEndpoint, setAiEditEndpoint] = useState("");
   const [aiEditModel, setAiEditModel] = useState("");
+  const [aiEditTlsInsecure, setAiEditTlsInsecure] = useState(false);
   const [aiModels, setAiModels] = useState<string[]>([]);
   const [aiModelsLoading, setAiModelsLoading] = useState(false);
   const [aiTesting, setAiTesting] = useState(false);
@@ -810,6 +811,7 @@ export default function SettingsPage() {
       if (aiEditKey) body.api_key = aiEditKey;
       if (aiEditEndpoint) body.endpoint = aiEditEndpoint;
       if (aiEditModel) body.model = aiEditModel;
+      body.tls_insecure = aiEditTlsInsecure;
       const res = await authFetch(`${API}/api/v1/settings/ai`, {
         method: "PUT", headers: authHeaders(), body: JSON.stringify(body),
       });
@@ -858,9 +860,10 @@ export default function SettingsPage() {
     setAiTesting(true);
     setAiTestResult(null);
     try {
-      const body: Record<string, string> = { provider };
+      const body: Record<string, unknown> = { provider };
       if (aiEditEndpoint) body.endpoint = aiEditEndpoint;
       if (aiEditKey) body.api_key = aiEditKey;
+      body.tls_insecure = aiEditTlsInsecure;
       const res = await authFetch(`${API}/api/v1/settings/ai/test`, {
         method: "POST", headers: authHeaders(), body: JSON.stringify(body),
       });
@@ -1938,6 +1941,7 @@ export default function SettingsPage() {
                               setAiEditKey("");
                               setAiEditEndpoint(cfg?.endpoint || prov.defaultEndpoint);
                               setAiEditModel(cfg?.model || prov.defaultModel);
+                              setAiEditTlsInsecure(cfg?.tls_insecure ?? false);
                               setAiModels([]);
                               setAiTestResult(null);
                             }
@@ -2013,6 +2017,20 @@ export default function SettingsPage() {
                             )}
                           </div>
                         </div>
+                        <label className="flex items-start gap-2 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={aiEditTlsInsecure}
+                            onChange={e => setAiEditTlsInsecure(e.target.checked)}
+                            className="mt-0.5"
+                          />
+                          <span className="text-xs text-[var(--text-secondary)]">
+                            Skip TLS certificate verification
+                            <span className="block text-[10px] text-[var(--text-muted)]">
+                              Only for local endpoints with a self-signed cert. Leave off for public providers.
+                            </span>
+                          </span>
+                        </label>
                         <div className="flex items-center justify-between">
                           <div className="flex items-center gap-2">
                             <button


### PR DESCRIPTION
Fixes **SEC-H4** (#289). The AI provider integration called `curl -sk`, which **unconditionally disabled TLS certificate verification** (silent MITM exposure) on every call — analysis, connection test, and model list.

## Why not the SSRF guard used for #286–288
A local LLM on loopback/RFC1918 (Ollama, LM Studio) is the **legitimate common case** here, so blanket-blocking internal endpoints would break real setups. Instead:

- **TLS verified by default:** `-sk` → `-s`, with `-k` added only on opt-in.
- **Per-provider opt-in** `ai_<provider>_tls_insecure` (default off). For operators running a local endpoint with a **self-signed cert**. Threaded through analysis (`call_ai_provider`), connection test (`http_get_status`), and model list (`http_get_body`).
- **Scheme guard** `require_http_url()` rejects non-`http(s)` endpoints (`file://`, `gopher://`) while still allowing `http` and local hosts.
- **UI toggle** in Settings → AI provider ("Skip TLS certificate verification"), persisted via `PUT /settings/ai`, returned by `GET`.

## ⚠️ Behavior change
TLS is now verified by default. Anyone previously relying on the implicit `-k` with an **https self-signed local endpoint** must tick the new opt-in. Plain-http local endpoints (e.g. Ollama on `http://localhost:11434`) are unaffected — no cert to verify.

## Tests
- `require_http_url` allow (http/https incl. local) / reject (`file://`, `gopher://`, `ftp://`, bare path).
- Settings round-trip: `tls_insecure` persists through PUT→GET and defaults to `false`.
- Full aifw-api suite green (129), `clippy -D warnings` clean, UI lint + `npm run build` pass.

Version bumped to 5.97.9.

Closes #289