### PR TITLE
cluster: restrict snapshot/cert push to a registered peer key (#297)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.10"
+version = "5.97.11"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/auth/mod.rs
+++ b/aifw-api/src/auth/mod.rs
@@ -755,11 +755,20 @@ pub async fn use_recovery_code(pool: &SqlitePool, user_id: &str, code: &str) -> 
 // API key operations
 // ============================================================
 
+/// API key names reserved for internal cluster identities (the daemon loopback
+/// key and the inbound peer key). `create_api_key` refuses to mint these via
+/// the normal Users → API Keys path so an operator can't self-grant peer /
+/// daemon privilege by naming a regular key one of them (SEC-H12).
+pub const RESERVED_API_KEY_NAMES: &[&str] = &["aifw-daemon-loopback", "aifw-cluster-peer"];
+
 pub async fn create_api_key(
     pool: &SqlitePool,
     user_id: Uuid,
     name: &str,
 ) -> Result<CreateApiKeyResponse, StatusCode> {
+    if RESERVED_API_KEY_NAMES.contains(&name) {
+        return Err(StatusCode::BAD_REQUEST);
+    }
     let raw_key = format!("aifw_{}", Uuid::new_v4().to_string().replace('-', ""));
     let prefix = raw_key[..12].to_string();
     let key_hash = hash_password(&raw_key)?;

--- a/aifw-api/src/cluster.rs
+++ b/aifw-api/src/cluster.rs
@@ -20,6 +20,24 @@ use uuid::Uuid;
 /// `/cluster/internal/*` endpoints.
 const DAEMON_LOOPBACK_KEY_NAME: &str = "aifw-daemon-loopback";
 
+/// SEC-H12: reserved name for the inbound peer key that a node registers so a
+/// master can push snapshots / certs to it. Only requests authenticated with a
+/// key of this name (or the daemon-loopback key) may call `snapshot_put` /
+/// `cert_push`. The name is reserved — `create_api_key` refuses to mint it via
+/// the normal Users → API Keys path, so an operator can't self-grant peer
+/// privilege by naming a regular key this. See [`crate::auth::RESERVED_API_KEY_NAMES`].
+pub(crate) const PEER_KEY_NAME: &str = "aifw-cluster-peer";
+
+/// True if `auth` presents the reserved inbound peer key or the daemon-loopback
+/// key. Everything else — a broad `HaManage` JWT, an operator API key — is
+/// rejected on the replication endpoints (SEC-H12).
+fn is_authorized_peer(auth: &crate::auth::AuthUser) -> bool {
+    matches!(
+        auth.api_key_name.as_deref(),
+        Some(PEER_KEY_NAME) | Some(DAEMON_LOOPBACK_KEY_NAME)
+    )
+}
+
 pub fn read_routes() -> Router<AppState> {
     Router::new()
         .route("/api/v1/cluster/carp", get(list_carp))
@@ -67,6 +85,8 @@ pub fn write_routes() -> Router<AppState> {
             "/api/v1/cluster/loopback-key/generate",
             post(generate_loopback_key),
         )
+        // SEC-H12: import the inbound peer key so a master can push to us.
+        .route("/api/v1/cluster/peer-key", post(register_peer_key))
         // Internal endpoints — called by aifw-daemon's RoleWatcher and HealthProber.
         // Protected by the same Permission::HaManage middleware as the rest of
         // cluster_write; the daemon authenticates via AIFW_LOOPBACK_API_KEY.
@@ -674,15 +694,26 @@ async fn snapshot_get(State(s): State<AppState>) -> Result<String, StatusCode> {
     Ok(data)
 }
 
-async fn snapshot_put(State(s): State<AppState>, body: String) -> StatusCode {
+async fn snapshot_put(
+    State(s): State<AppState>,
+    Extension(auth): Extension<crate::auth::AuthUser>,
+    body: String,
+) -> StatusCode {
+    // SEC-H12: only a registered peer / the daemon may replace the DB. A broad
+    // HaManage credential is no longer sufficient.
+    if !is_authorized_peer(&auth) {
+        tracing::warn!(
+            key_name = ?auth.api_key_name,
+            "snapshot_put: rejected non-peer caller"
+        );
+        return StatusCode::FORBIDDEN;
+    }
     // Master never accepts pushes — split-brain protection
     if is_carp_master_locally().await {
         return StatusCode::CONFLICT;
     }
     match apply_snapshot_data(&s, &body).await {
         Ok(hash) => {
-            // Use Uuid::nil as node_id placeholder (peer identity improvable later
-            // once per-peer API key is cross-referenced with the authenticated key)
             let _ = s
                 .cluster_engine
                 .record_snapshot_apply(Uuid::nil(), &hash, "peer")
@@ -821,7 +852,20 @@ struct CertPushReq {
     private_key_pem: String,
 }
 
-async fn cert_push(State(s): State<AppState>, Json(r): Json<CertPushReq>) -> StatusCode {
+async fn cert_push(
+    State(s): State<AppState>,
+    Extension(auth): Extension<crate::auth::AuthUser>,
+    Json(r): Json<CertPushReq>,
+) -> StatusCode {
+    // SEC-H12: only a registered peer / the daemon may push a cert + private
+    // key. A broad HaManage credential is no longer sufficient.
+    if !is_authorized_peer(&auth) {
+        tracing::warn!(
+            key_name = ?auth.api_key_name,
+            "cert_push: rejected non-peer caller"
+        );
+        return StatusCode::FORBIDDEN;
+    }
     // Master never accepts cert pushes — defends against a stale standby
     // pushing back during a network partition.
     if aifw_core::is_local_master().await {
@@ -862,6 +906,9 @@ async fn cert_push(State(s): State<AppState>, Json(r): Json<CertPushReq>) -> Sta
 struct HealthSummary {
     missing_peer_keys: Vec<String>,
     loopback_key_missing: bool,
+    /// SEC-H12: true when this node has no inbound peer key registered under
+    /// the reserved name, so a master's snapshot/cert push would be refused.
+    inbound_peer_key_missing: bool,
     warnings: Vec<String>,
 }
 
@@ -895,6 +942,16 @@ async fn health_summary(State(s): State<AppState>) -> Result<Json<HealthSummary>
     .unwrap_or(0)
         == 0;
 
+    // SEC-H12: a standby needs a registered inbound peer key or the master's
+    // snapshot/cert push is now refused (a broad HaManage key no longer works).
+    let inbound_peer_key_missing =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM api_keys WHERE name = ?1")
+            .bind(PEER_KEY_NAME)
+            .fetch_one(&s.pool)
+            .await
+            .unwrap_or(0)
+            == 0;
+
     let mut warnings: Vec<String> = Vec::new();
     if !missing.is_empty() {
         warnings.push(format!(
@@ -907,10 +964,16 @@ async fn health_summary(State(s): State<AppState>) -> Result<Json<HealthSummary>
             "Loopback API key not registered — cluster background tasks (replicator, role watcher, health prober) are disabled. Generate it below or re-run aifw-setup.".to_string(),
         );
     }
+    if inbound_peer_key_missing && local_role != ClusterRole::Standalone {
+        warnings.push(
+            "No inbound peer key registered — this node will REFUSE snapshot/cert pushes from the master. Generate a peer key on the master for this node, copy it, and register it here via 'Register Peer Key'.".to_string(),
+        );
+    }
 
     Ok(Json(HealthSummary {
         missing_peer_keys: missing,
         loopback_key_missing,
+        inbound_peer_key_missing,
         warnings,
     }))
 }
@@ -927,6 +990,93 @@ async fn health_summary(State(s): State<AppState>) -> Result<Json<HealthSummary>
 // without a CARP-enabled FreeBSD host. These cases are deferred to FreeBSD CI.
 // See: aifw-core/src/ha.rs::current_local_role (is_local_master delegates here).
 // ============================================================
+
+#[derive(Deserialize)]
+struct PeerKeyReq {
+    /// The raw peer API key value generated on the master (via
+    /// `POST /cluster/nodes/{id}/generate-key`), copied here by the operator.
+    key: String,
+}
+
+/// SEC-H12: register (import) the inbound peer API key on this node under the
+/// reserved [`PEER_KEY_NAME`], so the master can authenticate to `snapshot_put`
+/// / `cert_push`. Replaces any existing inbound peer key (a node accepts pushes
+/// from a single master). Mirrors `generate_loopback_key`, but imports a known
+/// value rather than generating one.
+async fn register_peer_key(
+    State(s): State<AppState>,
+    Json(r): Json<PeerKeyReq>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let key = r.key.trim().to_string();
+    if key.len() < 32 {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let prefix = key[..12].to_string();
+    let hash = crate::auth::hash_password(&key)?;
+
+    // Reuse (or create) the locked aifw-daemon system user that also owns the
+    // loopback key.
+    let user_id: String = match sqlx::query_scalar::<_, String>(
+        "SELECT id FROM users WHERE username = 'aifw-daemon' LIMIT 1",
+    )
+    .fetch_optional(&s.pool)
+    .await
+    .map_err(|e| {
+        tracing::warn!(?e, "register_peer_key: user lookup");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })? {
+        Some(id) => id,
+        None => {
+            let uid = Uuid::new_v4().to_string();
+            let dummy = crate::auth::hash_password(&format!(
+                "{}{}",
+                Uuid::new_v4().simple(),
+                Uuid::new_v4().simple()
+            ))?;
+            sqlx::query(
+                "INSERT INTO users (id, username, password_hash, totp_enabled, auth_provider, created_at) \
+                 VALUES (?1, 'aifw-daemon', ?2, 0, 'system', ?3)",
+            )
+            .bind(&uid)
+            .bind(&dummy)
+            .bind(chrono::Utc::now().to_rfc3339())
+            .execute(&s.pool)
+            .await
+            .map_err(|e| {
+                tracing::warn!(?e, "register_peer_key: user insert");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+            uid
+        }
+    };
+
+    // A node accepts pushes from one master — replace any prior inbound key.
+    let _ = sqlx::query("DELETE FROM api_keys WHERE name = ?1")
+        .bind(PEER_KEY_NAME)
+        .execute(&s.pool)
+        .await;
+
+    sqlx::query(
+        "INSERT INTO api_keys (id, name, key_hash, prefix, user_id, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .bind(PEER_KEY_NAME)
+    .bind(&hash)
+    .bind(&prefix)
+    .bind(&user_id)
+    .bind(chrono::Utc::now().to_rfc3339())
+    .execute(&s.pool)
+    .await
+    .map_err(|e| {
+        tracing::warn!(?e, "register_peer_key: api_key insert");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    tracing::info!("ha: registered inbound peer key for replication");
+    Ok(Json(
+        serde_json::json!({ "message": "Peer key registered" }),
+    ))
+}
 
 async fn generate_loopback_key(
     State(s): State<AppState>,

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -921,6 +921,61 @@ mod tests {
         assert_eq!(ollama(&resp.json::<Value>())["tls_insecure"], false);
     }
 
+    /// SEC-H12 (#297): cluster snapshot/cert push must reject a broad HaManage
+    /// credential (a JWT, or any non-peer key) — only a registered peer key or
+    /// the daemon-loopback key is accepted.
+    #[tokio::test]
+    async fn test_cluster_replication_endpoints_reject_non_peer() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await; // admin JWT (has HaManage)
+
+        // snapshot_put (String body) — admin JWT is not a peer → 403.
+        let resp = server
+            .put("/api/v1/cluster/snapshot")
+            .authorization_bearer(&token)
+            .text("{}")
+            .await;
+        resp.assert_status(StatusCode::FORBIDDEN);
+
+        // cert_push (valid JSON so the handler body runs) — also 403.
+        let resp = server
+            .post("/api/v1/cluster/cert-push")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "cert_id": 1,
+                "fullchain_pem": "x",
+                "private_key_pem": "y"
+            }))
+            .await;
+        resp.assert_status(StatusCode::FORBIDDEN);
+    }
+
+    /// SEC-H12 (#297): the reserved cluster key names can't be minted through
+    /// the normal Users → API Keys path (would otherwise self-grant peer
+    /// privilege).
+    #[tokio::test]
+    async fn test_reserved_api_key_names_rejected() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        for name in ["aifw-cluster-peer", "aifw-daemon-loopback"] {
+            let resp = server
+                .post("/api/v1/auth/api-keys")
+                .authorization_bearer(&token)
+                .json(&json!({ "name": name }))
+                .await;
+            resp.assert_status(StatusCode::BAD_REQUEST);
+        }
+
+        // A normal name still works.
+        let resp = server
+            .post("/api/v1/auth/api-keys")
+            .authorization_bearer(&token)
+            .json(&json!({ "name": "my-key" }))
+            .await;
+        resp.assert_status(StatusCode::CREATED);
+    }
+
     /// Helper: create admin + a viewer user, return (admin_token, viewer_token)
     async fn create_admin_and_viewer(server: &TestServer) -> (String, String) {
         let admin_token = create_user_and_login(server).await;

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.10",
+  "version": "5.97.11",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/src/app/cluster/page.tsx
+++ b/aifw-ui/src/app/cluster/page.tsx
@@ -54,6 +54,7 @@ type HealthCheck = {
 type HealthSummary = {
   missing_peer_keys: string[];
   loopback_key_missing: boolean;
+  inbound_peer_key_missing: boolean;
   warnings: string[];
 };
 
@@ -252,6 +253,10 @@ export default function ClusterPage() {
   // Loopback key success message
   const [loopbackMsg, setLoopbackMsg] = useState<string | null>(null);
 
+  // Inbound peer key registration (SEC-H12)
+  const [peerKeyInput, setPeerKeyInput] = useState("");
+  const [peerKeyMsg, setPeerKeyMsg] = useState<string | null>(null);
+
   // CARP VIP form
   const defaultVipForm = {
     vhid: "",
@@ -394,6 +399,29 @@ export default function ClusterPage() {
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to generate loopback key");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Register the inbound peer key so a master can push snapshots/certs here.
+  const registerPeerKey = async () => {
+    const key = peerKeyInput.trim();
+    if (key.length < 32) {
+      setError("Peer key looks too short — paste the full key generated on the master.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const r = await fetchApi<{ message: string }>("/api/v1/cluster/peer-key", {
+        method: "POST",
+        body: JSON.stringify({ key }),
+      });
+      setPeerKeyMsg(r.message || "Peer key registered.");
+      setPeerKeyInput("");
+      await reload();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to register peer key");
     } finally {
       setBusy(false);
     }
@@ -793,6 +821,46 @@ export default function ClusterPage() {
         </div>
       )}
 
+      {/* SEC-H12: register the inbound peer key so the master can push here */}
+      <div
+        className={`rounded p-3 text-sm ${
+          summary?.inbound_peer_key_missing
+            ? "bg-yellow-500/10 border border-yellow-500/40"
+            : "bg-[var(--bg-card)] border border-[var(--border)]"
+        }`}
+      >
+        <div className="font-semibold mb-1">Register Peer Key</div>
+        <div className="text-xs opacity-80 mb-2">
+          Paste the peer key generated on the master (via &quot;Generate Peer
+          Key&quot; for this node) so this node accepts snapshot / cert pushes
+          from it. A broad HaManage key is no longer accepted.
+        </div>
+        <div className="flex gap-2">
+          <input
+            type="password"
+            value={peerKeyInput}
+            onChange={(e) => setPeerKeyInput(e.target.value)}
+            placeholder="Paste peer API key"
+            className="flex-1 bg-[var(--bg-input)] border border-[var(--border)] rounded px-2 py-1.5 text-sm font-mono"
+          />
+          <button
+            onClick={registerPeerKey}
+            disabled={busy || !peerKeyInput.trim()}
+            className="px-3 py-1.5 rounded bg-[var(--accent)] hover:opacity-90 disabled:opacity-50 whitespace-nowrap text-sm"
+          >
+            Register
+          </button>
+        </div>
+        {peerKeyMsg && (
+          <div className="text-xs text-green-400 mt-2 flex justify-between">
+            <span>{peerKeyMsg}</span>
+            <button onClick={() => setPeerKeyMsg(null)} className="underline">
+              dismiss
+            </button>
+          </div>
+        )}
+      </div>
+
       {/* Status banner (existing) */}
       <StatusBanner />
 
@@ -815,10 +883,10 @@ export default function ClusterPage() {
             Peer API key for {generatedKey.nodeName}
           </div>
           <div className="text-xs opacity-80 mb-2">
-            This key is shown ONCE. Copy it and register it on the peer node as
-            an API key (in the peer&apos;s Users &#x2192; API Keys page) before
-            dismissing. This local node will use it to authenticate to{" "}
-            {generatedKey.nodeName}.
+            This key is shown ONCE. Copy it and register it on{" "}
+            {generatedKey.nodeName} via its cluster page &rarr;{" "}
+            &quot;Register Peer Key&quot; before dismissing. This local node
+            will use it to authenticate to {generatedKey.nodeName}.
           </div>
           <code className="block break-all bg-[var(--bg-card)] p-2 rounded mb-2">
             {generatedKey.key}


### PR DESCRIPTION
Fixes **SEC-H12** (#297). `PUT /cluster/snapshot` (**full DB replacement**) and `POST /cluster/cert-push` (installs a **cert + private key** on a standby) were gated only by the `HaManage` permission. **Any** HaManage credential — a broadly-granted operator JWT or API key — could push a malicious snapshot to a standby and fully compromise it.

## Why a mechanical fix wasn't possible
The audit suggested "compare `auth.api_key_name` against the per-peer key name in `cluster_nodes`," but tracing the code:
- Peer keys live in `cluster_nodes` (sha256), **not** `api_keys`, and are **per-direction/distinct**.
- The operator was told to "register" the key via Users → API Keys under an **arbitrary name** — and **no import path for a known key value even existed**. So "register the peer key" wasn't actually possible.

## Fix — identity binding via a reserved name (chosen over hash-match to avoid a bootstrap deadlock)
- **Reserved name** `aifw-cluster-peer` for the inbound peer key. `snapshot_put`/`cert_push` now require the caller's `api_key_name` to be that reserved peer name **or** the daemon-loopback key — everything else is `403`.
- **New `POST /cluster/peer-key`** imports a known peer-key value under the reserved name (mirrors the loopback-key registration) — the previously-missing "register" step. UI: a **"Register Peer Key"** field on the cluster page; the generate-key banner now points operators to it.
- **Reserved both cluster key names in `create_api_key`** so an operator can't self-grant peer/daemon privilege by naming a regular key one of them.
- **`health-summary` warns** when a standby has no inbound peer key registered — guides the migration.

## Migration (existing HA pairs)
Re-register the peer key **once** via the new field. The health warning surfaces this automatically. No bootstrap deadlock (unlike a hash-match approach) because the reserved name is set at registration time, before any replication.

## Tests
`snapshot_put`/`cert_push` reject a non-peer admin JWT (`403`); reserved key names rejected by `create_api_key` while normal names still work. Full aifw-api suite green (132), clippy clean, UI lint + build pass.

Version 5.97.11.

Closes #297