### PR TITLE
security: pf rule-load stdin (drop /tmp TOCTOU) + WS/SSE Origin guard (#290 #295)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.11"
+version = "5.97.12"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -299,6 +299,20 @@ struct Args {
     log_level: String,
 }
 
+/// SEC-H10: is this `Origin` allowed to open a WebSocket / SSE stream?
+/// Native clients (curl, native WS libraries) send no `Origin` and are allowed.
+/// A `None` policy means CORS is `*` (no meaningful allow-list) so any Origin
+/// passes; otherwise the Origin must be in the operator's configured list.
+pub fn origin_allowed(origin: Option<&str>, allowed: &Option<Vec<String>>) -> bool {
+    match origin {
+        None => true,
+        Some(o) => match allowed {
+            None => true,
+            Some(list) => list.iter().any(|a| a.eq_ignore_ascii_case(o)),
+        },
+    }
+}
+
 pub fn build_router(
     state: AppState,
     ui_dir: Option<&std::path::Path>,
@@ -320,6 +334,44 @@ pub fn build_router(
             .allow_origin(AllowOrigin::list(origins))
             .allow_methods(Any)
             .allow_headers(Any)
+    };
+
+    // SEC-H10: defense-in-depth Origin allow-list for the WebSocket / SSE
+    // upgrades. CORS headers don't gate WS upgrades (browsers skip preflight
+    // for them), so a leaked ws-ticket could otherwise be wired up from any
+    // origin. `None` policy means CORS is `*` and we can't allow-list — any
+    // Origin (or none) is accepted; the single-use ticket still gates.
+    let ws_origins: std::sync::Arc<Option<Vec<String>>> =
+        std::sync::Arc::new(if cors_origins == "*" {
+            None
+        } else {
+            Some(
+                cors_origins
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect(),
+            )
+        });
+    let origin_guard = {
+        let ws_origins = ws_origins.clone();
+        middleware::from_fn(
+            move |req: axum::extract::Request, next: axum::middleware::Next| {
+                let ws_origins = ws_origins.clone();
+                async move {
+                    use axum::response::IntoResponse;
+                    let origin = req
+                        .headers()
+                        .get(axum::http::header::ORIGIN)
+                        .and_then(|v| v.to_str().ok());
+                    if !origin_allowed(origin, &ws_origins) {
+                        tracing::warn!(?origin, "rejected WS/SSE upgrade: origin not allowed");
+                        return axum::http::StatusCode::FORBIDDEN.into_response();
+                    }
+                    next.run(req).await
+                }
+            },
+        )
     };
 
     // Public routes (no auth)
@@ -362,8 +414,14 @@ pub fn build_router(
         .route("/api/v1/metrics", get(routes::metrics))
         .route("/api/v1/metrics/list", get(metrics_series::list))
         .route("/api/v1/metrics/series", get(metrics_series::query))
-        .route("/api/v1/ws", get(ws::ws_handler))
-        .route("/api/v1/pending/stream", get(routes::pending_stream))
+        .route(
+            "/api/v1/ws",
+            get(ws::ws_handler).layer(origin_guard.clone()),
+        )
+        .route(
+            "/api/v1/pending/stream",
+            get(routes::pending_stream).layer(origin_guard.clone()),
+        )
         .route("/api/v1/pending", get(routes::get_pending))
         .layer(middleware::from_fn(perm_check!(Permission::DashboardView)));
 
@@ -538,7 +596,10 @@ pub fn build_router(
             get(dns_blocklists::list_customblocks),
         )
         .route("/api/v1/dns/stats", get(dns_blocklists::get_stats_snapshot))
-        .route("/api/v1/dns/stream", get(dns_blocklists::stream_metrics))
+        .route(
+            "/api/v1/dns/stream",
+            get(dns_blocklists::stream_metrics).layer(origin_guard.clone()),
+        )
         .layer(middleware::from_fn(perm_check!(Permission::DnsRead)));
 
     // dns:write

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -976,6 +976,61 @@ mod tests {
         resp.assert_status(StatusCode::CREATED);
     }
 
+    /// Build a test server with a specific CORS/WS origin allow-list.
+    async fn test_app_cors(origins: &str) -> TestServer {
+        let auth_settings = AuthSettings {
+            jwt_secret: "test-secret-key".to_string(),
+            access_token_expiry_mins: 60,
+            refresh_token_expiry_days: 7,
+            require_totp: false,
+            require_totp_for_oauth: false,
+            auto_create_oauth_users: true,
+            max_login_attempts: 5,
+            lockout_duration_secs: 300,
+            allow_registration: true,
+            password_min_length: 8,
+        };
+        let state = crate::create_app_state_in_memory(auth_settings)
+            .await
+            .unwrap();
+        TestServer::new(crate::build_router(state, None, origins, false))
+    }
+
+    /// SEC-H10 (#295): the WS/SSE Origin policy.
+    #[test]
+    fn test_origin_allowed_policy() {
+        // No policy (CORS = "*"): any origin, and no origin, allowed.
+        assert!(crate::origin_allowed(Some("https://evil.test"), &None));
+        assert!(crate::origin_allowed(None, &None));
+
+        // Allow-list: only listed origins; case-insensitive; native (no
+        // Origin) clients still allowed.
+        let allow = Some(vec!["https://ui.example".to_string()]);
+        assert!(crate::origin_allowed(Some("https://ui.example"), &allow));
+        assert!(crate::origin_allowed(Some("HTTPS://UI.EXAMPLE"), &allow));
+        assert!(crate::origin_allowed(None, &allow));
+        assert!(!crate::origin_allowed(Some("https://evil.example"), &allow));
+    }
+
+    /// SEC-H10 (#295): a WebSocket upgrade from a disallowed browser Origin is
+    /// rejected (403) before it reaches the handler, even with valid auth.
+    #[tokio::test]
+    async fn test_ws_rejects_disallowed_origin() {
+        use axum::http::{HeaderName, HeaderValue};
+        let server = test_app_cors("https://ui.example").await;
+        let token = create_user_and_login(&server).await;
+
+        let resp = server
+            .get("/api/v1/ws")
+            .authorization_bearer(&token)
+            .add_header(
+                HeaderName::from_static("origin"),
+                HeaderValue::from_static("https://evil.example"),
+            )
+            .await;
+        resp.assert_status(StatusCode::FORBIDDEN);
+    }
+
     /// Helper: create admin + a viewer user, return (admin_token, viewer_token)
     async fn create_admin_and_viewer(server: &TestServer) -> (String, String) {
         let admin_token = create_user_and_login(server).await;

--- a/aifw-pf/src/ioctl.rs
+++ b/aifw-pf/src/ioctl.rs
@@ -59,24 +59,38 @@ async fn pfctl(args: &[&str]) -> Result<String, PfError> {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+/// Run `sudo /sbin/pfctl <args>` feeding `input` on stdin (via `pfctl -f -`),
+/// so a ruleset is never staged in a world-writable `/tmp` file. Closes the
+/// SEC-H5 TOCTOU where a local user could swap the temp file between the
+/// aifw-user write and the root pfctl read. Shared by every rule/NAT/queue
+/// load path (the pattern `add_rule` always used).
+async fn pfctl_stdin(args: &[&str], input: &str) -> Result<std::process::Output, PfError> {
+    let mut child = Command::new("/usr/local/bin/sudo")
+        .arg("/sbin/pfctl")
+        .args(args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| PfError::Rule(format!("pfctl spawn failed: {e}")))?;
+    if let Some(mut stdin) = child.stdin.take() {
+        use tokio::io::AsyncWriteExt;
+        stdin
+            .write_all(input.as_bytes())
+            .await
+            .map_err(|e| PfError::Rule(format!("pfctl stdin write failed: {e}")))?;
+        // `stdin` drops here, sending EOF before we wait for the process.
+    }
+    child
+        .wait_with_output()
+        .await
+        .map_err(|e| PfError::Rule(format!("pfctl wait failed: {e}")))
+}
+
 #[async_trait]
 impl PfBackend for PfIoctl {
     async fn add_rule(&self, anchor: &str, rule: &str) -> Result<(), PfError> {
-        let mut child = Command::new("/usr/local/bin/sudo")
-            .args(["/sbin/pfctl", "-a", anchor, "-f", "-"])
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-            .map_err(|e| PfError::Rule(format!("pfctl add_rule spawn failed: {e}")))?;
-        if let Some(ref mut stdin) = child.stdin {
-            use tokio::io::AsyncWriteExt;
-            let _ = stdin.write_all(rule.as_bytes()).await;
-        }
-        let output = child
-            .wait_with_output()
-            .await
-            .map_err(|e| PfError::Rule(format!("pfctl add_rule failed: {e}")))?;
+        let output = pfctl_stdin(&["-a", anchor, "-f", "-"], rule).await?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             if stderr.contains("syntax error") {
@@ -98,19 +112,9 @@ impl PfBackend for PfIoctl {
         let ruleset = rules.join("\n");
         tracing::debug!(anchor, rules = %ruleset, "loading pf rules");
 
-        // Write to temp file then load — avoids shell quoting issues with echo
-        let tmp = format!("/tmp/aifw_pf_{}.conf", anchor.replace('/', "_"));
-        tokio::fs::write(&tmp, &ruleset)
-            .await
-            .map_err(|e| PfError::Rule(format!("failed to write temp rules: {e}")))?;
-
-        let output = Command::new("/usr/local/bin/sudo")
-            .args(["/sbin/pfctl", "-a", anchor, "-f", &tmp])
-            .output()
-            .await
-            .map_err(|e| PfError::Rule(format!("pfctl load_rules failed: {e}")))?;
-
-        let _ = tokio::fs::remove_file(&tmp).await;
+        // SEC-H5: pipe the ruleset to `pfctl -f -` via stdin instead of staging
+        // it in a world-writable /tmp file that root then reads.
+        let output = pfctl_stdin(&["-a", anchor, "-f", "-"], &ruleset).await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -416,18 +420,8 @@ impl PfBackend for PfIoctl {
         let ruleset = rules.join("\n");
         tracing::debug!(anchor, rules = %ruleset, "loading pf NAT rules");
 
-        let tmp = format!("/tmp/aifw_pf_nat_{}.conf", anchor.replace('/', "_"));
-        tokio::fs::write(&tmp, &ruleset)
-            .await
-            .map_err(|e| PfError::Rule(format!("failed to write temp NAT rules: {e}")))?;
-
-        let output = Command::new("/usr/local/bin/sudo")
-            .args(["/sbin/pfctl", "-a", anchor, "-N", "-f", &tmp])
-            .output()
-            .await
-            .map_err(|e| PfError::Rule(format!("pfctl load_nat failed: {e}")))?;
-
-        let _ = tokio::fs::remove_file(&tmp).await;
+        // SEC-H5: pipe via stdin (`pfctl -N -f -`) — no /tmp staging.
+        let output = pfctl_stdin(&["-a", anchor, "-N", "-f", "-"], &ruleset).await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -455,16 +449,8 @@ impl PfBackend for PfIoctl {
             return self.flush_queues(anchor).await;
         }
         let ruleset = queues.join("\n");
-        let tmp = format!("/tmp/aifw_pf_queue_{}.conf", anchor.replace('/', "_"));
-        tokio::fs::write(&tmp, &ruleset)
-            .await
-            .map_err(|e| PfError::Rule(format!("failed to write temp queue rules: {e}")))?;
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/sbin/pfctl", "-a", anchor, "-f", &tmp])
-            .output()
-            .await
-            .map_err(|e| PfError::Rule(format!("pfctl load_queues failed: {e}")))?;
-        let _ = tokio::fs::remove_file(&tmp).await;
+        // SEC-H5: pipe via stdin — no /tmp staging.
+        let _ = pfctl_stdin(&["-a", anchor, "-f", "-"], &ruleset).await?;
         Ok(())
     }
 

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -2351,11 +2351,13 @@ pub fn sudoers_content() -> &'static str {
 # aifw-core/src/pf_tuning.rs and aifw-api/src/main.rs. A test in apply.rs
 # (pfctl_sudoers_covers_invocations) guards against forms going missing
 # (the SEC-C2 narrowing dropped `-ss -vv`, breaking the connection list).
-# Per-anchor rule/NAT/queue load, flush and show:
+# Per-anchor rule/NAT/queue load, flush and show. Rule/NAT/queue loads pipe
+# via stdin (`-f -` / `-N -f -`) so no ruleset is ever staged in a
+# world-writable /tmp file (SEC-H5); the old `-f /tmp/aifw_pf_*.conf` grants
+# were removed with that fix.
 aifw ALL=(root) NOPASSWD: /sbin/pfctl -a aifw* -f -
-aifw ALL=(root) NOPASSWD: /sbin/pfctl -a aifw* -f /tmp/aifw_pf_*.conf
+aifw ALL=(root) NOPASSWD: /sbin/pfctl -a aifw* -N -f -
 aifw ALL=(root) NOPASSWD: /sbin/pfctl -a aifw* -f /usr/local/etc/aifw/anchors/aifw*
-aifw ALL=(root) NOPASSWD: /sbin/pfctl -a aifw* -N -f /tmp/aifw_pf_*.conf
 aifw ALL=(root) NOPASSWD: /sbin/pfctl -a aifw* -sr
 aifw ALL=(root) NOPASSWD: /sbin/pfctl -a aifw* -sn
 aifw ALL=(root) NOPASSWD: /sbin/pfctl -a aifw* -sq
@@ -2530,12 +2532,11 @@ mod sudoers_tests {
         let content = sudoers_content();
         // (call site, grant body that must appear verbatim in sudoers)
         let required: &[(&str, &str)] = &[
-            ("load_rules", "/sbin/pfctl -a aifw* -f /tmp/aifw_pf_*.conf"),
+            // SEC-H5: rule/NAT/queue loads pipe via stdin, not a /tmp file.
+            ("load_rules (stdin)", "/sbin/pfctl -a aifw* -f -"),
             ("add_rule (stdin)", "/sbin/pfctl -a aifw* -f -"),
-            (
-                "load_nat_rules",
-                "/sbin/pfctl -a aifw* -N -f /tmp/aifw_pf_*.conf",
-            ),
+            ("load_queues (stdin)", "/sbin/pfctl -a aifw* -f -"),
+            ("load_nat_rules (stdin)", "/sbin/pfctl -a aifw* -N -f -"),
             ("get_rules", "/sbin/pfctl -a aifw* -sr"),
             ("get_nat_rules", "/sbin/pfctl -a aifw* -sn"),
             ("daemon pf drift auto-heal (global -sn)", "/sbin/pfctl -sn"),
@@ -2576,6 +2577,19 @@ mod sudoers_tests {
                 content.contains(grant),
                 "pfctl form for `{site}` is not granted in sudoers — missing `{grant}`. \
                  An uncovered form makes `sudo {grant}` prompt for a password and fail."
+            );
+        }
+
+        // SEC-H5 regression guard: the world-writable /tmp rule-load grants
+        // must NOT come back. Rule/NAT loads now pipe via stdin; a grant that
+        // fnmatch-covers `/tmp/aifw_pf_*.conf` would reopen the TOCTOU.
+        for forbidden in [
+            "/sbin/pfctl -a aifw* -f /tmp/aifw_pf_*.conf",
+            "/sbin/pfctl -a aifw* -N -f /tmp/aifw_pf_*.conf",
+        ] {
+            assert!(
+                !content.contains(forbidden),
+                "SEC-H5: removed /tmp pfctl load grant reappeared: `{forbidden}`"
             );
         }
     }

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.11",
+  "version": "5.97.12",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes the final two HIGH security audit findings.

## SEC-H5 (#290) — pf rule load TOCTOU via world-writable /tmp
`load_rules` / `load_nat_rules` / `load_queues` staged the ruleset in `/tmp/aifw_pf_*.conf`, which root then read via `sudo pfctl -f <tmp>`. A local non-aifw user could **swap the file** in the write→root-read window and inject **arbitrary pf rules into the kernel anchor**. (`load_nat_rules`/`load_queues` shared the same pattern, so all three are fixed.)

- All three now pipe the ruleset to `pfctl -f -` / `-N -f -` over **stdin** — the pattern `add_rule` already used — via a shared `pfctl_stdin` helper. **No temp file exists.**
- Removed the now-unused `/sbin/pfctl -a aifw* -f /tmp/aifw_pf_*.conf` and `-N -f /tmp/...` sudoers grants; added `-N -f -`.
- Updated the `pfctl_sudoers_covers_invocations` guard test to the stdin forms **and added a regression assertion** that the `/tmp` load grants can't reappear (per prior sudoers-drift incidents).

## SEC-H10 (#295) — no Origin validation on WS/SSE upgrades
`/api/v1/ws`, `/api/v1/pending/stream` (SSE) and `/api/v1/dns/stream` did no Origin check. CORS doesn't gate WS upgrades (browsers skip preflight), so a leaked single-use ws-ticket could be wired up cross-origin.

- Added an **Origin allow-list middleware** (derived from the operator's CORS config) on those three routes: a browser `Origin` must be in the list; native clients (no `Origin`) pass; when CORS is `*` any Origin passes (the single-use ticket still gates). Defense-in-depth.

## Tests
`origin_allowed` policy unit test + a WS-upgrade-from-disallowed-origin `403` integration test. pf changes covered by mock/ioctl + the sudoers guard suite (34 pass). Full aifw-api suite green (134), clippy clean.

Version 5.97.12.

Closes #290
Closes #295