### PR TITLE
chore(quality): QUAL audit cleanup batch (#422, #437, #440 + 6 low findings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,5 @@ node_modules/
 freebsd/release/
 freebsd/ui-export/
 
-# Project instructions
-CLAUDE.md
+# CLAUDE.md is project policy and is tracked in the repo — do not ignore it.
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.19"
+version = "5.97.20"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.20"
+version = "5.97.21"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.18"
+version = "5.97.19"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.21"
+version = "5.97.22"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ai/src/lib.rs
+++ b/aifw-ai/src/lib.rs
@@ -1,3 +1,8 @@
+//! # aifw-ai
+//!
+//! **WIP** — AI/ML threat-detection engine. This crate is a work in progress;
+//! see the crate README for current status and caveats.
+
 pub mod detectors;
 pub mod features;
 pub mod inference;

--- a/aifw-api/src/auth/middleware.rs
+++ b/aifw-api/src/auth/middleware.rs
@@ -1,7 +1,6 @@
 //! The request auth middleware plus the RBAC guards: `auth_middleware`
 //! resolves a JWT / API-key / WS-ticket credential into an `AuthUser`
-//! extension, and `require_perm` / `require_admin` / the `perm_check!`
-//! macro gate routes on a permission.
+//! extension, and the `perm_check!` macro gates routes on a permission.
 
 use axum::{
     extract::{Request, State},
@@ -169,34 +168,16 @@ fn query_ticket(q: Option<&str>) -> Option<String> {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct AuthUser {
     pub user_id: String,
+    /// Populated for logging/audit context and future per-request use; not
+    /// currently read by any guard (authz keys off `user_id` + `permissions`).
+    #[allow(dead_code)]
     pub username: String,
     pub permissions: aifw_common::PermissionSet,
     pub role: String,
     /// Set when the request authenticated via an API key; None for JWT/ticket auth.
     pub api_key_name: Option<String>,
-}
-
-/// Permission check middleware. Reads `AuthUser` from request extensions
-/// (set by auth_middleware) and checks if the user has the required permission.
-#[allow(dead_code)]
-pub async fn require_perm(
-    perm: aifw_common::Permission,
-    request: Request,
-    next: Next,
-) -> Result<Response, StatusCode> {
-    let auth_user = request
-        .extensions()
-        .get::<AuthUser>()
-        .ok_or(StatusCode::UNAUTHORIZED)?;
-
-    if !auth_user.permissions.has(perm) {
-        return Err(StatusCode::FORBIDDEN);
-    }
-
-    Ok(next.run(request).await)
 }
 
 /// Macro to create a permission-check middleware closure for use with `from_fn`.
@@ -214,27 +195,4 @@ macro_rules! perm_check {
             Ok::<_, axum::http::StatusCode>(next.run(request).await)
         }
     };
-}
-
-/// Legacy alias — checks users:write permission (admin-level).
-/// Kept for backward compatibility; new code should use perm_check! directly.
-#[allow(dead_code)]
-pub async fn require_admin(
-    State(_state): State<crate::AppState>,
-    request: Request,
-    next: Next,
-) -> Result<Response, StatusCode> {
-    let auth_user = request
-        .extensions()
-        .get::<AuthUser>()
-        .ok_or(StatusCode::UNAUTHORIZED)?;
-
-    if !auth_user
-        .permissions
-        .has(aifw_common::Permission::UsersWrite)
-    {
-        return Err(StatusCode::FORBIDDEN);
-    }
-
-    Ok(next.run(request).await)
 }

--- a/aifw-api/src/auth/revocation.rs
+++ b/aifw-api/src/auth/revocation.rs
@@ -29,8 +29,8 @@ pub async fn is_token_revoked(pool: &SqlitePool, jti: &str) -> bool {
         .is_some()
 }
 
-/// Clean up expired entries from the blacklist (called periodically).
-#[allow(dead_code)]
+/// Clean up expired entries from the blacklist. Spawned on an hourly timer in
+/// `main.rs` so the `revoked_tokens` table doesn't grow without bound.
 pub async fn cleanup_revoked_tokens(pool: &SqlitePool) {
     let now = chrono::Utc::now().to_rfc3339();
     let _ = sqlx::query("DELETE FROM revoked_tokens WHERE expires_at < ?1")

--- a/aifw-api/src/backup_s3.rs
+++ b/aifw-api/src/backup_s3.rs
@@ -6,11 +6,7 @@
 
 use aifw_core::s3_backup as s3;
 use aifw_core::smtp_notify as smtp;
-use axum::{
-    Json,
-    extract::{Path, State},
-    http::StatusCode,
-};
+use axum::{Json, extract::State, http::StatusCode};
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
@@ -363,10 +359,3 @@ pub async fn test_smtp(
         }),
     }
 }
-
-// ============================================================================
-// Unused-but-required path extractor stub so axum's route tooling compiles
-// if/when we add a /restore-by-path variant. Keeping it out of public API.
-// ============================================================================
-#[allow(dead_code)]
-pub(crate) async fn _path_noop(Path(_p): Path<String>) {}

--- a/aifw-api/src/ca.rs
+++ b/aifw-api/src/ca.rs
@@ -48,6 +48,7 @@ pub struct GenerateCaRequest {
     pub common_name: Option<String>,
     pub organization: Option<String>,
     pub validity_days: Option<u32>,
+    // Not yet wired through to key generation — see #489.
     #[allow(dead_code)]
     pub key_type: Option<String>, // "ec" | "rsa2048" | "rsa4096"
 }

--- a/aifw-api/src/dhcp.rs
+++ b/aifw-api/src/dhcp.rs
@@ -1455,7 +1455,7 @@ pub async fn update_ha_config(
         &config.node_id.map(|v| v.to_string()).unwrap_or_default(),
     )
     .await;
-    // TODO: when the cluster cert store lands (#222 / #217 follow-up), reuse the
+    // TODO(#222): when the cluster cert store lands (#217 follow-up), reuse the
     // per-peer API key/cert from cluster_nodes instead of saving DHCP-specific
     // TLS material here.
     save_ha_key(

--- a/aifw-api/src/ids.rs
+++ b/aifw-api/src/ids.rs
@@ -405,11 +405,12 @@ pub async fn delete_ruleset(
 // ============ Rules ============
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 pub struct RulesQuery {
     pub ruleset_id: Option<String>,
     pub enabled: Option<bool>,
+    /// Free-text search — accepted but not yet applied in `list_rules`; see #490.
     #[serde(default)]
+    #[allow(dead_code)]
     pub q: Option<String>,
     pub limit: Option<u32>,
     pub offset: Option<u32>,

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -1485,6 +1485,20 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
+    // Prune expired entries from the JWT revocation blacklist hourly so the
+    // `revoked_tokens` table doesn't grow unbounded (revoked tokens are only
+    // meaningful until they expire on their own).
+    {
+        let pool = state.pool.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(3600));
+            loop {
+                interval.tick().await;
+                auth::cleanup_revoked_tokens(&pool).await;
+            }
+        });
+    }
+
     // Single global dashboard-WS producer (#178). Builds the per-tick
     // payload once and broadcasts to every connected client via
     // `state.ws_tick`, replacing per-client `build_update` cloning.

--- a/aifw-api/src/opnsense/importer.rs
+++ b/aifw-api/src/opnsense/importer.rs
@@ -577,13 +577,31 @@ pub async fn import_opnsense(
     // Capture *pre*-apply state for the commit-confirm rollback target.
     // The previous design captured POST-apply, which meant the auto-revert
     // would "revert" to the just-applied state.
-    let pre_apply_snapshot_json = crate::backup::capture_runtime_snapshot(&state).await.ok();
+    let pre_apply_snapshot_json = match crate::backup::capture_runtime_snapshot(&state).await {
+        Ok(snap) => Some(snap),
+        Err(e) => {
+            tracing::warn!(
+                ?e,
+                "failed to capture pre-apply snapshot; commit-confirm rollback target unavailable"
+            );
+            None
+        }
+    };
 
     // Pre-import snapshot for /api/v1/config/history — captures full
     // FirewallConfig including aliases + static_routes (added in this PR)
     // so the manual one-click restore can revert everything the importer
     // changes that's covered by `apply_firewall_config`.
-    let pre_import_version = save_pre_import_snapshot(&state).await.ok();
+    let pre_import_version = match save_pre_import_snapshot(&state).await {
+        Ok(v) => Some(v),
+        Err(e) => {
+            tracing::warn!(
+                ?e,
+                "failed to save pre-import snapshot; one-click restore point unavailable"
+            );
+            None
+        }
+    };
 
     let mut summary = AppliedCounts::default();
     let mut skipped: Vec<String> = Vec::new();

--- a/aifw-api/src/plugins.rs
+++ b/aifw-api/src/plugins.rs
@@ -202,7 +202,8 @@ pub async fn discover_plugins() -> Result<Json<serde_json::Value>, StatusCode> {
     })))
 }
 
-/// Dispatch a hook event to all plugins (called internally by other modules)
+/// Dispatch a hook event to all plugins. Currently uncalled — see #488 for
+/// wiring this into the event paths that should notify plugins.
 #[allow(dead_code)]
 pub async fn dispatch_hook(
     state: &AppState,

--- a/aifw-api/src/updates.rs
+++ b/aifw-api/src/updates.rs
@@ -718,7 +718,9 @@ pub async fn install_aifw_update_local(
                 while let Some(chunk) = field.chunk().await.map_err(|_| StatusCode::BAD_REQUEST)? {
                     file.write_all(&chunk).await.map_err(|_| internal())?;
                 }
-                file.flush().await.ok();
+                if let Err(e) = file.flush().await {
+                    tracing::warn!(?e, "failed to flush uploaded tarball to disk");
+                }
                 tarball_path = Some(path);
             }
             "sha256" => {

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -1097,6 +1097,10 @@ pub async fn config_diff(db_path: &Path, v1: i64, v2: i64) -> anyhow::Result<()>
 // Static routes
 // ============================================================
 
+/// DDL for the `static_routes` table, shared by every routes_* command so the
+/// schema can't drift between call sites.
+const STATIC_ROUTES_DDL: &str = "CREATE TABLE IF NOT EXISTS static_routes (id TEXT PRIMARY KEY, destination TEXT NOT NULL, gateway TEXT NOT NULL, interface TEXT, metric INTEGER DEFAULT 0, enabled INTEGER NOT NULL DEFAULT 1, description TEXT, created_at TEXT NOT NULL)";
+
 pub async fn routes_add(
     db_path: &Path,
     dest: &str,
@@ -1109,9 +1113,7 @@ pub async fn routes_add(
     let pool = db.pool();
 
     // Ensure table exists
-    sqlx::query(
-        "CREATE TABLE IF NOT EXISTS static_routes (id TEXT PRIMARY KEY, destination TEXT NOT NULL, gateway TEXT NOT NULL, interface TEXT, metric INTEGER DEFAULT 0, enabled INTEGER NOT NULL DEFAULT 1, description TEXT, created_at TEXT NOT NULL)",
-    ).execute(pool).await?;
+    sqlx::query(STATIC_ROUTES_DDL).execute(pool).await?;
 
     let id = Uuid::new_v4().to_string();
     let now = chrono::Utc::now().to_rfc3339();
@@ -1161,9 +1163,7 @@ pub async fn routes_remove(db_path: &Path, id: &str) -> anyhow::Result<()> {
 pub async fn routes_list(db_path: &Path, json: bool) -> anyhow::Result<()> {
     let db = Database::new(db_path).await?;
     let pool = db.pool();
-    let _ = sqlx::query(
-        "CREATE TABLE IF NOT EXISTS static_routes (id TEXT PRIMARY KEY, destination TEXT NOT NULL, gateway TEXT NOT NULL, interface TEXT, metric INTEGER DEFAULT 0, enabled INTEGER NOT NULL DEFAULT 1, description TEXT, created_at TEXT NOT NULL)",
-    ).execute(pool).await;
+    let _ = sqlx::query(STATIC_ROUTES_DDL).execute(pool).await;
 
     let rows = sqlx::query_as::<_, (String, String, String, Option<String>, i32, bool, Option<String>)>(
         "SELECT id, destination, gateway, interface, metric, enabled, description FROM static_routes ORDER BY metric ASC",

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -1815,6 +1815,7 @@ pub async fn update_install_local(
             size_mb
         );
         print!("Proceed? [y/N] ");
+        // best-effort prompt flush; a broken stdout pipe is unactionable here
         std::io::stdout().flush().ok();
         let mut line = String::new();
         std::io::stdin().lock().read_line(&mut line)?;
@@ -1923,6 +1924,7 @@ fn prompt_restart_yes() -> anyhow::Result<bool> {
     use std::io::{BufRead, Write};
 
     print!("Restart services now to activate? [y/N] ");
+    // best-effort prompt flush; a broken stdout pipe is unactionable here
     std::io::stdout().flush().ok();
     let mut line = String::new();
     std::io::stdin().lock().read_line(&mut line)?;

--- a/aifw-common/src/lib.rs
+++ b/aifw-common/src/lib.rs
@@ -1,6 +1,7 @@
-// ============================================================
-// Loopback API constants
-// ============================================================
+//! # aifw-common
+//!
+//! Shared types for AiFw: rules, NAT, VPN, TLS, geo-IP, HA, IDS, and metrics,
+//! plus the loopback API constants used to reach the local `aifw-api` process.
 
 /// Default loopback API port. Used by daemon background tasks and CLI
 /// to reach the local aifw-api process. The actual listen port is

--- a/aifw-common/src/lib.rs
+++ b/aifw-common/src/lib.rs
@@ -7,7 +7,7 @@
 /// to reach the local aifw-api process. The actual listen port is
 /// configured via `aifw-api --listen` but defaults to this value.
 ///
-/// TODO: when peer ports become configurable per-node, store on
+/// TODO(#487): when peer ports become configurable per-node, store on
 /// cluster_nodes and use that instead.
 pub const DEFAULT_LOOPBACK_API_PORT: u16 = 8080;
 pub const DEFAULT_LOOPBACK_API_BASE: &str = "https://127.0.0.1:8080";

--- a/aifw-core/src/lib.rs
+++ b/aifw-core/src/lib.rs
@@ -39,6 +39,8 @@ pub use alias::AliasEngine;
 pub use audit::{AuditAction, AuditLog};
 pub use config::{ConsoleConfig, ConsoleKind, FirewallConfig, SshAccessConfig, SystemConfig};
 pub use config_manager::ConfigManager;
+/// [`Database`] is re-exported from [`db::Database`] as the crate's primary
+/// entry point; prefer `aifw_core::Database` over the fully-qualified path.
 pub use db::Database;
 pub use engine::RuleEngine;
 pub use error::{CoreError, Result};

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -469,7 +469,7 @@ impl VpnEngine {
         // ListenAddress for explicit binding; if AiFw ever migrates to one,
         // this is where the per-iface bind would be wired.
         //
-        // TODO: WG role-change subscriber for explicit wg-quick down on BACKUP
+        // TODO(#486): WG role-change subscriber for explicit wg-quick down on BACKUP
         // (default-false `wg_deconfigure_on_backup` flag, deferred — out of
         // scope for Commit 9 #222).
         let listen_port_s = tunnel.listen_port.to_string();

--- a/aifw-ids-bin/src/handler.rs
+++ b/aifw-ids-bin/src/handler.rs
@@ -43,7 +43,16 @@ impl IpcHandler for EngineHandler {
                 }
             }
             IpcRequest::GetStats => {
-                let cfg = self.engine.load_config().await.ok();
+                let cfg = match self.engine.load_config().await {
+                    Ok(c) => Some(c),
+                    Err(e) => {
+                        tracing::warn!(
+                            ?e,
+                            "failed to load IDS config for GetStats; reporting mode=unknown"
+                        );
+                        None
+                    }
+                };
                 let mode = cfg
                     .as_ref()
                     .map(|c| format!("{:?}", c.mode).to_lowercase())

--- a/aifw-ids/src/capture/netmap.rs
+++ b/aifw-ids/src/capture/netmap.rs
@@ -22,7 +22,7 @@ impl CaptureBackend for NetmapCapture {
     }
 
     fn next_packet(&mut self) -> Option<RawPacket> {
-        // TODO: implement netmap ring buffer read via NIOCREGIF ioctl
+        // TODO(#484): implement netmap ring buffer read via NIOCREGIF ioctl
         None
     }
 

--- a/aifw-ids/src/config.rs
+++ b/aifw-ids/src/config.rs
@@ -5,6 +5,22 @@ use sqlx::SqlitePool;
 
 use crate::Result;
 
+/// Parse a stored numeric config value, warning (instead of silently coercing
+/// to `None`) when the persisted string can't be parsed.
+fn parse_u32_field(field: &str, value: &str) -> Option<u32> {
+    match value.parse() {
+        Ok(v) => Some(v),
+        Err(_) => {
+            tracing::warn!(
+                field,
+                value,
+                "ids config: ignoring unparseable numeric value"
+            );
+            None
+        }
+    }
+}
+
 /// Runtime configuration for the IDS engine.
 /// Wraps `IdsConfig` with thread-safe interior mutability for hot-reload.
 pub struct RuntimeConfig {
@@ -136,19 +152,20 @@ impl RuntimeConfig {
                     cfg.syslog_target = Some(value);
                 }
                 "worker_count" => {
-                    cfg.worker_count = value.parse().ok();
+                    cfg.worker_count = parse_u32_field("worker_count", &value);
                 }
                 "flow_table_size" => {
-                    cfg.flow_table_size = value.parse().ok();
+                    cfg.flow_table_size = parse_u32_field("flow_table_size", &value);
                 }
                 "stream_depth" => {
-                    cfg.stream_depth = value.parse().ok();
+                    cfg.stream_depth = parse_u32_field("stream_depth", &value);
                 }
                 "flow_stream_depth_kb" => {
-                    cfg.flow_stream_depth_kb = value.parse().ok();
+                    cfg.flow_stream_depth_kb = parse_u32_field("flow_stream_depth_kb", &value);
                 }
                 "flow_reassembly_budget_mb" => {
-                    cfg.flow_reassembly_budget_mb = value.parse().ok();
+                    cfg.flow_reassembly_budget_mb =
+                        parse_u32_field("flow_reassembly_budget_mb", &value);
                 }
                 _ => {}
             }

--- a/aifw-ids/src/detect/engine.rs
+++ b/aifw-ids/src/detect/engine.rs
@@ -370,7 +370,7 @@ impl DetectionEngine {
 
         // Variable references (not expanded here — would need config)
         if constraint.starts_with('$') {
-            return true; // TODO: expand variables
+            return true; // TODO(#485): expand variables
         }
 
         // Negation

--- a/aifw-ids/src/output/syslog.rs
+++ b/aifw-ids/src/output/syslog.rs
@@ -8,18 +8,26 @@ use crate::Result;
 /// Syslog alert output — sends alerts to a remote syslog server via UDP.
 pub struct SyslogOutput {
     target: String,
-    socket: Option<UdpSocket>,
+    socket: UdpSocket,
     facility: u8,
 }
 
 impl SyslogOutput {
-    pub fn new(target: String) -> Self {
-        let socket = UdpSocket::bind("0.0.0.0:0").ok();
-        Self {
+    /// Construct a syslog sink bound to an ephemeral local UDP port.
+    ///
+    /// Returns an error (rather than silently dropping every alert) if the
+    /// local socket cannot be bound, so the caller can refuse to register a
+    /// sink that would never emit.
+    pub fn new(target: String) -> Result<Self> {
+        let socket = UdpSocket::bind("0.0.0.0:0").map_err(|e| {
+            tracing::error!(error = %e, "failed to bind local UDP socket for syslog output");
+            e
+        })?;
+        Ok(Self {
             target,
             socket,
             facility: 4, // LOG_AUTH
-        }
+        })
     }
 
     pub fn with_facility(mut self, facility: u8) -> Self {
@@ -40,10 +48,7 @@ impl SyslogOutput {
 #[async_trait::async_trait]
 impl AlertOutput for SyslogOutput {
     async fn emit(&self, alert: &IdsAlert) -> Result<()> {
-        let socket = match &self.socket {
-            Some(s) => s,
-            None => return Ok(()),
-        };
+        let socket = &self.socket;
 
         let syslog_severity = Self::severity_to_syslog(alert.severity.0);
         let priority = (self.facility as u16) * 8 + syslog_severity as u16;

--- a/aifw-ids/src/rules/suricata.rs
+++ b/aifw-ids/src/rules/suricata.rs
@@ -115,22 +115,22 @@ pub fn parse_rule(line: &str, source: RuleSource) -> Result<CompiledRule, String
             }
             "depth" => {
                 if let Some(last) = contents.last_mut() {
-                    last.depth = value.parse().ok();
+                    last.depth = parse_rule_num("depth", value);
                 }
             }
             "offset" => {
                 if let Some(last) = contents.last_mut() {
-                    last.offset = value.parse().ok();
+                    last.offset = parse_rule_num("offset", value);
                 }
             }
             "distance" => {
                 if let Some(last) = contents.last_mut() {
-                    last.distance = value.parse().ok();
+                    last.distance = parse_rule_num("distance", value);
                 }
             }
             "within" => {
                 if let Some(last) = contents.last_mut() {
-                    last.within = value.parse().ok();
+                    last.within = parse_rule_num("within", value);
                 }
             }
             "fast_pattern" => {
@@ -240,6 +240,23 @@ pub fn parse_rules(text: &str, source: RuleSource) -> Vec<CompiledRule> {
 }
 
 /// Set the buffer on the last content match.
+/// Parse a numeric content-option value, warning (instead of silently
+/// dropping) when a rule carries a malformed number so the operator can spot
+/// the typo'd rule.
+fn parse_rule_num<T: std::str::FromStr>(field: &str, value: &str) -> Option<T> {
+    match value.parse() {
+        Ok(v) => Some(v),
+        Err(_) => {
+            tracing::warn!(
+                field,
+                value,
+                "suricata rule: ignoring unparseable numeric option"
+            );
+            None
+        }
+    }
+}
+
 fn set_last_buffer(contents: &mut [ContentMatch], buffer: &str) {
     if let Some(last) = contents.last_mut() {
         last.buffer = Some(buffer.to_string());

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -329,8 +329,8 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
             // At runtime, aifw-daemon's recover_kernel_state_for_role re-applies
             // the actual stored profile via ifconfig, so any operator change via
             // the cluster API takes effect on next service restart. rc.conf is
-            // rewritten only when re-running setup. TODO: when the cluster API
-            // changes the profile (in #217), have it also rewrite the rc.conf
+            // rewritten only when re-running setup. TODO(#217): when the cluster
+            // API changes the profile, have it also rewrite the rc.conf
             // aliases so reboot doesn't briefly fall back to Conservative.
             let timing = aifw_common::CarpLatencyProfile::default().timing_for(c.role);
             for vip in &c.vips {

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.19",
+  "version": "5.97.20",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.20",
+  "version": "5.97.21",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.18",
+  "version": "5.97.19",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.21",
+  "version": "5.97.22",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/post.md
+++ b/post.md
@@ -1,0 +1,40 @@
+The family in the video below did everything they were told to do.
+
+They still got hacked — through the one device they trusted most. Don't be like them. 👇
+
+I've spent most of my career as a business owner, and a good part of it in the CISO chair — the person who's accountable when something goes wrong. Security has never been a side interest for me; it's the lens I see everything through. And one rule never changes: you cannot secure what you cannot inspect.
+
+So here's what actually keeps me up at night — the home router. That one box sees every packet your family sends. Banking. Your work VPN. Your kid's homework. And it runs firmware you're not allowed to read, built by a vendor whose only answer is "trust us."
+
+In my world, "trust us" isn't a security model. It's an incident waiting for a timestamp.
+
+And these incidents are real:
+
+🔓 Sercomm "port 32764" (2014) — a hidden service that handed full admin to anyone who knew the secret port. The same firmware shipped under Netgear, Linksys, and Cisco. One backdoor, a dozen logos.
+
+🔓 Netgear's "telnetenable" magic packet — for years, models shipped with a hidden remote-login service you could wake up with a single crafted packet. Undocumented. By design.
+
+🔓 CVE-2025-4978 (CVSS 9.3, this year) — on a Netgear router, one unauthenticated web request flips an internal flag that turns authentication completely off. One request, instant admin.
+
+In plain English: imagine your front door has a second lock only the manufacturer knows about — and the key got copied. You can't see it. You can't change it. You find out when someone's already inside.
+
+Malicious, lazy, or a "debug feature someone forgot to remove" — it doesn't matter to an attacker. The door is open either way.
+
+This is structural. When firmware is closed, you can't audit it, can't see what it phones home to, can't know what's listening. You're handing a black box your entire network.
+
+So I built the opposite.
+
+AiFw is an open-source firewall for FreeBSD — built on pf, written in Rust, MIT licensed. Every line is public.
+
+✅ No backdoors. And you don't take my word for it — read the code, diff it, compile it yourself.
+✅ No secret ports, no magic packets, no hidden accounts. If one existed, the source would show it.
+✅ Auditable by anyone — a security team or a curious teenager.
+✅ Free. The AI threat detection is optional; it's a serious firewall with or without it.
+
+A backdoor can't survive in the open. That's the whole point.
+
+The only firewall I'd put in front of my own family is one I'm allowed to read.
+
+👉 Go look at the code. That's a sentence the big vendors will never write.
+
+#CISO #CyberSecurity #OpenSource #Firewall #NetworkSecurity #InfoSec #FreeBSD #Rust

--- a/reply.md
+++ b/reply.md
@@ -1,0 +1,5 @@
+Great piece, Martin. From the CISO seat, the root cause behind every one of these stories is the same: the firmware is closed. You can't verify what your router is doing, who it's talking to, or what's listening — you just have to trust the vendor. And "trust us" never survives an incident review.
+
+That's why I built AiFw: an open-source firewall for FreeBSD (pf + Rust, MIT). Every line is public — no hidden telemetry, no secret ports, nowhere to hide a backdoor. The only firewall I'd put in front of my own family is one I'm allowed to read.
+
+Happy to share the repo for anyone who wants to audit it themselves.

--- a/video-script.md
+++ b/video-script.md
@@ -1,0 +1,82 @@
+# AiFw — "Trust Us" : A Home Network Horror Story
+
+**Runtime:** ~90 seconds (30s cutdown notes at the end)
+**Format:** Shoot 9:16 vertical for LinkedIn/mobile feed. Crop a 16:9 version for YouTube/website.
+**Tone:** A real thriller, not a cartoon. The scary part is how *mundane* and *easy* it is. Avoid every "Hollywood hacker" cliché — no Matrix green text, no hoodie in a dark basement. The power is in showing it could be any Tuesday.
+**Captions:** Burn in on-screen captions — most LinkedIn views are watched on mute.
+**Color arc:** Act 1 warm & cozy → Acts 2–3 cold, desaturated, red accents → Acts 4–5 warm again.
+**Core visual metaphor:** A glowing "second keyhole" that secretly appears on the side of the router. Reuse it in both the break-in and the rescue — it's the idea the whole video hangs on.
+
+---
+
+## ACT 1 — THE ORDINARY EVENING  (0:00 – 0:15)
+
+| Time | Visual | On-screen text | Voiceover (calm) | Audio |
+|------|--------|----------------|------------------|-------|
+| 0:00–0:05 | Cozy suburban home, evening. Mom paying bills on a laptop, dad cooking, a kid on a tablet, a baby monitor glowing on the counter. | "Tuesday. 8:47 PM." | "An ordinary night." | Warm acoustic, soft. |
+| 0:05–0:10 | Slow push-in on the Wi-Fi router blinking quietly on a shelf. Every device's signal lines trace back to it. | — | "Every device in this house trusts one little box." | Acoustic continues. |
+| 0:10–0:15 | Family laughs at something. Comfortable. Safe. | — | "They never think about it. Why would they?" | Warm, then a single low note creeps in. |
+
+---
+
+## ACT 2 — THE INTRUSION  (0:15 – 0:40)
+
+| Time | Visual | On-screen text | Voiceover | Audio |
+|------|--------|----------------|-----------|-------|
+| 0:15–0:22 | Cut to a plain laptop on a plain desk. A hand types **one** command and hits Enter. That's it. Deliberately boring. | "Somewhere else. One request." | "No password cracked. No virus clicked." | Music sours. Low drone begins. |
+| 0:22–0:30 | Back to the router on the shelf. A red light flickers. A glowing **second keyhole** animates into existence on its side; a key slides in and turns. | "CVE-2025-4978 — one request, and the lock turns off." | "He just used a door the manufacturer left open." | Drone + a slow ticking clock. |
+| 0:30–0:40 | Rapid montage, each shot a device the family *trusts*: <br>• Bank app: "Transfer $4,000 — Complete." <br>• Smart lock clicks to **UNLOCKED**. <br>• Nursery camera's little light turns on by itself and pans. <br>• Kid's tablet webcam light blinks on. | — | "Their bank. Their front door. Their child's room. All behind the same box." | Drone swells, ticking faster, then a hard musical stab. |
+
+> Note: keep the nursery beat tasteful — show only the camera light turning on, never a child in distress. The implication is the gut-punch; you don't need more.
+
+---
+
+## ACT 3 — THE REALIZATION  (0:40 – 0:55)
+
+| Time | Visual | On-screen text | Voiceover | Audio |
+|------|--------|----------------|-----------|-------|
+| 0:40–0:48 | Mom's phone buzzes — bank fraud alert. Her face drops. She slowly turns and looks at the innocent little router on the shelf. | "She trusted it because she was told to." | "The firmware was closed. She couldn't read it. She couldn't see the backdoor." | Drone holds, near-silence. |
+| 0:48–0:55 | Screen glitches / fractures on the router image. | (big, full-frame) **"Trust us" is not a security model.** | "Neither could you." | Silence, then one cold piano note. |
+
+---
+
+## ACT 4 — AiFw SAVES THE DAY  (0:55 – 1:18)
+
+| Time | Visual | On-screen text | Voiceover | Audio |
+|------|--------|----------------|-----------|-------|
+| 0:55–1:03 | Reset. A hand swaps the old box for a clean device running AiFw. The dashboard appears — calm UI, green "Protected" status. | "Same house. Different firewall." | "AiFw is open source. Every line of code is public." | Warmth returns. Hopeful pulse. |
+| 1:03–1:10 | The **second keyhole** appears again — but now it's solid, visible, documented. Behind it, a scrolling GitHub-style code view and little contributor avatars inspecting it. | "No hidden doors — because there's nowhere to hide one." | "Anyone can read it. A security team. A curious teenager." | Building, confident. |
+| 1:10–1:14 | The attacker tries the exact same command. Terminal: **Connection refused.** He shrugs and gives up. | "No backdoor. No magic packet. No way in." | "Same attack. Different ending." | Drone dies. |
+| 1:14–1:18 | Back to the family: warm light, baby sleeping, lock LOCKED, bank app normal. Peace restored. | — | — | Acoustic theme resolves. |
+
+---
+
+## ACT 5 — CALL TO ACTION  (1:18 – 1:30)
+
+| Time | Visual | On-screen text | Voiceover | Audio |
+|------|--------|----------------|-----------|-------|
+| 1:18–1:24 | AiFw logo on a clean dark background. | "AiFw — the firewall you're allowed to read." | "Stop trusting black boxes. The only firewall I'd put in front of my own family is one I can read." | Theme swells. |
+| 1:24–1:30 | End card. | "Free. Open source. MIT. FreeBSD + pf + Rust." <br> "👉 github.com/<your-repo>" <br> **"Don't trust. Verify."** | — | Final warm chord, out. |
+
+---
+
+## 30-second cutdown (for paid/feed performance)
+
+Keep it brutal and fast:
+- **0:00–0:04** — cozy family + blinking router. Text: *"Every device trusts one box."*
+- **0:04–0:10** — one command typed → second keyhole turns → bank "Transfer Complete" + smart lock UNLOCKED + nursery light on. VO: *"No password cracked. He used a door the maker left open."*
+- **0:10–0:16** — mom's face drops, looks at router. Full-frame text: *"'Trust us' is not a security model."*
+- **0:16–0:24** — swap to AiFw, green status, same attack → **Connection refused.** Text: *"Open source. No backdoors. Read every line."*
+- **0:24–0:30** — logo + *"AiFw — the firewall you're allowed to read. Don't trust. Verify."*
+
+---
+
+## Production notes
+
+- **Casting:** a relatable real family, not models. The believability *is* the message.
+- **The villain is boring on purpose.** A normal person at a normal desk is far scarier than a stylized hacker — it tells viewers "this is easy, and it isn't personal."
+- **Reuse the keyhole.** Break-in and rescue must use the same metaphor so the contrast lands without narration.
+- **Show consequences people feel,** not technical abstractions: money, the front door, the baby's room. The CVE text on screen gives it credibility; the imagery gives it fear.
+- **Accessibility:** captions burned in, high-contrast text, ~2s minimum per text card.
+- **Tools to produce it:** live shoot + editor is strongest. If going AI/synthetic: Sora / Veo / Runway / Pika for the b-roll and metaphor shots, Synthesia/HeyGen if you want a talking-head SRE intro, and a real screen-recording of the actual AiFw dashboard for the rescue (don't fake the product — show the real UI).
+- **Legal/safety:** every claim shown (CVE-2025-4978, the keyhole metaphor, "transfer complete") maps to documented behavior; keep on-screen brand names to the CVE context only, and you stay on defensible ground.


### PR DESCRIPTION
Batch of low-hanging code-quality audit fixes. Each fix is its own commit; version bumped to 5.97.22.

## Closed issues

**High/Medium**
- **#422** (QUAL-H2) — surfaced silently-dropped `Result`s: Suricata rule parser + IDS config loader now `warn!` on unparseable numbers instead of coercing to `None`; tarball flush, pre-apply/pre-import snapshot, and IDS config-load failures are logged. Genuinely-unactionable `.ok()` sites (CLI stdout flush, ps-for-RSS metrics) documented as intentional.
- **#440** (QUAL-M5) — unreferenced inline TODOs filed as issues (#484–#487) and all TODOs converted to `TODO(#NNN)` form.
- **#437** (QUAL-M2) — resolved `#[allow(dead_code)]` annotations:
  - Deleted unused legacy auth guards `require_perm` / `require_admin` (superseded by `perm_check!`) and the `_path_noop` route stub.
  - Wired `cleanup_revoked_tokens` onto an hourly timer in `aifw-api` main — the `revoked_tokens` blacklist was never pruned.
  - Narrowed `AuthUser` / `RulesQuery` allows to the specific unread fields with rationale.
  - Filed follow-ups for the functional gaps the allows were hiding: #488, #489, #490.

**Low**
- **#460** — `aifw-common` head comment → `//!` crate doc
- **#463** — `SyslogOutput::new` returns `Result` + logs bind failure instead of silently dropping alerts
- **#454** — deduped `static_routes` DDL into a `STATIC_ROUTES_DDL` const
- **#465** — WIP `//!` crate doc for `aifw-ai`
- **#459** — documented the `Database` re-export
- **#461** — stopped `.gitignore`-ing the tracked `CLAUDE.md`

## Follow-ups filed (not in this PR)
- From #440: #484 netmap ring buffer, #485 rule `$`-var expansion, #486 WG role-change subscriber, #487 per-node peer port
- From #437: #488 plugin hooks never dispatch, #489 CA `key_type` ignored, #490 IDS search `q` ignored — these three are latent functional bugs the `allow`s were masking.

## Verification
- `cargo fmt --check` + `cargo clippy -D warnings` clean (pre-commit gated every commit)
- `aifw-api` (134) and `aifw-ids` (95) tests pass