### PR TITLE
docs(quality): crate docs, SAFETY comments, dep centralization (#425, #430, #453, #457)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.23"
+version = "5.97.24"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.22"
+version = "5.97.23"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -1214,6 +1214,8 @@ async fn main() -> anyhow::Result<()> {
     let _instance_lock = match aifw_common::single_instance::acquire("aifw-api") {
         Ok(lock) => Some(lock),
         Err(aifw_common::single_instance::InstanceLockError::AlreadyRunning(pid)) => {
+            // stderr, not tracing: the subscriber isn't initialized until below,
+            // so this pre-init startup diagnostic would otherwise be dropped.
             eprintln!("aifw-api: another instance is already running (pid {pid})");
             std::process::exit(1);
         }

--- a/aifw-api/src/native_metrics.rs
+++ b/aifw-api/src/native_metrics.rs
@@ -236,6 +236,10 @@ fn use_freebsd_getmntinfo(out: &mut Vec<DiskInfo>) {
     }
 }
 
+/// # Safety
+///
+/// `p` must be either null or a pointer to a nul-terminated C string that
+/// remains valid for the duration of the call.
 #[cfg(target_os = "freebsd")]
 unsafe fn c_str_to_string(p: *const libc::c_char) -> String {
     if p.is_null() {

--- a/aifw-common/src/single_instance.rs
+++ b/aifw-common/src/single_instance.rs
@@ -75,6 +75,10 @@ pub fn acquire_at(path: &Path) -> Result<InstanceLock, InstanceLockError> {
     };
 
     let fd = file.as_raw_fd();
+    // SAFETY: `fd` is a valid, open file descriptor owned by `file` (kept alive
+    // for the duration of the call), and `flock` is a fully-initialized
+    // `struct flock` living on the stack. `fcntl(F_SETLK)` only reads through
+    // the pointer for the duration of the call.
     let res = unsafe { nix::libc::fcntl(fd, nix::libc::F_SETLK, &flock) };
     if res == -1 {
         let errno = nix::errno::Errno::last();
@@ -157,6 +161,9 @@ mod tests {
         let path = tmp_lock("conflict");
         let _ = std::fs::remove_file(&path);
 
+        // SAFETY: single-threaded test harness at this point; between fork and
+        // exec/exit the child only calls async-signal-safe operations (acquire
+        // the lock, sleep, exit), satisfying the post-fork constraints.
         match unsafe { fork() }.expect("fork") {
             ForkResult::Child => {
                 let _lock = acquire_at(&path).expect("child acquire");

--- a/aifw-conntrack/src/lib.rs
+++ b/aifw-conntrack/src/lib.rs
@@ -1,3 +1,9 @@
+//! # aifw-conntrack
+//!
+//! Connection tracking and pflog ingestion: parses `pflog` events, maintains
+//! the live connection/state table, and exposes queries and rolled-up stats
+//! consumed by the API status and metrics surfaces.
+
 pub mod pflog;
 pub mod query;
 pub mod stats;

--- a/aifw-core/src/lib.rs
+++ b/aifw-core/src/lib.rs
@@ -1,3 +1,11 @@
+//! # aifw-core
+//!
+//! Core firewall engines built on top of [`aifw_pf`] and [`aifw_common`]:
+//! rules, NAT, aliases, geo-IP, VPN, traffic shaping, HA/clustering, audit,
+//! ACME/TLS, DDNS, and the multiwan family. Each engine owns a pf anchor and
+//! an inline `migrate()` that creates its SQLite tables; the shared
+//! [`Database`] handle wraps the `SqlitePool` used throughout.
+
 pub mod acme;
 pub mod acme_dns;
 pub mod acme_engine;

--- a/aifw-daemon/Cargo.toml
+++ b/aifw-daemon/Cargo.toml
@@ -22,7 +22,7 @@ clap = { workspace = true }
 anyhow = { workspace = true }
 reqwest = { workspace = true }
 libc = { workspace = true }
-nix = { version = "0.31", features = ["user"] }
+nix = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
 

--- a/aifw-daemon/src/main.rs
+++ b/aifw-daemon/src/main.rs
@@ -47,6 +47,8 @@ async fn main() -> anyhow::Result<()> {
     let _instance_lock = match aifw_common::single_instance::acquire("aifw-daemon") {
         Ok(lock) => Some(lock),
         Err(aifw_common::single_instance::InstanceLockError::AlreadyRunning(pid)) => {
+            // stderr, not tracing: the subscriber isn't initialized until below,
+            // so this pre-init startup diagnostic would otherwise be dropped.
             eprintln!("aifw-daemon: another instance is already running (pid {pid})");
             std::process::exit(1);
         }

--- a/aifw-ids-bin/src/main.rs
+++ b/aifw-ids-bin/src/main.rs
@@ -42,6 +42,8 @@ async fn main() -> anyhow::Result<()> {
     let _instance_lock = match acquire("aifw-ids") {
         Ok(lock) => Some(lock),
         Err(aifw_common::single_instance::InstanceLockError::AlreadyRunning(pid)) => {
+            // stderr, not tracing: the subscriber isn't initialized until below,
+            // so this pre-init startup diagnostic would otherwise be dropped.
             eprintln!("aifw-ids: another instance is already running (pid {pid})");
             std::process::exit(1);
         }

--- a/aifw-ids/src/capture/bpf.rs
+++ b/aifw-ids/src/capture/bpf.rs
@@ -70,6 +70,9 @@ impl CaptureBackend for BpfCapture {
 
         // Set buffer size
         let mut buf_size = config.buffer_size as libc::c_uint;
+        // SAFETY: `fd` is a valid bpf descriptor from open_bpf_device; both
+        // ioctls read/write the single `c_uint` pointed to by `&mut buf_size`,
+        // which lives on the stack for the whole block.
         unsafe {
             if libc::ioctl(fd, BIOCSBLEN, &mut buf_size) < 0 {
                 // If we can't set it, read the default
@@ -86,6 +89,9 @@ impl CaptureBackend for BpfCapture {
         let copy_len = name_bytes.len().min(15);
         ifr.ifr_name[..copy_len].copy_from_slice(&name_bytes[..copy_len]);
 
+        // SAFETY: `fd` is valid and `ifr` is a fully-initialized `Ifreq` whose
+        // name field was bounded to 15 bytes above. On failure we close `fd`
+        // (still valid here) before returning.
         unsafe {
             if libc::ioctl(fd, BIOCSETIF, &ifr) < 0 {
                 let err = std::io::Error::last_os_error();
@@ -98,12 +104,14 @@ impl CaptureBackend for BpfCapture {
 
         // Enable immediate mode (don't wait for buffer to fill)
         let enable: libc::c_uint = 1;
+        // SAFETY: `fd` is valid; `&enable` points to a live stack `c_uint`.
         unsafe {
             libc::ioctl(fd, BIOCIMMEDIATE, &enable);
         }
 
         // Enable promiscuous mode if requested
         if config.promiscuous {
+            // SAFETY: `fd` is valid; BIOCPROMISC takes no argument.
             unsafe {
                 libc::ioctl(fd, BIOCPROMISC);
             }
@@ -114,6 +122,7 @@ impl CaptureBackend for BpfCapture {
             tv_sec: 0,
             tv_usec: (config.timeout_ms as libc::c_long) * 1000,
         };
+        // SAFETY: `fd` is valid; `&timeout` points to a live stack `Timeval`.
         unsafe {
             libc::ioctl(fd, BIOCSRTIMEOUT, &timeout);
         }
@@ -147,6 +156,9 @@ impl CaptureBackend for BpfCapture {
     fn next_packet(&mut self) -> Option<RawPacket> {
         // If we've consumed all packets in the current buffer, read more
         if self.buf_pos >= self.buf_read {
+            // SAFETY: `self.fd` is a valid bpf descriptor and `self.buffer` is a
+            // `Vec<u8>` of `self.buf_len` bytes, so writing up to `buf_len` bytes
+            // through its pointer stays in bounds.
             let n = unsafe {
                 libc::read(
                     self.fd,
@@ -167,6 +179,10 @@ impl CaptureBackend for BpfCapture {
             return None;
         }
 
+        // SAFETY: the bounds check above guarantees at least
+        // `size_of::<BpfHeader>()` bytes remain at `buf_pos`. BpfHeader is
+        // `#[repr(C)]` POD, so reinterpreting the kernel-filled bytes is valid;
+        // the borrow lives only as long as `self.buffer` is untouched below.
         let hdr = unsafe { &*(self.buffer.as_ptr().add(self.buf_pos) as *const BpfHeader) };
 
         let caplen = hdr.bh_caplen as usize;
@@ -220,6 +236,8 @@ impl CaptureBackend for BpfCapture {
             bs_recv: 0,
             bs_drop: 0,
         };
+        // SAFETY: `self.fd` is valid; BIOCGSTATS writes a `struct bpf_stat`
+        // into the live stack `bpf_stats`.
         unsafe {
             if libc::ioctl(self.fd, BIOCGSTATS, &mut bpf_stats) == 0 {
                 stats.packets_received = bpf_stats.bs_recv as u64;
@@ -231,6 +249,9 @@ impl CaptureBackend for BpfCapture {
 
     fn close(&mut self) {
         if self.fd >= 0 {
+            // SAFETY: `self.fd` is a valid, open descriptor (guarded by >= 0)
+            // that we own; it is set to -1 immediately after so we never
+            // double-close.
             unsafe {
                 libc::close(self.fd);
             }
@@ -251,6 +272,8 @@ fn open_bpf_device() -> Result<RawFd> {
     for i in 0..256 {
         let path =
             CString::new(format!("/dev/bpf{i}")).expect("/dev/bpf{i} format has no interior null");
+        // SAFETY: `path` is a valid nul-terminated C string that outlives the
+        // call; `open` merely reads it and returns a new descriptor or -1.
         let fd = unsafe { libc::open(path.as_ptr(), libc::O_RDONLY) };
         if fd >= 0 {
             return Ok(fd);

--- a/aifw-ids/src/lib.rs
+++ b/aifw-ids/src/lib.rs
@@ -1,3 +1,10 @@
+//! # aifw-ids
+//!
+//! Intrusion detection/prevention engine: packet capture, protocol decode,
+//! flow tracking, Suricata-format rule parsing and matching, and alert
+//! output sinks (SQLite, EVE JSON, syslog, in-memory). Runs in IDS (alert)
+//! or IPS (drop) mode; configuration and rules live in SQLite and hot-reload.
+
 pub mod action;
 pub mod capture;
 pub mod config;

--- a/aifw-metrics/src/lib.rs
+++ b/aifw-metrics/src/lib.rs
@@ -1,3 +1,8 @@
+//! # aifw-metrics
+//!
+//! Time-series metrics collection and storage: pluggable collectors feed a
+//! ring-buffered series store, exposed to the API for dashboards and history.
+
 pub mod backend;
 pub mod collector;
 pub mod config;

--- a/aifw-pf/src/lib.rs
+++ b/aifw-pf/src/lib.rs
@@ -1,3 +1,10 @@
+//! # aifw-pf
+//!
+//! Abstraction over FreeBSD `pf`. The [`backend::PfBackend`] trait is
+//! implemented by an in-memory mock (Linux/WSL, for development and tests)
+//! and an ioctl/pfctl backend (FreeBSD), selected at compile time via
+//! `#[cfg(target_os)]`. Use [`create_backend`] to get the right one.
+
 pub mod backend;
 pub mod error;
 #[cfg(test)]
@@ -16,6 +23,16 @@ pub use ioctl::PfIoctl;
 pub use mock::PfMock;
 pub use types::{PfState, PfStats, PfTableEntry};
 
+/// Return the [`PfBackend`] for the current platform.
+///
+/// Backend selection is compile-time via `#[cfg(target_os)]`, not a runtime
+/// flag: FreeBSD gets the real [`PfIoctl`] (pfctl/ioctl), every other target
+/// gets the in-memory [`PfMock`]. The two `cfg` arms are mutually exclusive
+/// and exhaustive, so exactly one is compiled in.
+///
+/// The `.expect` on FreeBSD is justified: the daemon cannot function without
+/// `/dev/pf`, and failing to open it is an unrecoverable boot-time condition
+/// that should abort loudly rather than silently degrade.
 pub fn create_backend() -> Box<dyn PfBackend> {
     #[cfg(not(target_os = "freebsd"))]
     {

--- a/aifw-plugins/src/lib.rs
+++ b/aifw-plugins/src/lib.rs
@@ -1,3 +1,9 @@
+//! # aifw-plugins
+//!
+//! Plugin subsystem: discovers, loads, and manages the lifecycle of plugins,
+//! and dispatches hook events (with `HookAction` responses such as `Block`)
+//! at defined points like incoming API requests. See [`manager::PluginManager`].
+
 pub mod context;
 pub mod discovery;
 pub mod examples;

--- a/aifw-setup/Cargo.toml
+++ b/aifw-setup/Cargo.toml
@@ -23,7 +23,7 @@ argon2 = { workspace = true }
 chrono = { workspace = true }
 anyhow = { workspace = true }
 libc = { workspace = true }
-nix = { version = "0.31", features = ["term"] }
+nix = { workspace = true, features = ["term"] }
 
 [lints]
 workspace = true

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.23",
+  "version": "5.97.24",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.22",
+  "version": "5.97.23",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Second code-quality cleanup batch — docs, consistency, and safety annotations. No behavior change; version bumped to 5.97.24.

## Closed issues
- **#425** (QUAL-H5) — `//!` crate docs added to aifw-core, aifw-ids, aifw-conntrack, aifw-plugins, aifw-metrics, aifw-pf (completes the set; aifw-common/aifw-ai were done last batch).
- **#453** (QUAL-M18) — documented `create_backend` compile-time cfg selection + the `/dev/pf` expect.
- **#430** (QUAL-H10) — `// SAFETY:` on every `unsafe` block in `bpf.rs` + `single_instance.rs`; `# Safety` doc on `native_metrics::c_str_to_string`. **No new unsafe introduced.**
- **#457** (QUAL-L2) — finished dep centralization (only aifw-daemon/aifw-setup `nix` remained; deps were already mostly on `workspace = true`).

## Closed as not-planned (stale / false-positive)
- **#444** (QUAL-M9) — the flagged `eprintln!`s all fire *before* `tracing_subscriber::init()`; converting them would drop the message. Annotated as intentional.
- **#435** (QUAL-H15) — `rust-toolchain.toml`, `rustfmt.toml`, pre-commit hook, and `[workspace.lints.clippy]` all already exist; nothing left to do.

## Verification
- `cargo clippy -D warnings` + `cargo fmt --check` clean (pre-commit gated both commits)
- `aifw-common` (112) + `aifw-pf` (7) tests pass
- FreeBSD-only files (`bpf.rs`, `native_metrics.rs`) are comment-only changes