### PR TITLE
refactor(core): engine API consistency — RuleEngine ctor + migrate() types (#423, #424)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.25"
+version = "5.97.26"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.24"
+version = "5.97.25"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -2505,7 +2505,7 @@ pub async fn put_retention(
     let mgr = ConfigManager::new(state.pool.clone());
     mgr.migrate()
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     mgr.set_retention_limit(req.max_versions)
         .await
         .map_err(|e| (StatusCode::BAD_REQUEST, e))?;

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -641,7 +641,7 @@ async fn create_state_from_db(
 
     auth::migrate(&pool).await?;
 
-    let rule_engine = Arc::new(RuleEngine::new(db, pf.clone()));
+    let rule_engine = Arc::new(RuleEngine::new(pool.clone(), pf.clone()));
     let nat_engine =
         Arc::new(NatEngine::new(pool.clone(), pf.clone()).with_anchor("aifw-nat".to_string()));
     nat_engine.migrate().await?;

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -48,7 +48,7 @@ fn parse_direction(s: &str) -> anyhow::Result<Direction> {
 async fn create_engine(db_path: &Path) -> anyhow::Result<RuleEngine> {
     let db = Database::new(db_path).await?;
     let pf = Arc::from(aifw_pf::create_backend());
-    Ok(RuleEngine::new(db, pf))
+    Ok(RuleEngine::new(db.pool().clone(), pf))
 }
 
 pub async fn init(db_path: &Path) -> anyhow::Result<()> {

--- a/aifw-core/src/acme.rs
+++ b/aifw-core/src/acme.rs
@@ -252,7 +252,7 @@ pub struct AcmeExportTarget {
 // Schema
 // =============================================================================
 
-pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+pub async fn migrate(pool: &SqlitePool) -> aifw_common::Result<()> {
     sqlx::query(
         r#"
         CREATE TABLE IF NOT EXISTS acme_account (

--- a/aifw-core/src/config_manager.rs
+++ b/aifw-core/src/config_manager.rs
@@ -37,7 +37,7 @@ impl ConfigManager {
         self
     }
 
-    pub async fn migrate(&self) -> Result<(), String> {
+    pub async fn migrate(&self) -> aifw_common::Result<()> {
         sqlx::query(
             r#"CREATE TABLE IF NOT EXISTS config_versions (
                 version INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -52,8 +52,7 @@ impl ConfigManager {
             )"#,
         )
         .execute(&self.pool)
-        .await
-        .map_err(|e| format!("migration error: {e}"))?;
+        .await?;
 
         // Hash lookups happen on every auto-snapshot — one index pays for itself
         // after the first handful of saves.
@@ -61,8 +60,7 @@ impl ConfigManager {
             "CREATE INDEX IF NOT EXISTS idx_config_versions_created_at ON config_versions(created_at DESC)",
         )
         .execute(&self.pool)
-        .await
-        .map_err(|e| format!("migration error: {e}"))?;
+        .await?;
 
         Ok(())
     }

--- a/aifw-core/src/db.rs
+++ b/aifw-core/src/db.rs
@@ -46,6 +46,14 @@ impl Database {
         Ok(db)
     }
 
+    /// Wrap an existing [`SqlitePool`] without opening a new connection or
+    /// running migrations. Used by engines (e.g. [`crate::RuleEngine`]) that
+    /// take a shared pool for constructor consistency but still need the
+    /// typed `Database` query helpers.
+    pub fn from_pool(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
     pub async fn new_in_memory() -> Result<Self> {
         let opts = SqliteConnectOptions::from_str("sqlite::memory:")?;
         let pool = SqlitePoolOptions::new()

--- a/aifw-core/src/ddns.rs
+++ b/aifw-core/src/ddns.rs
@@ -114,7 +114,7 @@ pub struct DdnsRecord {
 // Schema
 // =============================================================================
 
-pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+pub async fn migrate(pool: &SqlitePool) -> aifw_common::Result<()> {
     sqlx::query(
         r#"
         CREATE TABLE IF NOT EXISTS ddns_record (

--- a/aifw-core/src/dns_blocklists.rs
+++ b/aifw-core/src/dns_blocklists.rs
@@ -132,7 +132,7 @@ pub struct RefreshOutcome {
 // Schema + seed
 // ============================================================================
 
-pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+pub async fn migrate(pool: &SqlitePool) -> aifw_common::Result<()> {
     sqlx::query(
         r#"
         CREATE TABLE IF NOT EXISTS dns_blocklist_source (

--- a/aifw-core/src/engine.rs
+++ b/aifw-core/src/engine.rs
@@ -1,5 +1,6 @@
 use aifw_common::{AifwError, Result, Rule, RuleStatus};
 use aifw_pf::PfBackend;
+use sqlx::SqlitePool;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -20,8 +21,9 @@ pub struct RuleEngine {
 }
 
 impl RuleEngine {
-    pub fn new(db: Database, pf: Arc<dyn PfBackend>) -> Self {
-        let audit = AuditLog::new(db.pool().clone());
+    pub fn new(pool: SqlitePool, pf: Arc<dyn PfBackend>) -> Self {
+        let audit = AuditLog::new(pool.clone());
+        let db = Database::from_pool(pool);
         Self {
             db,
             pf,

--- a/aifw-core/src/s3_backup.rs
+++ b/aifw-core/src/s3_backup.rs
@@ -71,7 +71,7 @@ impl Default for S3Config {
 // Schema
 // ============================================================================
 
-pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+pub async fn migrate(pool: &SqlitePool) -> aifw_common::Result<()> {
     sqlx::query(
         r#"CREATE TABLE IF NOT EXISTS s3_backup_config (
             id                INTEGER PRIMARY KEY CHECK (id = 1),

--- a/aifw-core/src/smtp_notify.rs
+++ b/aifw-core/src/smtp_notify.rs
@@ -159,7 +159,7 @@ impl SmtpConfig {
 // Schema
 // ============================================================================
 
-pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+pub async fn migrate(pool: &SqlitePool) -> aifw_common::Result<()> {
     sqlx::query(
         r#"CREATE TABLE IF NOT EXISTS smtp_notify_config (
             id             INTEGER PRIMARY KEY CHECK (id = 1),

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -94,7 +94,7 @@ mod tests {
     async fn test_engine_add_list_rules() {
         let db = Database::new_in_memory().await.unwrap();
         let pf: Arc<dyn PfBackend> = Arc::new(aifw_pf::PfMock::new());
-        let engine = RuleEngine::new(db, pf);
+        let engine = RuleEngine::new(db.pool().clone(), pf);
 
         let rule = make_test_rule();
         let id = rule.id;
@@ -109,7 +109,7 @@ mod tests {
     async fn test_engine_delete_rule() {
         let db = Database::new_in_memory().await.unwrap();
         let pf: Arc<dyn PfBackend> = Arc::new(aifw_pf::PfMock::new());
-        let engine = RuleEngine::new(db, pf);
+        let engine = RuleEngine::new(db.pool().clone(), pf);
 
         let rule = make_test_rule();
         let id = rule.id;
@@ -124,7 +124,7 @@ mod tests {
     async fn test_engine_delete_nonexistent() {
         let db = Database::new_in_memory().await.unwrap();
         let pf: Arc<dyn PfBackend> = Arc::new(aifw_pf::PfMock::new());
-        let engine = RuleEngine::new(db, pf);
+        let engine = RuleEngine::new(db.pool().clone(), pf);
 
         let result = engine.delete_rule(uuid::Uuid::new_v4()).await;
         assert!(result.is_err());
@@ -135,7 +135,7 @@ mod tests {
         let db = Database::new_in_memory().await.unwrap();
         let mock = Arc::new(aifw_pf::PfMock::new());
         let pf: Arc<dyn PfBackend> = mock.clone();
-        let engine = RuleEngine::new(db, pf);
+        let engine = RuleEngine::new(db.pool().clone(), pf);
 
         engine.add_rule(make_test_rule()).await.unwrap();
 
@@ -170,7 +170,7 @@ mod tests {
         let db = Database::new_in_memory().await.unwrap();
         let mock = Arc::new(aifw_pf::PfMock::new());
         let pf: Arc<dyn PfBackend> = mock.clone();
-        let engine = RuleEngine::new(db, pf);
+        let engine = RuleEngine::new(db.pool().clone(), pf);
 
         engine.add_rule(make_test_rule()).await.unwrap();
         engine.apply_rules().await.unwrap();
@@ -254,7 +254,7 @@ mod tests {
     async fn test_audit_trail() {
         let db = Database::new_in_memory().await.unwrap();
         let pf: Arc<dyn PfBackend> = Arc::new(aifw_pf::PfMock::new());
-        let engine = RuleEngine::new(db, pf);
+        let engine = RuleEngine::new(db.pool().clone(), pf);
 
         let rule = make_test_rule();
         let id = rule.id;
@@ -273,7 +273,7 @@ mod tests {
         let db = Database::new_in_memory().await.unwrap();
         let mock = Arc::new(aifw_pf::PfMock::new());
         let pf: Arc<dyn PfBackend> = mock.clone();
-        let engine = RuleEngine::new(db, pf);
+        let engine = RuleEngine::new(db.pool().clone(), pf);
 
         engine.add_rule(make_test_rule()).await.unwrap();
         engine.apply_rules().await.unwrap();

--- a/aifw-daemon/src/main.rs
+++ b/aifw-daemon/src/main.rs
@@ -75,7 +75,7 @@ async fn main() -> anyhow::Result<()> {
     let db = Database::new(&args.db).await?;
     let pool = db.pool().clone();
     let pf: Arc<dyn aifw_pf::PfBackend> = Arc::from(aifw_pf::create_backend());
-    let engine = RuleEngine::new(db, pf.clone()).with_anchor(args.anchor.clone());
+    let engine = RuleEngine::new(pool.clone(), pf.clone()).with_anchor(args.anchor.clone());
     let nat_engine = NatEngine::new(pool.clone(), pf.clone());
     let alias_engine = AliasEngine::new(pool.clone(), pf.clone());
 

--- a/aifw-tui/src/app.rs
+++ b/aifw-tui/src/app.rs
@@ -88,7 +88,7 @@ impl App {
         let pool = db.pool().clone();
         let pf: Arc<dyn PfBackend> = Arc::from(aifw_pf::create_backend());
 
-        let rule_engine = Arc::new(RuleEngine::new(db, pf.clone()));
+        let rule_engine = Arc::new(RuleEngine::new(pool.clone(), pf.clone()));
         let nat_engine = Arc::new(NatEngine::new(pool.clone(), pf.clone()));
         nat_engine.migrate().await?;
         let shaping_engine = Arc::new(ShapingEngine::new(pool.clone(), pf.clone()));

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.25",
+  "version": "5.97.26",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.24",
+  "version": "5.97.25",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Engine API consistency refactor. No behavior change; version bumped to 5.97.26.

## #423 (QUAL-H3) — RuleEngine constructor
`RuleEngine::new` was the only engine taking `(Database, pf)`; every other engine takes `(SqlitePool, pf)`. Added `Database::from_pool` (wraps a shared pool without reopening/migrating) and changed `RuleEngine::new(pool, pf)` to build its internal `Database` from the pool. Updated all 11 call sites (4 binaries + 7 tests).

## #424 (QUAL-H4) — migrate() return types
`migrate()` drifted across three error types — `Result<()>` (AifwError, 8 engines), `Result<(), sqlx::Error>` (5 free fns), `Result<(), String>` (config_manager). Normalized the six outliers to `aifw_common::Result<()>` to match the engine majority. `AifwError: From<sqlx::Error>` already exists so bodies just use `?`; all callers use `Display`/`to_string`/`anyhow`, so only one handler in backup.rs needed `.to_string()` on the error.

## Verification
- `cargo clippy -D warnings --all-targets` + `cargo fmt --check` clean (pre-commit gated both commits)
- Full `cargo test --workspace` green (27 suites, incl. 146 aifw-core + 134 aifw-api)