### PR TITLE
refactor(crates): thiserror Error enums for the 4 library crates (#448)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.26"
+version = "5.97.27"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ai/src/error.rs
+++ b/aifw-ai/src/error.rs
@@ -1,0 +1,23 @@
+use thiserror::Error;
+
+/// Errors produced by the aifw-ai inference / threat-detection engine.
+#[derive(Debug, Error)]
+pub enum AiError {
+    #[error("inference error: {0}")]
+    Inference(String),
+
+    #[error("model load error: {0}")]
+    ModelLoad(String),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+/// Crate-local result alias.
+pub type Result<T> = std::result::Result<T, AiError>;
+
+impl From<AiError> for aifw_common::AifwError {
+    fn from(e: AiError) -> Self {
+        aifw_common::AifwError::Other(e.to_string())
+    }
+}

--- a/aifw-ai/src/inference.rs
+++ b/aifw-ai/src/inference.rs
@@ -1,14 +1,16 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
+use crate::error::{AiError, Result};
+
 /// Trait for ML inference backends (ONNX, etc.)
 #[async_trait]
 pub trait InferenceBackend: Send + Sync {
     /// Run inference on a feature vector, return anomaly score (0.0-1.0)
-    async fn predict(&self, features: &[f64]) -> Result<f64, String>;
+    async fn predict(&self, features: &[f64]) -> Result<f64>;
 
     /// Load or reload a model from the given path
-    async fn load_model(&mut self, path: &str) -> Result<(), String>;
+    async fn load_model(&mut self, path: &str) -> Result<()>;
 
     /// Get model info
     fn model_info(&self) -> ModelInfo;
@@ -48,12 +50,12 @@ impl Default for StubInference {
 
 #[async_trait]
 impl InferenceBackend for StubInference {
-    async fn predict(&self, features: &[f64]) -> Result<f64, String> {
+    async fn predict(&self, features: &[f64]) -> Result<f64> {
         // Simple heuristic-based "prediction" for development:
         // High connection rate + high unique ports = likely scan
         // High SYN count + low established = likely DDoS
         if features.len() < self.info.input_size {
-            return Err("feature vector too short".to_string());
+            return Err(AiError::Inference("feature vector too short".to_string()));
         }
 
         let conn_count = features[0];
@@ -84,7 +86,7 @@ impl InferenceBackend for StubInference {
         Ok(score.min(1.0))
     }
 
-    async fn load_model(&mut self, path: &str) -> Result<(), String> {
+    async fn load_model(&mut self, path: &str) -> Result<()> {
         tracing::info!(path, "stub: model load (no-op)");
         self.info.loaded = true;
         self.info.name = path.to_string();

--- a/aifw-ai/src/lib.rs
+++ b/aifw-ai/src/lib.rs
@@ -4,6 +4,7 @@
 //! see the crate README for current status and caveats.
 
 pub mod detectors;
+pub mod error;
 pub mod features;
 pub mod inference;
 pub mod response;
@@ -12,6 +13,7 @@ pub mod types;
 #[cfg(test)]
 mod tests;
 
+pub use error::{AiError, Result};
 pub use features::TrafficFeatures;
 pub use inference::InferenceBackend;
 pub use response::{AutoResponder, ResponseAction, ResponseConfig};

--- a/aifw-conntrack/src/error.rs
+++ b/aifw-conntrack/src/error.rs
@@ -1,0 +1,29 @@
+use thiserror::Error;
+
+/// Errors produced by the connection-tracking / pflog subsystem.
+#[derive(Debug, Error)]
+pub enum ConntrackError {
+    #[error("pf error: {0}")]
+    Pf(String),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+/// Crate-local result alias.
+pub type Result<T> = std::result::Result<T, ConntrackError>;
+
+impl From<aifw_pf::PfError> for ConntrackError {
+    fn from(e: aifw_pf::PfError) -> Self {
+        ConntrackError::Pf(e.to_string())
+    }
+}
+
+impl From<ConntrackError> for aifw_common::AifwError {
+    fn from(e: ConntrackError) -> Self {
+        match e {
+            ConntrackError::Pf(s) => aifw_common::AifwError::Pf(s),
+            ConntrackError::Other(s) => aifw_common::AifwError::Other(s),
+        }
+    }
+}

--- a/aifw-conntrack/src/lib.rs
+++ b/aifw-conntrack/src/lib.rs
@@ -4,6 +4,7 @@
 //! the live connection/state table, and exposes queries and rolled-up stats
 //! consumed by the API status and metrics surfaces.
 
+pub mod error;
 pub mod pflog;
 pub mod query;
 pub mod stats;
@@ -12,6 +13,7 @@ pub mod tracker;
 #[cfg(test)]
 mod tests;
 
+pub use error::{ConntrackError, Result};
 pub use pflog::{PfLogEntry, PfLogParser};
 pub use query::{ConnectionFilter, ConnectionQuery};
 pub use stats::ConntrackStats;

--- a/aifw-conntrack/src/tracker.rs
+++ b/aifw-conntrack/src/tracker.rs
@@ -43,12 +43,8 @@ impl ConnectionTracker {
 
     /// Refresh the state table from pf once. Useful for tests and one-shot
     /// callers; production code should rely on `start_polling`.
-    pub async fn refresh(&self) -> aifw_common::Result<()> {
-        let new_states = self
-            .pf
-            .get_states()
-            .await
-            .map_err(|e| aifw_common::AifwError::Pf(e.to_string()))?;
+    pub async fn refresh(&self) -> crate::Result<()> {
+        let new_states = self.pf.get_states().await?;
         debug!(count = new_states.len(), "refreshed connection states");
         self.states.store(Arc::new(new_states));
         Ok(())

--- a/aifw-metrics/Cargo.toml
+++ b/aifw-metrics/Cargo.toml
@@ -11,6 +11,7 @@ tokio = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }
 sqlx = { workspace = true }

--- a/aifw-metrics/src/backend.rs
+++ b/aifw-metrics/src/backend.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
+use crate::Result;
 use crate::series::{MetricPoint, Tier};
 
 /// Response type for metric queries
@@ -15,7 +16,7 @@ pub struct MetricQueryResult {
 #[async_trait]
 pub trait MetricsBackend: Send + Sync {
     /// Record a metric value
-    async fn record(&self, name: &str, value: f64) -> Result<(), String>;
+    async fn record(&self, name: &str, value: f64) -> Result<()>;
 
     /// Query metric data for a given tier
     async fn query(
@@ -23,14 +24,14 @@ pub trait MetricsBackend: Send + Sync {
         name: &str,
         tier: Tier,
         last_n: Option<usize>,
-    ) -> Result<MetricQueryResult, String>;
+    ) -> Result<MetricQueryResult>;
 
     /// Get the latest value for a metric
-    async fn latest(&self, name: &str) -> Result<Option<f64>, String>;
+    async fn latest(&self, name: &str) -> Result<Option<f64>>;
 
     /// List all available metric names
-    async fn list_metrics(&self) -> Result<Vec<String>, String>;
+    async fn list_metrics(&self) -> Result<Vec<String>>;
 
     /// Get a summary of all metrics (latest values)
-    async fn summary(&self) -> Result<Vec<(String, f64)>, String>;
+    async fn summary(&self) -> Result<Vec<(String, f64)>>;
 }

--- a/aifw-metrics/src/error.rs
+++ b/aifw-metrics/src/error.rs
@@ -1,0 +1,20 @@
+use thiserror::Error;
+
+/// Errors produced by the metrics storage backends.
+#[derive(Debug, Error)]
+pub enum MetricsError {
+    #[error("metric not found: {0}")]
+    NotFound(String),
+
+    #[error("{0}")]
+    Backend(String),
+}
+
+/// Crate-local result alias.
+pub type Result<T> = std::result::Result<T, MetricsError>;
+
+impl From<MetricsError> for aifw_common::AifwError {
+    fn from(e: MetricsError) -> Self {
+        aifw_common::AifwError::Other(e.to_string())
+    }
+}

--- a/aifw-metrics/src/lib.rs
+++ b/aifw-metrics/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod backend;
 pub mod collector;
 pub mod config;
+pub mod error;
 pub mod ring;
 pub mod series;
 pub mod store;
@@ -16,6 +17,7 @@ mod tests;
 pub use backend::MetricsBackend;
 pub use collector::MetricsCollector;
 pub use config::MetricsConfig;
+pub use error::{MetricsError, Result};
 pub use ring::RingBuffer;
 pub use series::{Aggregation, MetricPoint, MetricSeries};
 pub use store::MetricsStore;

--- a/aifw-metrics/src/store.rs
+++ b/aifw-metrics/src/store.rs
@@ -2,7 +2,9 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use std::sync::Mutex;
 
+use crate::Result;
 use crate::backend::{MetricQueryResult, MetricsBackend};
+use crate::error::MetricsError;
 use crate::series::{Aggregation, MetricPoint, MetricSeries, Tier};
 
 /// Default local metrics store using in-memory ring buffers.
@@ -56,7 +58,7 @@ impl Default for MetricsStore {
 
 #[async_trait]
 impl MetricsBackend for MetricsStore {
-    async fn record(&self, name: &str, value: f64) -> Result<(), String> {
+    async fn record(&self, name: &str, value: f64) -> Result<()> {
         let entry = self
             .series
             .entry(name.to_string())
@@ -74,11 +76,11 @@ impl MetricsBackend for MetricsStore {
         name: &str,
         tier: Tier,
         last_n: Option<usize>,
-    ) -> Result<MetricQueryResult, String> {
+    ) -> Result<MetricQueryResult> {
         let entry = self
             .series
             .get(name)
-            .ok_or_else(|| format!("metric '{name}' not found"))?;
+            .ok_or_else(|| MetricsError::NotFound(name.to_string()))?;
         let s = entry.value().lock().expect("series mutex poisoned");
         let points: Vec<MetricPoint> = match last_n {
             Some(n) => s.get_last(tier, n).into_iter().cloned().collect(),
@@ -92,18 +94,18 @@ impl MetricsBackend for MetricsStore {
         })
     }
 
-    async fn latest(&self, name: &str) -> Result<Option<f64>, String> {
+    async fn latest(&self, name: &str) -> Result<Option<f64>> {
         Ok(self
             .series
             .get(name)
             .and_then(|e| e.value().lock().expect("series mutex poisoned").latest()))
     }
 
-    async fn list_metrics(&self) -> Result<Vec<String>, String> {
+    async fn list_metrics(&self) -> Result<Vec<String>> {
         Ok(self.series.iter().map(|e| e.key().clone()).collect())
     }
 
-    async fn summary(&self) -> Result<Vec<(String, f64)>, String> {
+    async fn summary(&self) -> Result<Vec<(String, f64)>> {
         Ok(self
             .series
             .iter()

--- a/aifw-plugins/src/context.rs
+++ b/aifw-plugins/src/context.rs
@@ -2,6 +2,8 @@ use aifw_pf::PfBackend;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use crate::error::PluginError;
+
 /// Tables that plugins are allowed to modify (plugin-specific tables only).
 const PLUGIN_ALLOWED_TABLE_PREFIX: &str = "plugin_";
 
@@ -42,28 +44,28 @@ impl PluginContext {
     }
 
     /// Add an IP to a pf table (restricted to plugin_ prefixed tables)
-    pub async fn add_to_table(&self, table: &str, ip: std::net::IpAddr) -> Result<(), String> {
+    pub async fn add_to_table(&self, table: &str, ip: std::net::IpAddr) -> crate::Result<()> {
         if !Self::is_table_allowed(table) {
-            return Err(format!(
+            return Err(PluginError::Table(format!(
                 "plugins can only modify tables with prefix '{PLUGIN_ALLOWED_TABLE_PREFIX}'"
-            ));
+            )));
         }
         self.pf
             .add_table_entry(table, ip)
             .await
-            .map_err(|e| e.to_string())
+            .map_err(|e| PluginError::Table(e.to_string()))
     }
 
     /// Remove an IP from a pf table (restricted to plugin_ prefixed tables)
-    pub async fn remove_from_table(&self, table: &str, ip: std::net::IpAddr) -> Result<(), String> {
+    pub async fn remove_from_table(&self, table: &str, ip: std::net::IpAddr) -> crate::Result<()> {
         if !Self::is_table_allowed(table) {
-            return Err(format!(
+            return Err(PluginError::Table(format!(
                 "plugins can only modify tables with prefix '{PLUGIN_ALLOWED_TABLE_PREFIX}'"
-            ));
+            )));
         }
         self.pf
             .remove_table_entry(table, ip)
             .await
-            .map_err(|e| e.to_string())
+            .map_err(|e| PluginError::Table(e.to_string()))
     }
 }

--- a/aifw-plugins/src/error.rs
+++ b/aifw-plugins/src/error.rs
@@ -1,0 +1,38 @@
+use thiserror::Error;
+
+/// Errors produced by the plugin subsystem and returned by plugin authors
+/// from [`crate::plugin::Plugin`] lifecycle hooks.
+#[derive(Debug, Error)]
+pub enum PluginError {
+    #[error("plugin error: {0}")]
+    Plugin(String),
+
+    #[error("pf table error: {0}")]
+    Table(String),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+/// Crate-local result alias.
+pub type Result<T> = std::result::Result<T, PluginError>;
+
+// Ergonomic conversions so plugin authors can keep returning `Err("msg".into())`
+// and existing `.map_err(|e| e.to_string())?` chains still convert via `?`.
+impl From<String> for PluginError {
+    fn from(s: String) -> Self {
+        PluginError::Plugin(s)
+    }
+}
+
+impl From<&str> for PluginError {
+    fn from(s: &str) -> Self {
+        PluginError::Plugin(s.to_string())
+    }
+}
+
+impl From<PluginError> for aifw_common::AifwError {
+    fn from(e: PluginError) -> Self {
+        aifw_common::AifwError::Other(e.to_string())
+    }
+}

--- a/aifw-plugins/src/examples/ip_reputation.rs
+++ b/aifw-plugins/src/examples/ip_reputation.rs
@@ -55,7 +55,7 @@ impl Plugin for IpReputationPlugin {
         }
     }
 
-    async fn init(&mut self, config: &PluginConfig, _ctx: &PluginContext) -> Result<(), String> {
+    async fn init(&mut self, config: &PluginConfig, _ctx: &PluginContext) -> crate::Result<()> {
         if let Some(table) = config.get_str("table_name") {
             self.table_name = table.to_string();
         }
@@ -101,7 +101,7 @@ impl Plugin for IpReputationPlugin {
         HookAction::Continue
     }
 
-    async fn shutdown(&mut self) -> Result<(), String> {
+    async fn shutdown(&mut self) -> crate::Result<()> {
         let size = self.blocklist.read().await.len();
         tracing::info!(blocklist_size = size, "IP reputation plugin shutting down");
         Ok(())

--- a/aifw-plugins/src/examples/logging.rs
+++ b/aifw-plugins/src/examples/logging.rs
@@ -72,7 +72,7 @@ impl Plugin for LoggingPlugin {
         }
     }
 
-    async fn init(&mut self, config: &PluginConfig, _ctx: &PluginContext) -> Result<(), String> {
+    async fn init(&mut self, config: &PluginConfig, _ctx: &PluginContext) -> crate::Result<()> {
         if let Some(max) = config.get_u64("max_entries") {
             self.max_entries = max as usize;
         }
@@ -124,7 +124,7 @@ impl Plugin for LoggingPlugin {
         HookAction::Continue
     }
 
-    async fn shutdown(&mut self) -> Result<(), String> {
+    async fn shutdown(&mut self) -> crate::Result<()> {
         let count = self.log_buffer.read().await.len();
         tracing::info!(entries = count, "logging plugin shutting down");
         Ok(())

--- a/aifw-plugins/src/examples/webhook.rs
+++ b/aifw-plugins/src/examples/webhook.rs
@@ -86,7 +86,7 @@ impl Plugin for WebhookPlugin {
         }
     }
 
-    async fn init(&mut self, config: &PluginConfig, _ctx: &PluginContext) -> Result<(), String> {
+    async fn init(&mut self, config: &PluginConfig, _ctx: &PluginContext) -> crate::Result<()> {
         self.url = config
             .get_str("url")
             .unwrap_or("http://localhost:9999/webhook")
@@ -161,7 +161,7 @@ impl Plugin for WebhookPlugin {
         HookAction::Continue
     }
 
-    async fn shutdown(&mut self) -> Result<(), String> {
+    async fn shutdown(&mut self) -> crate::Result<()> {
         let pending = self.notifications.read().await.len();
         tracing::info!(pending, "webhook plugin shutting down");
         Ok(())

--- a/aifw-plugins/src/lib.rs
+++ b/aifw-plugins/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod context;
 pub mod discovery;
+pub mod error;
 pub mod examples;
 pub mod hooks;
 pub mod manager;
@@ -16,6 +17,7 @@ pub mod wasm;
 mod tests;
 
 pub use context::PluginContext;
+pub use error::{PluginError, Result};
 pub use hooks::{HookAction, HookEvent, HookPoint};
 pub use manager::PluginManager;
 pub use plugin::{Plugin, PluginConfig, PluginInfo, PluginState};

--- a/aifw-plugins/src/manager.rs
+++ b/aifw-plugins/src/manager.rs
@@ -32,12 +32,12 @@ impl PluginManager {
         &mut self,
         plugin: Box<dyn Plugin>,
         config: PluginConfig,
-    ) -> Result<(), String> {
+    ) -> crate::Result<()> {
         let info = plugin.info();
         let name = info.name.clone();
 
         if self.plugins.contains_key(&name) {
-            return Err(format!("plugin '{name}' already registered"));
+            return Err(format!("plugin '{name}' already registered").into());
         }
 
         info!(plugin = %name, version = %info.version, "registering plugin");
@@ -70,7 +70,7 @@ impl PluginManager {
     }
 
     /// Unload a plugin by name
-    pub async fn unload(&mut self, name: &str) -> Result<(), String> {
+    pub async fn unload(&mut self, name: &str) -> crate::Result<()> {
         let mut loaded = self
             .plugins
             .remove(name)

--- a/aifw-plugins/src/plugin.rs
+++ b/aifw-plugins/src/plugin.rs
@@ -67,11 +67,11 @@ pub trait Plugin: Send + Sync {
     fn info(&self) -> PluginInfo;
 
     /// Initialize the plugin with its configuration
-    async fn init(&mut self, config: &PluginConfig, ctx: &PluginContext) -> Result<(), String>;
+    async fn init(&mut self, config: &PluginConfig, ctx: &PluginContext) -> crate::Result<()>;
 
     /// Handle a hook event. Return an action to influence firewall behavior.
     async fn on_hook(&self, event: &HookEvent, ctx: &PluginContext) -> HookAction;
 
     /// Graceful shutdown
-    async fn shutdown(&mut self) -> Result<(), String>;
+    async fn shutdown(&mut self) -> crate::Result<()>;
 }

--- a/aifw-plugins/src/wasm.rs
+++ b/aifw-plugins/src/wasm.rs
@@ -85,7 +85,7 @@ impl Plugin for WasmPlugin {
         self.info.clone()
     }
 
-    async fn init(&mut self, _config: &PluginConfig, _ctx: &PluginContext) -> Result<(), String> {
+    async fn init(&mut self, _config: &PluginConfig, _ctx: &PluginContext) -> crate::Result<()> {
         // WASM sandbox is not yet implemented — refuse to load WASM plugins
         // to prevent running untrusted code without proper isolation.
         if !self.config.wasm_path.as_os_str().is_empty() {
@@ -93,7 +93,7 @@ impl Plugin for WasmPlugin {
                 wasm = ?self.config.wasm_path,
                 "WASM plugin loading is disabled — sandbox not implemented"
             );
-            return Err("WASM plugin loading is disabled: sandbox not yet implemented. Only native Rust plugins are supported.".to_string());
+            return Err("WASM plugin loading is disabled: sandbox not yet implemented. Only native Rust plugins are supported.".into());
         }
         self.state = PluginState::Running;
         Ok(())
@@ -113,7 +113,7 @@ impl Plugin for WasmPlugin {
         HookAction::Continue
     }
 
-    async fn shutdown(&mut self) -> Result<(), String> {
+    async fn shutdown(&mut self) -> crate::Result<()> {
         self.state = PluginState::Stopped;
         Ok(())
     }

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.26",
+  "version": "5.97.27",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Give the four remaining library crates a proper crate-local `thiserror` `Error` enum + `Result<T>` alias, matching the pattern `aifw-core`/`aifw-ids`/`aifw-pf` already follow (per the #188 error policy). No behavior change; version 5.97.27.

| Crate | Error enum | Notes |
|-------|-----------|-------|
| aifw-ai | `AiError` (Inference / ModelLoad / Other) | converted `InferenceBackend` trait |
| aifw-conntrack | `ConntrackError` (Pf / Other) | `From<PfError>`; `refresh()` now returns it |
| aifw-metrics | `MetricsError` (NotFound / Backend) | added `thiserror` dep; converted `MetricsBackend` trait + store |
| aifw-plugins | `PluginError` (Plugin / Table / Other) | `From<String>`/`From<&str>` keeps plugin-author ergonomics |

Each enum has `From<Self> for aifw_common::AifwError` for cross-crate propagation. The `aifw-plugins` `Plugin` trait is a public extension point, so `PluginError: From<String>` keeps `Err("msg".into())` working for authors and lets existing `.map_err(|e| e.to_string())?` chains convert via `?`.

## Verification
- `cargo clippy -D warnings --all-targets` + `cargo fmt --check` clean
- Tests pass: aifw-ai (14), aifw-conntrack (16), aifw-metrics (27), aifw-plugins (15)
- External callers (aifw-api/aifw-daemon) unaffected — they already `let _ =` or `.map_err(|_| StatusCode)` these results