### PR TITLE
perf(build): add release profile (LTO, codegen-units=1, strip) (PERF-H2 #346)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.27"
+version = "5.97.28"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"
@@ -76,3 +76,13 @@ module_inception = "allow"
 too_many_arguments = "allow"
 type_complexity = "allow"
 should_implement_trait = "allow"
+
+# Release profile (PERF-H2 #346). LTO + single codegen unit enable cross-crate
+# inlining on hot paths (notably the aifw-ids ↔ aho-corasick prefilter);
+# strip shrinks binaries for faster cold start on the appliance.
+# `panic = "abort"` deliberately omitted: the long-running daemon/API must not
+# let a panic in one request handler abort the whole firewall process.
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = "symbols"

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.27",
+  "version": "5.97.28",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Adds a `[profile.release]` section — the workspace previously had none, so release binaries used Cargo defaults (`codegen-units=16`, no LTO).

## Changes
```toml
[profile.release]
lto = "thin"
codegen-units = 1
strip = "symbols"
```

- **`lto = "thin"` + `codegen-units = 1`** — enable cross-crate inlining on hot paths, notably the `aifw-ids` ↔ `aho-corasick` prefilter the audit flagged.
- **`strip = "symbols"`** — smaller binaries, faster cold start on the appliance.
- **`panic = "abort"` deliberately omitted** — the daemon/API is long-running; under `abort` a panic in one request handler would kill the whole firewall process instead of failing just that request. Marginal perf gain isn't worth the availability risk. No `catch_unwind` exists in the codebase, and CI tests run in dev profile, so this only affects the availability tradeoff.

Closes #346 (PERF-H2).

## Test
`cargo check` clean (zero warnings); pre-commit fmt + clippy `-D warnings` pass.