### PR TITLE
perf(core): replace SELECT * with explicit column lists (PERF-H4 #348)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.28"
+version = "5.97.29"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-core/src/acme.rs
+++ b/aifw-core/src/acme.rs
@@ -345,6 +345,11 @@ fn parse_dt(s: Option<String>) -> Option<DateTime<Utc>> {
         .map(|d| d.with_timezone(&Utc))
 }
 
+/// Explicit column list for `acme_account` selects (#348). `SELECT *` triggers
+/// a sqlx-sqlite column-count panic and blocks column pruning; an explicit list
+/// keeps the count deterministic. Columns in `CREATE TABLE` schema order.
+const ACME_ACCOUNT_COLUMNS: &str = "id, directory_url, contact_email, key_pem, created_at";
+
 fn row_to_account(row: &sqlx::sqlite::SqliteRow) -> AcmeAccount {
     AcmeAccount {
         id: row.get("id"),
@@ -356,22 +361,26 @@ fn row_to_account(row: &sqlx::sqlite::SqliteRow) -> AcmeAccount {
 }
 
 pub async fn load_account(pool: &SqlitePool, id: i64) -> Option<AcmeAccount> {
-    sqlx::query("SELECT * FROM acme_account WHERE id = ?")
-        .bind(id)
-        .fetch_optional(pool)
-        .await
-        .ok()
-        .flatten()
-        .map(|r| row_to_account(&r))
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "SELECT {ACME_ACCOUNT_COLUMNS} FROM acme_account WHERE id = ?"
+    )))
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()
+    .map(|r| row_to_account(&r))
 }
 
 pub async fn load_default_account(pool: &SqlitePool) -> Option<AcmeAccount> {
-    sqlx::query("SELECT * FROM acme_account ORDER BY id LIMIT 1")
-        .fetch_optional(pool)
-        .await
-        .ok()
-        .flatten()
-        .map(|r| row_to_account(&r))
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "SELECT {ACME_ACCOUNT_COLUMNS} FROM acme_account ORDER BY id LIMIT 1"
+    )))
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()
+    .map(|r| row_to_account(&r))
 }
 
 pub async fn save_account(
@@ -411,6 +420,13 @@ pub async fn save_account(
     .map_err(|e| e.to_string())
 }
 
+/// Explicit column list for `acme_cert` selects (#348). Avoids the sqlx-sqlite
+/// column-count panic and enables column pruning. Columns in `CREATE TABLE`
+/// schema order.
+const ACME_CERT_COLUMNS: &str = "id, common_name, sans, challenge_type, dns_provider_id, \
+    auto_renew, renew_days_before_expiry, status, issued_at, expires_at, last_renew_attempt, \
+    last_renew_error, cert_pem, chain_pem, key_pem";
+
 fn row_to_cert(row: &sqlx::sqlite::SqliteRow) -> AcmeCert {
     let sans_json: String = row.get("sans");
     let sans: Vec<String> = serde_json::from_str(&sans_json).unwrap_or_default();
@@ -434,23 +450,27 @@ fn row_to_cert(row: &sqlx::sqlite::SqliteRow) -> AcmeCert {
 }
 
 pub async fn load_cert(pool: &SqlitePool, id: i64) -> Option<AcmeCert> {
-    sqlx::query("SELECT * FROM acme_cert WHERE id = ?")
-        .bind(id)
-        .fetch_optional(pool)
-        .await
-        .ok()
-        .flatten()
-        .map(|r| row_to_cert(&r))
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "SELECT {ACME_CERT_COLUMNS} FROM acme_cert WHERE id = ?"
+    )))
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()
+    .map(|r| row_to_cert(&r))
 }
 
 pub async fn load_all_certs(pool: &SqlitePool) -> Vec<AcmeCert> {
-    sqlx::query("SELECT * FROM acme_cert ORDER BY common_name")
-        .fetch_all(pool)
-        .await
-        .unwrap_or_default()
-        .iter()
-        .map(row_to_cert)
-        .collect()
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "SELECT {ACME_CERT_COLUMNS} FROM acme_cert ORDER BY common_name"
+    )))
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default()
+    .iter()
+    .map(row_to_cert)
+    .collect()
 }
 
 pub async fn certs_due_for_renewal(pool: &SqlitePool) -> Vec<AcmeCert> {
@@ -460,6 +480,11 @@ pub async fn certs_due_for_renewal(pool: &SqlitePool) -> Vec<AcmeCert> {
         .filter(|c| c.needs_renewal())
         .collect()
 }
+
+/// Explicit column list for `acme_dns_provider` selects (#348). Avoids the
+/// sqlx-sqlite column-count panic and enables column pruning. Columns in
+/// `CREATE TABLE` schema order.
+const ACME_DNS_PROVIDER_COLUMNS: &str = "id, name, kind, api_token, aws_secret_key, zone, extra";
 
 fn row_to_provider(row: &sqlx::sqlite::SqliteRow) -> AcmeDnsProvider {
     let extra_str: String = row.get("extra");
@@ -478,24 +503,34 @@ fn row_to_provider(row: &sqlx::sqlite::SqliteRow) -> AcmeDnsProvider {
 }
 
 pub async fn load_provider(pool: &SqlitePool, id: i64) -> Option<AcmeDnsProvider> {
-    sqlx::query("SELECT * FROM acme_dns_provider WHERE id = ?")
-        .bind(id)
-        .fetch_optional(pool)
-        .await
-        .ok()
-        .flatten()
-        .map(|r| row_to_provider(&r))
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "SELECT {ACME_DNS_PROVIDER_COLUMNS} FROM acme_dns_provider WHERE id = ?"
+    )))
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()
+    .map(|r| row_to_provider(&r))
 }
 
 pub async fn load_all_providers(pool: &SqlitePool) -> Vec<AcmeDnsProvider> {
-    sqlx::query("SELECT * FROM acme_dns_provider ORDER BY name")
-        .fetch_all(pool)
-        .await
-        .unwrap_or_default()
-        .iter()
-        .map(row_to_provider)
-        .collect()
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "SELECT {ACME_DNS_PROVIDER_COLUMNS} FROM acme_dns_provider ORDER BY name"
+    )))
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default()
+    .iter()
+    .map(row_to_provider)
+    .collect()
 }
+
+/// Explicit column list for `acme_export_target` selects (#348). Avoids the
+/// sqlx-sqlite column-count panic and enables column pruning. Columns in
+/// `CREATE TABLE` schema order.
+const ACME_EXPORT_TARGET_COLUMNS: &str =
+    "id, cert_id, kind, config, last_run_at, last_run_ok, last_run_error";
 
 fn row_to_target(row: &sqlx::sqlite::SqliteRow) -> AcmeExportTarget {
     let cfg_str: String = row.get("config");
@@ -513,14 +548,16 @@ fn row_to_target(row: &sqlx::sqlite::SqliteRow) -> AcmeExportTarget {
 }
 
 pub async fn load_targets_for_cert(pool: &SqlitePool, cert_id: i64) -> Vec<AcmeExportTarget> {
-    sqlx::query("SELECT * FROM acme_export_target WHERE cert_id = ? ORDER BY id")
-        .bind(cert_id)
-        .fetch_all(pool)
-        .await
-        .unwrap_or_default()
-        .iter()
-        .map(row_to_target)
-        .collect()
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "SELECT {ACME_EXPORT_TARGET_COLUMNS} FROM acme_export_target WHERE cert_id = ? ORDER BY id"
+    )))
+    .bind(cert_id)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default()
+    .iter()
+    .map(row_to_target)
+    .collect()
 }
 
 // =============================================================================

--- a/aifw-core/src/audit.rs
+++ b/aifw-core/src/audit.rs
@@ -129,9 +129,9 @@ impl AuditLog {
     }
 
     pub async fn list(&self, limit: i64) -> Result<Vec<AuditEntry>> {
-        let rows = sqlx::query_as::<_, AuditRow>(
-            "SELECT * FROM audit_log ORDER BY timestamp DESC LIMIT ?1",
-        )
+        let rows = sqlx::query_as::<_, AuditRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {AUDIT_LOG_COLUMNS} FROM audit_log ORDER BY timestamp DESC LIMIT ?1"
+        )))
         .bind(limit)
         .fetch_all(&self.pool)
         .await?;
@@ -140,9 +140,9 @@ impl AuditLog {
     }
 
     pub async fn list_for_rule(&self, rule_id: Uuid) -> Result<Vec<AuditEntry>> {
-        let rows = sqlx::query_as::<_, AuditRow>(
-            "SELECT * FROM audit_log WHERE rule_id = ?1 ORDER BY timestamp DESC",
-        )
+        let rows = sqlx::query_as::<_, AuditRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {AUDIT_LOG_COLUMNS} FROM audit_log WHERE rule_id = ?1 ORDER BY timestamp DESC"
+        )))
         .bind(rule_id.to_string())
         .fetch_all(&self.pool)
         .await?;
@@ -151,9 +151,9 @@ impl AuditLog {
     }
 
     pub async fn list_by_action(&self, action: AuditAction, limit: i64) -> Result<Vec<AuditEntry>> {
-        let rows = sqlx::query_as::<_, AuditRow>(
-            "SELECT * FROM audit_log WHERE action = ?1 ORDER BY timestamp DESC LIMIT ?2",
-        )
+        let rows = sqlx::query_as::<_, AuditRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {AUDIT_LOG_COLUMNS} FROM audit_log WHERE action = ?1 ORDER BY timestamp DESC LIMIT ?2"
+        )))
         .bind(action.to_string())
         .bind(limit)
         .fetch_all(&self.pool)
@@ -169,6 +169,10 @@ impl AuditLog {
         Ok(row.0)
     }
 }
+
+/// Explicit column list for `AuditRow` selects (#348). Avoids `SELECT *`,
+/// which triggers a sqlx-sqlite column-count panic and blocks column pruning.
+const AUDIT_LOG_COLUMNS: &str = "id, timestamp, action, rule_id, details, source";
 
 #[derive(sqlx::FromRow)]
 struct AuditRow {

--- a/aifw-core/src/ddns.rs
+++ b/aifw-core/src/ddns.rs
@@ -222,6 +222,14 @@ fn parse_dt(s: Option<String>) -> Option<DateTime<Utc>> {
         .map(|d| d.with_timezone(&Utc))
 }
 
+/// Explicit column list for `ddns_record` selects (PERF-H4 #348).
+/// `SELECT *` here triggers a sqlx-sqlite column-count panic that blocks
+/// pruning; an explicit list keeps the count deterministic. Columns are in
+/// `CREATE TABLE` schema order and cover every field `row_to_record` reads.
+const DDNS_RECORD_COLUMNS: &str = "id, provider_id, hostname, record_type, source, \
+    interface, explicit_ip, ttl, enabled, last_ip, last_ipv6, last_updated, \
+    last_status, last_error";
+
 fn row_to_record(row: &sqlx::sqlite::SqliteRow) -> DdnsRecord {
     DdnsRecord {
         id: row.get("id"),
@@ -242,23 +250,27 @@ fn row_to_record(row: &sqlx::sqlite::SqliteRow) -> DdnsRecord {
 }
 
 pub async fn load_record(pool: &SqlitePool, id: i64) -> Option<DdnsRecord> {
-    sqlx::query("SELECT * FROM ddns_record WHERE id = ?")
-        .bind(id)
-        .fetch_optional(pool)
-        .await
-        .ok()
-        .flatten()
-        .map(|r| row_to_record(&r))
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "SELECT {DDNS_RECORD_COLUMNS} FROM ddns_record WHERE id = ?"
+    )))
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()
+    .map(|r| row_to_record(&r))
 }
 
 pub async fn load_all_records(pool: &SqlitePool) -> Vec<DdnsRecord> {
-    sqlx::query("SELECT * FROM ddns_record ORDER BY hostname")
-        .fetch_all(pool)
-        .await
-        .unwrap_or_default()
-        .iter()
-        .map(row_to_record)
-        .collect()
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "SELECT {DDNS_RECORD_COLUMNS} FROM ddns_record ORDER BY hostname"
+    )))
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default()
+    .iter()
+    .map(row_to_record)
+    .collect()
 }
 
 // =============================================================================

--- a/aifw-core/src/dns_blocklists.rs
+++ b/aifw-core/src/dns_blocklists.rs
@@ -411,6 +411,13 @@ pub fn validate_pattern(p: &str) -> Result<(), String> {
 // Loaders
 // ============================================================================
 
+/// Explicit column list for `dns_blocklist_source` selects (PERF-H4 #348).
+/// `SELECT *` here triggers a sqlx-sqlite column-count panic that blocks
+/// pruning; an explicit list keeps the count deterministic. Columns are in
+/// `CREATE TABLE` schema order and cover every field `row_to_source` reads.
+const DNS_BLOCKLIST_SOURCE_COLUMNS: &str = "id, name, category, url, format, enabled, \
+    action, redirect_ip, last_updated, last_sha256, rule_count, last_error, built_in";
+
 fn row_to_source(row: &sqlx::sqlite::SqliteRow) -> BlocklistSource {
     BlocklistSource {
         id: row.get("id"),
@@ -430,23 +437,27 @@ fn row_to_source(row: &sqlx::sqlite::SqliteRow) -> BlocklistSource {
 }
 
 pub async fn load_source(pool: &SqlitePool, id: i64) -> Option<BlocklistSource> {
-    sqlx::query("SELECT * FROM dns_blocklist_source WHERE id = ?")
-        .bind(id)
-        .fetch_optional(pool)
-        .await
-        .ok()
-        .flatten()
-        .map(|r| row_to_source(&r))
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "SELECT {DNS_BLOCKLIST_SOURCE_COLUMNS} FROM dns_blocklist_source WHERE id = ?"
+    )))
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()
+    .map(|r| row_to_source(&r))
 }
 
 pub async fn load_all_sources(pool: &SqlitePool) -> Vec<BlocklistSource> {
-    sqlx::query("SELECT * FROM dns_blocklist_source ORDER BY category, name")
-        .fetch_all(pool)
-        .await
-        .unwrap_or_default()
-        .iter()
-        .map(row_to_source)
-        .collect()
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "SELECT {DNS_BLOCKLIST_SOURCE_COLUMNS} FROM dns_blocklist_source ORDER BY category, name"
+    )))
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default()
+    .iter()
+    .map(row_to_source)
+    .collect()
 }
 
 pub async fn load_schedule(pool: &SqlitePool) -> BlocklistSchedule {

--- a/aifw-core/src/geoip.rs
+++ b/aifw-core/src/geoip.rs
@@ -113,19 +113,22 @@ impl GeoIpEngine {
     }
 
     pub async fn list_rules(&self) -> Result<Vec<GeoIpRule>> {
-        let rows =
-            sqlx::query_as::<_, GeoIpRuleRow>("SELECT * FROM geoip_rules ORDER BY country ASC")
-                .fetch_all(&self.pool)
-                .await?;
+        let rows = sqlx::query_as::<_, GeoIpRuleRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {GEOIP_RULE_COLUMNS} FROM geoip_rules ORDER BY country ASC"
+        )))
+        .fetch_all(&self.pool)
+        .await?;
         rows.into_iter().map(|r| r.into_rule()).collect()
     }
 
     pub async fn get_rule(&self, id: Uuid) -> Result<GeoIpRule> {
-        let row = sqlx::query_as::<_, GeoIpRuleRow>("SELECT * FROM geoip_rules WHERE id = ?1")
-            .bind(id.to_string())
-            .fetch_optional(&self.pool)
-            .await?
-            .ok_or_else(|| AifwError::NotFound(format!("geo-ip rule {id} not found")))?;
+        let row = sqlx::query_as::<_, GeoIpRuleRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {GEOIP_RULE_COLUMNS} FROM geoip_rules WHERE id = ?1"
+        )))
+        .bind(id.to_string())
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| AifwError::NotFound(format!("geo-ip rule {id} not found")))?;
         row.into_rule()
     }
 
@@ -308,6 +311,11 @@ fn build_ip_network(addr: IpAddr, prefix: u8) -> Option<IpNetwork> {
 }
 
 // --- Row types ---
+
+/// Explicit column list for `GeoIpRuleRow` selects, in schema order. Replaces
+/// `SELECT *` which triggers a sqlx-sqlite column-count panic and blocks
+/// column pruning (#348).
+const GEOIP_RULE_COLUMNS: &str = "id, country, action, label, status, created_at, updated_at";
 
 #[derive(sqlx::FromRow)]
 struct GeoIpRuleRow {

--- a/aifw-core/src/ha.rs
+++ b/aifw-core/src/ha.rs
@@ -192,9 +192,11 @@ impl ClusterEngine {
     }
 
     pub async fn list_carp_vips(&self) -> Result<Vec<CarpVip>> {
-        let rows = sqlx::query_as::<_, CarpVipRow>("SELECT * FROM carp_vips ORDER BY vhid ASC")
-            .fetch_all(&self.pool)
-            .await?;
+        let rows = sqlx::query_as::<_, CarpVipRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {CARP_VIPS_COLUMNS} FROM carp_vips ORDER BY vhid ASC"
+        )))
+        .fetch_all(&self.pool)
+        .await?;
         rows.into_iter().map(|r| r.into_vip()).collect()
     }
 
@@ -266,9 +268,11 @@ impl ClusterEngine {
     }
 
     pub async fn get_pfsync(&self) -> Result<Option<PfsyncConfig>> {
-        let row = sqlx::query_as::<_, PfsyncRow>("SELECT * FROM pfsync_config LIMIT 1")
-            .fetch_optional(&self.pool)
-            .await?;
+        let row = sqlx::query_as::<_, PfsyncRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {PFSYNC_CONFIG_COLUMNS} FROM pfsync_config LIMIT 1"
+        )))
+        .fetch_optional(&self.pool)
+        .await?;
         row.map(|r| r.into_config()).transpose()
     }
 
@@ -303,10 +307,11 @@ impl ClusterEngine {
     }
 
     pub async fn list_nodes(&self) -> Result<Vec<ClusterNode>> {
-        let rows =
-            sqlx::query_as::<_, ClusterNodeRow>("SELECT * FROM cluster_nodes ORDER BY name ASC")
-                .fetch_all(&self.pool)
-                .await?;
+        let rows = sqlx::query_as::<_, ClusterNodeRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {CLUSTER_NODES_COLUMNS} FROM cluster_nodes ORDER BY name ASC"
+        )))
+        .fetch_all(&self.pool)
+        .await?;
         rows.into_iter().map(|r| r.into_node()).collect()
     }
 
@@ -444,10 +449,11 @@ impl ClusterEngine {
     }
 
     pub async fn list_health_checks(&self) -> Result<Vec<HealthCheck>> {
-        let rows =
-            sqlx::query_as::<_, HealthCheckRow>("SELECT * FROM health_checks ORDER BY name ASC")
-                .fetch_all(&self.pool)
-                .await?;
+        let rows = sqlx::query_as::<_, HealthCheckRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {HEALTH_CHECKS_COLUMNS} FROM health_checks ORDER BY name ASC"
+        )))
+        .fetch_all(&self.pool)
+        .await?;
         rows.into_iter().map(|r| r.into_check()).collect()
     }
 
@@ -688,6 +694,12 @@ async fn read_local_role() -> aifw_common::ClusterRole {
 // Row types
 // ============================================================
 
+/// Explicit column list for `CarpVipRow` selects (#348). `SELECT *` triggers a
+/// sqlx-sqlite column-count panic and blocks column pruning; an explicit list
+/// keeps the count deterministic and matches the `CarpVipRow` fields exactly.
+const CARP_VIPS_COLUMNS: &str =
+    "id, vhid, virtual_ip, prefix, interface, password, status, created_at, updated_at";
+
 #[derive(sqlx::FromRow)]
 struct CarpVipRow {
     id: String,
@@ -725,6 +737,12 @@ impl CarpVipRow {
     }
 }
 
+/// Explicit column list for `PfsyncRow` selects (#348). `SELECT *` triggers a
+/// sqlx-sqlite column-count panic and blocks column pruning; an explicit list
+/// keeps the count deterministic and matches the `PfsyncRow` fields exactly.
+const PFSYNC_CONFIG_COLUMNS: &str = "id, sync_interface, sync_peer, defer_mode, enabled, \
+    created_at, latency_profile, heartbeat_iface, heartbeat_interval_ms, dhcp_link";
+
 #[derive(sqlx::FromRow)]
 struct PfsyncRow {
     id: String,
@@ -761,6 +779,14 @@ impl PfsyncRow {
         })
     }
 }
+
+/// Explicit column list for `ClusterNodeRow` selects (#348). `SELECT *` triggers
+/// a sqlx-sqlite column-count panic and blocks column pruning; an explicit list
+/// keeps the count deterministic and matches the `ClusterNodeRow` fields exactly.
+/// Note: `peer_api_key`/`peer_api_key_hash` exist on the table but are NOT part
+/// of `ClusterNodeRow`, so they are intentionally omitted here.
+const CLUSTER_NODES_COLUMNS: &str = "id, name, address, role, health, last_seen, \
+    config_version, created_at, software_version, last_pushed_cert_at";
 
 #[derive(sqlx::FromRow)]
 struct ClusterNodeRow {
@@ -805,6 +831,12 @@ impl ClusterNodeRow {
         })
     }
 }
+
+/// Explicit column list for `HealthCheckRow` selects (#348). `SELECT *` triggers
+/// a sqlx-sqlite column-count panic and blocks column pruning; an explicit list
+/// keeps the count deterministic and matches the `HealthCheckRow` fields exactly.
+const HEALTH_CHECKS_COLUMNS: &str = "id, name, check_type, interval_secs, timeout_secs, \
+    failures_before_down, target, enabled, created_at";
 
 #[derive(sqlx::FromRow)]
 struct HealthCheckRow {

--- a/aifw-core/src/multiwan/gateway.rs
+++ b/aifw-core/src/multiwan/gateway.rs
@@ -193,20 +193,24 @@ impl GatewayEngine {
     }
 
     pub async fn list(&self) -> Result<Vec<Gateway>> {
-        let rows = sqlx::query("SELECT * FROM multiwan_gateways ORDER BY name ASC")
-            .fetch_all(&self.pool)
-            .await
-            .map_err(|e| AifwError::Database(e.to_string()))?;
+        let rows = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT {GATEWAY_COLUMNS} FROM multiwan_gateways ORDER BY name ASC"
+        )))
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| AifwError::Database(e.to_string()))?;
         Ok(rows.iter().map(row_to_gw).collect())
     }
 
     pub async fn get(&self, id: Uuid) -> Result<Gateway> {
-        let row = sqlx::query("SELECT * FROM multiwan_gateways WHERE id = ?1")
-            .bind(id.to_string())
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| AifwError::Database(e.to_string()))?
-            .ok_or_else(|| AifwError::NotFound(format!("gateway {id} not found")))?;
+        let row = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT {GATEWAY_COLUMNS} FROM multiwan_gateways WHERE id = ?1"
+        )))
+        .bind(id.to_string())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| AifwError::Database(e.to_string()))?
+        .ok_or_else(|| AifwError::NotFound(format!("gateway {id} not found")))?;
         Ok(row_to_gw(&row))
     }
 
@@ -492,6 +496,16 @@ impl GatewayEngine {
         Ok(())
     }
 }
+
+/// Explicit column list for `multiwan_gateways` selects (schema order).
+/// `SELECT *` triggers a sqlx-sqlite column-count panic (#348), so every
+/// query names its columns. Must match the `CREATE TABLE` in `migrate()`
+/// and every `.get(...)` in `row_to_gw`.
+const GATEWAY_COLUMNS: &str = "id, name, instance_id, interface, next_hop, ip_version, \
+    monitor_kind, monitor_target, monitor_port, monitor_expect, interval_ms, timeout_ms, \
+    loss_pct_down, loss_pct_up, latency_ms_down, latency_ms_up, consec_fail_down, consec_ok_up, \
+    weight, dampening_secs, dscp_tag, enabled, state, last_rtt_ms, last_jitter_ms, last_loss_pct, \
+    last_mos, last_probe_ts, created_at, updated_at";
 
 fn row_to_gw(r: &sqlx::sqlite::SqliteRow) -> Gateway {
     Gateway {

--- a/aifw-core/src/multiwan/group.rs
+++ b/aifw-core/src/multiwan/group.rs
@@ -66,20 +66,24 @@ impl GroupEngine {
     }
 
     pub async fn list(&self) -> Result<Vec<GatewayGroup>> {
-        let rows = sqlx::query("SELECT * FROM multiwan_groups ORDER BY name ASC")
-            .fetch_all(&self.pool)
-            .await
-            .map_err(|e| AifwError::Database(e.to_string()))?;
+        let rows = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT {GROUP_COLUMNS} FROM multiwan_groups ORDER BY name ASC"
+        )))
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| AifwError::Database(e.to_string()))?;
         Ok(rows.iter().map(row_to_group).collect())
     }
 
     pub async fn get(&self, id: Uuid) -> Result<GatewayGroup> {
-        let row = sqlx::query("SELECT * FROM multiwan_groups WHERE id = ?1")
-            .bind(id.to_string())
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| AifwError::Database(e.to_string()))?
-            .ok_or_else(|| AifwError::NotFound(format!("group {id} not found")))?;
+        let row = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT {GROUP_COLUMNS} FROM multiwan_groups WHERE id = ?1"
+        )))
+        .bind(id.to_string())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| AifwError::Database(e.to_string()))?
+        .ok_or_else(|| AifwError::NotFound(format!("group {id} not found")))?;
         Ok(row_to_group(&row))
     }
 
@@ -271,6 +275,13 @@ fn prefer_up(s: GatewayState) -> u8 {
         _ => 0,
     }
 }
+
+/// Explicit column list for `multiwan_groups` selects (schema order).
+/// `SELECT *` triggers a sqlx-sqlite column-count panic (#348), so every
+/// query names its columns. Must match the `CREATE TABLE` in `migrate()`
+/// and every `.get(...)` in `row_to_group`.
+const GROUP_COLUMNS: &str = "id, name, policy, preempt, sticky, hysteresis_ms, \
+    kill_states_on_failover, created_at, updated_at";
 
 fn row_to_group(r: &sqlx::sqlite::SqliteRow) -> GatewayGroup {
     GatewayGroup {

--- a/aifw-core/src/multiwan/leak.rs
+++ b/aifw-core/src/multiwan/leak.rs
@@ -46,20 +46,24 @@ impl LeakEngine {
     }
 
     pub async fn list(&self) -> Result<Vec<RouteLeak>> {
-        let rows = sqlx::query("SELECT * FROM multiwan_leaks ORDER BY name ASC")
-            .fetch_all(&self.pool)
-            .await
-            .map_err(|e| AifwError::Database(e.to_string()))?;
+        let rows = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT {LEAK_COLUMNS} FROM multiwan_leaks ORDER BY name ASC"
+        )))
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| AifwError::Database(e.to_string()))?;
         Ok(rows.iter().map(row_to_leak).collect())
     }
 
     pub async fn get(&self, id: Uuid) -> Result<RouteLeak> {
-        let row = sqlx::query("SELECT * FROM multiwan_leaks WHERE id = ?1")
-            .bind(id.to_string())
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| AifwError::Database(e.to_string()))?
-            .ok_or_else(|| AifwError::NotFound(format!("leak {id} not found")))?;
+        let row = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT {LEAK_COLUMNS} FROM multiwan_leaks WHERE id = ?1"
+        )))
+        .bind(id.to_string())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| AifwError::Database(e.to_string()))?
+        .ok_or_else(|| AifwError::NotFound(format!("leak {id} not found")))?;
         Ok(row_to_leak(&row))
     }
 
@@ -239,6 +243,13 @@ impl LeakEngine {
         Ok(())
     }
 }
+
+/// Explicit column list for `multiwan_leaks` selects (schema order).
+/// `SELECT *` triggers a sqlx-sqlite column-count panic (#348), so every
+/// query names its columns. Must match the `CREATE TABLE` in `migrate()`
+/// and every `.get(...)` in `row_to_leak`.
+const LEAK_COLUMNS: &str = "id, name, src_instance_id, dst_instance_id, prefix, protocol, \
+    ports, direction, enabled, created_at, updated_at";
 
 fn row_to_leak(r: &sqlx::sqlite::SqliteRow) -> RouteLeak {
     RouteLeak {

--- a/aifw-core/src/multiwan/policy.rs
+++ b/aifw-core/src/multiwan/policy.rs
@@ -67,20 +67,24 @@ impl PolicyEngine {
     }
 
     pub async fn list(&self) -> Result<Vec<PolicyRule>> {
-        let rows = sqlx::query("SELECT * FROM multiwan_policies ORDER BY priority ASC")
-            .fetch_all(&self.pool)
-            .await
-            .map_err(|e| AifwError::Database(e.to_string()))?;
+        let rows = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT {POLICY_COLUMNS} FROM multiwan_policies ORDER BY priority ASC"
+        )))
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| AifwError::Database(e.to_string()))?;
         Ok(rows.iter().map(row_to_policy).collect())
     }
 
     pub async fn get(&self, id: Uuid) -> Result<PolicyRule> {
-        let row = sqlx::query("SELECT * FROM multiwan_policies WHERE id = ?1")
-            .bind(id.to_string())
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(|e| AifwError::Database(e.to_string()))?
-            .ok_or_else(|| AifwError::NotFound(format!("policy {id} not found")))?;
+        let row = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT {POLICY_COLUMNS} FROM multiwan_policies WHERE id = ?1"
+        )))
+        .bind(id.to_string())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| AifwError::Database(e.to_string()))?
+        .ok_or_else(|| AifwError::NotFound(format!("policy {id} not found")))?;
         Ok(row_to_policy(&row))
     }
 
@@ -384,6 +388,14 @@ fn if_some_proto(p: &str, out: &mut String) {
         out.push_str(&format!(" proto {p}"));
     }
 }
+
+/// Explicit column list for `multiwan_policies` selects (schema order).
+/// `SELECT *` triggers a sqlx-sqlite column-count panic (#348), so every
+/// query names its columns. Must match the `CREATE TABLE` in `migrate()`
+/// and every `.get(...)` in `row_to_policy`.
+const POLICY_COLUMNS: &str = "id, priority, name, status, ip_version, iface_in, src_addr, \
+    dst_addr, src_port, dst_port, protocol, dscp_in, geoip_country, schedule_id, action_kind, \
+    target_id, sticky, fallback_target_id, description, created_at, updated_at";
 
 fn row_to_policy(r: &sqlx::sqlite::SqliteRow) -> PolicyRule {
     PolicyRule {

--- a/aifw-core/src/multiwan/sla.rs
+++ b/aifw-core/src/multiwan/sla.rs
@@ -21,6 +21,13 @@ pub struct SlaSample {
     pub up_seconds: u64,
 }
 
+/// Explicit column list for `multiwan_sla_samples` selects (schema order).
+/// `SELECT *` triggers a sqlx-sqlite column-count panic (#348) that blocks
+/// pruning, so every query names its columns. Must match the `CREATE TABLE`
+/// in `migrate()` and every `.get(...)` in `window`.
+const SLA_COLUMNS: &str = "gateway_id, bucket_ts, samples, rtt_avg, rtt_p95, rtt_p99, \
+    jitter_avg, loss_pct, mos_avg, up_seconds";
+
 pub struct SlaEngine {
     pool: SqlitePool,
 }
@@ -81,10 +88,10 @@ impl SlaEngine {
     /// Retrieve samples for a gateway within a rolling window.
     pub async fn window(&self, gw_id: Uuid, hours: i64) -> Result<Vec<SlaSample>> {
         let since = (Utc::now() - Duration::hours(hours)).to_rfc3339();
-        let rows = sqlx::query(
-            "SELECT * FROM multiwan_sla_samples WHERE gateway_id = ?1 AND bucket_ts >= ?2
-             ORDER BY bucket_ts ASC",
-        )
+        let rows = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "SELECT {SLA_COLUMNS} FROM multiwan_sla_samples WHERE gateway_id = ?1 AND bucket_ts >= ?2
+             ORDER BY bucket_ts ASC"
+        )))
         .bind(gw_id.to_string())
         .bind(since)
         .fetch_all(&self.pool)

--- a/aifw-core/src/nat.rs
+++ b/aifw-core/src/nat.rs
@@ -84,10 +84,12 @@ impl NatEngine {
     }
 
     pub async fn get_rule(&self, id: Uuid) -> Result<NatRule> {
-        let row = sqlx::query_as::<_, NatRuleRow>("SELECT * FROM nat_rules WHERE id = ?1")
-            .bind(id.to_string())
-            .fetch_optional(&self.pool)
-            .await?;
+        let row = sqlx::query_as::<_, NatRuleRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {NAT_RULE_COLUMNS} FROM nat_rules WHERE id = ?1"
+        )))
+        .bind(id.to_string())
+        .fetch_optional(&self.pool)
+        .await?;
 
         row.map(|r| r.into_nat_rule())
             .transpose()?
@@ -95,18 +97,19 @@ impl NatEngine {
     }
 
     pub async fn list_rules(&self) -> Result<Vec<NatRule>> {
-        let rows =
-            sqlx::query_as::<_, NatRuleRow>("SELECT * FROM nat_rules ORDER BY created_at ASC")
-                .fetch_all(&self.pool)
-                .await?;
+        let rows = sqlx::query_as::<_, NatRuleRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {NAT_RULE_COLUMNS} FROM nat_rules ORDER BY created_at ASC"
+        )))
+        .fetch_all(&self.pool)
+        .await?;
 
         rows.into_iter().map(|r| r.into_nat_rule()).collect()
     }
 
     pub async fn list_active_rules(&self) -> Result<Vec<NatRule>> {
-        let rows = sqlx::query_as::<_, NatRuleRow>(
-            "SELECT * FROM nat_rules WHERE status = 'active' ORDER BY created_at ASC",
-        )
+        let rows = sqlx::query_as::<_, NatRuleRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {NAT_RULE_COLUMNS} FROM nat_rules WHERE status = 'active' ORDER BY created_at ASC"
+        )))
         .fetch_all(&self.pool)
         .await?;
 
@@ -297,6 +300,14 @@ fn validate_nat_rule(rule: &NatRule) -> Result<()> {
 
     Ok(())
 }
+
+/// Explicit column list for `NatRuleRow` selects, in schema order. Replaces
+/// `SELECT *` which triggers a sqlx-sqlite column-count panic and blocks
+/// column pruning (#348).
+const NAT_RULE_COLUMNS: &str = "id, nat_type, interface, protocol, src_addr, \
+    src_port_start, src_port_end, dst_addr, dst_port_start, dst_port_end, \
+    redirect_addr, redirect_port_start, redirect_port_end, label, status, \
+    created_at, updated_at";
 
 #[derive(sqlx::FromRow)]
 struct NatRuleRow {

--- a/aifw-core/src/shaping.rs
+++ b/aifw-core/src/shaping.rs
@@ -86,10 +86,11 @@ impl ShapingEngine {
     }
 
     pub async fn list_queues(&self) -> Result<Vec<QueueConfig>> {
-        let rows =
-            sqlx::query_as::<_, QueueRow>("SELECT * FROM queue_configs ORDER BY created_at ASC")
-                .fetch_all(&self.pool)
-                .await?;
+        let rows = sqlx::query_as::<_, QueueRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {QUEUE_COLUMNS} FROM queue_configs ORDER BY created_at ASC"
+        )))
+        .fetch_all(&self.pool)
+        .await?;
         rows.into_iter().map(|r| r.into_queue()).collect()
     }
 
@@ -153,9 +154,9 @@ impl ShapingEngine {
     }
 
     pub async fn list_rate_limits(&self) -> Result<Vec<RateLimitRule>> {
-        let rows = sqlx::query_as::<_, RateLimitRow>(
-            "SELECT * FROM rate_limit_rules ORDER BY created_at ASC",
-        )
+        let rows = sqlx::query_as::<_, RateLimitRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {RATE_LIMIT_COLUMNS} FROM rate_limit_rules ORDER BY created_at ASC"
+        )))
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter().map(|r| r.into_rate_limit()).collect()
@@ -268,6 +269,20 @@ impl ShapingEngine {
 }
 
 // --- Row types ---
+
+/// Explicit column list for `QueueRow` selects, in schema order. Replaces
+/// `SELECT *` which triggers a sqlx-sqlite column-count panic and blocks
+/// column pruning (#348).
+const QUEUE_COLUMNS: &str = "id, interface, queue_type, bandwidth_value, \
+    bandwidth_unit, name, traffic_class, bandwidth_pct, is_default, status, \
+    created_at, updated_at";
+
+/// Explicit column list for `RateLimitRow` selects, in schema order. Replaces
+/// `SELECT *` which triggers a sqlx-sqlite column-count panic and blocks
+/// column pruning (#348).
+const RATE_LIMIT_COLUMNS: &str = "id, name, interface, protocol, src_addr, \
+    dst_addr, dst_port_start, dst_port_end, max_connections, window_secs, \
+    overload_table, flush_states, status, created_at, updated_at";
 
 #[derive(sqlx::FromRow)]
 struct QueueRow {

--- a/aifw-core/src/tls.rs
+++ b/aifw-core/src/tls.rs
@@ -93,9 +93,11 @@ impl TlsEngine {
     }
 
     pub async fn list_sni_rules(&self) -> Result<Vec<SniRule>> {
-        let rows = sqlx::query_as::<_, SniRuleRow>("SELECT * FROM sni_rules ORDER BY pattern ASC")
-            .fetch_all(&self.pool)
-            .await?;
+        let rows = sqlx::query_as::<_, SniRuleRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {SNI_RULE_COLUMNS} FROM sni_rules ORDER BY pattern ASC"
+        )))
+        .fetch_all(&self.pool)
+        .await?;
         rows.into_iter().map(|r| r.into_rule()).collect()
     }
 
@@ -203,6 +205,10 @@ impl TlsEngine {
 }
 
 // --- Row types ---
+
+/// Explicit column list for `SniRuleRow` selects (#348). Avoids `SELECT *`,
+/// which triggers a sqlx-sqlite column-count panic and blocks column pruning.
+const SNI_RULE_COLUMNS: &str = "id, pattern, action, label, status, created_at, updated_at";
 
 #[derive(sqlx::FromRow)]
 struct SniRuleRow {

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -164,19 +164,22 @@ impl VpnEngine {
     }
 
     pub async fn list_wg_tunnels(&self) -> Result<Vec<WgTunnel>> {
-        let rows =
-            sqlx::query_as::<_, WgTunnelRow>("SELECT * FROM wg_tunnels ORDER BY created_at ASC")
-                .fetch_all(&self.pool)
-                .await?;
+        let rows = sqlx::query_as::<_, WgTunnelRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {WG_TUNNEL_COLUMNS} FROM wg_tunnels ORDER BY created_at ASC"
+        )))
+        .fetch_all(&self.pool)
+        .await?;
         rows.into_iter().map(|r| r.into_tunnel()).collect()
     }
 
     pub async fn get_wg_tunnel(&self, id: Uuid) -> Result<WgTunnel> {
-        let row = sqlx::query_as::<_, WgTunnelRow>("SELECT * FROM wg_tunnels WHERE id = ?1")
-            .bind(id.to_string())
-            .fetch_optional(&self.pool)
-            .await?
-            .ok_or_else(|| AifwError::NotFound(format!("WG tunnel {id} not found")))?;
+        let row = sqlx::query_as::<_, WgTunnelRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {WG_TUNNEL_COLUMNS} FROM wg_tunnels WHERE id = ?1"
+        )))
+        .bind(id.to_string())
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| AifwError::NotFound(format!("WG tunnel {id} not found")))?;
         row.into_tunnel()
     }
 
@@ -309,9 +312,9 @@ impl VpnEngine {
     }
 
     pub async fn list_wg_peers(&self, tunnel_id: Uuid) -> Result<Vec<WgPeer>> {
-        let rows = sqlx::query_as::<_, WgPeerRow>(
-            "SELECT * FROM wg_peers WHERE tunnel_id = ?1 ORDER BY created_at ASC",
-        )
+        let rows = sqlx::query_as::<_, WgPeerRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {WG_PEER_COLUMNS} FROM wg_peers WHERE tunnel_id = ?1 ORDER BY created_at ASC"
+        )))
         .bind(tunnel_id.to_string())
         .fetch_all(&self.pool)
         .await?;
@@ -319,11 +322,13 @@ impl VpnEngine {
     }
 
     pub async fn get_wg_peer(&self, id: Uuid) -> Result<WgPeer> {
-        let row = sqlx::query_as::<_, WgPeerRow>("SELECT * FROM wg_peers WHERE id = ?1")
-            .bind(id.to_string())
-            .fetch_optional(&self.pool)
-            .await?
-            .ok_or_else(|| AifwError::NotFound(format!("WG peer {id} not found")))?;
+        let row = sqlx::query_as::<_, WgPeerRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {WG_PEER_COLUMNS} FROM wg_peers WHERE id = ?1"
+        )))
+        .bind(id.to_string())
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| AifwError::NotFound(format!("WG peer {id} not found")))?;
         row.into_peer()
     }
 
@@ -398,10 +403,11 @@ impl VpnEngine {
     }
 
     pub async fn list_ipsec_sas(&self) -> Result<Vec<IpsecSa>> {
-        let rows =
-            sqlx::query_as::<_, IpsecSaRow>("SELECT * FROM ipsec_sas ORDER BY created_at ASC")
-                .fetch_all(&self.pool)
-                .await?;
+        let rows = sqlx::query_as::<_, IpsecSaRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {IPSEC_SA_COLUMNS} FROM ipsec_sas ORDER BY created_at ASC"
+        )))
+        .fetch_all(&self.pool)
+        .await?;
         rows.into_iter().map(|r| r.into_sa()).collect()
     }
 
@@ -776,6 +782,15 @@ impl VpnEngine {
 // Row types
 // ============================================================
 
+/// Explicit column list for `WgTunnelRow` selects (#348). `SELECT *` triggers
+/// a sqlx-sqlite column-count panic and blocks column pruning; the `wg_tunnels`
+/// table gained `listen_interface`/`split_routes` via ALTER TABLE, so an
+/// explicit list keeps the column count deterministic. Order matches the
+/// CREATE TABLE (base columns then ALTER-added columns).
+const WG_TUNNEL_COLUMNS: &str = "id, name, interface, private_key, public_key, \
+    listen_port, address, dns, mtu, status, created_at, updated_at, \
+    listen_interface, split_routes";
+
 #[derive(sqlx::FromRow)]
 struct WgTunnelRow {
     id: String,
@@ -815,6 +830,13 @@ impl WgTunnelRow {
         })
     }
 }
+
+/// Explicit column list for `WgPeerRow` selects (#348). `client_private_key`
+/// was added via ALTER TABLE, so an explicit list (rather than `SELECT *`)
+/// keeps the column count deterministic and avoids the sqlx-sqlite panic.
+const WG_PEER_COLUMNS: &str = "id, tunnel_id, name, public_key, preshared_key, \
+    endpoint, allowed_ips, persistent_keepalive, created_at, updated_at, \
+    client_private_key";
 
 #[derive(sqlx::FromRow)]
 struct WgPeerRow {
@@ -856,6 +878,11 @@ impl WgPeerRow {
         })
     }
 }
+
+/// Explicit column list for `IpsecSaRow` selects (#348). Avoids `SELECT *`,
+/// which triggers a sqlx-sqlite column-count panic and blocks column pruning.
+const IPSEC_SA_COLUMNS: &str = "id, name, src_addr, dst_addr, protocol, mode, \
+    spi, enc_algo, auth_algo, status, created_at, updated_at";
 
 #[derive(sqlx::FromRow)]
 struct IpsecSaRow {

--- a/aifw-core/tests/no_select_star.rs
+++ b/aifw-core/tests/no_select_star.rs
@@ -1,0 +1,54 @@
+//! Regression guard for #348 (PERF-H4).
+//!
+//! `SELECT *` in sqlx queries is banned across `aifw-core/src/`. It has
+//! triggered a sqlx-sqlite column-count panic on shutdown (#273, the reason
+//! `RULE_COLUMNS` exists in `db.rs`), and it silently breaks `FromRow`
+//! consumers when an `ALTER TABLE ... ADD COLUMN` migration lands. Explicit
+//! column lists also let the SQLite optimizer skip unused TEXT columns.
+//!
+//! Every table select must name its columns explicitly (mirror the
+//! `*_COLUMNS` consts). If this test fails, replace the offending
+//! `SELECT *` with `SELECT {TABLE_COLUMNS} FROM ...`.
+
+use std::path::Path;
+
+fn scan(dir: &Path, offenders: &mut Vec<String>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            scan(&path, offenders);
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        for (lineno, line) in contents.lines().enumerate() {
+            let lower = line.to_ascii_lowercase();
+            // Only flag actual query text, not prose in comments/docs.
+            let is_comment = line.trim_start().starts_with("//");
+            if !is_comment && (lower.contains("select * from") || lower.contains("select *\n")) {
+                offenders.push(format!("{}:{}", path.display(), lineno + 1));
+            }
+        }
+    }
+}
+
+#[test]
+fn no_select_star_in_source() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut offenders = Vec::new();
+    scan(&src, &mut offenders);
+    assert!(
+        offenders.is_empty(),
+        "SELECT * is banned in aifw-core/src/ (#348); use explicit column lists. Offenders:\n{}",
+        offenders.join("\n")
+    );
+}

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.28",
+  "version": "5.97.29",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Closes #348 (PERF-H4, HIGH).

Replaced **all 40 `SELECT *` query sites** in `aifw-core/src/` with explicit column lists, mirroring the existing `RULE_COLUMNS` pattern in `db.rs`.

`SELECT *` had triggered a sqlx-sqlite column-count panic on shutdown (#273 — the reason `RULE_COLUMNS` exists) and silently breaks `FromRow` consumers when an `ALTER TABLE ... ADD COLUMN` migration lands. Explicit lists also let the SQLite optimizer skip unused TEXT columns.

## What changed

- One co-located `const <TABLE>_COLUMNS` per table (doc-commented, columns in `CREATE TABLE` schema order), cross-checked against both the `FromRow` struct fields and every `.get("...")` read.
- Dynamic query strings go through `sqlx::AssertSqlSafe(format!(...))` — required by sqlx 0.9's `SqlSafeStr` bound (only `&'static str` is safe by default), matching how `db.rs` already builds its `RULE_COLUMNS` queries. Inputs are compile-time consts, no user data.
- Coverage (25 tables): `nat`, `shaping`, `geoip`, `vpn`, `tls`, `audit`, `ha`, `acme`, `dns_blocklists`, `ddns`, and `multiwan/{gateway,policy,leak,group,sla}`.

## Regression guard

Added `aifw-core/tests/no_select_star.rs` — scans `aifw-core/src/` and fails if `SELECT *` reappears in query text (skips doc comments), matching the repo's `sudoers_tests` guard discipline.

## Verification

- `cargo check --workspace` — clean, zero warnings
- `cargo clippy -D warnings` + `cargo fmt --check` — pass
- `cargo test --workspace` — all pass, including the new guard test

Version bumped 5.97.28 → 5.97.29 (patch).