### PR TITLE
perf(build): per-crate tokio feature sets, drop workspace-wide full (PERF-H3 #347)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.29"
+version = "5.97.30"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"
@@ -40,7 +40,12 @@ tower = { version = "0.5", features = ["full"] }
 tower-http = { version = "0.7", features = ["cors", "trace", "fs", "set-header", "compression-gzip", "compression-br"] }
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 argon2 = { version = "0.5", features = ["std"] }
-tokio = { version = "1", features = ["full"] }
+# tokio base carries no runtime features (PERF-H3 #347). Every crate — library
+# and binary alike — opts into exactly the features it uses (no crate uses
+# "full"). Cargo unions features per build graph, so validate a library crate's
+# minimal set in isolation with `cargo check -p <crate>`; binaries are covered
+# by the workspace union build + test suite.
+tokio = { version = "1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.9", features = ["runtime-tokio", "sqlite", "migrate"] }

--- a/aifw-ai/Cargo.toml
+++ b/aifw-ai/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 aifw-common = { workspace = true }
 aifw-pf = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["sync", "time", "rt", "macros"] }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/aifw-api/Cargo.toml
+++ b/aifw-api/Cargo.toml
@@ -17,7 +17,7 @@ aifw-plugins = { workspace = true }
 aifw-ids = { workspace = true }
 aifw-ids-ipc = { workspace = true }
 aifw-metrics = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "fs", "process", "time", "sync", "io-util"] }
 axum = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }

--- a/aifw-cli/Cargo.toml
+++ b/aifw-cli/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 aifw-common = { workspace = true }
 aifw-core = { workspace = true }
 aifw-pf = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "process"] }
 clap = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/aifw-common/Cargo.toml
+++ b/aifw-common/Cargo.toml
@@ -11,7 +11,7 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 sqlx = { workspace = true }
-tokio = { workspace = true, features = ["sync", "net"] }
+tokio = { workspace = true, features = ["sync", "net", "rt", "macros"] }
 url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/aifw-conntrack/Cargo.toml
+++ b/aifw-conntrack/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 aifw-common = { workspace = true }
 aifw-pf = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "time", "macros"] }
 tracing = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }

--- a/aifw-core/Cargo.toml
+++ b/aifw-core/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 aifw-common = { workspace = true }
 aifw-pf = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync", "time", "net", "io-util", "fs", "process", "macros"] }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/aifw-daemon/Cargo.toml
+++ b/aifw-daemon/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 aifw-common = { workspace = true }
 aifw-pf = { workspace = true }
 aifw-core = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "net", "fs", "process", "time"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true }

--- a/aifw-ids-bin/Cargo.toml
+++ b/aifw-ids-bin/Cargo.toml
@@ -13,7 +13,7 @@ aifw-common = { workspace = true }
 aifw-ids = { workspace = true }
 aifw-ids-ipc = { workspace = true }
 aifw-pf = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal", "net", "time"] }
 sqlx = { workspace = true }
 clap = { workspace = true }
 tracing = { workspace = true }

--- a/aifw-ids-ipc/Cargo.toml
+++ b/aifw-ids-ipc/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync", "time", "net", "io-util", "macros"] }
 thiserror = { workspace = true }
 chrono = { workspace = true }
 aifw-common = { workspace = true }

--- a/aifw-ids/Cargo.toml
+++ b/aifw-ids/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 aifw-common = { workspace = true }
 aifw-pf = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync", "time", "io-util", "fs", "process", "macros"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }

--- a/aifw-metrics/Cargo.toml
+++ b/aifw-metrics/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 aifw-common = { workspace = true }
 aifw-pf = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync", "macros"] }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/aifw-pf/Cargo.toml
+++ b/aifw-pf/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 aifw-common = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["sync", "io-util", "process", "rt", "macros"] }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/aifw-plugins/Cargo.toml
+++ b/aifw-plugins/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 aifw-common = { workspace = true }
 aifw-pf = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["sync", "rt", "macros"] }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/aifw-setup/Cargo.toml
+++ b/aifw-setup/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 aifw-common = { workspace = true }
 aifw-pf = { workspace = true }
 aifw-core = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/aifw-tui/Cargo.toml
+++ b/aifw-tui/Cargo.toml
@@ -13,7 +13,7 @@ aifw-common = { workspace = true }
 aifw-pf = { workspace = true }
 aifw-core = { workspace = true }
 aifw-conntrack = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
 ratatui = { workspace = true }
 crossterm = { workspace = true }
 tracing = { workspace = true }

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.29",
+  "version": "5.97.30",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Closes #347 (PERF-H3, HIGH).

Removes `tokio = { features = ["full"] }` from the workspace base so no crate inherits the full runtime surface (signal, fs, process, net, rt-multi-thread, macros, parking_lot). Every crate now opts into exactly the tokio features it uses.

## Per-crate feature sets

**Libraries** (validated in isolation via `cargo check -p <crate>` so missing features aren't masked by binaries):

| crate | features |
|-------|----------|
| aifw-common | sync, net, rt, macros |
| aifw-pf | sync, io-util, process, rt, macros |
| aifw-core | rt, sync, time, net, io-util, fs, process, macros |
| aifw-conntrack | rt, time, macros |
| aifw-plugins | sync, rt, macros |
| aifw-ai | sync, time, rt, macros |
| aifw-ids | rt, sync, time, io-util, fs, process, macros |
| aifw-ids-ipc | rt, sync, time, net, io-util, macros |
| aifw-metrics | rt, sync, macros |

**Binaries** (`rt-multi-thread` for `#[tokio::main]`; no `io-std` — all stdin/stdout use `std::io`, not tokio):

| crate | features |
|-------|----------|
| aifw-api | rt-multi-thread, macros, net, fs, process, time, sync, io-util |
| aifw-daemon | rt-multi-thread, macros, signal, net, fs, process, time |
| aifw-cli | rt-multi-thread, macros, fs, process |
| aifw-setup | rt-multi-thread, macros |
| aifw-tui | rt-multi-thread, macros, fs |
| aifw-ids-bin | rt-multi-thread, macros, signal, net, time |

Drops the unused `parking_lot` feature everywhere and `signal` from the four binaries that don't handle signals.

## Caveat (documented in Cargo.toml)

Cargo unions features per build graph, so a full-workspace build still compiles tokio with a broad set (binaries pull in aifw-core's features). The concrete wins are: faster **isolated** library-crate builds/tests, and preventing library crates from silently depending on runtime features they shouldn't (`rt-multi-thread`, `signal`, etc.).

## Verification

- `cargo check -p <crate>` for every library crate in isolation — pass
- `cargo check --workspace --all-targets` — clean, zero warnings
- `cargo clippy -D warnings` + `cargo fmt --check` — pass
- `cargo test --workspace` — all 27 suites pass, zero failures

Version bumped 5.97.28 → 5.97.30 (patch; .29 belongs to the #348 PR).