### PR TITLE
fix(api): log error context at INTERNAL_SERVER_ERROR sites (QUAL-H12 #432)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.30"
+version = "5.97.31"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/ai_analysis.rs
+++ b/aifw-api/src/ai_analysis.rs
@@ -464,7 +464,7 @@ pub async fn get_audit_log(
     .bind(limit)
     .fetch_all(&state.pool)
     .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    .map_err(|e| { tracing::error!(error = %e, "ai_analysis: failed to query audit log"); StatusCode::INTERNAL_SERVER_ERROR })?;
 
     let entries: Vec<serde_json::Value> = rows
         .into_iter()

--- a/aifw-api/src/auth/api_keys.rs
+++ b/aifw-api/src/auth/api_keys.rs
@@ -37,7 +37,7 @@ pub async fn create_api_key(
         .bind(Utc::now().to_rfc3339())
         .execute(pool)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|e| { tracing::error!(error = %e, "auth: failed to insert API key"); StatusCode::INTERNAL_SERVER_ERROR })?;
 
     Ok(CreateApiKeyResponse {
         id,
@@ -57,7 +57,7 @@ pub async fn verify_api_key(pool: &SqlitePool, key: &str) -> Result<(String, Str
     .bind(prefix)
     .fetch_all(pool)
     .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    .map_err(|e| { tracing::error!(error = %e, "auth: failed to query API keys"); StatusCode::INTERNAL_SERVER_ERROR })?;
 
     for (key_hash, user_id, key_name) in rows {
         if verify_password(key, &key_hash) {

--- a/aifw-api/src/auth/middleware.rs
+++ b/aifw-api/src/auth/middleware.rs
@@ -111,7 +111,10 @@ pub async fn auth_middleware(
             let (bits, name) =
                 tokens::resolve_token_permissions(&state.pool, &user.role, user.role_id.as_deref())
                     .await
-                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+                    .map_err(|e| {
+                        tracing::error!(error = %e, "auth: failed to resolve token permissions");
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    })?;
             (PermissionSet::from_bits(bits), name)
         }
     };

--- a/aifw-api/src/auth/password.rs
+++ b/aifw-api/src/auth/password.rs
@@ -37,7 +37,10 @@ pub fn hash_password(password: &str) -> Result<String, StatusCode> {
     hasher()
         .hash_password(password.as_bytes(), &salt)
         .map(|h| h.to_string())
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+        .map_err(|e| {
+            tracing::error!(error = %e, "auth: password hashing failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
 }
 
 pub fn verify_password(password: &str, hash: &str) -> bool {

--- a/aifw-api/src/auth/revocation.rs
+++ b/aifw-api/src/auth/revocation.rs
@@ -14,7 +14,10 @@ pub async fn revoke_access_token(
         .bind(expires_at)
         .execute(pool)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|e| {
+            tracing::error!(error = %e, "auth: failed to insert token revocation");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     Ok(())
 }
 

--- a/aifw-api/src/auth/totp_store.rs
+++ b/aifw-api/src/auth/totp_store.rs
@@ -17,7 +17,10 @@ pub async fn save_totp_secret(
         .bind(user_id)
         .execute(pool)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|e| {
+            tracing::error!(error = %e, "auth: failed to save TOTP secret");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     Ok(())
 }
 
@@ -26,7 +29,10 @@ pub async fn enable_totp(pool: &SqlitePool, user_id: &str) -> Result<(), StatusC
         .bind(user_id)
         .execute(pool)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|e| {
+            tracing::error!(error = %e, "auth: failed to enable TOTP");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     Ok(())
 }
 
@@ -35,13 +41,19 @@ pub async fn disable_totp(pool: &SqlitePool, user_id: &str) -> Result<(), Status
         .bind(user_id)
         .execute(pool)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|e| {
+            tracing::error!(error = %e, "auth: failed to disable TOTP");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     // Also delete recovery codes
     sqlx::query("DELETE FROM recovery_codes WHERE user_id = ?1")
         .bind(user_id)
         .execute(pool)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|e| {
+            tracing::error!(error = %e, "auth: failed to delete recovery codes on TOTP disable");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     Ok(())
 }
 
@@ -55,7 +67,10 @@ pub async fn save_recovery_codes(
         .bind(user_id)
         .execute(pool)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|e| {
+            tracing::error!(error = %e, "auth: failed to delete existing recovery codes");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     for code in codes {
         let code_hash = hash_password(code)?;
@@ -67,7 +82,10 @@ pub async fn save_recovery_codes(
         .bind(&code_hash)
         .execute(pool)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|e| {
+            tracing::error!(error = %e, "auth: failed to insert recovery code");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     }
     Ok(())
 }

--- a/aifw-api/src/auth/users.rs
+++ b/aifw-api/src/auth/users.rs
@@ -84,7 +84,7 @@ pub async fn list_users(pool: &SqlitePool) -> Result<Vec<User>, StatusCode> {
     )
     .fetch_all(pool)
     .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    .map_err(|e| { tracing::error!(error = %e, "auth: failed to list users"); StatusCode::INTERNAL_SERVER_ERROR })?;
 
     Ok(rows
         .into_iter()
@@ -158,7 +158,7 @@ pub async fn update_user(
     .bind(user.enabled)
     .execute(pool)
     .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    .map_err(|e| { tracing::error!(error = %e, "auth: failed to update user"); StatusCode::INTERNAL_SERVER_ERROR })?;
 
     Ok(user)
 }
@@ -168,7 +168,10 @@ pub async fn delete_user(pool: &SqlitePool, user_id: &str) -> Result<(), StatusC
         .bind(user_id)
         .execute(pool)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|e| {
+            tracing::error!(error = %e, "auth: failed to delete user");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     if result.rows_affected() == 0 {
         return Err(StatusCode::NOT_FOUND);
     }
@@ -218,7 +221,7 @@ pub async fn list_user_audit_log(
     .bind(limit)
     .fetch_all(pool)
     .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    .map_err(|e| { tracing::error!(error = %e, "auth: failed to query user audit log"); StatusCode::INTERNAL_SERVER_ERROR })?;
 
     Ok(rows
         .into_iter()
@@ -246,7 +249,7 @@ pub async fn get_user_by_username(
     .bind(username)
     .fetch_optional(pool)
     .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    .map_err(|e| { tracing::error!(error = %e, "auth: failed to query user by username"); StatusCode::INTERNAL_SERVER_ERROR })?;
 
     Ok(row.map(
         |(id, username, pw, totp_on, totp_sec, provider, role, role_id, enabled, ca)| User {
@@ -271,7 +274,7 @@ pub async fn get_user_by_id(pool: &SqlitePool, user_id: &str) -> Result<Option<U
     .bind(user_id)
     .fetch_optional(pool)
     .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    .map_err(|e| { tracing::error!(error = %e, "auth: failed to query user by id"); StatusCode::INTERNAL_SERVER_ERROR })?;
 
     Ok(row.map(
         |(id, username, pw, totp_on, totp_sec, provider, role, role_id, enabled, ca)| User {

--- a/aifw-api/src/ca.rs
+++ b/aifw-api/src/ca.rs
@@ -284,7 +284,7 @@ fn next_serial() -> String {
 pub async fn get_ca_info(State(state): State<AppState>) -> Result<Json<CaInfo>, StatusCode> {
     let row = sqlx::query_as::<_, (String, String, String, String, String, String)>(
         "SELECT subject, serial, not_before, not_after, fingerprint, algorithm FROM ca_root WHERE id = 1",
-    ).fetch_optional(&state.pool).await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    ).fetch_optional(&state.pool).await.map_err(|e| { tracing::error!(error = %e, "ca: failed to query CA info"); StatusCode::INTERNAL_SERVER_ERROR })?;
 
     match row {
         Some((subject, serial, not_before, not_after, fingerprint, algorithm)) => {
@@ -319,10 +319,15 @@ pub async fn generate_ca(
     let days = req.validity_days.unwrap_or(3650);
     let serial = next_serial();
 
-    let key_pair = KeyPair::generate().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let key_pair = KeyPair::generate().map_err(|e| {
+        tracing::error!(error = %e, "ca: CA key generation failed");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
-    let mut params = CertificateParams::new(Vec::<String>::new())
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let mut params = CertificateParams::new(Vec::<String>::new()).map_err(|e| {
+        tracing::error!(error = %e, "ca: failed to build CA cert params");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     params
         .distinguished_name
         .push(DnType::CommonName, DnValue::Utf8String(cn.to_string()));
@@ -339,9 +344,10 @@ pub async fn generate_ca(
     params.not_before = time::OffsetDateTime::now_utc();
     params.not_after = time::OffsetDateTime::now_utc() + time::Duration::days(days as i64);
 
-    let cert = params
-        .self_signed(&key_pair)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let cert = params.self_signed(&key_pair).map_err(|e| {
+        tracing::error!(error = %e, "ca: failed to self-sign CA certificate");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     let cert_pem = cert.pem();
     let key_pem = key_pair.serialize_pem();
     let fingerprint = sha256_fingerprint(&cert_pem);
@@ -359,7 +365,7 @@ pub async fn generate_ca(
     )
     .bind(&cert_pem).bind(&key_pem).bind(&subject).bind(&serial)
     .bind(&not_before).bind(&not_after).bind(&fingerprint).bind("ECDSA P-256").bind(&now)
-    .execute(&state.pool).await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    .execute(&state.pool).await.map_err(|e| { tracing::error!(error = %e, "ca: failed to persist CA to database"); StatusCode::INTERNAL_SERVER_ERROR })?;
 
     Ok((
         StatusCode::CREATED,
@@ -379,7 +385,10 @@ pub async fn get_ca_cert_pem(State(state): State<AppState>) -> Result<String, St
     let row = sqlx::query_as::<_, (String,)>("SELECT cert_pem FROM ca_root WHERE id = 1")
         .fetch_optional(&state.pool)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|e| {
+            tracing::error!(error = %e, "ca: failed to query CA cert PEM");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     row.map(|r| r.0).ok_or(StatusCode::NOT_FOUND)
 }
 
@@ -392,18 +401,27 @@ pub async fn issue_cert(
         sqlx::query_as::<_, (String, String)>("SELECT cert_pem, key_pem FROM ca_root WHERE id = 1")
             .fetch_optional(&state.pool)
             .await
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+            .map_err(|e| {
+                tracing::error!(error = %e, "ca: failed to load CA for signing");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?
             .ok_or(StatusCode::BAD_REQUEST)?; // CA not initialized
 
-    let ca_key = KeyPair::from_pem(&ca.1).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let ca_key = KeyPair::from_pem(&ca.1).map_err(|e| {
+        tracing::error!(error = %e, "ca: failed to parse CA private key");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     // Rebuild CA cert params for signing
-    let mut ca_params = CertificateParams::new(Vec::<String>::new())
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let mut ca_params = CertificateParams::new(Vec::<String>::new()).map_err(|e| {
+        tracing::error!(error = %e, "ca: failed to build CA params for signing");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
     ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
-    let ca_cert = ca_params
-        .self_signed(&ca_key)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let ca_cert = ca_params.self_signed(&ca_key).map_err(|e| {
+        tracing::error!(error = %e, "ca: failed to rebuild CA certificate");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     let days = req.validity_days.unwrap_or(365);
     let serial = next_serial();
@@ -426,9 +444,14 @@ pub async fn issue_cert(
         }
     }
 
-    let cert_key = KeyPair::generate().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let mut params = CertificateParams::new(Vec::<String>::new())
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let cert_key = KeyPair::generate().map_err(|e| {
+        tracing::error!(error = %e, "ca: certificate key generation failed");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    let mut params = CertificateParams::new(Vec::<String>::new()).map_err(|e| {
+        tracing::error!(error = %e, "ca: failed to build certificate params");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     params.distinguished_name.push(
         DnType::CommonName,
         DnValue::Utf8String(req.common_name.clone()),
@@ -457,9 +480,10 @@ pub async fn issue_cert(
     // the source of truth for the embedded CA certificate.
     let _ = &ca_cert; // kept for code clarity; not passed to signed_by anymore
     let issuer = Issuer::new(ca_params, ca_key);
-    let cert = params
-        .signed_by(&cert_key, &issuer)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let cert = params.signed_by(&cert_key, &issuer).map_err(|e| {
+        tracing::error!(error = %e, "ca: failed to sign certificate");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     let cert_pem = cert.pem();
     let key_pem = cert_key.serialize_pem();
@@ -473,7 +497,7 @@ pub async fn issue_cert(
     )
     .bind(&id).bind(&req.cert_type).bind(&req.common_name).bind(&sans_str).bind(&serial)
     .bind(&cert_pem).bind(&key_pem).bind(&not_before).bind(&not_after).bind(&now)
-    .execute(&state.pool).await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    .execute(&state.pool).await.map_err(|e| { tracing::error!(error = %e, "ca: failed to persist issued certificate"); StatusCode::INTERNAL_SERVER_ERROR })?;
 
     Ok((
         StatusCode::CREATED,
@@ -491,7 +515,7 @@ pub async fn list_certs(
 ) -> Result<Json<ApiResponse<Vec<CertRecord>>>, StatusCode> {
     let rows = sqlx::query_as::<_, (String, String, String, String, String, String, String, String, Option<String>, String)>(
         "SELECT id, cert_type, common_name, sans, serial, not_before, not_after, status, revoked_at, created_at FROM ca_certificates ORDER BY created_at DESC"
-    ).fetch_all(&state.pool).await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    ).fetch_all(&state.pool).await.map_err(|e| { tracing::error!(error = %e, "ca: failed to list certificates"); StatusCode::INTERNAL_SERVER_ERROR })?;
 
     let certs: Vec<CertRecord> = rows
         .into_iter()
@@ -525,7 +549,7 @@ pub async fn get_cert(
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     let row = sqlx::query_as::<_, (String, String, String, String, String, String, String, String, String, Option<String>, String)>(
         "SELECT id, cert_type, common_name, sans, serial, cert_pem, not_before, not_after, status, revoked_at, created_at FROM ca_certificates WHERE id = ?1"
-    ).bind(&id).fetch_optional(&state.pool).await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    ).bind(&id).fetch_optional(&state.pool).await.map_err(|e| { tracing::error!(error = %e, "ca: failed to query certificate"); StatusCode::INTERNAL_SERVER_ERROR })?
     .ok_or(StatusCode::NOT_FOUND)?;
 
     Ok(Json(serde_json::json!({
@@ -567,7 +591,7 @@ pub async fn revoke_cert(
 ) -> Result<Json<MessageResponse>, StatusCode> {
     let now = Utc::now().to_rfc3339();
     let result = sqlx::query("UPDATE ca_certificates SET status = 'revoked', revoked_at = ?1 WHERE id = ?2 AND status = 'active'")
-        .bind(&now).bind(&id).execute(&state.pool).await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .bind(&now).bind(&id).execute(&state.pool).await.map_err(|e| { tracing::error!(error = %e, "ca: failed to revoke certificate"); StatusCode::INTERNAL_SERVER_ERROR })?;
     if result.rows_affected() == 0 {
         return Err(StatusCode::NOT_FOUND);
     }
@@ -584,7 +608,10 @@ pub async fn delete_cert(
         .bind(&id)
         .execute(&state.pool)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|e| {
+            tracing::error!(error = %e, "ca: failed to delete certificate");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
     if result.rows_affected() == 0 {
         return Err(StatusCode::NOT_FOUND);
     }
@@ -597,7 +624,7 @@ pub async fn get_crl(State(state): State<AppState>) -> Result<String, StatusCode
     // Simple text-based CRL listing revoked serials
     let rows = sqlx::query_as::<_, (String, String, String)>(
         "SELECT serial, common_name, revoked_at FROM ca_certificates WHERE status = 'revoked' ORDER BY revoked_at DESC"
-    ).fetch_all(&state.pool).await.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    ).fetch_all(&state.pool).await.map_err(|e| { tracing::error!(error = %e, "ca: failed to query CRL"); StatusCode::INTERNAL_SERVER_ERROR })?;
 
     let mut crl = String::from("# AiFw Certificate Revocation List\n");
     crl.push_str(&format!("# Generated: {}\n", Utc::now().to_rfc3339()));

--- a/aifw-api/src/cluster.rs
+++ b/aifw-api/src/cluster.rs
@@ -283,15 +283,14 @@ async fn create_carp(
         Interface(r.interface),
         r.password,
     );
-    let vip = s
-        .cluster_engine
-        .add_carp_vip(vip)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    s.cluster_engine
-        .apply_ha_rules()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let vip = s.cluster_engine.add_carp_vip(vip).await.map_err(|e| {
+        tracing::error!(error = %e, "cluster: failed to add CARP VIP");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    s.cluster_engine.apply_ha_rules().await.map_err(|e| {
+        tracing::error!(error = %e, "cluster: failed to apply HA rules after adding CARP VIP");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     Ok(Json(vip))
 }
 
@@ -318,10 +317,10 @@ async fn update_carp(
                 StatusCode::INTERNAL_SERVER_ERROR
             }
         })?;
-    s.cluster_engine
-        .apply_ha_rules()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    s.cluster_engine.apply_ha_rules().await.map_err(|e| {
+        tracing::error!(error = %e, "cluster: failed to apply HA rules after updating CARP VIP");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     Ok(Json(vip))
 }
 
@@ -336,11 +335,10 @@ async fn delete_carp(State(s): State<AppState>, Path(id): Path<Uuid>) -> StatusC
 }
 
 async fn get_pfsync(State(s): State<AppState>) -> Result<Json<Option<PfsyncConfig>>, StatusCode> {
-    s.cluster_engine
-        .get_pfsync()
-        .await
-        .map(Json)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+    s.cluster_engine.get_pfsync().await.map(Json).map_err(|e| {
+        tracing::error!(error = %e, "cluster: failed to get pfsync config");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
 }
 
 #[derive(Deserialize)]
@@ -363,7 +361,10 @@ async fn update_pfsync(
         .cluster_engine
         .get_pfsync()
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .map_err(|e| {
+            tracing::error!(error = %e, "cluster: failed to get pfsync config");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
         .unwrap_or_else(|| PfsyncConfig::new(Interface(r.sync_interface.clone())));
     p.sync_interface = Interface(r.sync_interface);
     p.sync_peer = r.sync_peer;
@@ -373,24 +374,22 @@ async fn update_pfsync(
     p.heartbeat_iface = r.heartbeat_iface.map(Interface);
     p.heartbeat_interval_ms = r.heartbeat_interval_ms;
     p.dhcp_link = r.dhcp_link;
-    let p = s
-        .cluster_engine
-        .set_pfsync(p)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    s.cluster_engine
-        .apply_ha_rules()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let p = s.cluster_engine.set_pfsync(p).await.map_err(|e| {
+        tracing::error!(error = %e, "cluster: failed to set pfsync config");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    s.cluster_engine.apply_ha_rules().await.map_err(|e| {
+        tracing::error!(error = %e, "cluster: failed to apply HA rules after pfsync update");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     Ok(Json(p))
 }
 
 async fn list_nodes(State(s): State<AppState>) -> Result<Json<Vec<ClusterNode>>, StatusCode> {
-    s.cluster_engine
-        .list_nodes()
-        .await
-        .map(Json)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+    s.cluster_engine.list_nodes().await.map(Json).map_err(|e| {
+        tracing::error!(error = %e, "cluster: failed to list nodes");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
 }
 
 #[derive(Deserialize)]
@@ -405,11 +404,10 @@ async fn create_node(
     Json(r): Json<NodeReq>,
 ) -> Result<Json<ClusterNode>, StatusCode> {
     let node = ClusterNode::new(r.name, r.address, r.role);
-    let node = s
-        .cluster_engine
-        .add_node(node)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let node = s.cluster_engine.add_node(node).await.map_err(|e| {
+        tracing::error!(error = %e, "cluster: failed to add node");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     Ok(Json(node))
 }
 
@@ -474,7 +472,10 @@ async fn list_health(State(s): State<AppState>) -> Result<Json<Vec<HealthCheck>>
         .list_health_checks()
         .await
         .map(Json)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+        .map_err(|e| {
+            tracing::error!(error = %e, "cluster: failed to list health checks");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })
 }
 
 #[derive(Deserialize)]
@@ -517,11 +518,10 @@ async fn create_health(
     h.timeout_secs = r.timeout_secs;
     h.failures_before_down = r.failures_before_down;
     h.enabled = r.enabled;
-    let h = s
-        .cluster_engine
-        .add_health_check(h)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let h = s.cluster_engine.add_health_check(h).await.map_err(|e| {
+        tracing::error!(error = %e, "cluster: failed to add health check");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     Ok(Json(h))
 }
 

--- a/aifw-api/src/metrics_series.rs
+++ b/aifw-api/src/metrics_series.rs
@@ -47,11 +47,10 @@ pub struct SeriesResponse {
 }
 
 pub async fn list(State(state): State<AppState>) -> Result<Json<SeriesListResponse>, StatusCode> {
-    let mut names = state
-        .metrics_store
-        .list_metrics()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let mut names = state.metrics_store.list_metrics().await.map_err(|e| {
+        tracing::error!(error = %e, "metrics_series: failed to list series");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     names.sort();
     Ok(Json(SeriesListResponse { names }))
 }

--- a/aifw-api/src/plugins.rs
+++ b/aifw-api/src/plugins.rs
@@ -132,7 +132,10 @@ pub async fn get_plugin_config(
     .bind(&name)
     .fetch_optional(&state.pool)
     .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    .map_err(|e| {
+        tracing::error!(error = %e, "plugins: failed to query plugin config");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     let (enabled, settings) = row.unwrap_or((0, None));
     let settings_json: serde_json::Value = settings

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.30",
+  "version": "5.97.31",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #432 (QUAL-H12, HIGH · code-quality audit).

## Problem
50 `.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)` sites across `aifw-api` discarded the underlying error entirely — a failure surfaced as a bare 500 with no log, no body, no context, forcing debugging with an attached debugger.

## Fix
Each site now logs the discarded error with context before returning the 500 (the issue's recommended per-site fix):

```rust
.map_err(|e| {
    tracing::error!(error = %e, "ca: CA key generation failed");
    StatusCode::INTERNAL_SERVER_ERROR
})?;
```

Handler signatures are unchanged (each still returns `StatusCode`) — behavior-preserving, log-only change.

## Sites by file
- `ca.rs` — 19 (key gen, cert params, self-sign/sign, CA/cert DB queries)
- `cluster.rs` — 11 (CARP VIP, pfsync, nodes, health checks, HA-rule apply)
- `auth/users.rs` — 6, `auth/totp_store.rs` — 6, `auth/api_keys.rs` — 2, `middleware.rs` / `password.rs` / `revocation.rs` — 1 each
- `plugins.rs`, `ai_analysis.rs`, `metrics_series.rs` — 1 each

The "even better" central `ApiError`/`IntoResponse` option from the issue was intentionally not taken — it would rewrite 100+ handler signatures.

## Verification
- `cargo fmt --check` ✓
- `cargo clippy -D warnings` ✓ (workspace)
- `cargo check` ✓
- Version bumped 5.97.30 → 5.97.31