### PR TITLE
perf(db): tune SQLite pool pragmas (PERF-H1 #345)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.31"
+version = "5.97.32"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-core/src/db.rs
+++ b/aifw-core/src/db.rs
@@ -23,7 +23,13 @@ impl Database {
             // concurrently without blocking the dashboard / metrics loops.
             .journal_mode(SqliteJournalMode::Wal)
             .synchronous(SqliteSynchronous::Normal)
-            .busy_timeout(std::time::Duration::from_secs(5));
+            .busy_timeout(std::time::Duration::from_secs(5))
+            // PERF-H1: default cache is 2 MB and mmap is off, so aggregate
+            // queries over multi-GB tables (e.g. ids_alerts on /ids/stats)
+            // fault in from disk. Run per-connection on connect.
+            .pragma("cache_size", "-65536") // ~64 MB page cache (negative = KiB)
+            .pragma("mmap_size", "268435456") // 256 MiB memory-mapped reads
+            .pragma("temp_store", "MEMORY"); // sorts/temp b-trees stay in RAM
 
         let pool = SqlitePoolOptions::new()
             .max_connections(20)
@@ -322,6 +328,41 @@ impl Database {
 
     pub fn pool(&self) -> &SqlitePool {
         &self.pool
+    }
+}
+
+#[cfg(test)]
+mod pragma_tests {
+    use super::*;
+
+    // PERF-H1 regression: the file-based pool must ship the tuned pragmas so
+    // aggregate scans over large tables don't fall back to disk. In-memory
+    // DBs don't exercise this path, so use a real temp file.
+    #[tokio::test]
+    async fn file_pool_applies_perf_pragmas() {
+        let path = std::env::temp_dir().join(format!("aifw-pragma-{}.db", Uuid::new_v4()));
+        let db = Database::new(&path).await.unwrap();
+
+        let cache_size: i64 = sqlx::query_scalar("PRAGMA cache_size")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(cache_size, -65536, "cache_size pragma not applied");
+
+        let temp_store: i64 = sqlx::query_scalar("PRAGMA temp_store")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(temp_store, 2, "temp_store should be MEMORY (2)");
+
+        let mmap_size: i64 = sqlx::query_scalar("PRAGMA mmap_size")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(mmap_size, 268435456, "mmap_size pragma not applied");
+
+        drop(db);
+        let _ = std::fs::remove_file(&path);
     }
 }
 

--- a/aifw-ids-bin/src/main.rs
+++ b/aifw-ids-bin/src/main.rs
@@ -70,6 +70,12 @@ async fn main() -> anyhow::Result<()> {
         .busy_timeout(Duration::from_secs(5))
         .journal_mode(SqliteJournalMode::Wal)
         .synchronous(SqliteSynchronous::Normal)
+        // PERF-H1: match aifw-core's pool tuning. ids_alerts grows into the
+        // millions; without a bigger cache + mmap every aggregate scan hits
+        // disk. Applied per-connection on connect.
+        .pragma("cache_size", "-65536") // ~64 MB page cache (negative = KiB)
+        .pragma("mmap_size", "268435456") // 256 MiB memory-mapped reads
+        .pragma("temp_store", "MEMORY") // sorts/temp b-trees stay in RAM
         .foreign_keys(true);
     let pool = SqlitePoolOptions::new()
         .max_connections(8)

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.31",
+  "version": "5.97.32",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #345 (PERF-H1, HIGH · perf audit).

## Problem
Both SQLite pools (`aifw-core` `Database::new` and `aifw-ids-bin`) only set WAL + `synchronous=NORMAL` + `busy_timeout`. That leaves `cache_size` at the 2 MB default and `mmap_size` off. With `ids_alerts` reaching millions of rows, the `/ids/stats` aggregates (`count_by_severity`, `top_signatures`, `top_sources`) fault in from disk on every dashboard load (100s of ms).

## Fix
Add per-connection pragmas on connect (via `SqliteConnectOptions::pragma`):

| pragma | value | effect |
|--------|-------|--------|
| `cache_size` | `-65536` | ~64 MB page cache (negative = KiB) |
| `mmap_size` | `268435456` | 256 MiB memory-mapped reads |
| `temp_store` | `MEMORY` | sorts / temp b-trees stay in RAM |

`page_size` from the issue is intentionally omitted — it only takes effect at DB creation (before any table) and modern SQLite already defaults to 4096.

## Verification
- New file-backed regression test `db::pragma_tests::file_pool_applies_perf_pragmas` asserts all three pragmas are live on a real pool connection.
- `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test -p aifw-core` ✓
- Version 5.97.31 → 5.97.32