### PR TITLE
perf(ids): bind LIMIT/OFFSET instead of format!() (PERF-H9 #353)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.32"
+version = "5.97.33"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ids/src/output/sqlite.rs
+++ b/aifw-ids/src/output/sqlite.rs
@@ -85,8 +85,10 @@ impl SqliteOutput {
 
         // SQLx tuple FromRow maxes out at 16 fields. We pack classification|notes
         // into field 13 (replacing flow_id which is rarely used) and shift.
+        // PERF-H9: keep LIMIT/OFFSET as bind params so a single prepared
+        // statement is cached regardless of the paging window.
         let sql = format!(
-            "SELECT id, timestamp, signature_id, signature_msg, severity, src_ip, src_port, dst_ip, dst_port, protocol, action, rule_source, payload_excerpt, metadata, acknowledged, COALESCE(classification, 'unreviewed') || '|' || COALESCE(analyst_notes, '') FROM ids_alerts{where_clause} ORDER BY timestamp DESC LIMIT {limit} OFFSET {offset}"
+            "SELECT id, timestamp, signature_id, signature_msg, severity, src_ip, src_port, dst_ip, dst_port, protocol, action, rule_source, payload_excerpt, metadata, acknowledged, COALESCE(classification, 'unreviewed') || '|' || COALESCE(analyst_notes, '') FROM ids_alerts{where_clause} ORDER BY timestamp DESC LIMIT ? OFFSET ?"
         );
 
         let mut query = sqlx::query_as::<
@@ -114,6 +116,7 @@ impl SqliteOutput {
         for val in &bind_values {
             query = query.bind(val);
         }
+        query = query.bind(limit as i64).bind(offset as i64);
 
         let rows = query.fetch_all(&self.pool).await?;
 
@@ -279,11 +282,13 @@ impl SqliteOutput {
     /// Get top N alerting signatures over the last 24 hours.
     /// See `count_by_severity` for the rationale on the time window.
     pub async fn top_signatures(&self, limit: u32) -> Result<Vec<(String, i64)>> {
-        let rows: Vec<(String, i64)> = sqlx::query_as(sqlx::AssertSqlSafe(format!(
+        // PERF-H9: bind LIMIT so this aggregate reuses one cached statement.
+        let rows: Vec<(String, i64)> = sqlx::query_as(
             "SELECT signature_msg, count(*) as cnt FROM ids_alerts \
              WHERE timestamp >= datetime('now', '-1 day') \
-             GROUP BY signature_msg ORDER BY cnt DESC LIMIT {limit}"
-        )))
+             GROUP BY signature_msg ORDER BY cnt DESC LIMIT ?",
+        )
+        .bind(limit as i64)
         .fetch_all(&self.pool)
         .await?;
         Ok(rows)
@@ -292,11 +297,13 @@ impl SqliteOutput {
     /// Get top N source IPs over the last 24 hours.
     /// See `count_by_severity` for the rationale on the time window.
     pub async fn top_sources(&self, limit: u32) -> Result<Vec<(String, i64)>> {
-        let rows: Vec<(String, i64)> = sqlx::query_as(sqlx::AssertSqlSafe(format!(
+        // PERF-H9: bind LIMIT so this aggregate reuses one cached statement.
+        let rows: Vec<(String, i64)> = sqlx::query_as(
             "SELECT src_ip, count(*) as cnt FROM ids_alerts \
              WHERE timestamp >= datetime('now', '-1 day') \
-             GROUP BY src_ip ORDER BY cnt DESC LIMIT {limit}"
-        )))
+             GROUP BY src_ip ORDER BY cnt DESC LIMIT ?",
+        )
+        .bind(limit as i64)
         .fetch_all(&self.pool)
         .await?;
         Ok(rows)

--- a/aifw-ids/src/rules/manager.rs
+++ b/aifw-ids/src/rules/manager.rs
@@ -273,7 +273,8 @@ impl RulesetManager {
             sql.push_str(" AND enabled = 1 AND ruleset_id IN (SELECT id FROM ids_rulesets WHERE enabled = 1)");
         }
         sql.push_str(" ORDER BY sid ASC, created_at ASC");
-        sql.push_str(&format!(" LIMIT {limit} OFFSET {offset}"));
+        // PERF-H9: bind LIMIT/OFFSET so paging reuses one cached statement.
+        sql.push_str(" LIMIT ? OFFSET ?");
 
         let mut query = sqlx::query_as::<
             _,
@@ -295,6 +296,7 @@ impl RulesetManager {
         for bind in &binds {
             query = query.bind(bind);
         }
+        query = query.bind(limit as i64).bind(offset as i64);
 
         let rows = query.fetch_all(&self.pool).await?;
 

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.32",
+  "version": "5.97.33",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #353 (PERF-H9, HIGH · perf audit).

> **Stacked on #499** (PERF-H1). Base will auto-retarget to `main` once #499 merges. Review just the top commit.

## Problem
`query_alerts`, `list_rules`, `top_signatures`, `top_sources` interpolated the `u32` `limit`/`offset` straight into the SQL text via `format!()`. Type-safe (no injection), but each distinct paging window produced a fresh SQL string, so SQLite's prepared-statement cache thrashed.

## Fix
Use `LIMIT ? OFFSET ?` bind params (bound as `i64`) so a single prepared statement is reused across windows. `top_signatures`/`top_sources` also drop `AssertSqlSafe(format!())` in favour of a static query string.

## Verification
- `cargo test -p aifw-ids` — 95 passed
- `cargo fmt --check`, `cargo clippy -D warnings` ✓
- Version 5.97.32 → 5.97.33