### PR TITLE
perf(api): cache decoded JWTs in the auth middleware (PERF-H21 #365)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.33"
+version = "5.97.34"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/auth/middleware.rs
+++ b/aifw-api/src/auth/middleware.rs
@@ -22,6 +22,23 @@ const AUTH_USER_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(
 /// stays revoked for its remaining lifetime; we cache the *positive*
 /// not-revoked result for 60 s so logout takes effect within the window.
 const AUTH_JTI_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+/// PERF-H21: cap on how long a decoded JWT is trusted from cache. Entries are
+/// also bounded by the token's own `exp`; this cap only limits how long a
+/// rotated `jwt_secret` could keep an old token accepted.
+const AUTH_TOKEN_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+/// PERF-H21: soft ceiling on decoded-token cache entries. On reaching it we
+/// sweep expired entries before inserting, keeping memory bounded without a
+/// background task.
+const AUTH_TOKEN_CACHE_MAX: usize = 10_000;
+
+/// PERF-H21: seconds a decoded JWT may stay cached — the smaller of the
+/// token's remaining lifetime and [`AUTH_TOKEN_CACHE_TTL`]. Returns 0 for an
+/// already-expired token so it is effectively never cached, ensuring an
+/// expired token can't be served from a live cache entry.
+fn token_cache_ttl_secs(exp_unix: i64, now_unix: i64) -> u64 {
+    let remaining = (exp_unix - now_unix).max(0) as u64;
+    remaining.min(AUTH_TOKEN_CACHE_TTL.as_secs())
+}
 
 pub async fn auth_middleware(
     State(state): State<crate::AppState>,
@@ -39,12 +56,40 @@ pub async fn auth_middleware(
     // Resolve (user_id, perm_from_token, role_from_token, api_key_name) from the credential
     let (user_id, jwt_perm, jwt_role, api_key_name) =
         if let Some(token) = auth_header.and_then(|h| h.strip_prefix("Bearer ")) {
-            let token_data = verify_access_token(token, &state.auth_settings)
-                .map_err(|_| StatusCode::UNAUTHORIZED)?;
-            let jti = &token_data.claims.jti;
+            // PERF-H21: reuse a previously decoded token. The entry deadline
+            // is capped at the token's `exp` on insert, so a live cache hit
+            // is always still within the token's validity window.
+            let now = Instant::now();
+            let claims = if let Some(entry) = state.auth_token_cache.get(token)
+                && entry.value().1 > now
+            {
+                entry.value().0.clone()
+            } else {
+                let claims = verify_access_token(token, &state.auth_settings)
+                    .map_err(|_| StatusCode::UNAUTHORIZED)?
+                    .claims;
+                // Cap TTL at the token's remaining lifetime (never negative),
+                // and at AUTH_TOKEN_CACHE_TTL so a rotated jwt_secret can't
+                // keep validating an old token for longer than that window.
+                let ttl = std::time::Duration::from_secs(token_cache_ttl_secs(
+                    claims.exp,
+                    chrono::Utc::now().timestamp(),
+                ));
+                // Bound memory: sweep expired entries when the map grows large
+                // (these caches are otherwise evicted only lazily).
+                if state.auth_token_cache.len() >= AUTH_TOKEN_CACHE_MAX {
+                    state
+                        .auth_token_cache
+                        .retain(|_, (_, deadline)| *deadline > now);
+                }
+                state
+                    .auth_token_cache
+                    .insert(token.to_string(), (claims.clone(), now + ttl));
+                claims
+            };
+            let jti = &claims.jti;
             // JTI revocation: positive cache to skip the DB lookup. Cached
             // entry value=true means revoked, value=false means not revoked.
-            let now = Instant::now();
             let revoked = if let Some(entry) = state.auth_jti_cache.get(jti)
                 && entry.value().1 > now
             {
@@ -59,12 +104,7 @@ pub async fn auth_middleware(
             if revoked {
                 return Err(StatusCode::UNAUTHORIZED);
             }
-            (
-                token_data.claims.sub,
-                token_data.claims.perm,
-                token_data.claims.role,
-                None,
-            )
+            (claims.sub, claims.perm, claims.role, None)
         } else if let Some(key) = auth_header.and_then(|h| h.strip_prefix("ApiKey ")) {
             let (uid, key_name) = verify_api_key(&state.pool, key).await?;
             (uid, None, None, Some(key_name)) // API keys don't carry JWT claims — will do DB lookup
@@ -198,4 +238,32 @@ macro_rules! perm_check {
             Ok::<_, axum::http::StatusCode>(next.run(request).await)
         }
     };
+}
+
+#[cfg(test)]
+mod token_cache_tests {
+    use super::{AUTH_TOKEN_CACHE_TTL, token_cache_ttl_secs};
+
+    // PERF-H21 safety: an already-expired token must yield a 0s TTL so it is
+    // never served from a live cache entry.
+    #[test]
+    fn expired_token_not_cached() {
+        assert_eq!(token_cache_ttl_secs(1_000, 2_000), 0);
+        assert_eq!(token_cache_ttl_secs(2_000, 2_000), 0);
+    }
+
+    // A token with lots of life left is capped at the rotation-safety window.
+    #[test]
+    fn long_lived_token_capped_at_ttl() {
+        let cap = AUTH_TOKEN_CACHE_TTL.as_secs();
+        assert_eq!(token_cache_ttl_secs(10_000, 0), cap);
+    }
+
+    // A token expiring inside the cap window is bounded by its own exp.
+    #[test]
+    fn short_lived_token_bounded_by_exp() {
+        let cap = AUTH_TOKEN_CACHE_TTL.as_secs() as i64;
+        // 10 seconds of life, which is below the cap.
+        assert_eq!(token_cache_ttl_secs(cap - 50 + 10, cap - 50), 10);
+    }
 }

--- a/aifw-api/src/auth/mod.rs
+++ b/aifw-api/src/auth/mod.rs
@@ -26,7 +26,7 @@ pub use middleware::*;
 pub use migrate::*;
 pub use password::{hash_password, verify_password};
 pub use revocation::*;
-pub use tokens::{TokenPair, verify_access_token};
+pub use tokens::{Claims, TokenPair, verify_access_token};
 pub use totp_store::*;
 pub use types::*;
 pub use users::*;

--- a/aifw-api/src/auth/tokens.rs
+++ b/aifw-api/src/auth/tokens.rs
@@ -11,7 +11,7 @@ use super::password::hash_password;
 // JWT Access Tokens
 // ============================================================
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Claims {
     pub sub: String,
     pub username: String,

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -194,6 +194,12 @@ pub struct AppState {
     /// breaking the user-disable-takes-effect-within-Ns expectation.
     pub auth_user_cache: Arc<dashmap::DashMap<String, (auth::User, std::time::Instant)>>,
     pub auth_jti_cache: Arc<dashmap::DashMap<String, (bool, std::time::Instant)>>,
+    /// PERF-H21: decoded-JWT cache keyed by the raw token string. The hot
+    /// path (WS polls re-sending the same Bearer token) skips the HMAC
+    /// verify, base64 decode, and JSON deserialize on a hit. The entry
+    /// deadline is capped at the token's own `exp`, so an expired token is
+    /// never served from cache.
+    pub auth_token_cache: Arc<dashmap::DashMap<String, (auth::Claims, std::time::Instant)>>,
     /// Shadow counter of `plugin_manager.read().await.running_count()` —
     /// kept in sync by every register/unload call site. The auth middleware
     /// uses this to skip the read lock + dispatch entirely when no plugins
@@ -920,6 +926,7 @@ async fn create_state_from_db(
         ws_tick: tokio::sync::broadcast::channel::<Arc<String>>(256).0,
         auth_user_cache: Arc::new(dashmap::DashMap::new()),
         auth_jti_cache: Arc::new(dashmap::DashMap::new()),
+        auth_token_cache: Arc::new(dashmap::DashMap::new()),
         plugin_running_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
     })
 }

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.33",
+  "version": "5.97.34",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #365 (PERF-H21, HIGH · perf audit).

## Problem
Every authenticated request re-ran the full `jsonwebtoken` decode — HMAC verify + base64 + JSON deserialize of the claims. At WS-poll rates the same Bearer token is re-sent many times a second, so this repeats needlessly (~200 µs/request).

## Fix
Add `auth_token_cache: DashMap<raw_jwt, (Claims, deadline)>` on `AppState`, checked in the Bearer hot path of `auth_middleware`. On a hit the decode is skipped entirely. The existing jti-revocation and user-by-id caches still run afterward, so **logout and user-disable semantics are unchanged**.

### Safety
- **Expiry:** entry deadline = `min(remaining token lifetime, 60s)`. An already-expired token yields a 0s TTL → never served from a live entry. (`token_cache_ttl_secs`, unit-tested.)
- **Secret rotation:** the 60s cap bounds how long a rotated `jwt_secret` could keep an old token accepted — same tradeoff already accepted by the jti/user caches.
- **Memory:** size-bounded — expired entries are swept once the map reaches 10k, no background task.

## Verification
- `cargo test -p aifw-api` — 137 passed (134 existing + 3 new TTL edge tests)
- `cargo fmt --check`, `cargo clippy -D warnings` ✓
- Version 5.97.33 → 5.97.34