### PR TITLE
perf(vpn): targeted duplicate-port validation for WG tunnels (PERF-H5 #349)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.34"
+version = "5.97.35"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -743,6 +743,35 @@ mod tests {
         );
         t.listen_port = 0;
         assert!(engine.add_wg_tunnel(t).await.is_err());
+
+        // PERF-H5: duplicate listen_port is rejected via the targeted query.
+        let first = WgTunnel::new(
+            "first".to_string(),
+            Interface("wg0".to_string()),
+            51820,
+            Address::Any,
+        );
+        engine.add_wg_tunnel(first).await.unwrap();
+
+        let dup = WgTunnel::new(
+            "second".to_string(),
+            Interface("wg1".to_string()),
+            51820,
+            Address::Any,
+        );
+        assert!(
+            engine.add_wg_tunnel(dup).await.is_err(),
+            "second tunnel on the same port must be rejected"
+        );
+
+        // A different port is fine.
+        let ok = WgTunnel::new(
+            "third".to_string(),
+            Interface("wg2".to_string()),
+            51821,
+            Address::Any,
+        );
+        assert!(engine.add_wg_tunnel(ok).await.is_ok());
     }
 
     #[tokio::test]

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -109,6 +109,17 @@ impl VpnEngine {
         .execute(&self.pool)
         .await?;
 
+        // PERF-H5: index the columns the write-path validation queries hit so
+        // the duplicate-port and per-tunnel peer lookups don't scan.
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_wg_tunnels_listen_port ON wg_tunnels(listen_port);",
+        )
+        .execute(&self.pool)
+        .await?;
+        sqlx::query("CREATE INDEX IF NOT EXISTS idx_wg_peers_tunnel_id ON wg_peers(tunnel_id);")
+            .execute(&self.pool)
+            .await?;
+
         Ok(())
     }
 
@@ -124,15 +135,19 @@ impl VpnEngine {
             return Err(AifwError::Validation("listen port required".to_string()));
         }
 
-        // Check for duplicate port across all tunnels
-        let existing = self.list_wg_tunnels().await?;
-        for t in &existing {
-            if t.id != tunnel.id && t.listen_port == tunnel.listen_port {
-                return Err(AifwError::Validation(format!(
-                    "Port {} is already used by tunnel '{}'",
-                    tunnel.listen_port, t.name
-                )));
-            }
+        // Check for duplicate port (PERF-H5: targeted query, not a full scan).
+        if let Some((name,)) = sqlx::query_as::<_, (String,)>(
+            "SELECT name FROM wg_tunnels WHERE listen_port = ?1 AND id != ?2 LIMIT 1",
+        )
+        .bind(tunnel.listen_port as i64)
+        .bind(tunnel.id.to_string())
+        .fetch_optional(&self.pool)
+        .await?
+        {
+            return Err(AifwError::Validation(format!(
+                "Port {} is already used by tunnel '{}'",
+                tunnel.listen_port, name
+            )));
         }
 
         sqlx::query(
@@ -191,14 +206,19 @@ impl VpnEngine {
             return Err(AifwError::Validation("listen port required".to_string()));
         }
 
-        let existing = self.list_wg_tunnels().await?;
-        for t in &existing {
-            if t.id != tunnel.id && t.listen_port == tunnel.listen_port {
-                return Err(AifwError::Validation(format!(
-                    "Port {} is already used by tunnel '{}'",
-                    tunnel.listen_port, t.name
-                )));
-            }
+        // PERF-H5: targeted duplicate-port check, not a full-table scan.
+        if let Some((name,)) = sqlx::query_as::<_, (String,)>(
+            "SELECT name FROM wg_tunnels WHERE listen_port = ?1 AND id != ?2 LIMIT 1",
+        )
+        .bind(tunnel.listen_port as i64)
+        .bind(tunnel.id.to_string())
+        .fetch_optional(&self.pool)
+        .await?
+        {
+            return Err(AifwError::Validation(format!(
+                "Port {} is already used by tunnel '{}'",
+                tunnel.listen_port, name
+            )));
         }
 
         let result = sqlx::query(

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.34",
+  "version": "5.97.35",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #349 (PERF-H5, HIGH · perf audit).

> **Stacked on #501** (PERF-H21). Base auto-retargets to `main` once #501 merges — review just the top commit.

## Problem
`add_wg_tunnel` / `update_wg_tunnel` called `list_wg_tunnels()` — a full read + deserialize of every tunnel row — solely to check for a `listen_port` collision. O(N) round-trip on each write.

## Fix
Single targeted query, still returning the conflicting tunnel's name for the error message:
```sql
SELECT name FROM wg_tunnels WHERE listen_port = ?1 AND id != ?2 LIMIT 1
```
Plus indexes on `wg_tunnels(listen_port)` and `wg_peers(tunnel_id)` so these write-path lookups (and `list_wg_peers`) are index-backed.

**Not changed:** the per-tunnel peer-IP overlap check (`add_wg_peer`) — it scans only one tunnel's peers and compares CSV-stored `allowed_ips`, which doesn't map cleanly/safely to a SQL predicate, and is already bounded by peers-per-tunnel.

## Verification
- `test_wg_tunnel_validation` extended with duplicate-port coverage
- `cargo test -p aifw-core`, `cargo fmt --check`, `cargo clippy -D warnings` ✓
- Version 5.97.34 → 5.97.35