### PR TITLE
perf(backup): single grouped query for WG peers (PERF-H7 #351)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.35"
+version = "5.97.36"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -599,13 +599,15 @@ pub(crate) async fn build_current_config(state: &AppState) -> Result<FirewallCon
 
     let auth = &state.auth_settings;
 
+    // PERF-H7: one query for all peers, grouped by tunnel, instead of N+1.
+    let mut peers_by_tunnel = state
+        .vpn_engine
+        .list_all_wg_peers_grouped()
+        .await
+        .unwrap_or_default();
     let mut wireguard: Vec<WireguardTunnelConfig> = Vec::with_capacity(wg_tunnels.len());
     for t in &wg_tunnels {
-        let peers = state
-            .vpn_engine
-            .list_wg_peers(t.id)
-            .await
-            .unwrap_or_default();
+        let peers = peers_by_tunnel.remove(&t.id).unwrap_or_default();
         wireguard.push(WireguardTunnelConfig {
             id: t.id.to_string(),
             name: t.name.clone(),

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -721,6 +721,47 @@ mod tests {
         assert!(engine.list_wg_peers(tid).await.unwrap().is_empty());
     }
 
+    // PERF-H7: list_all_wg_peers_grouped returns one bucket per tunnel and
+    // matches the per-tunnel list_wg_peers results (no N+1 needed).
+    #[tokio::test]
+    async fn test_wg_peers_grouped() {
+        let engine = create_vpn_engine().await;
+
+        let t1 = WgTunnel::new(
+            "wg0".to_string(),
+            Interface("wg0".to_string()),
+            51820,
+            Address::Any,
+        );
+        let t2 = WgTunnel::new(
+            "wg1".to_string(),
+            Interface("wg1".to_string()),
+            51821,
+            Address::Any,
+        );
+        let (id1, id2) = (t1.id, t2.id);
+        engine.add_wg_tunnel(t1).await.unwrap();
+        engine.add_wg_tunnel(t2).await.unwrap();
+
+        let peer = |tid, name: &str, pk: &str, last: u8| {
+            let mut p = WgPeer::new(tid, name.to_string(), pk.to_string());
+            p.allowed_ips = vec![Address::Network(
+                std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, last)),
+                32,
+            )];
+            p
+        };
+        engine.add_wg_peer(peer(id1, "a", "pubA", 2)).await.unwrap();
+        engine.add_wg_peer(peer(id1, "b", "pubB", 3)).await.unwrap();
+        engine.add_wg_peer(peer(id2, "c", "pubC", 4)).await.unwrap();
+
+        let grouped = engine.list_all_wg_peers_grouped().await.unwrap();
+        assert_eq!(grouped.get(&id1).map(|v| v.len()), Some(2));
+        assert_eq!(grouped.get(&id2).map(|v| v.len()), Some(1));
+        // Empty tunnel (none added) has no bucket.
+        assert!(!grouped.contains_key(&uuid::Uuid::new_v4()));
+    }
+
     #[tokio::test]
     async fn test_wg_tunnel_validation() {
         let engine = create_vpn_engine().await;

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -341,6 +341,27 @@ impl VpnEngine {
         rows.into_iter().map(|r| r.into_peer()).collect()
     }
 
+    /// PERF-H7: fetch every peer in one query and group by tunnel id. Callers
+    /// that need peers for many tunnels at once (e.g. config snapshot/backup)
+    /// use this instead of an N+1 loop of [`Self::list_wg_peers`].
+    pub async fn list_all_wg_peers_grouped(
+        &self,
+    ) -> Result<std::collections::HashMap<Uuid, Vec<WgPeer>>> {
+        let rows = sqlx::query_as::<_, WgPeerRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {WG_PEER_COLUMNS} FROM wg_peers ORDER BY tunnel_id ASC, created_at ASC"
+        )))
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut grouped: std::collections::HashMap<Uuid, Vec<WgPeer>> =
+            std::collections::HashMap::new();
+        for row in rows {
+            let peer = row.into_peer()?;
+            grouped.entry(peer.tunnel_id).or_default().push(peer);
+        }
+        Ok(grouped)
+    }
+
     pub async fn get_wg_peer(&self, id: Uuid) -> Result<WgPeer> {
         let row = sqlx::query_as::<_, WgPeerRow>(sqlx::AssertSqlSafe(format!(
             "SELECT {WG_PEER_COLUMNS} FROM wg_peers WHERE id = ?1"

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.35",
+  "version": "5.97.36",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #351 (PERF-H7, HIGH · perf audit).

> **Stacked on #502 → #501** (PERF-H5, PERF-H21). Base auto-retargets to `main` as the parents merge — review just the top commit.

## Problem
`build_current_config` looped over every WireGuard tunnel calling `list_wg_peers(t.id)` — `1 + N` queries per snapshot. The auto-snapshot middleware fires on **every mutating request**, so a 20-tunnel deployment paid 21 queries on each save.

## Fix
`VpnEngine::list_all_wg_peers_grouped()` runs one
`SELECT ... FROM wg_peers ORDER BY tunnel_id, created_at`
and groups into `HashMap<tunnel_id, Vec<WgPeer>>` in Rust. The backup builder drains a tunnel's bucket via `remove(&t.id)`. Per-tunnel ordering is preserved. (Backed by the `idx_wg_peers_tunnel_id` index added in #502.)

## Verification
- New `test_wg_peers_grouped` (multi-tunnel grouping)
- `cargo test -p aifw-core`, `cargo fmt --check`, `cargo clippy -D warnings` ✓
- Version 5.97.35 → 5.97.36