### PR TITLE
perf(ws): native per-pid RSS instead of `ps aux` x2 (PERF-H12 #356)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.37"
+version = "5.97.38"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/native_metrics.rs
+++ b/aifw-api/src/native_metrics.rs
@@ -82,6 +82,63 @@ pub mod sysctl {
     }
 }
 
+/// Resident set size of a process, in MiB, via a single O(1) syscall — no
+/// `ps` fork (PERF-H12 #356). Returns None if the pid is gone or the query
+/// fails, so callers keep their `unwrap_or(0.0)` dashboard fallback.
+#[cfg(target_os = "freebsd")]
+pub fn process_rss_mb(pid: u32) -> Option<f64> {
+    let page_size = sysctl::read_u64("hw.pagesize").unwrap_or(4096);
+    // MIB for `kern.proc.pid.<pid>`, which returns a single `struct
+    // kinfo_proc` for the target process.
+    let mut mib: [libc::c_int; 4] = [
+        libc::CTL_KERN,
+        libc::KERN_PROC,
+        libc::KERN_PROC_PID,
+        pid as libc::c_int,
+    ];
+    let mut kp: libc::kinfo_proc = unsafe { std::mem::zeroed() };
+    let mut len: libc::size_t = std::mem::size_of::<libc::kinfo_proc>();
+    // SAFETY: `mib` is a valid 4-element MIB (kern.proc.pid.<pid>). `kp` is a
+    // stack-allocated `kinfo_proc` and `len` its byte length; sysctl writes at
+    // most `len` bytes into it and updates `len` to the count written. We read
+    // only the plain integer field `ki_rssize` afterward — no embedded pointer
+    // in `kp` is dereferenced. `newp` is null (read-only query).
+    let r = unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            mib.len() as libc::c_uint,
+            &mut kp as *mut libc::kinfo_proc as *mut libc::c_void,
+            &mut len,
+            std::ptr::null(),
+            0,
+        )
+    };
+    if r != 0 || len == 0 {
+        return None;
+    }
+    // ki_rssize is the current resident set size in pages.
+    let pages = (kp.ki_rssize as i64).max(0) as u64;
+    Some(pages.saturating_mul(page_size) as f64 / (1024.0 * 1024.0))
+}
+
+/// Linux / dev fallback: read resident pages from `/proc/<pid>/statm`
+/// (field 2). FreeBSD's procfs isn't mounted on the appliance, so the real
+/// path above uses sysctl; this keeps the dashboard coherent in dev/CI.
+#[cfg(not(target_os = "freebsd"))]
+pub fn process_rss_mb(pid: u32) -> Option<f64> {
+    let statm = std::fs::read_to_string(format!("/proc/{pid}/statm")).ok()?;
+    let resident_pages: u64 = statm.split_whitespace().nth(1)?.parse().ok()?;
+    // Linux default page size; exact value would need sysconf(_SC_PAGESIZE),
+    // but this path is dev-only and x86-64 pages are 4 KiB.
+    Some((resident_pages.saturating_mul(4096)) as f64 / (1024.0 * 1024.0))
+}
+
+/// Read a pidfile (e.g. `/var/run/aifw_daemon.pid`) into a pid. Returns None
+/// if the file is missing/unreadable or doesn't contain a number.
+pub fn read_pidfile(path: &str) -> Option<u32> {
+    std::fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
 /// Hostname via `gethostname(3)`. Cached for the lifetime of the process —
 /// hostname can change at runtime via `sysrc`, but the dashboard refresh
 /// already pays an rc-config restart for that, so a stale value would only
@@ -385,5 +442,35 @@ pub fn uptime_secs() -> u64 {
     #[cfg(not(any(target_os = "freebsd", target_os = "linux")))]
     {
         0
+    }
+}
+
+#[cfg(test)]
+mod rss_tests {
+    use super::{process_rss_mb, read_pidfile};
+
+    // PERF-H12: the current process always has a resident set. On Linux/CI
+    // this exercises the /proc/<pid>/statm path; on FreeBSD, the sysctl path.
+    #[test]
+    fn self_rss_is_positive() {
+        let rss = process_rss_mb(std::process::id());
+        assert!(rss.is_some(), "self RSS should be readable");
+        assert!(rss.unwrap() > 0.0, "self RSS should be > 0 MiB");
+    }
+
+    #[test]
+    fn dead_pid_is_none_or_zeroish() {
+        // pid 0 is never a normal userland process; the query should not
+        // yield a real RSS. (None on both platforms.)
+        assert!(process_rss_mb(0).unwrap_or(0.0) == 0.0);
+    }
+
+    #[test]
+    fn read_pidfile_parses_and_handles_missing() {
+        let path = std::env::temp_dir().join(format!("aifw-pidtest-{}.pid", std::process::id()));
+        std::fs::write(&path, "  4242\n").unwrap();
+        assert_eq!(read_pidfile(path.to_str().unwrap()), Some(4242));
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(read_pidfile("/no/such/aifw/pidfile"), None);
     }
 }

--- a/aifw-api/src/ws.rs
+++ b/aifw-api/src/ws.rs
@@ -917,29 +917,14 @@ pub async fn collect_memory_breakdown(state: &AppState) -> MemoryBreakdown {
     let cached_mb = pages_to_mb("vm.stats.vm.v_cache_count");
     let free_mb = pages_to_mb("vm.stats.vm.v_free_count");
 
-    // Process RSS via ps (lightweight)
-    let get_rss =
-        |pid_name: &str| -> std::pin::Pin<Box<dyn std::future::Future<Output = f64> + Send + '_>> {
-            let pid_name = pid_name.to_string();
-            Box::pin(async move {
-                let out = Command::new("ps").args(["aux"]).output().await.ok();
-                if let Some(out) = out {
-                    let stdout = String::from_utf8_lossy(&out.stdout);
-                    for line in stdout.lines() {
-                        if line.contains(&pid_name) && !line.contains("grep") {
-                            let parts: Vec<&str> = line.split_whitespace().collect();
-                            if parts.len() >= 6 {
-                                // RSS is in KB in column 5 (0-indexed)
-                                return parts[5].parse::<f64>().unwrap_or(0.0) / 1024.0;
-                            }
-                        }
-                    }
-                }
-                0.0
-            })
-        };
-    let api_rss_mb = get_rss("aifw-api").await;
-    let daemon_rss_mb = get_rss("aifw-daemon").await;
+    // Process RSS via a single O(1) syscall each — no `ps` fork (PERF-H12).
+    // The API is the current process; the daemon's pid comes from its
+    // rc.d pidfile. Missing/unreadable -> 0.0, same as the old ps miss.
+    use crate::native_metrics::{process_rss_mb, read_pidfile};
+    let api_rss_mb = process_rss_mb(std::process::id()).unwrap_or(0.0);
+    let daemon_rss_mb = read_pidfile("/var/run/aifw_daemon.pid")
+        .and_then(process_rss_mb)
+        .unwrap_or(0.0);
 
     // IDS alert buffer — lives in aifw-ids; stats over IPC (best-effort).
     // alerts_total isn't the buffer size, but it's the closest metric we

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.37",
+  "version": "5.97.38",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #356 (PERF-H12, HIGH · perf audit).

## Problem
`ws::collect_memory_breakdown` ran `ps aux` (every process on the box) **twice** per call — once matching `aifw-api`, once `aifw-daemon` — scanning the whole output for a name substring. On the memstats heartbeat that's two ~50 KB fork+exec+parse cycles.

## Fix
`native_metrics::process_rss_mb(pid)` — one O(1) syscall each:
- **FreeBSD:** `sysctl kern.proc.pid.<pid>` → `kinfo_proc.ki_rssize` (pages × pagesize). One new `unsafe` FFI block, same pattern + SAFETY discipline as the existing `sysctlbyname` helpers in this module (approved).
- **Linux/dev:** `/proc/<pid>/statm` field 2 — safe file read.

PIDs: `aifw-api` is the current process (`std::process::id()`); `aifw-daemon` comes from its rc.d pidfile `/var/run/aifw_daemon.pid`. Missing/unreadable → `0.0`, matching the old ps-miss behaviour.

## Verifying the FreeBSD branch
It isn't compiled by Linux CI, so I verified it separately:
- Symbols cross-checked against **libc 0.2.186** source: `CTL_KERN=1`, `KERN_PROC=14`, `KERN_PROC_PID=1`, `kinfo_proc.ki_rssize: segsz_t` ("resident set size in pages"), `libc::sysctl` signature.
- `cargo check --target x86_64-unknown-freebsd` type-checked the whole graph; it only stopped at an unrelated **C** dep (`aws-lc-sys`) that needs a FreeBSD C toolchain — no Rust error in this change.
- The ISO build on real FreeBSD is the final gate.

## Verification
- New tests: self-RSS positive, dead-pid → 0, pidfile parse/missing (3)
- `cargo test -p aifw-api` (144 passed), `cargo fmt --check`, `cargo clippy -D warnings`
- Version 5.97.37 → 5.97.38