### PR TITLE
perf(memstats): window the ids_alerts heartbeat count + drop last ps (PERF-H11 #355)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.38"
+version = "5.97.39"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -1564,31 +1564,30 @@ async fn main() -> anyhow::Result<()> {
                     .as_ref()
                     .map(|s| s.flow_reassembly_bytes / 1024)
                     .unwrap_or(0);
-                let (ids_alerts_db,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM ids_alerts")
-                    .fetch_one(&mem_state.pool)
-                    .await
-                    .unwrap_or((0,));
-                let rss_kb = tokio::process::Command::new("ps")
-                    .args(["-o", "rss=", "-p", &std::process::id().to_string()])
-                    .output()
-                    .await
-                    .ok()
-                    .and_then(|o| {
-                        String::from_utf8_lossy(&o.stdout)
-                            .trim()
-                            .parse::<u64>()
-                            .ok()
-                    })
-                    .unwrap_or(0);
+                // PERF-H11: bound the heartbeat count to the last 24h so it
+                // rides idx_ids_alerts_ts instead of full-scanning a
+                // multi-million-row table every tick (and contending with
+                // ingestion). This is a health signal — recent persistence,
+                // not lifetime total — hence the _24h field name.
+                let (ids_alerts_db_24h,): (i64,) = sqlx::query_as(
+                    "SELECT COUNT(*) FROM ids_alerts WHERE timestamp >= datetime('now', '-1 day')",
+                )
+                .fetch_one(&mem_state.pool)
+                .await
+                .unwrap_or((0,));
+                // PERF-H12: native RSS syscall, not a `ps` fork (finishes the
+                // main.rs shell-out #356 also cited).
+                let rss_mb =
+                    crate::native_metrics::process_rss_mb(std::process::id()).unwrap_or(0.0);
 
                 tracing::info!(
                     target: "aifw_api::memstats",
-                    rss_mb = rss_kb / 1024,
+                    rss_mb = rss_mb,
                     ids_ipc_ok = ids_ipc_ok,
                     ids_alerts_total = ids_stats.as_ref().map(|s| s.alerts_total).unwrap_or(0),
                     flow_count = flow_count,
                     flow_reassembly_kb = flow_reassembly_kb,
-                    ids_alerts_db = ids_alerts_db,
+                    ids_alerts_db_24h = ids_alerts_db_24h,
                     ids_rules_loaded = ids_rules,
                     metrics_history_entries = hist_entries,
                     metrics_history_kb = hist_bytes / 1024,

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.38",
+  "version": "5.97.39",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #355 (PERF-H11, HIGH · perf audit).

## Problem
The memstats heartbeat ran `SELECT COUNT(*) FROM ids_alerts` — no filter — every tick. On a multi-million-row table that's a full scan once a minute, contending with alert ingestion.

## Fix
Bound the count to the last 24h so it rides `idx_ids_alerts_ts` (the exact windowed pattern already used by `count_by_severity` / `top_signatures`):
```sql
SELECT COUNT(*) FROM ids_alerts WHERE timestamp >= datetime('now', '-1 day')
```
It's a health signal (recent persistence, not lifetime total), so the heartbeat log field is renamed **`ids_alerts_db` → `ids_alerts_db_24h`** to reflect the new meaning. *(Heads-up: adjust any CloudWatch metric filter keyed on the old field name.)*

### Also finishes PERF-H12 (#356)
The same heartbeat block had a second shell-out — `ps -o rss= -p <self>` — which #356 explicitly cited (`main.rs`) but PR #506 only fixed in `ws.rs`. Replaced with `native_metrics::process_rss_mb()`. **aifw-api now has zero `ps` shell-outs.**

## Verification
- `cargo test -p aifw-api` (144 passed), `cargo fmt --check`, `cargo clippy -D warnings`
- Windowed predicate + `idx_ids_alerts_ts` already proven by the sibling stats queries
- Version 5.97.38 → 5.97.39