### PR TITLE
perf(audit): commit rule/NAT mutation + audit row in one transaction (PERF-H6 #350)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.38"
+version = "5.97.40"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-core/src/audit.rs
+++ b/aifw-core/src/audit.rs
@@ -101,6 +101,23 @@ impl AuditLog {
         details: &str,
         source: &str,
     ) -> Result<AuditEntry> {
+        Self::log_on(&self.pool, action, rule_id, details, source).await
+    }
+
+    /// Insert an audit entry on an arbitrary executor. Lets engines pair the
+    /// audit row with its mutation in a single transaction (PERF-H6 #350) so
+    /// a rule change costs one commit instead of two, and the audit trail
+    /// can never diverge from the mutated table.
+    pub async fn log_on<'e, E>(
+        exec: E,
+        action: AuditAction,
+        rule_id: Option<Uuid>,
+        details: &str,
+        source: &str,
+    ) -> Result<AuditEntry>
+    where
+        E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+    {
         let entry = AuditEntry {
             id: Uuid::new_v4(),
             timestamp: Utc::now(),
@@ -122,7 +139,7 @@ impl AuditLog {
         .bind(entry.rule_id.map(|id| id.to_string()))
         .bind(&entry.details)
         .bind(&entry.source)
-        .execute(&self.pool)
+        .execute(exec)
         .await?;
 
         Ok(entry)

--- a/aifw-core/src/db.rs
+++ b/aifw-core/src/db.rs
@@ -152,6 +152,15 @@ impl Database {
     }
 
     pub async fn insert_rule(&self, rule: &Rule) -> Result<()> {
+        Self::insert_rule_on(&self.pool, rule).await
+    }
+
+    /// Executor-generic variant so engines can run the insert inside a
+    /// transaction alongside its audit row (PERF-H6 #350).
+    pub(crate) async fn insert_rule_on<'e, E>(exec: E, rule: &Rule) -> Result<()>
+    where
+        E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+    {
         sqlx::query(
             r#"
             INSERT INTO rules (id, priority, action, direction, interface, protocol,
@@ -208,7 +217,7 @@ impl Database {
         .bind(format!("{:?}", rule.ip_version).to_lowercase())
         .bind(rule.src_invert)
         .bind(rule.dst_invert)
-        .execute(&self.pool)
+        .execute(exec)
         .await?;
 
         Ok(())
@@ -247,6 +256,15 @@ impl Database {
     }
 
     pub async fn update_rule(&self, rule: &Rule) -> Result<()> {
+        Self::update_rule_on(&self.pool, rule).await
+    }
+
+    /// Executor-generic variant so engines can run the update inside a
+    /// transaction alongside its audit row (PERF-H6 #350).
+    pub(crate) async fn update_rule_on<'e, E>(exec: E, rule: &Rule) -> Result<()>
+    where
+        E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+    {
         let result = sqlx::query(
             r#"
             UPDATE rules SET priority = ?2, action = ?3, direction = ?4, interface = ?5,
@@ -305,7 +323,7 @@ impl Database {
         .bind(format!("{:?}", rule.ip_version).to_lowercase())
         .bind(rule.src_invert)
         .bind(rule.dst_invert)
-        .execute(&self.pool)
+        .execute(exec)
         .await?;
 
         if result.rows_affected() == 0 {
@@ -315,9 +333,18 @@ impl Database {
     }
 
     pub async fn delete_rule(&self, id: Uuid) -> Result<()> {
+        Self::delete_rule_on(&self.pool, id).await
+    }
+
+    /// Executor-generic variant so engines can run the delete inside a
+    /// transaction alongside its audit row (PERF-H6 #350).
+    pub(crate) async fn delete_rule_on<'e, E>(exec: E, id: Uuid) -> Result<()>
+    where
+        E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+    {
         let result = sqlx::query("DELETE FROM rules WHERE id = ?1")
             .bind(id.to_string())
-            .execute(&self.pool)
+            .execute(exec)
             .await?;
 
         if result.rows_affected() == 0 {

--- a/aifw-core/src/engine.rs
+++ b/aifw-core/src/engine.rs
@@ -40,16 +40,20 @@ impl RuleEngine {
 
     pub async fn add_rule(&self, rule: Rule) -> Result<Rule> {
         validate_rule(&rule)?;
-        self.db.insert_rule(&rule).await?;
         let pf_syntax = rule.to_pf_rule(&self.anchor);
-        self.audit
-            .log(
-                AuditAction::RuleAdded,
-                Some(rule.id),
-                &format!("pf: {pf_syntax}"),
-                "engine",
-            )
-            .await?;
+        // PERF-H6 (#350): mutation + audit row commit together — one fsync
+        // instead of two per rule change.
+        let mut tx = self.db.pool().begin().await?;
+        Database::insert_rule_on(&mut *tx, &rule).await?;
+        AuditLog::log_on(
+            &mut *tx,
+            AuditAction::RuleAdded,
+            Some(rule.id),
+            &format!("pf: {pf_syntax}"),
+            "engine",
+        )
+        .await?;
+        tx.commit().await?;
         tracing::info!(id = %rule.id, label = ?rule.label, "rule added");
         Ok(rule)
     }
@@ -67,24 +71,33 @@ impl RuleEngine {
 
     pub async fn update_rule(&self, rule: Rule) -> Result<()> {
         validate_rule(&rule)?;
-        self.db.update_rule(&rule).await?;
-        self.audit
-            .log(
-                AuditAction::RuleUpdated,
-                Some(rule.id),
-                &format!("pf: {}", rule.to_pf_rule(&self.anchor)),
-                "engine",
-            )
-            .await?;
+        let mut tx = self.db.pool().begin().await?;
+        Database::update_rule_on(&mut *tx, &rule).await?;
+        AuditLog::log_on(
+            &mut *tx,
+            AuditAction::RuleUpdated,
+            Some(rule.id),
+            &format!("pf: {}", rule.to_pf_rule(&self.anchor)),
+            "engine",
+        )
+        .await?;
+        tx.commit().await?;
         tracing::info!(id = %rule.id, "rule updated");
         Ok(())
     }
 
     pub async fn delete_rule(&self, id: Uuid) -> Result<()> {
-        self.db.delete_rule(id).await?;
-        self.audit
-            .log(AuditAction::RuleRemoved, Some(id), "rule deleted", "engine")
-            .await?;
+        let mut tx = self.db.pool().begin().await?;
+        Database::delete_rule_on(&mut *tx, id).await?;
+        AuditLog::log_on(
+            &mut *tx,
+            AuditAction::RuleRemoved,
+            Some(id),
+            "rule deleted",
+            "engine",
+        )
+        .await?;
+        tx.commit().await?;
         tracing::info!(%id, "rule deleted");
         Ok(())
     }

--- a/aifw-core/src/nat.rs
+++ b/aifw-core/src/nat.rs
@@ -69,16 +69,20 @@ impl NatEngine {
 
     pub async fn add_rule(&self, rule: NatRule) -> Result<NatRule> {
         validate_nat_rule(&rule)?;
-        self.insert_rule(&rule).await?;
         let pf_syntax = rule.to_pf_rule();
-        self.audit
-            .log(
-                AuditAction::RuleAdded,
-                Some(rule.id),
-                &format!("nat: {pf_syntax}"),
-                "nat_engine",
-            )
-            .await?;
+        // PERF-H6 (#350): mutation + audit row commit together — one fsync
+        // instead of two per NAT rule change.
+        let mut tx = self.pool.begin().await?;
+        Self::insert_rule_on(&mut *tx, &rule).await?;
+        AuditLog::log_on(
+            &mut *tx,
+            AuditAction::RuleAdded,
+            Some(rule.id),
+            &format!("nat: {pf_syntax}"),
+            "nat_engine",
+        )
+        .await?;
+        tx.commit().await?;
         tracing::info!(id = %rule.id, nat_type = %rule.nat_type, "NAT rule added");
         Ok(rule)
     }
@@ -118,6 +122,7 @@ impl NatEngine {
 
     pub async fn update_rule(&self, rule: &NatRule) -> Result<()> {
         validate_nat_rule(rule)?;
+        let mut tx = self.pool.begin().await?;
         let result = sqlx::query(
             r#"
             UPDATE nat_rules SET nat_type = ?2, interface = ?3, protocol = ?4,
@@ -147,7 +152,7 @@ impl NatEngine {
             NatStatus::Disabled => "disabled",
         })
         .bind(chrono::Utc::now().to_rfc3339())
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
 
         if result.rows_affected() == 0 {
@@ -157,36 +162,39 @@ impl NatEngine {
             )));
         }
 
-        self.audit
-            .log(
-                AuditAction::RuleUpdated,
-                Some(rule.id),
-                &format!("nat: {}", rule.to_pf_rule()),
-                "nat_engine",
-            )
-            .await?;
+        AuditLog::log_on(
+            &mut *tx,
+            AuditAction::RuleUpdated,
+            Some(rule.id),
+            &format!("nat: {}", rule.to_pf_rule()),
+            "nat_engine",
+        )
+        .await?;
+        tx.commit().await?;
         tracing::info!(id = %rule.id, "NAT rule updated");
         Ok(())
     }
 
     pub async fn delete_rule(&self, id: Uuid) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
         let result = sqlx::query("DELETE FROM nat_rules WHERE id = ?1")
             .bind(id.to_string())
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
 
         if result.rows_affected() == 0 {
             return Err(AifwError::NotFound(format!("NAT rule {id} not found")));
         }
 
-        self.audit
-            .log(
-                AuditAction::RuleRemoved,
-                Some(id),
-                "NAT rule deleted",
-                "nat_engine",
-            )
-            .await?;
+        AuditLog::log_on(
+            &mut *tx,
+            AuditAction::RuleRemoved,
+            Some(id),
+            "NAT rule deleted",
+            "nat_engine",
+        )
+        .await?;
+        tx.commit().await?;
         tracing::info!(%id, "NAT rule deleted");
         Ok(())
     }
@@ -242,7 +250,10 @@ impl NatEngine {
         Ok(())
     }
 
-    async fn insert_rule(&self, rule: &NatRule) -> Result<()> {
+    async fn insert_rule_on<'e, E>(exec: E, rule: &NatRule) -> Result<()>
+    where
+        E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+    {
         sqlx::query(
             r#"
             INSERT INTO nat_rules (id, nat_type, interface, protocol, src_addr,
@@ -272,7 +283,7 @@ impl NatEngine {
         })
         .bind(rule.created_at.to_rfc3339())
         .bind(rule.updated_at.to_rfc3339())
-        .execute(&self.pool)
+        .execute(exec)
         .await?;
 
         Ok(())

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.38",
+  "version": "5.97.40",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #350 (PERF-H6, HIGH · perf audit).

## Problem
Every `add_rule`/`update_rule`/`delete_rule` on `RuleEngine` and `NatEngine` issued two separate SQLite commits on the same write path: the mutation, then `INSERT INTO audit_log`. That doubles write latency per mutation, and bulk import / config restore pays 2N commits.

## Fix
- `AuditLog::log_on(exec, ...)` — executor-generic audit insert; `log()` delegates to it with the pool.
- `Database::{insert,update,delete}_rule_on(exec, ...)` — executor-generic mutation helpers; the pool-based methods delegate.
- Both engines now `BEGIN` one transaction, run mutation + audit insert on it, and `COMMIT` once.

Same durability, half the fsyncs. Side benefit: the audit trail is now atomic with the mutation — a crash between the two writes can no longer leave a rule change with no audit row (or roll back a mutation whose audit row survived).

`apply_rules`/`flush_rules` keep the pool-based `log()` since their audit row pairs with a pf operation, not a DB write.

## Verification
- `cargo check` — zero warnings (pre-commit also ran fmt + clippy `-D warnings`)
- `cargo test` — 652 passed, 0 failed; includes `test_audit_trail` / `test_audit_for_apply_and_flush` which assert audit rows are readable immediately after each mutation