### PR TITLE
perf(ws): keep metrics_history write lock to O(1) pop/push (PERF-H10 #354)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.38"
+version = "5.97.42"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/ws.rs
+++ b/aifw-api/src/ws.rs
@@ -347,16 +347,9 @@ pub async fn run_dashboard_producer(state: AppState) {
         let started = Instant::now();
         match build_update(&state).await {
             Ok((live_msg, history_msg)) => {
-                // Slim history → in-memory ring buffer (so reconnects can
-                // backfill the dashboard) and Valkey (so the ring survives
-                // process restart when configured).
-                if max > 0 {
-                    let mut buf = state.metrics_history.write().await;
-                    while buf.len() >= max {
-                        buf.pop_front();
-                    }
-                    buf.push_back(history_msg.clone());
-                }
+                // Slim history → Valkey (so the ring survives process
+                // restart when configured) and the in-memory ring buffer
+                // (so reconnects can backfill the dashboard).
                 if let Some(ref redis) = state.redis {
                     let mut conn = redis.clone();
                     let _: Result<(), _> = redis::pipe()
@@ -369,6 +362,18 @@ pub async fn run_dashboard_producer(state: AppState) {
                         .arg(max as i64 - 1)
                         .query_async(&mut conn)
                         .await;
+                }
+                // PERF-H10 (#354): history_msg moves into the deque — the
+                // write() critical section is only O(1) pop/push, so WS
+                // connects reading the history don't stall behind a large
+                // String clone (tokio's fair RwLock queues new readers
+                // behind a waiting writer).
+                if max > 0 {
+                    let mut buf = state.metrics_history.write().await;
+                    while buf.len() >= max {
+                        buf.pop_front();
+                    }
+                    buf.push_back(history_msg);
                 }
                 // Live frame to dashboard clients. `send` errors only if
                 // there are no subscribers, which is fine — we wanted to

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.38",
+  "version": "5.97.42",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #354 (PERF-H10, HIGH · perf audit).

## Problem
The dashboard producer held the `metrics_history` `write()` lock across `buf.push_back(history_msg.clone())` — the clone of a large per-tick JSON `String` executed inside the critical section. tokio's `RwLock` is fair: while a writer waits/holds, **new readers queue behind it**, so during a dashboard refresh storm every WS connect's history read (`ws.rs` `handle_socket`) stalled behind the producer's allocation.

## Fix
Reorder the tick body: the Valkey persistence step (which only borrows `&history_msg`) runs first, then `history_msg` is **moved** into the ring buffer. The clone is eliminated entirely, and the write critical section shrinks to an amortized-O(1) `pop_front`/`push_back`.

## Verification
- `cargo test` — all passing (0 failures), fmt + clippy `-D warnings` clean via pre-commit hook