### PR TITLE
perf(ids-ipc): stop zero-filling frame reads up to 16 MiB (PERF-H13 #357)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.38"
+version = "5.97.43"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ids-ipc/src/framing.rs
+++ b/aifw-ids-ipc/src/framing.rs
@@ -10,6 +10,11 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 const MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
 
+/// Upfront allocation cap for a frame body. Typical IPC frames are well
+/// under this; larger bodies grow the buffer as bytes actually arrive
+/// instead of trusting the length prefix (PERF-H13 #357).
+const INITIAL_BODY_CAPACITY: usize = 64 * 1024;
+
 #[derive(Debug, Error)]
 pub enum FrameError {
     #[error("io error: {0}")]
@@ -31,8 +36,23 @@ where
     if (len as usize) > MAX_FRAME_BYTES {
         return Err(FrameError::TooLarge(len));
     }
-    let mut buf = vec![0u8; len as usize];
-    reader.read_exact(&mut buf).await?;
+    // PERF-H13 (#357): `vec![0u8; len]` zero-filled up to 16 MiB that
+    // read_exact immediately overwrote, and committed the full claimed
+    // length before a single body byte arrived. `take(len).read_to_end`
+    // appends into uninitialized spare capacity (no memset) and grows
+    // with the bytes actually received, so a client claiming a huge
+    // frame but sending nothing can't pin 16 MiB per connection.
+    let mut buf = Vec::with_capacity((len as usize).min(INITIAL_BODY_CAPACITY));
+    let read = (&mut *reader)
+        .take(len as u64)
+        .read_to_end(&mut buf)
+        .await?;
+    if read < len as usize {
+        return Err(FrameError::Io(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "frame body truncated",
+        )));
+    }
     let msg = serde_json::from_slice(&buf)?;
     Ok(msg)
 }
@@ -66,6 +86,37 @@ mod tests {
         write_frame(&mut a, &sent).await.unwrap();
         let received: IpcRequest = read_frame(&mut b).await.unwrap();
         assert!(matches!(received, IpcRequest::GetStats));
+    }
+
+    #[tokio::test]
+    async fn truncated_body_errors() {
+        let (mut a, mut b) = duplex(64 * 1024);
+        // Claim 100 bytes, deliver 5, then EOF.
+        a.write_all(&100u32.to_be_bytes()).await.unwrap();
+        a.write_all(b"short").await.unwrap();
+        drop(a);
+        let result: Result<IpcRequest, _> = read_frame(&mut b).await;
+        assert!(matches!(result, Err(FrameError::Io(_))));
+    }
+
+    #[tokio::test]
+    async fn round_trips_body_larger_than_initial_capacity() {
+        let (mut a, mut b) = duplex(1024 * 1024);
+        // A body that exceeds INITIAL_BODY_CAPACITY must still arrive intact.
+        let sent = IpcRequest::GetRule {
+            id: "x".repeat(super::INITIAL_BODY_CAPACITY * 2),
+        };
+        let write = async {
+            write_frame(&mut a, &sent).await.unwrap();
+        };
+        let read = async { read_frame::<IpcRequest, _>(&mut b).await.unwrap() };
+        let (_, received) = tokio::join!(write, read);
+        match received {
+            IpcRequest::GetRule { id } => {
+                assert_eq!(id.len(), super::INITIAL_BODY_CAPACITY * 2)
+            }
+            other => panic!("unexpected frame: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.38",
+  "version": "5.97.43",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #357 (PERF-H13, HIGH · perf audit).

## Problem
`read_frame` allocated `vec![0u8; len]` with `len` taken straight from the wire, bounded only by `MAX_FRAME_BYTES` (16 MiB). Two costs:
- a full memset of the claimed length on **every** frame, immediately overwritten by `read_exact`;
- the whole claimed allocation was committed before a single body byte arrived — a buggy or stalled client claiming 16 MiB pinned 16 MiB per connection.

## Fix
`Vec::with_capacity(min(len, 64 KiB))` + `(&mut reader).take(len).read_to_end(&mut buf)`:
- `read_to_end` appends into uninitialized spare capacity — no memset, and **no `unsafe`** (the issue's suggested `set_len` route is disallowed by project policy);
- memory grows with bytes actually received, never past `len`;
- a short read (peer EOF mid-body) surfaces as `UnexpectedEof`, matching `read_exact`'s previous behaviour.

## Verification
- New tests: truncated body errors; body larger than the initial 64 KiB capacity round-trips intact
- `cargo test` — all passing (0 failures); fmt + clippy `-D warnings` clean