### PR TITLE
perf(plugins): dispatch via snapshot, not under the manager lock (PERF-H17 #361)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.43"
+version = "5.97.44"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/auth/middleware.rs
+++ b/aifw-api/src/auth/middleware.rs
@@ -166,8 +166,10 @@ pub async fn auth_middleware(
         .load(std::sync::atomic::Ordering::Relaxed)
         > 0
     {
-        let mgr = state.plugin_manager.read().await;
-        if mgr.running_count() > 0 {
+        // PERF-H17 (#361): snapshot under a short read lock, dispatch after
+        // dropping it — a slow plugin can't block enable/disable (write()).
+        let plugins = state.plugin_manager.read().await.dispatch_set();
+        if !plugins.is_empty() {
             let method = request.method().to_string();
             let path = request.uri().path().to_string();
             let event = aifw_plugins::HookEvent {
@@ -178,7 +180,7 @@ pub async fn auth_middleware(
                     remote_addr: None,
                 },
             };
-            let actions = mgr.dispatch(&event).await;
+            let actions = plugins.dispatch(&event).await;
             for action in &actions {
                 if matches!(action, aifw_plugins::HookAction::Block) {
                     return Err(StatusCode::FORBIDDEN);

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -1448,8 +1448,11 @@ async fn main() -> anyhow::Result<()> {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
             loop {
                 interval.tick().await;
-                let mgr = pmgr.read().await;
-                if mgr.running_count() > 0 {
+                // PERF-H17/PERF-M20 (#361/#389): snapshot under a short read
+                // lock; the 60s timer dispatch runs unlocked so cron-like
+                // plugins doing slow I/O don't block enable/disable.
+                let plugins = pmgr.read().await.dispatch_set();
+                if !plugins.is_empty() {
                     let event = aifw_plugins::HookEvent {
                         hook: aifw_plugins::HookPoint::Timer,
                         data: aifw_plugins::hooks::HookEventData::Tick {
@@ -1459,7 +1462,7 @@ async fn main() -> anyhow::Result<()> {
                                 .as_secs(),
                         },
                     };
-                    let _ = mgr.dispatch(&event).await;
+                    let _ = plugins.dispatch(&event).await;
                 }
             }
         });

--- a/aifw-api/src/plugins.rs
+++ b/aifw-api/src/plugins.rs
@@ -212,6 +212,6 @@ pub async fn dispatch_hook(
     state: &AppState,
     event: aifw_plugins::HookEvent,
 ) -> Vec<aifw_plugins::HookAction> {
-    let mgr = state.plugin_manager.read().await;
-    mgr.dispatch(&event).await
+    let plugins = state.plugin_manager.read().await.dispatch_set();
+    plugins.dispatch(&event).await
 }

--- a/aifw-api/src/ws.rs
+++ b/aifw-api/src/ws.rs
@@ -428,8 +428,10 @@ async fn build_update(state: &AppState) -> Result<(String, String), String> {
     type ConnKey = (std::net::IpAddr, u16, std::net::IpAddr, u16);
     {
         use std::collections::HashSet;
-        let plugins_active = state.plugin_manager.read().await.running_count() > 0;
-        if plugins_active {
+        // PERF-H17 (#361): snapshot the running plugins under a short read
+        // lock; all dispatching below happens without the manager lock.
+        let plugins = state.plugin_manager.read().await.dispatch_set();
+        if !plugins.is_empty() {
             static PREV_CONNS: std::sync::OnceLock<tokio::sync::RwLock<HashSet<ConnKey>>> =
                 std::sync::OnceLock::new();
             let prev_lock = PREV_CONNS.get_or_init(|| tokio::sync::RwLock::new(HashSet::new()));
@@ -438,12 +440,8 @@ async fn build_update(state: &AppState) -> Result<(String, String), String> {
                 .iter()
                 .map(|c| (c.src_addr, c.src_port, c.dst_addr, c.dst_port))
                 .collect();
-            // Snapshot under read lock, drop the guard, then drop the plugin
-            // manager guard before any dispatch.await — avoids holding read
-            // locks across slow plugin I/O.
             let prev_keys = prev_lock.read().await.clone();
 
-            let mgr = state.plugin_manager.read().await;
             for c in conns.iter() {
                 let key = (c.src_addr, c.src_port, c.dst_addr, c.dst_port);
                 if !prev_keys.contains(&key) {
@@ -458,7 +456,7 @@ async fn build_update(state: &AppState) -> Result<(String, String), String> {
                             state: c.state.clone(),
                         },
                     };
-                    let actions = mgr.dispatch(&event).await;
+                    let actions = plugins.dispatch(&event).await;
                     for action in actions {
                         if let aifw_plugins::HookAction::AddToTable { ref table, ip } = action {
                             let _ = state.pf.add_table_entry(table, ip).await;
@@ -480,10 +478,9 @@ async fn build_update(state: &AppState) -> Result<(String, String), String> {
                             state: "closed".to_string(),
                         },
                     };
-                    let _ = mgr.dispatch(&event).await;
+                    let _ = plugins.dispatch(&event).await;
                 }
             }
-            drop(mgr);
             *prev_lock.write().await = current_keys;
         }
     }
@@ -1164,10 +1161,11 @@ pub fn start_pflog_collector(
                     let mut reader = BufReader::new(stdout).lines();
                     while let Ok(Some(line)) = reader.next_line().await {
                         if let Some(entry) = parse_pflog_line(&line) {
-                            // Dispatch PostRule hook for blocked/passed traffic
+                            // Dispatch PostRule hook for blocked/passed traffic.
+                            // PERF-H17 (#361): snapshot, then dispatch unlocked.
                             {
-                                let mgr = pmgr.read().await;
-                                if mgr.running_count() > 0 {
+                                let plugins = pmgr.read().await.dispatch_set();
+                                if !plugins.is_empty() {
                                     let event = aifw_plugins::HookEvent {
                                         hook: aifw_plugins::HookPoint::PostRule,
                                         data: aifw_plugins::hooks::HookEventData::Rule {
@@ -1188,7 +1186,7 @@ pub fn start_pflog_collector(
                                             rule_id: None,
                                         },
                                     };
-                                    let _ = mgr.dispatch(&event).await;
+                                    let _ = plugins.dispatch(&event).await;
                                 }
                             }
                             let mut buf = buf2.write().await;

--- a/aifw-plugins/src/lib.rs
+++ b/aifw-plugins/src/lib.rs
@@ -19,5 +19,5 @@ mod tests;
 pub use context::PluginContext;
 pub use error::{PluginError, Result};
 pub use hooks::{HookAction, HookEvent, HookPoint};
-pub use manager::PluginManager;
+pub use manager::{DispatchSet, PluginManager};
 pub use plugin::{Plugin, PluginConfig, PluginInfo, PluginState};

--- a/aifw-plugins/src/manager.rs
+++ b/aifw-plugins/src/manager.rs
@@ -1,16 +1,49 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use tracing::{error, info, warn};
 
 use crate::context::PluginContext;
-use crate::hooks::{HookAction, HookEvent};
+use crate::hooks::{HookAction, HookEvent, HookPoint};
 use crate::plugin::{Plugin, PluginConfig, PluginInfo, PluginState};
 
 struct LoadedPlugin {
-    plugin: Box<dyn Plugin>,
+    plugin: Arc<dyn Plugin>,
     #[allow(dead_code)]
     config: PluginConfig,
     state: PluginState,
     info: PluginInfo,
+}
+
+/// A snapshot of the running plugins plus the shared context, detached from
+/// the manager (PERF-H17 #361). Callers hold the manager lock only long
+/// enough to clone Arcs via [`PluginManager::dispatch_set`], then dispatch
+/// through the snapshot — so a slow plugin (e.g. a webhook HTTP POST) can't
+/// block enable/disable, which needs the manager `write()` lock.
+pub struct DispatchSet {
+    plugins: Vec<(String, Vec<HookPoint>, Arc<dyn Plugin>)>,
+    ctx: PluginContext,
+}
+
+impl DispatchSet {
+    pub fn is_empty(&self) -> bool {
+        self.plugins.is_empty()
+    }
+
+    /// Dispatch a hook event to every snapshotted plugin subscribed to it.
+    pub async fn dispatch(&self, event: &HookEvent) -> Vec<HookAction> {
+        let mut actions = Vec::new();
+        for (name, hooks, plugin) in &self.plugins {
+            if !hooks.contains(&event.hook) {
+                continue;
+            }
+            let action = plugin.on_hook(event, &self.ctx).await;
+            if action != HookAction::Continue {
+                tracing::debug!(plugin = %name, hook = %event.hook, "plugin returned action");
+                actions.push(action);
+            }
+        }
+        actions
+    }
 }
 
 /// Manages the lifecycle of all loaded plugins
@@ -42,30 +75,33 @@ impl PluginManager {
 
         info!(plugin = %name, version = %info.version, "registering plugin");
 
-        let mut loaded = LoadedPlugin {
-            plugin,
-            config: config.clone(),
-            state: PluginState::Loaded,
-            info,
-        };
-
-        if config.enabled {
-            match loaded.plugin.init(&config, &self.ctx).await {
+        // init() needs `&mut`, so it runs on the Box before the plugin is
+        // wrapped in the Arc that dispatch snapshots share.
+        let mut plugin = plugin;
+        let state = if config.enabled {
+            match plugin.init(&config, &self.ctx).await {
                 Ok(()) => {
-                    loaded.state = PluginState::Running;
                     info!(plugin = %name, "plugin initialized and running");
+                    PluginState::Running
                 }
                 Err(e) => {
-                    loaded.state = PluginState::Error;
                     error!(plugin = %name, error = %e, "plugin init failed");
                     return Err(e);
                 }
             }
         } else {
-            loaded.state = PluginState::Stopped;
-        }
+            PluginState::Stopped
+        };
 
-        self.plugins.insert(name, loaded);
+        self.plugins.insert(
+            name,
+            LoadedPlugin {
+                plugin: Arc::from(plugin),
+                config,
+                state,
+                info,
+            },
+        );
         Ok(())
     }
 
@@ -76,36 +112,53 @@ impl PluginManager {
             .remove(name)
             .ok_or_else(|| format!("plugin '{name}' not found"))?;
 
-        if loaded.state == PluginState::Running
-            && let Err(e) = loaded.plugin.shutdown().await
-        {
-            warn!(plugin = %name, error = %e, "plugin shutdown error");
+        if loaded.state == PluginState::Running {
+            // The plugin is already out of the map, so no new DispatchSet
+            // can include it. shutdown() needs `&mut`, which Arc::get_mut
+            // only yields once in-flight dispatch snapshots drop their
+            // clones — wait bounded for that.
+            let mut waited_ms = 0u32;
+            loop {
+                match Arc::get_mut(&mut loaded.plugin) {
+                    Some(plugin) => {
+                        if let Err(e) = plugin.shutdown().await {
+                            warn!(plugin = %name, error = %e, "plugin shutdown error");
+                        }
+                        break;
+                    }
+                    None if waited_ms < 5_000 => {
+                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                        waited_ms += 50;
+                    }
+                    None => {
+                        warn!(plugin = %name, "shutdown skipped: dispatch still in flight after 5s");
+                        break;
+                    }
+                }
+            }
         }
 
         info!(plugin = %name, "plugin unloaded");
         Ok(())
     }
 
+    /// Snapshot the running plugins for dispatch without holding the
+    /// manager lock (PERF-H17 #361).
+    pub fn dispatch_set(&self) -> DispatchSet {
+        DispatchSet {
+            plugins: self
+                .plugins
+                .iter()
+                .filter(|(_, l)| l.state == PluginState::Running)
+                .map(|(n, l)| (n.clone(), l.info.hooks.clone(), Arc::clone(&l.plugin)))
+                .collect(),
+            ctx: self.ctx.clone(),
+        }
+    }
+
     /// Dispatch a hook event to all plugins that are subscribed
     pub async fn dispatch(&self, event: &HookEvent) -> Vec<HookAction> {
-        let mut actions = Vec::new();
-
-        for (name, loaded) in &self.plugins {
-            if loaded.state != PluginState::Running {
-                continue;
-            }
-            if !loaded.info.hooks.contains(&event.hook) {
-                continue;
-            }
-
-            let action = loaded.plugin.on_hook(event, &self.ctx).await;
-            if action != HookAction::Continue {
-                tracing::debug!(plugin = %name, hook = %event.hook, "plugin returned action");
-                actions.push(action);
-            }
-        }
-
-        actions
+        self.dispatch_set().dispatch(event).await
     }
 
     /// Get a list of all registered plugins and their states

--- a/aifw-plugins/src/tests.rs
+++ b/aifw-plugins/src/tests.rs
@@ -126,6 +126,39 @@ mod tests {
         assert!(actions.is_empty()); // Continue actions are filtered out
     }
 
+    // PERF-H17 (#361): dispatch goes through a snapshot detached from the
+    // manager, so a slow plugin can't hold callers off the manager lock.
+    #[tokio::test]
+    async fn test_dispatch_set_snapshot() {
+        let ctx = make_ctx();
+        let mut mgr = PluginManager::new(ctx);
+
+        mgr.register(Box::new(LoggingPlugin::new()), default_config())
+            .await
+            .unwrap();
+        let disabled = PluginConfig {
+            enabled: false,
+            settings: Default::default(),
+        };
+        mgr.register(Box::new(WebhookPlugin::new()), disabled)
+            .await
+            .unwrap();
+
+        // Only the running plugin lands in the snapshot.
+        let set = mgr.dispatch_set();
+        assert!(!set.is_empty());
+
+        // Dispatch goes through the snapshot; the manager isn't involved.
+        let actions = set.dispatch(&make_log_event()).await;
+        assert!(actions.is_empty()); // LoggingPlugin returns Continue
+        drop(set);
+
+        // Empty manager → empty snapshot.
+        mgr.unload("custom-logger").await.unwrap();
+        mgr.unload("webhook-notifier").await.unwrap();
+        assert!(mgr.dispatch_set().is_empty());
+    }
+
     #[tokio::test]
     async fn test_manager_disabled_plugin() {
         let ctx = make_ctx();

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.43",
+  "version": "5.97.44",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #361 (PERF-H17, HIGH · perf audit).
Closes #389 (PERF-M20, MEDIUM — same defect at the timer-hook call site, fixed by the same change).

## Problem
Every dispatch path held `state.plugin_manager.read()` across `dispatch(&event).await`. Plugins can do slow I/O (`WebhookPlugin` HTTP POSTs), so any code needing the `write()` lock — plugin enable/disable — hung while a dispatch was in flight. Affected sites: auth middleware `ApiRequest` hook, dashboard tick connection hooks (`ws.rs`), pflog `PostRule` hook, and the 60s timer hook (PERF-M20's finding).

## Fix
- `PluginManager` stores plugins as `Arc<dyn Plugin>` and gains `dispatch_set()` → a `DispatchSet` snapshot (Arc clones of running plugins + their hook lists + a `PluginContext` clone).
- All call sites now take the read lock only long enough to snapshot, then dispatch through the snapshot with no lock held.
- `init()` runs on the `Box` before Arc-wrapping (it needs `&mut self`).
- `unload()` waits bounded (5s, 50ms polls) for in-flight snapshots to drop their Arc clones before calling the `&mut shutdown()`; if a dispatch is still in flight it warns and skips shutdown rather than deadlocking.
- `PluginManager::dispatch()` remains as a delegate (`dispatch_set().dispatch()`), so existing callers/tests keep working.

## Verification
- New test `test_dispatch_set_snapshot`: snapshot filters to running plugins, dispatches independently of the manager, empty manager → empty set
- `cargo test` — 657 passed, 0 failed; fmt + clippy `-D warnings` clean