### PR TITLE
fix(plugins): wire dispatch_hook into audit-log tail (#488)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.97.46"
+version = "5.98.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/Cargo.toml
+++ b/aifw-api/Cargo.toml
@@ -53,6 +53,7 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 axum-test = "21"
+async-trait = { workspace = true }
 
 [lints]
 workspace = true

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -864,9 +864,13 @@ async fn create_state_from_db(
         }
     }
 
+    // Seed the shadow counter with the boot-time running count (#488) —
+    // previously it started at 0, so plugins enabled in the DB never
+    // received hooks until toggled through the API once.
+    let plugin_running = plugin_mgr.running_count();
     tracing::info!(
         plugins = plugin_mgr.count(),
-        running = plugin_mgr.running_count(),
+        running = plugin_running,
         "plugin system initialized"
     );
 
@@ -931,7 +935,7 @@ async fn create_state_from_db(
         auth_user_cache: Arc::new(dashmap::DashMap::new()),
         auth_jti_cache: Arc::new(dashmap::DashMap::new()),
         auth_token_cache: Arc::new(dashmap::DashMap::new()),
-        plugin_running_count: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        plugin_running_count: Arc::new(std::sync::atomic::AtomicUsize::new(plugin_running)),
         auto_snapshot_pending: Arc::new(tokio::sync::Mutex::new(
             backup::AutoSnapshotPending::default(),
         )),
@@ -1467,6 +1471,10 @@ async fn main() -> anyhow::Result<()> {
             }
         });
     }
+
+    // Tail the audit log into plugin LogEvent hooks (#488) — the bridge
+    // between aifw-core audit writes and plugins subscribed to LogEvent.
+    plugins::start_audit_hook_dispatcher(state.clone());
 
     // Start AI analysis background task — reviews unclassified critical/high alerts every 5 minutes.
     // Now reads alerts directly from the SQLite ids_alerts table, since the

--- a/aifw-api/src/plugins.rs
+++ b/aifw-api/src/plugins.rs
@@ -205,13 +205,255 @@ pub async fn discover_plugins() -> Result<Json<serde_json::Value>, StatusCode> {
     })))
 }
 
-/// Dispatch a hook event to all plugins. Currently uncalled — see #488 for
-/// wiring this into the event paths that should notify plugins.
-#[allow(dead_code)]
+/// Dispatch a hook event to all running plugins.
+///
+/// Short-circuits on the atomic shadow counter — no plugins running means
+/// no read-lock acquisition and an empty action list. Otherwise snapshots
+/// the dispatch set under a short read lock and dispatches after dropping
+/// it (PERF-H17 #361), so a slow plugin can't block enable/disable.
 pub async fn dispatch_hook(
     state: &AppState,
     event: aifw_plugins::HookEvent,
 ) -> Vec<aifw_plugins::HookAction> {
+    if state
+        .plugin_running_count
+        .load(std::sync::atomic::Ordering::Relaxed)
+        == 0
+    {
+        return Vec::new();
+    }
     let plugins = state.plugin_manager.read().await.dispatch_set();
     plugins.dispatch(&event).await
+}
+
+/// Current tail position (max rowid) of the audit_log table.
+async fn audit_log_tail(pool: &SqlitePool) -> i64 {
+    sqlx::query_scalar("SELECT COALESCE(MAX(rowid), 0) FROM audit_log")
+        .fetch_one(pool)
+        .await
+        .unwrap_or(0)
+}
+
+/// Fetch audit rows past `last_rowid` and dispatch each to plugins as a
+/// `LogEvent` hook (#488). Returns the new cursor. Table-mutation actions
+/// returned by plugins are applied to pf, mirroring the ConnectionNew site
+/// in ws.rs. Split from the spawn loop so tests can drive a single poll.
+async fn dispatch_new_audit_entries(state: &AppState, last_rowid: i64) -> i64 {
+    let rows: Vec<(i64, String, String, String)> = match sqlx::query_as(
+        "SELECT rowid, action, details, source FROM audit_log WHERE rowid > ?1 ORDER BY rowid ASC LIMIT 200",
+    )
+    .bind(last_rowid)
+    .fetch_all(&state.pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!(error = %e, "plugins: audit hook tail query failed");
+            return last_rowid;
+        }
+    };
+
+    let mut cursor = last_rowid;
+    for (rowid, action, details, source) in rows {
+        cursor = rowid;
+        let event = aifw_plugins::HookEvent {
+            hook: aifw_plugins::HookPoint::LogEvent,
+            data: aifw_plugins::hooks::HookEventData::Log {
+                action,
+                details,
+                source,
+            },
+        };
+        for act in dispatch_hook(state, event).await {
+            match act {
+                aifw_plugins::HookAction::AddToTable { ref table, ip } => {
+                    if let Err(e) = state.pf.add_table_entry(table, ip).await {
+                        tracing::warn!(error = %e, %table, %ip, "plugins: AddToTable from LogEvent hook failed");
+                    }
+                }
+                aifw_plugins::HookAction::RemoveFromTable { ref table, ip } => {
+                    if let Err(e) = state.pf.remove_table_entry(table, ip).await {
+                        tracing::warn!(error = %e, %table, %ip, "plugins: RemoveFromTable from LogEvent hook failed");
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    cursor
+}
+
+/// Background task: tail the audit_log table and fan new entries out to
+/// plugins subscribed to the `LogEvent` hook (#488). Audit rows are written
+/// inside the aifw-core engines (rule/NAT/config mutations), and aifw-core
+/// cannot depend on aifw-plugins — so the API bridges the two here.
+///
+/// Entries written while no plugin is running are skipped: the cursor
+/// re-snaps to the table tail on the 0→N running transition, so enabling a
+/// plugin doesn't replay a backlog of historical events into it.
+pub fn start_audit_hook_dispatcher(state: AppState) {
+    tokio::spawn(async move {
+        let mut cursor = audit_log_tail(&state.pool).await;
+        let mut was_active = false;
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+        loop {
+            interval.tick().await;
+            let active = state
+                .plugin_running_count
+                .load(std::sync::atomic::Ordering::Relaxed)
+                > 0;
+            if !active {
+                was_active = false;
+                continue;
+            }
+            if !was_active {
+                // Plugins just became active — skip events from the idle gap.
+                cursor = audit_log_tail(&state.pool).await;
+                was_active = true;
+                continue;
+            }
+            cursor = dispatch_new_audit_entries(&state, cursor).await;
+        }
+    });
+}
+
+#[cfg(test)]
+mod dispatch_tests {
+    use super::*;
+    use std::sync::Arc;
+
+    /// Test plugin that records every event it receives.
+    struct CapturePlugin {
+        events: Arc<tokio::sync::Mutex<Vec<aifw_plugins::HookEvent>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl aifw_plugins::Plugin for CapturePlugin {
+        fn info(&self) -> aifw_plugins::PluginInfo {
+            aifw_plugins::PluginInfo {
+                name: "capture".to_string(),
+                version: "0.0.0".to_string(),
+                description: "test capture plugin".to_string(),
+                author: "test".to_string(),
+                hooks: vec![aifw_plugins::HookPoint::LogEvent],
+            }
+        }
+
+        async fn init(
+            &mut self,
+            _config: &aifw_plugins::PluginConfig,
+            _ctx: &aifw_plugins::PluginContext,
+        ) -> aifw_plugins::Result<()> {
+            Ok(())
+        }
+
+        async fn on_hook(
+            &self,
+            event: &aifw_plugins::HookEvent,
+            _ctx: &aifw_plugins::PluginContext,
+        ) -> aifw_plugins::HookAction {
+            self.events.lock().await.push(event.clone());
+            aifw_plugins::HookAction::Continue
+        }
+
+        async fn shutdown(&mut self) -> aifw_plugins::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn test_auth_settings() -> crate::auth::AuthSettings {
+        crate::auth::AuthSettings {
+            jwt_secret: "test-secret-key".to_string(),
+            access_token_expiry_mins: 60,
+            refresh_token_expiry_days: 7,
+            require_totp: false,
+            require_totp_for_oauth: false,
+            auto_create_oauth_users: true,
+            max_login_attempts: 5,
+            lockout_duration_secs: 300,
+            allow_registration: true,
+            password_min_length: 8,
+        }
+    }
+
+    #[tokio::test]
+    async fn audit_log_entries_reach_log_event_hook() {
+        let state = crate::create_app_state_in_memory(test_auth_settings())
+            .await
+            .unwrap();
+
+        let events = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        {
+            let mut mgr = state.plugin_manager.write().await;
+            mgr.register(
+                Box::new(CapturePlugin {
+                    events: events.clone(),
+                }),
+                aifw_plugins::PluginConfig {
+                    enabled: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+            state
+                .plugin_running_count
+                .store(mgr.running_count(), std::sync::atomic::Ordering::Relaxed);
+        }
+
+        let cursor = audit_log_tail(&state.pool).await;
+
+        // Write an audit row the same way the aifw-core engines do.
+        aifw_core::audit::AuditLog::new(state.pool.clone())
+            .log(
+                aifw_core::audit::AuditAction::ConfigChanged,
+                None,
+                "test details",
+                "test",
+            )
+            .await
+            .unwrap();
+
+        let new_cursor = dispatch_new_audit_entries(&state, cursor).await;
+        assert!(new_cursor > cursor, "cursor must advance past the new row");
+
+        let captured = events.lock().await;
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].hook, aifw_plugins::HookPoint::LogEvent);
+        match &captured[0].data {
+            aifw_plugins::hooks::HookEventData::Log {
+                action,
+                details,
+                source,
+            } => {
+                assert_eq!(action, "config_changed");
+                assert_eq!(details, "test details");
+                assert_eq!(source, "test");
+            }
+            other => panic!("unexpected event data: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_hook_short_circuits_with_no_plugins() {
+        let state = crate::create_app_state_in_memory(test_auth_settings())
+            .await
+            .unwrap();
+
+        // Shadow counter is 0 — dispatch must return empty without touching
+        // the manager lock.
+        let actions = dispatch_hook(
+            &state,
+            aifw_plugins::HookEvent {
+                hook: aifw_plugins::HookPoint::LogEvent,
+                data: aifw_plugins::hooks::HookEventData::Log {
+                    action: "x".to_string(),
+                    details: "y".to_string(),
+                    source: "z".to_string(),
+                },
+            },
+        )
+        .await;
+        assert!(actions.is_empty());
+    }
 }

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.97.46",
+  "version": "5.98.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #488.

QUAL-M2 (#437) flagged `aifw-api/src/plugins.rs::dispatch_hook` as documented-but-uncalled. Rather than delete it, this wires it into the event path it was missing: both shipped plugins (`custom-logger`, `webhook-notifier`) subscribe to the `LogEvent` hook, and nothing anywhere dispatched it — audit rows are written inside the `aifw-core` engines, which can't depend on `aifw-plugins`.

## Changes

- **`dispatch_hook` is now live**: short-circuits on the `plugin_running_count` shadow counter (zero cost when no plugins run), then snapshots the dispatch set under a short read lock per PERF-H17 (#361).
- **New audit-tail background task** (`start_audit_hook_dispatcher`): polls `audit_log` by rowid every 5s and fans new entries out as `LogEvent` hooks. Plugin-returned `AddToTable`/`RemoveFromTable` actions are applied to pf, mirroring the ConnectionNew site in ws.rs. The cursor re-snaps to the table tail on the 0→N running transition, so enabling a plugin never replays a historical backlog into it (e.g. thousands of webhook POSTs).
- **Boot counter fix**: `plugin_running_count` was initialized to 0 even when plugins were re-registered as enabled from the DB, so boot-enabled plugins received no ApiRequest hooks until toggled through the API once. Now seeded with the boot-time running count.

## Tests

- `audit_log_entries_reach_log_event_hook` — registers a capture plugin, writes an audit row the way engines do, drives one poll, asserts the plugin received the `LogEvent` with action/details/source intact.
- `dispatch_hook_short_circuits_with_no_plugins` — empty result with counter at 0.

Full `cargo test` green; `cargo check --all-targets` zero warnings.