### PR TITLE
fix(ca): honor requested key_type in CA generation and cert issuance (#489)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.98.0"
+version = "5.98.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/ca.rs
+++ b/aifw-api/src/ca.rs
@@ -48,8 +48,6 @@ pub struct GenerateCaRequest {
     pub common_name: Option<String>,
     pub organization: Option<String>,
     pub validity_days: Option<u32>,
-    // Not yet wired through to key generation — see #489.
-    #[allow(dead_code)]
     pub key_type: Option<String>, // "ec" | "rsa2048" | "rsa4096"
 }
 
@@ -59,6 +57,7 @@ pub struct IssueCertRequest {
     pub common_name: String,
     pub sans: Option<Vec<String>>, // DNS names and/or IPs
     pub validity_days: Option<u32>,
+    pub key_type: Option<String>, // "ec" | "rsa2048" | "rsa4096"
 }
 
 #[derive(Debug, Serialize)]
@@ -268,6 +267,71 @@ fn base64_decode(s: &str) -> Result<Vec<u8>, ()> {
     Ok(out)
 }
 
+/// Key type requested for CA / issued-cert key generation (#489).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CaKeyType {
+    Ec,
+    Rsa2048,
+    Rsa4096,
+}
+
+impl CaKeyType {
+    /// Parse the request field. `None` keeps the historical default (EC).
+    fn parse(s: Option<&str>) -> Option<Self> {
+        match s.map(|v| v.to_ascii_lowercase()).as_deref() {
+            None | Some("ec") => Some(Self::Ec),
+            Some("rsa2048") => Some(Self::Rsa2048),
+            Some("rsa4096") => Some(Self::Rsa4096),
+            Some(_) => None,
+        }
+    }
+
+    /// Human-readable algorithm label stored in ca_root / shown in CaInfo.
+    fn label(self) -> &'static str {
+        match self {
+            Self::Ec => "ECDSA P-256",
+            Self::Rsa2048 => "RSA-2048",
+            Self::Rsa4096 => "RSA-4096",
+        }
+    }
+
+    fn generate(self) -> Result<KeyPair, rcgen::Error> {
+        match self {
+            Self::Ec => KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256),
+            Self::Rsa2048 => {
+                KeyPair::generate_rsa_for(&rcgen::PKCS_RSA_SHA256, rcgen::RsaKeySize::_2048)
+            }
+            Self::Rsa4096 => {
+                KeyPair::generate_rsa_for(&rcgen::PKCS_RSA_SHA256, rcgen::RsaKeySize::_4096)
+            }
+        }
+    }
+}
+
+/// Parse the requested key type and generate a matching key pair.
+/// Unknown values are a client error; RSA generation is CPU-bound (seconds
+/// for 4096-bit) so it runs on the blocking pool instead of an async worker.
+async fn generate_key_for_type(key_type: Option<&str>) -> Result<(KeyPair, CaKeyType), StatusCode> {
+    let Some(kt) = CaKeyType::parse(key_type) else {
+        tracing::warn!(
+            key_type = key_type.unwrap_or_default(),
+            "ca: unsupported key_type requested (expected ec | rsa2048 | rsa4096)"
+        );
+        return Err(StatusCode::BAD_REQUEST);
+    };
+    let key_pair = tokio::task::spawn_blocking(move || kt.generate())
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "ca: key generation task failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .map_err(|e| {
+            tracing::error!(error = %e, key_type = kt.label(), "ca: key generation failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    Ok((key_pair, kt))
+}
+
 fn next_serial() -> String {
     let id = Uuid::new_v4();
     let bytes = id.as_bytes();
@@ -319,10 +383,8 @@ pub async fn generate_ca(
     let days = req.validity_days.unwrap_or(3650);
     let serial = next_serial();
 
-    let key_pair = KeyPair::generate().map_err(|e| {
-        tracing::error!(error = %e, "ca: CA key generation failed");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let (key_pair, key_type) = generate_key_for_type(req.key_type.as_deref()).await?;
+    let algorithm = key_type.label();
 
     let mut params = CertificateParams::new(Vec::<String>::new()).map_err(|e| {
         tracing::error!(error = %e, "ca: failed to build CA cert params");
@@ -364,7 +426,7 @@ pub async fn generate_ca(
         "INSERT INTO ca_root (id, cert_pem, key_pem, subject, serial, not_before, not_after, fingerprint, algorithm, created_at) VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)"
     )
     .bind(&cert_pem).bind(&key_pem).bind(&subject).bind(&serial)
-    .bind(&not_before).bind(&not_after).bind(&fingerprint).bind("ECDSA P-256").bind(&now)
+    .bind(&not_before).bind(&not_after).bind(&fingerprint).bind(algorithm).bind(&now)
     .execute(&state.pool).await.map_err(|e| { tracing::error!(error = %e, "ca: failed to persist CA to database"); StatusCode::INTERNAL_SERVER_ERROR })?;
 
     Ok((
@@ -376,7 +438,7 @@ pub async fn generate_ca(
             not_before,
             not_after,
             fingerprint,
-            algorithm: "ECDSA P-256".to_string(),
+            algorithm: algorithm.to_string(),
         }),
     ))
 }
@@ -444,10 +506,7 @@ pub async fn issue_cert(
         }
     }
 
-    let cert_key = KeyPair::generate().map_err(|e| {
-        tracing::error!(error = %e, "ca: certificate key generation failed");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let (cert_key, _key_type) = generate_key_for_type(req.key_type.as_deref()).await?;
     let mut params = CertificateParams::new(Vec::<String>::new()).map_err(|e| {
         tracing::error!(error = %e, "ca: failed to build certificate params");
         StatusCode::INTERNAL_SERVER_ERROR

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -2046,4 +2046,103 @@ mod tests {
             "without short-circuit all 3 nodes would appear"
         );
     }
+
+    #[tokio::test]
+    async fn test_ca_generate_honors_key_type() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        // Default (no key_type) stays ECDSA P-256.
+        let resp = server
+            .post("/api/v1/ca")
+            .authorization_bearer(&token)
+            .json(&json!({}))
+            .await;
+        resp.assert_status(StatusCode::CREATED);
+        let body: Value = resp.json();
+        assert_eq!(body["algorithm"], "ECDSA P-256");
+
+        // rsa2048 is honored (regenerating replaces the CA).
+        let resp = server
+            .post("/api/v1/ca")
+            .authorization_bearer(&token)
+            .json(&json!({ "key_type": "rsa2048" }))
+            .await;
+        resp.assert_status(StatusCode::CREATED);
+        let body: Value = resp.json();
+        assert_eq!(body["algorithm"], "RSA-2048");
+
+        // ...and the stored algorithm reflects it.
+        let resp = server.get("/api/v1/ca").authorization_bearer(&token).await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["initialized"], true);
+        assert_eq!(body["algorithm"], "RSA-2048");
+
+        // Unknown key_type is rejected, not silently defaulted (#489).
+        let resp = server
+            .post("/api/v1/ca")
+            .authorization_bearer(&token)
+            .json(&json!({ "key_type": "dsa" }))
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_issue_cert_honors_key_type() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        let resp = server
+            .post("/api/v1/ca")
+            .authorization_bearer(&token)
+            .json(&json!({}))
+            .await;
+        resp.assert_status(StatusCode::CREATED);
+
+        // EC leaf (default) for a size baseline.
+        let resp = server
+            .post("/api/v1/ca/certs")
+            .authorization_bearer(&token)
+            .json(&json!({ "cert_type": "server", "common_name": "ec.example.com" }))
+            .await;
+        resp.assert_status(StatusCode::CREATED);
+        let body: Value = resp.json();
+        let ec_key_len = body["private_key_pem"].as_str().unwrap().len();
+
+        // RSA-2048 leaf under the EC CA. PKCS#8 PEM headers are identical
+        // across algorithms, so tell them apart by encoded key size — an
+        // RSA-2048 private key is several times larger than a P-256 key.
+        let resp = server
+            .post("/api/v1/ca/certs")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "cert_type": "server",
+                "common_name": "rsa.example.com",
+                "key_type": "rsa2048"
+            }))
+            .await;
+        resp.assert_status(StatusCode::CREATED);
+        let body: Value = resp.json();
+        let rsa_key_pem = body["private_key_pem"].as_str().unwrap();
+        assert!(rsa_key_pem.contains("BEGIN PRIVATE KEY"));
+        assert!(
+            rsa_key_pem.len() > ec_key_len * 3,
+            "rsa2048 key ({} bytes) should dwarf the EC key ({} bytes)",
+            rsa_key_pem.len(),
+            ec_key_len
+        );
+
+        // Unknown key_type is rejected before any cert is issued.
+        let resp = server
+            .post("/api/v1/ca/certs")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "cert_type": "server",
+                "common_name": "bad.example.com",
+                "key_type": "ed25519"
+            }))
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+    }
 }

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.98.0",
+  "version": "5.98.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #489.

QUAL-M2 (#437) flagged `key_type` on the CA request as deserialized-but-ignored: callers asking for `rsa2048`/`rsa4096` silently got ECDSA P-256. The rcgen `aws_lc_rs` feature is already enabled in our dependency graph (via `instant-acme`), so RSA key generation is available with **zero new dependencies** — this wires the field through instead of deprecating it.

## Changes

- `POST /api/v1/ca` honors `key_type`: `ec` (default, unchanged) → ECDSA P-256, `rsa2048`/`rsa4096` → real RSA keys via `KeyPair::generate_rsa_for`.
- `POST /api/v1/ca/certs` (issue cert) gains the same optional `key_type` for leaf keys, per the issue title.
- Unknown values are rejected with 400 + a warn log instead of silently defaulting.
- Key generation runs on `spawn_blocking` — RSA-4096 keygen takes seconds of CPU and must not stall an async worker.
- `CaInfo.algorithm` / `ca_root.algorithm` now record the actual algorithm instead of the hardcoded "ECDSA P-256" string.

## Tests

- `test_ca_generate_honors_key_type` — default stays EC; `rsa2048` produces and persists `RSA-2048`; bogus `key_type` → 400.
- `test_issue_cert_honors_key_type` — RSA-2048 leaf under an EC CA (verified by PKCS#8 key size vs the EC baseline); bogus `key_type` → 400.

Full `cargo test` green; `cargo check --all-targets` zero warnings.