### PR TITLE
refactor(ui): migrate all direct fetch() calls onto central api client (#429)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.98.1"
+version = "5.98.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.98.1",
+  "version": "5.98.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/src/app/about/page.tsx
+++ b/aifw-ui/src/app/about/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { api } from "@/lib/api";
 
 interface ServiceInfo {
   name: string;
@@ -37,11 +38,6 @@ interface AboutInfo {
   memory: MemoryBreakdown;
 }
 
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
-
 function fmtMb(mb: number): string {
   if (mb >= 1024) return `${(mb / 1024).toFixed(2)} GB`;
   if (mb >= 1)    return `${mb.toFixed(0)} MB`;
@@ -62,23 +58,18 @@ export default function AboutPage() {
 
   useEffect(() => {
     (async () => {
-      const headers = authHeaders();
       const results: ServiceInfo[] = [];
 
       // /api/v1/about returns version + memory breakdown in one shot.
       try {
-        const res = await fetch("/api/v1/about", { headers });
-        if (res.ok) {
-          const data: AboutInfo = await res.json();
-          setAbout(data);
-          setAifwVersion(data.version);
-        }
+        const data = await api.get<AboutInfo>("/api/v1/about");
+        setAbout(data);
+        setAifwVersion(data.version);
       } catch {}
 
       // Firewall daemon
       try {
-        const res = await fetch("/api/v1/status", { headers });
-        const data = res.ok ? await res.json() : {};
+        const data = await api.get<{ version?: string; data?: { version?: string } }>("/api/v1/status");
         results.push({
           name: "AiFw Daemon",
           binary: "aifw-daemon",
@@ -103,8 +94,7 @@ export default function AboutPage() {
 
       // DNS
       try {
-        const res = await fetch("/api/v1/dns/resolver/status", { headers });
-        const data = res.ok ? await res.json() : {};
+        const data = await api.get<{ version?: string; running?: boolean }>("/api/v1/dns/resolver/status");
         results.push({
           name: "rDNS",
           binary: "rdns",
@@ -119,8 +109,8 @@ export default function AboutPage() {
 
       // DHCP
       try {
-        const res = await fetch("/api/v1/dhcp/status", { headers });
-        const data = res.ok ? await res.json() : {};
+        type SvcStatus = { version?: string; running?: boolean; status?: string };
+        const data = await api.get<SvcStatus & { data?: SvcStatus }>("/api/v1/dhcp/status");
         const d = data.data || data;
         results.push({
           name: "rDHCP",
@@ -136,8 +126,8 @@ export default function AboutPage() {
 
       // TrafficCop
       try {
-        const res = await fetch("/api/v1/reverse-proxy/status", { headers });
-        const data = res.ok ? await res.json() : {};
+        type SvcStatus = { version?: string; running?: boolean };
+        const data = await api.get<SvcStatus & { data?: SvcStatus }>("/api/v1/reverse-proxy/status");
         const d = data.data || data;
         results.push({
           name: "TrafficCop",

--- a/aifw-ui/src/app/acme/page.tsx
+++ b/aifw-ui/src/app/acme/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { api } from "@/lib/api";
 import Help, { HelpBanner } from "./Help";
 
 /* ---------- Types ---------- */
@@ -50,29 +51,6 @@ interface ExportTarget {
 }
 
 /* ---------- Helpers ---------- */
-
-function authHeaders(): HeadersInit {
-  const t = typeof window !== "undefined" ? localStorage.getItem("aifw_token") || "" : "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${t}` };
-}
-function authHeadersPlain(): HeadersInit {
-  const t = typeof window !== "undefined" ? localStorage.getItem("aifw_token") || "" : "";
-  return { Authorization: `Bearer ${t}` };
-}
-async function api<T>(method: string, path: string, body?: unknown): Promise<T> {
-  const res = await fetch(path, {
-    method,
-    headers: body !== undefined ? authHeaders() : authHeadersPlain(),
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
-  if (res.status === 204) return undefined as T;
-  if (!res.ok) {
-    const txt = await res.text().catch(() => "");
-    throw new Error(txt || `HTTP ${res.status}`);
-  }
-  const ct = res.headers.get("content-type") || "";
-  return ct.includes("application/json") ? res.json() : (undefined as T);
-}
 
 const DOMAIN_RE = /^(\*\.)?[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/i;
 function validateDomain(d: string): string | null {
@@ -155,8 +133,8 @@ function CertsTab() {
 
   const reload = useCallback(async () => {
     const [c, p] = await Promise.all([
-      api<CertSummary[]>("GET", "/api/v1/acme/certs"),
-      api<DnsProvider[]>("GET", "/api/v1/acme/dns-providers"),
+      api.get<CertSummary[]>("/api/v1/acme/certs"),
+      api.get<DnsProvider[]>("/api/v1/acme/dns-providers"),
     ]);
     setCerts(c); setProviders(p);
   }, []);
@@ -170,7 +148,7 @@ function CertsTab() {
   async function renewNow(id: number) {
     setBusy(id);
     try {
-      const r = await api<{ ok: boolean; message: string }>("POST", `/api/v1/acme/certs/${id}/renew`);
+      const r = await api.post<{ ok: boolean; message: string }>(`/api/v1/acme/certs/${id}/renew`);
       showToast(r.ok, r.message);
       await reload();
     } catch (e) { showToast(false, String(e)); }
@@ -179,7 +157,7 @@ function CertsTab() {
   async function deleteCert(id: number) {
     if (!confirm("Delete this cert? It will not be revoked at the CA.")) return;
     try {
-      await api("DELETE", `/api/v1/acme/certs/${id}`);
+      await api.delete(`/api/v1/acme/certs/${id}`);
       await reload();
     } catch (e) { showToast(false, String(e)); }
   }
@@ -282,7 +260,7 @@ function AddCertModal({ providers, onClose, onCreated }:
     if (!valid) return;
     setBusy(true); setErr(null);
     try {
-      await api("POST", "/api/v1/acme/certs", {
+      await api.post("/api/v1/acme/certs", {
         common_name: cn.trim(),
         sans: sansArr,
         challenge_type: "dns-01",
@@ -355,13 +333,13 @@ function ExportTargetsPanel({ certId }: { certId: number }) {
   const [showAdd, setShowAdd] = useState(false);
 
   const reload = useCallback(async () => {
-    setTargets(await api<ExportTarget[]>("GET", `/api/v1/acme/certs/${certId}/targets`));
+    setTargets(await api.get<ExportTarget[]>(`/api/v1/acme/certs/${certId}/targets`));
   }, [certId]);
   useEffect(() => { queueMicrotask(reload); }, [reload]);
 
   async function remove(id: number) {
     if (!confirm("Delete this export target?")) return;
-    await api("DELETE", `/api/v1/acme/export-targets/${id}`);
+    await api.delete(`/api/v1/acme/export-targets/${id}`);
     await reload();
   }
 
@@ -421,7 +399,7 @@ function AddExportTargetModal({ certId, onClose, onCreated }: { certId: number; 
     setBusy(true); setErr(null);
     try {
       const parsed = JSON.parse(cfg);
-      await api("POST", `/api/v1/acme/certs/${certId}/targets`, { kind, config: parsed });
+      await api.post(`/api/v1/acme/certs/${certId}/targets`, { kind, config: parsed });
       onCreated();
     } catch (e) { setErr(String(e)); }
     finally { setBusy(false); }
@@ -463,7 +441,7 @@ function ProvidersTab() {
   const [toast, setToast] = useState<{ ok: boolean; msg: string } | null>(null);
 
   const reload = useCallback(async () => {
-    setProviders(await api<DnsProvider[]>("GET", "/api/v1/acme/dns-providers"));
+    setProviders(await api.get<DnsProvider[]>("/api/v1/acme/dns-providers"));
   }, []);
   useEffect(() => { queueMicrotask(reload); }, [reload]);
 
@@ -474,7 +452,7 @@ function ProvidersTab() {
   async function test(id: number) {
     setTesting(id);
     try {
-      const r = await api<{ ok: boolean; message: string }>("POST", `/api/v1/acme/dns-providers/${id}/test`);
+      const r = await api.post<{ ok: boolean; message: string }>(`/api/v1/acme/dns-providers/${id}/test`);
       showToast(r.ok, r.message);
     } catch (e) { showToast(false, String(e)); }
     finally { setTesting(null); }
@@ -482,7 +460,7 @@ function ProvidersTab() {
 
   async function remove(id: number) {
     if (!confirm("Delete this provider? Certs using it will fail to renew.")) return;
-    await api("DELETE", `/api/v1/acme/dns-providers/${id}`);
+    await api.delete(`/api/v1/acme/dns-providers/${id}`);
     await reload();
   }
 
@@ -691,13 +669,13 @@ function ProviderModal({ initial, onClose, onSaved }: { initial: DnsProvider | n
     try {
       const body = buildBody();
       const created: DnsProvider = isNew
-        ? await api<DnsProvider>("POST", "/api/v1/acme/dns-providers", body)
-        : await api<DnsProvider>("PUT", `/api/v1/acme/dns-providers/${initial!.id}`, body);
+        ? await api.post<DnsProvider>("/api/v1/acme/dns-providers", body)
+        : await api.put<DnsProvider>(`/api/v1/acme/dns-providers/${initial!.id}`, body);
       if (testAfter) {
         setTesting(true);
         try {
-          const r = await api<{ ok: boolean; message: string }>(
-            "POST", `/api/v1/acme/dns-providers/${created.id}/test`,
+          const r = await api.post<{ ok: boolean; message: string }>(
+            `/api/v1/acme/dns-providers/${created.id}/test`,
           );
           setTestResult(r);
           if (!r.ok) { setBusy(false); setTesting(false); return; }
@@ -833,7 +811,7 @@ function AccountTab() {
   const [toast, setToast] = useState<{ ok: boolean; msg: string } | null>(null);
 
   const reload = useCallback(async () => {
-    const a = await api<Account>("GET", "/api/v1/acme/account");
+    const a = await api.get<Account>("/api/v1/acme/account");
     setAcct(a); setEmail(a.contact_email); setDirUrl(a.directory_url);
   }, []);
   useEffect(() => { queueMicrotask(reload); }, [reload]);
@@ -841,7 +819,7 @@ function AccountTab() {
   async function save() {
     setBusy(true);
     try {
-      await api("PUT", "/api/v1/acme/account", { directory_url: dirUrl, contact_email: email });
+      await api.put("/api/v1/acme/account", { directory_url: dirUrl, contact_email: email });
       await reload();
       setToast({ ok: true, msg: "Saved. Account is registered with the CA on the first cert issue." });
     } catch (e) { setToast({ ok: false, msg: String(e) }); }

--- a/aifw-ui/src/app/aliases/page.tsx
+++ b/aifw-ui/src/app/aliases/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 import { isValidAliasName, isValidIP, isValidCIDR, isValidPortRange, isValidURL } from "@/lib/validate";
 
 interface Alias {
@@ -24,11 +25,6 @@ const defaultForm = {
 
 type FormState = typeof defaultForm;
 
-function authHeaders(): HeadersInit {
-  const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
 const TYPE_LABELS: Record<string, { label: string; hint: string; placeholder: string; color: string }> = {
   host: { label: "Hosts", hint: "One IP address per line", placeholder: "192.168.1.10\n192.168.1.20\n10.0.0.5", color: "bg-blue-500/20 text-blue-400 border-blue-500/30" },
   network: { label: "Networks", hint: "One CIDR per line", placeholder: "192.168.1.0/24\n10.0.0.0/8\n172.16.0.0/12", color: "bg-emerald-500/20 text-emerald-400 border-emerald-500/30" },
@@ -48,9 +44,7 @@ export default function AliasesPage() {
   const fetchAliases = useCallback(async () => {
     try {
       setError(null);
-      const res = await fetch("/api/v1/aliases", { headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<{ data?: Alias[] }>("/api/v1/aliases");
       setAliases(body.data || []);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load aliases");
@@ -104,12 +98,10 @@ export default function AliasesPage() {
         description: form.description.trim() || undefined,
         enabled: form.enabled,
       };
-      const url = editingId ? `/api/v1/aliases/${editingId}` : "/api/v1/aliases";
-      const method = editingId ? "PUT" : "POST";
-      const res = await fetch(url, { method, headers: authHeaders(), body: JSON.stringify(body) });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.message || `HTTP ${res.status}`);
+      if (editingId) {
+        await api.put(`/api/v1/aliases/${editingId}`, body);
+      } else {
+        await api.post("/api/v1/aliases", body);
       }
       await fetchAliases();
       resetForm();
@@ -123,8 +115,7 @@ export default function AliasesPage() {
   const handleDelete = async (alias: Alias) => {
     setError(null);
     try {
-      const res = await fetch(`/api/v1/aliases/${alias.id}`, { method: "DELETE", headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(`/api/v1/aliases/${alias.id}`);
       setAliases(prev => prev.filter(a => a.id !== alias.id));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to delete alias");
@@ -140,7 +131,7 @@ export default function AliasesPage() {
         description: alias.description,
         enabled: !alias.enabled,
       };
-      await fetch(`/api/v1/aliases/${alias.id}`, { method: "PUT", headers: authHeaders(), body: JSON.stringify(body) });
+      await api.put(`/api/v1/aliases/${alias.id}`, body);
       setAliases(prev => prev.map(a => a.id === alias.id ? { ...a, enabled: !a.enabled } : a));
     } catch {
       setError("Failed to toggle alias");

--- a/aifw-ui/src/app/backup/page.tsx
+++ b/aifw-ui/src/app/backup/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { api } from "@/lib/api";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -65,16 +66,6 @@ interface DiffSummary {
 }
 
 /* -- Helpers --------------------------------------------------------- */
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
 
 function fmtDate(iso: string | null): string {
   if (!iso) return "-";
@@ -143,9 +134,7 @@ export default function BackupPage() {
 
   const fetchHistory = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/config/history?limit=10000", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<{ data?: ConfigVersion[] }>("/api/v1/config/history?limit=10000");
       setHistory(body.data || []);
     } catch {
       /* silent */
@@ -165,13 +154,7 @@ export default function BackupPage() {
   const saveSnapshot = async () => {
     setSaving(true);
     try {
-      const res = await fetch("/api/v1/config/save", {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify({ comment: comment || null }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.post<{ message?: string }>("/api/v1/config/save", { comment: comment || null });
       showFeedback("success", data.message || "Config snapshot saved");
       setComment("");
       await fetchHistory();
@@ -202,13 +185,7 @@ export default function BackupPage() {
   const sendRestore = async (version: number, interface_map: Record<string, string | null>) => {
     setRestoring(version);
     try {
-      const res = await fetch("/api/v1/config/restore", {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify({ version, interface_map }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.post<{ message?: string }>("/api/v1/config/restore", { version, interface_map });
       showFeedback("success", data.message || "Restored");
       await fetchHistory();
       setRestorePending(null);
@@ -224,8 +201,7 @@ export default function BackupPage() {
     setRestoring(version);
     let preview: ImportPreview | null = null;
     try {
-      const res = await fetch(`/api/v1/config/restore-preview?version=${version}`, { headers: authHeadersPlain() });
-      if (res.ok) preview = await res.json();
+      preview = await api.get<ImportPreview>(`/api/v1/config/restore-preview?version=${version}`);
     } catch { /* fall through */ }
     setRestoring(null);
 
@@ -250,9 +226,7 @@ export default function BackupPage() {
     setDiffV1(v1);
     setDiffV2(v2);
     try {
-      const res = await fetch(`/api/v1/config/diff?v1=${v1}&v2=${v2}`, { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<{ data: DiffSummary }>(`/api/v1/config/diff?v1=${v1}&v2=${v2}`);
       setDiff(body.data);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Diff failed");
@@ -266,9 +240,7 @@ export default function BackupPage() {
   const runCheck = async () => {
     setChecking(true);
     try {
-      const res = await fetch("/api/v1/config/check", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<{ data: ConfigCheck }>("/api/v1/config/check");
       setCheck(body.data);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Check failed");
@@ -282,9 +254,7 @@ export default function BackupPage() {
   const handleExport = async () => {
     setExporting(true);
     try {
-      const res = await fetch("/api/v1/config/export", { headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.get<unknown>("/api/v1/config/export");
       const json = JSON.stringify(data, null, 2);
       const blob = new Blob([json], { type: "application/json" });
       const url = URL.createObjectURL(blob);
@@ -314,18 +284,11 @@ export default function BackupPage() {
       setImportMap({});
       try {
         const parsed = JSON.parse(text);
-        const res = await fetch("/api/v1/config/import-preview", {
-          method: "POST",
-          headers: authHeaders(),
-          body: JSON.stringify(parsed),
-        });
-        if (res.ok) {
-          const data: ImportPreview = await res.json();
-          setImportPreview(data);
-          const defaults: Record<string, string> = {};
-          for (const m of data.interfaces_missing) defaults[m] = data.suggestions[m] ?? "__keep__";
-          setImportMap(defaults);
-        }
+        const data = await api.post<ImportPreview>("/api/v1/config/import-preview", parsed);
+        setImportPreview(data);
+        const defaults: Record<string, string> = {};
+        for (const m of data.interfaces_missing) defaults[m] = data.suggestions[m] ?? "__keep__";
+        setImportMap(defaults);
       } catch { /* leave preview null; import will still run without mapping */ }
     };
     reader.readAsText(file);
@@ -341,13 +304,7 @@ export default function BackupPage() {
     try {
       const data = JSON.parse(preview);
       const interface_map = importPreview ? buildInterfaceMapForApi(importPreview, importMap) : {};
-      const res = await fetch("/api/v1/config/import", {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify({ ...data, interface_map }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.post<{ message?: string }>("/api/v1/config/import", { ...data, interface_map });
       showFeedback("success", body.message || "Config imported");
       setPreview(null);
       setImportPreview(null);
@@ -388,13 +345,10 @@ export default function BackupPage() {
   };
 
   const fetchOpnPreview = async (ifaceMap: Record<string, string>) => {
-    const res = await fetch("/api/v1/config/preview-opnsense", {
-      method: "POST",
-      headers: authHeaders(),
-      body: JSON.stringify({ xml: opnXml, interface_map: ifaceMap }),
-    });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    return await res.json();
+    return await api.post<{ interfaces_found?: string[] } & Record<string, unknown>>(
+      "/api/v1/config/preview-opnsense",
+      { xml: opnXml, interface_map: ifaceMap },
+    );
   };
 
   const handleOpnPreview = async () => {
@@ -427,18 +381,12 @@ export default function BackupPage() {
     if (!opnXml.trim() || !opnPreview) return;
     setOpnImporting(true);
     try {
-      const res = await fetch("/api/v1/config/import-opnsense", {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify({
-          xml: opnXml,
-          interface_map: opnIfaceMap,
-          commit_confirm: true,
-          import_system_settings: opnImportSystemSettings,
-        }),
+      const body = await api.post<{ message?: string }>("/api/v1/config/import-opnsense", {
+        xml: opnXml,
+        interface_map: opnIfaceMap,
+        commit_confirm: true,
+        import_system_settings: opnImportSystemSettings,
       });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
       showFeedback("success", body.message || "OPNsense config imported");
       setOpnXml(""); setOpnPreview(null); setOpnIfaceMap({});
       if (opnFileRef.current) opnFileRef.current.value = "";
@@ -453,22 +401,18 @@ export default function BackupPage() {
 
   const fetchCommitStatus = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/config/commit-confirm/status", { headers: authHeadersPlain() });
-      if (res.ok) {
-        const data = await res.json();
-        setCommitConfirm(data.active ? data : null);
-      }
+      const data = await api.get<{ active: boolean; seconds_remaining: number; description: string }>(
+        "/api/v1/config/commit-confirm/status",
+      );
+      setCommitConfirm(data.active ? data : null);
     } catch { /* silent */ }
   }, []);
 
   const handleCommitConfirm = async () => {
     try {
-      const res = await fetch("/api/v1/config/commit-confirm/confirm", { method: "POST", headers: authHeaders() });
-      if (res.ok) {
-        const body = await res.json();
-        showFeedback("success", body.message);
-        setCommitConfirm(null);
-      }
+      const body = await api.post<{ message: string }>("/api/v1/config/commit-confirm/confirm");
+      showFeedback("success", body.message);
+      setCommitConfirm(null);
     } catch (err) {
       showFeedback("error", "Failed to confirm");
     }
@@ -1204,12 +1148,7 @@ function S3ArchiveTab() {
     setError(null);
     setStatus(null);
     try {
-      const res = await fetch("/api/v1/backup/s3/list?max=1000", { headers: authHeadersPlain() });
-      if (!res.ok) {
-        const txt = await res.text().catch(() => "");
-        throw new Error(txt || `HTTP ${res.status}`);
-      }
-      setItems(await res.json());
+      setItems(await api.get<S3Object[]>("/api/v1/backup/s3/list?max=1000"));
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -1224,16 +1163,7 @@ function S3ArchiveTab() {
     setImporting(key);
     setStatus(null);
     try {
-      const res = await fetch("/api/v1/backup/s3/import", {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify({ key }),
-      });
-      if (!res.ok) {
-        const txt = await res.text().catch(() => "");
-        throw new Error(txt || `HTTP ${res.status}`);
-      }
-      const d = await res.json();
+      const d = await api.post<{ message?: string; version?: number }>("/api/v1/backup/s3/import", { key });
       setStatus(d.message || `Imported as version ${d.version}`);
     } catch (e) {
       setStatus(e instanceof Error ? e.message : String(e));

--- a/aifw-ui/src/app/ca/page.tsx
+++ b/aifw-ui/src/app/ca/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 /* ── Types ─────────────────────────────────────────────────────── */
 
@@ -33,16 +34,6 @@ interface IssuedCertResponse {
 }
 
 /* ── Helpers ───────────────────────────────────────────────────── */
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
 
 function downloadBlob(body: string, filename: string, mime = "application/x-pem-file") {
   const blob = new Blob([body], { type: mime });
@@ -127,9 +118,7 @@ export default function CaPage() {
 
   const fetchCa = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/ca", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setCaInfo(await res.json());
+      setCaInfo(await api.get<CaInfo>("/api/v1/ca"));
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load CA info");
     }
@@ -137,9 +126,7 @@ export default function CaPage() {
 
   const fetchCerts = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/ca/certs", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<{ data?: CertRecord[] }>("/api/v1/ca/certs");
       setCerts(body.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load certificates");
@@ -159,12 +146,7 @@ export default function CaPage() {
   const generateCa = async () => {
     setGenerating(true);
     try {
-      const res = await fetch("/api/v1/ca", {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify({ common_name: genCn, organization: genOrg, validity_days: genDays }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.post("/api/v1/ca", { common_name: genCn, organization: genOrg, validity_days: genDays });
       showFeedback("success", "Root CA generated successfully");
       setConfirmRegen(false);
       await fetchCa();
@@ -177,9 +159,7 @@ export default function CaPage() {
 
   const downloadCaCert = async () => {
     try {
-      const res = await fetch("/api/v1/ca/cert.pem", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      downloadBlob(await res.text(), "aifw-ca.pem");
+      downloadBlob(await api.getText("/api/v1/ca/cert.pem"), "aifw-ca.pem");
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Download failed");
     }
@@ -196,24 +176,15 @@ export default function CaPage() {
         validity_days: issueDays,
       };
       if (issueSans.trim()) body.sans = issueSans.trim();
-      const res = await fetch("/api/v1/ca/certs", {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const result: IssuedCertResponse = await res.json();
+      const result = await api.post<IssuedCertResponse>("/api/v1/ca/certs", body);
       showFeedback("success", `Certificate issued (ID: ${result.id})`);
 
       // Fetch full cert details to get the PEM
       if (result.certificate_pem) {
         setIssuedPem(result.certificate_pem);
       } else {
-        const detailRes = await fetch(`/api/v1/ca/certs/${result.id}`, { headers: authHeadersPlain() });
-        if (detailRes.ok) {
-          const detail = await detailRes.json();
-          if (detail.certificate_pem) setIssuedPem(detail.certificate_pem);
-        }
+        const detail = await api.get<{ certificate_pem?: string }>(`/api/v1/ca/certs/${result.id}`).catch(() => undefined);
+        if (detail?.certificate_pem) setIssuedPem(detail.certificate_pem);
       }
 
       setIssueCn("");
@@ -229,9 +200,7 @@ export default function CaPage() {
 
   const downloadCert = async (id: string, cn: string) => {
     try {
-      const res = await fetch(`/api/v1/ca/certs/${id}/cert.pem`, { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      downloadBlob(await res.text(), `${cn}.cert.pem`);
+      downloadBlob(await api.getText(`/api/v1/ca/certs/${id}/cert.pem`), `${cn}.cert.pem`);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Download failed");
     }
@@ -239,9 +208,7 @@ export default function CaPage() {
 
   const downloadKey = async (id: string, cn: string) => {
     try {
-      const res = await fetch(`/api/v1/ca/certs/${id}/key.pem`, { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      downloadBlob(await res.text(), `${cn}.key.pem`);
+      downloadBlob(await api.getText(`/api/v1/ca/certs/${id}/key.pem`), `${cn}.key.pem`);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Download failed");
     }
@@ -249,11 +216,7 @@ export default function CaPage() {
 
   const revokeCert = async (id: string) => {
     try {
-      const res = await fetch(`/api/v1/ca/certs/${id}/revoke`, {
-        method: "POST",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.post(`/api/v1/ca/certs/${id}/revoke`);
       showFeedback("success", "Certificate revoked");
       setRevokeId(null);
       await fetchCerts();
@@ -264,11 +227,7 @@ export default function CaPage() {
 
   const deleteCert = async (id: string) => {
     try {
-      const res = await fetch(`/api/v1/ca/certs/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(`/api/v1/ca/certs/${id}`);
       showFeedback("success", "Certificate deleted");
       setDeleteId(null);
       await fetchCerts();
@@ -279,9 +238,7 @@ export default function CaPage() {
 
   const downloadCrl = async () => {
     try {
-      const res = await fetch("/api/v1/ca/crl", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      downloadBlob(await res.text(), "aifw-crl.pem");
+      downloadBlob(await api.getText("/api/v1/ca/crl"), "aifw-crl.pem");
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "CRL download failed");
     }

--- a/aifw-ui/src/app/cluster/components/StatusBanner.tsx
+++ b/aifw-ui/src/app/cluster/components/StatusBanner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
 
 type Status = {
   role: string;
@@ -16,11 +17,9 @@ export default function StatusBanner() {
     let cancelled = false;
     const fetchStatus = async () => {
       try {
-        const r = await fetch("/api/v1/cluster/status", {
-          credentials: "include",
-        });
-        if (!r.ok) return;
-        const j: Status = await r.json();
+        // Tolerant poller: failures (incl. 401) just leave the banner hidden,
+        // so don't bounce to /login from here.
+        const j = await api.get<Status>("/api/v1/cluster/status", { noAuthRedirect: true });
         if (!cancelled) setS(j);
       } catch {}
     };

--- a/aifw-ui/src/app/connections/page.tsx
+++ b/aifw-ui/src/app/connections/page.tsx
@@ -55,15 +55,6 @@ function formatNumber(n: number): string {
   return String(n);
 }
 
-async function apiFetch<T>(path: string): Promise<T> {
-  const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
-  const res = await fetch(path, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  return res.json();
-}
-
 function SortHeader({
   label,
   sortKey,

--- a/aifw-ui/src/app/ddns/page.tsx
+++ b/aifw-ui/src/app/ddns/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { api } from "@/lib/api";
 import Help, { HelpBanner } from "./Help";
 
 interface DdnsRecord {
@@ -34,29 +35,6 @@ interface DdnsConfig {
   ip_echo_url_v6: string;
 }
 
-function authHeaders(): HeadersInit {
-  const t = typeof window !== "undefined" ? localStorage.getItem("aifw_token") || "" : "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${t}` };
-}
-function authHeadersPlain(): HeadersInit {
-  const t = typeof window !== "undefined" ? localStorage.getItem("aifw_token") || "" : "";
-  return { Authorization: `Bearer ${t}` };
-}
-async function api<T>(method: string, path: string, body?: unknown): Promise<T> {
-  const res = await fetch(path, {
-    method,
-    headers: body !== undefined ? authHeaders() : authHeadersPlain(),
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
-  if (res.status === 204) return undefined as T;
-  if (!res.ok) {
-    const txt = await res.text().catch(() => "");
-    throw new Error(txt || `HTTP ${res.status}`);
-  }
-  const ct = res.headers.get("content-type") || "";
-  return ct.includes("application/json") ? res.json() : (undefined as T);
-}
-
 const DOMAIN_RE = /^(\*\.)?[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/i;
 function fmtWhen(s: string | null): string {
   if (!s) return "—";
@@ -73,9 +51,9 @@ export default function DdnsPage() {
 
   const reload = useCallback(async () => {
     const [r, p, c] = await Promise.all([
-      api<DdnsRecord[]>("GET", "/api/v1/ddns/records"),
-      api<DnsProvider[]>("GET", "/api/v1/acme/dns-providers"),
-      api<DdnsConfig>("GET", "/api/v1/ddns/config"),
+      api.get<DdnsRecord[]>("/api/v1/ddns/records"),
+      api.get<DnsProvider[]>("/api/v1/acme/dns-providers"),
+      api.get<DdnsConfig>("/api/v1/ddns/config"),
     ]);
     setRecords(r);
     // Cloudflare + Route53 only — manual / unimplemented can't auto-update.
@@ -92,7 +70,7 @@ export default function DdnsPage() {
   async function forceUpdate(id: number) {
     setBusy(id);
     try {
-      const r = await api<{ ok: boolean; message: string }>("POST", `/api/v1/ddns/records/${id}/update`);
+      const r = await api.post<{ ok: boolean; message: string }>(`/api/v1/ddns/records/${id}/update`);
       showToast(r.ok, r.message);
       await reload();
     } catch (e) { showToast(false, String(e)); }
@@ -101,12 +79,12 @@ export default function DdnsPage() {
 
   async function remove(id: number) {
     if (!confirm("Delete this DDNS record? It will not remove the actual DNS record at the provider.")) return;
-    await api("DELETE", `/api/v1/ddns/records/${id}`);
+    await api.delete(`/api/v1/ddns/records/${id}`);
     await reload();
   }
 
   async function toggleEnabled(rec: DdnsRecord) {
-    await api("PUT", `/api/v1/ddns/records/${rec.id}`, {
+    await api.put(`/api/v1/ddns/records/${rec.id}`, {
       provider_id: rec.provider_id,
       hostname: rec.hostname,
       record_type: rec.record_type,
@@ -241,7 +219,7 @@ function ConfigCard({ config, onSaved }: { config: DdnsConfig; onSaved: () => vo
   async function save() {
     setBusy(true); setErr(null);
     try {
-      await api("PUT", "/api/v1/ddns/config", {
+      await api.put("/api/v1/ddns/config", {
         poll_interval_secs: Number(interval) || 300,
         ip_echo_url_v4: v4.trim(),
         ip_echo_url_v6: v6.trim(),
@@ -309,8 +287,8 @@ function RecordModal({ initial, providers, onClose, onSaved }:
         ttl,
         enabled,
       };
-      if (isNew) await api("POST", "/api/v1/ddns/records", body);
-      else       await api("PUT", `/api/v1/ddns/records/${initial!.id}`, body);
+      if (isNew) await api.post("/api/v1/ddns/records", body);
+      else       await api.put(`/api/v1/ddns/records/${initial!.id}`, body);
       onSaved();
     } catch (e) { setErr(String(e)); }
     finally { setBusy(false); }

--- a/aifw-ui/src/app/dhcp/ddns/page.tsx
+++ b/aifw-ui/src/app/dhcp/ddns/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 interface DdnsConfig {
   enabled: boolean;
@@ -12,16 +13,6 @@ interface DdnsConfig {
   tsig_algorithm: string;
   tsig_secret: string;
   ttl: number;
-}
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
 }
 
 const defaultConfig: DdnsConfig = {
@@ -49,9 +40,8 @@ export default function DdnsConfigPage() {
 
   const fetchConfig = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dhcp/ddns", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setConfig(await res.json());
+      const data = await api.get<DdnsConfig>("/api/v1/dhcp/ddns");
+      setConfig(data);
     } catch {
       /* silent */
     } finally {
@@ -64,12 +54,7 @@ export default function DdnsConfigPage() {
   const saveConfig = async () => {
     setSaving(true);
     try {
-      const res = await fetch("/api/v1/dhcp/ddns", {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify(config),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.put("/api/v1/dhcp/ddns", config);
       showFeedback("success", "DDNS settings saved. Apply config to take effect.");
       await fetchConfig();
     } catch (err) {

--- a/aifw-ui/src/app/dhcp/leases/page.tsx
+++ b/aifw-ui/src/app/dhcp/leases/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { api } from "@/lib/api";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -17,16 +18,6 @@ interface DhcpLease {
 }
 
 /* -- Helpers --------------------------------------------------------- */
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
 
 function fmtDateTime(iso?: string): string {
   if (!iso) return "-";
@@ -75,9 +66,7 @@ export default function DhcpLeasesPage() {
 
   const fetchLeases = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dhcp/v4/leases", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<{ data?: DhcpLease[] }>("/api/v1/dhcp/v4/leases");
       setLeases(body.data || []);
     } catch {
       /* silent on auto-refresh failures */
@@ -102,11 +91,7 @@ export default function DhcpLeasesPage() {
 
   const releaseLease = async (ip: string) => {
     try {
-      const res = await fetch(`/api/v1/dhcp/v4/leases/${encodeURIComponent(ip)}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(`/api/v1/dhcp/v4/leases/${encodeURIComponent(ip)}`);
       showFeedback("success", `Lease for ${ip} released`);
       setReleaseIp(null);
       await fetchLeases();

--- a/aifw-ui/src/app/dhcp/logs/page.tsx
+++ b/aifw-ui/src/app/dhcp/logs/page.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
+import { api } from "@/lib/api";
 
 export default function DhcpLogsPage() {
   const [logs, setLogs] = useState<string[]>([]);
@@ -19,9 +15,7 @@ export default function DhcpLogsPage() {
     try {
       const params = new URLSearchParams({ lines: String(lines) });
       if (search) params.set("search", search);
-      const res = await fetch(`/api/v1/dhcp/logs?${params}`, { headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.get<{ data?: string[] }>(`/api/v1/dhcp/logs?${params}`);
       setLogs(data.data || []);
       setError(null);
     } catch (err) {

--- a/aifw-ui/src/app/dhcp/metrics/page.tsx
+++ b/aifw-ui/src/app/dhcp/metrics/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { api } from "@/lib/api";
 
 interface PoolStats {
   subnet: string;
@@ -8,11 +9,6 @@ interface PoolStats {
   allocated: number;
   available: number;
   utilization: number;
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
 }
 
 export default function DhcpMetricsPage() {
@@ -25,9 +21,7 @@ export default function DhcpMetricsPage() {
 
   const fetchStats = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dhcp/pool-stats", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<{ data?: PoolStats[] }>("/api/v1/dhcp/pool-stats");
       setStats(body.data || []);
     } catch {
       /* silent */
@@ -36,9 +30,7 @@ export default function DhcpMetricsPage() {
 
   const fetchRawMetrics = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dhcp/metrics", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setRawMetrics(await res.text());
+      setRawMetrics(await api.getText("/api/v1/dhcp/metrics"));
     } catch {
       setRawMetrics("# rDHCP metrics unavailable (service may not be running)");
     }

--- a/aifw-ui/src/app/dhcp/page.tsx
+++ b/aifw-ui/src/app/dhcp/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -57,16 +58,6 @@ interface NetInterface {
 
 /* -- Helpers --------------------------------------------------------- */
 
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
-
 const defaultConfig: DhcpGlobalConfig = {
   enabled: false,
   interfaces: [],
@@ -115,9 +106,8 @@ export default function DhcpOverviewPage() {
 
   const fetchStatus = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dhcp/status", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setStatus(await res.json());
+      const data = await api.get<DhcpStatus>("/api/v1/dhcp/status");
+      setStatus(data);
     } catch {
       /* silent */
     }
@@ -125,9 +115,7 @@ export default function DhcpOverviewPage() {
 
   const fetchConfig = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dhcp/v4/config", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data: DhcpGlobalConfig = await res.json();
+      const data = await api.get<DhcpGlobalConfig>("/api/v1/dhcp/v4/config");
       setConfigRaw(data);
       setDnsInput((data.dns_servers || []).join(", "));
     } catch {
@@ -137,9 +125,7 @@ export default function DhcpOverviewPage() {
 
   const fetchInterfaces = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/interfaces", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<{ data?: NetInterface[] }>("/api/v1/interfaces");
       const names = (body.data || [])
         .map((i: NetInterface) => i.name)
         .filter((n: string) => !n.startsWith("lo") && !n.startsWith("pflog"));
@@ -162,12 +148,8 @@ export default function DhcpOverviewPage() {
   const serviceAction = async (action: "start" | "stop" | "restart") => {
     setActionLoading(action);
     try {
-      const res = await fetch(`/api/v1/dhcp/${action}`, {
-        method: "POST",
-        headers: authHeaders(),
-      });
-      const data = await res.json().catch(() => ({ message: "" }));
-      const msg = data.message || `DHCP ${action} completed`;
+      const data = await api.post<{ message?: string }>(`/api/v1/dhcp/${action}`);
+      const msg = data?.message || `DHCP ${action} completed`;
       if (msg.toLowerCase().includes("fail") || msg.toLowerCase().includes("error")) {
         showFeedback("error", msg);
       } else {
@@ -200,12 +182,7 @@ export default function DhcpOverviewPage() {
           .map((s) => s.trim())
           .filter(Boolean),
       };
-      const res = await fetch("/api/v1/dhcp/v4/config", {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.put("/api/v1/dhcp/v4/config", payload);
       showFeedback("success", "Global settings saved");
       setIsDirty(false);
       await fetchConfig();
@@ -219,11 +196,7 @@ export default function DhcpOverviewPage() {
   const applyConfig = async () => {
     setApplying(true);
     try {
-      const res = await fetch("/api/v1/dhcp/v4/apply", {
-        method: "POST",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.post("/api/v1/dhcp/v4/apply");
       showFeedback("success", "Configuration applied and rDHCP restarted");
       setIsDirty(false);
       await fetchStatus();

--- a/aifw-ui/src/app/dhcp/reservations/page.tsx
+++ b/aifw-ui/src/app/dhcp/reservations/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { isValidMAC, validateIP } from "@/lib/validate";
+import { api } from "@/lib/api";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -41,16 +42,6 @@ const defaultForm: ReservationForm = {
 
 /* -- Helpers --------------------------------------------------------- */
 
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
-
 function fmtDate(iso: string): string {
   if (!iso) return "-";
   return new Date(iso).toLocaleDateString("en-US", {
@@ -86,9 +77,7 @@ export default function DhcpReservationsPage() {
 
   const fetchReservations = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dhcp/v4/reservations", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<{ data?: DhcpReservation[] }>("/api/v1/dhcp/v4/reservations");
       setReservations(body.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load reservations");
@@ -97,9 +86,7 @@ export default function DhcpReservationsPage() {
 
   const fetchSubnets = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dhcp/v4/subnets", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<{ data?: DhcpSubnet[] }>("/api/v1/dhcp/v4/subnets");
       setSubnets(body.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load subnets");
@@ -172,17 +159,11 @@ export default function DhcpReservationsPage() {
       if (form.subnet_id) payload.subnet_id = form.subnet_id;
       if (form.description.trim()) payload.description = form.description.trim();
 
-      const url = editingId
-        ? `/api/v1/dhcp/v4/reservations/${editingId}`
-        : "/api/v1/dhcp/v4/reservations";
-      const method = editingId ? "PUT" : "POST";
-
-      const res = await fetch(url, {
-        method,
-        headers: authHeaders(),
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      if (editingId) {
+        await api.put(`/api/v1/dhcp/v4/reservations/${editingId}`, payload);
+      } else {
+        await api.post("/api/v1/dhcp/v4/reservations", payload);
+      }
 
       showFeedback("success", editingId ? "Reservation updated" : "Reservation created");
       closeModal();
@@ -196,11 +177,7 @@ export default function DhcpReservationsPage() {
 
   const handleDelete = async (id: string) => {
     try {
-      const res = await fetch(`/api/v1/dhcp/v4/reservations/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(`/api/v1/dhcp/v4/reservations/${id}`);
       showFeedback("success", "Reservation deleted");
       setDeleteId(null);
       await fetchReservations();

--- a/aifw-ui/src/app/dhcp/subnets/page.tsx
+++ b/aifw-ui/src/app/dhcp/subnets/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { validateCIDR, validateIP, isValidIPv4 } from "@/lib/validate";
+import { api } from "@/lib/api";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -151,16 +152,6 @@ function fmtSeconds(s: number): string {
 
 /* -- Helpers --------------------------------------------------------- */
 
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
-
 function fmtDate(iso: string): string {
   if (!iso) return "-";
   return new Date(iso).toLocaleDateString("en-US", {
@@ -210,9 +201,7 @@ export default function DhcpSubnetsPage() {
 
   const fetchSubnets = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dhcp/v4/subnets", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<{ data?: DhcpSubnet[] }>("/api/v1/dhcp/v4/subnets");
       setSubnets(body.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load subnets");
@@ -221,9 +210,12 @@ export default function DhcpSubnetsPage() {
 
   const fetchGlobalDefaults = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dhcp/v4/config", { headers: authHeadersPlain() });
-      if (!res.ok) return;
-      const cfg = await res.json();
+      const cfg = await api.get<{
+        dns_servers?: string[];
+        ntp_servers?: string[];
+        domain_name?: string;
+        default_lease_time?: number;
+      }>("/api/v1/dhcp/v4/config");
       setGlobalDefaults({
         dns_servers: Array.isArray(cfg.dns_servers) ? cfg.dns_servers : [],
         ntp_servers: Array.isArray(cfg.ntp_servers) ? cfg.ntp_servers : [],
@@ -408,17 +400,11 @@ export default function DhcpSubnetsPage() {
       if (form.delegated_length.trim()) payload.delegated_length = Number(form.delegated_length);
       if (form.description.trim()) payload.description = form.description.trim();
 
-      const url = editingId
-        ? `/api/v1/dhcp/v4/subnets/${editingId}`
-        : "/api/v1/dhcp/v4/subnets";
-      const method = editingId ? "PUT" : "POST";
-
-      const res = await fetch(url, {
-        method,
-        headers: authHeaders(),
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      if (editingId) {
+        await api.put(`/api/v1/dhcp/v4/subnets/${editingId}`, payload);
+      } else {
+        await api.post("/api/v1/dhcp/v4/subnets", payload);
+      }
 
       showFeedback("success", editingId ? "Subnet updated" : "Subnet created");
       closeModal();
@@ -432,11 +418,7 @@ export default function DhcpSubnetsPage() {
 
   const handleDelete = async (id: string) => {
     try {
-      const res = await fetch(`/api/v1/dhcp/v4/subnets/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(`/api/v1/dhcp/v4/subnets/${id}`);
       showFeedback("success", "Subnet deleted");
       setDeleteId(null);
       await fetchSubnets();

--- a/aifw-ui/src/app/dns/acls/page.tsx
+++ b/aifw-ui/src/app/dns/acls/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { validateCIDR } from "@/lib/validate";
+import { api } from "@/lib/api";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -28,16 +29,6 @@ const defaultForm: AclForm = {
 const ACL_ACTIONS = ["allow", "deny", "refuse", "allow_snoop"];
 
 /* -- Helpers --------------------------------------------------------- */
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
 
 function fmtDate(iso: string): string {
   if (!iso) return "-";
@@ -84,9 +75,7 @@ export default function DnsAclsPage() {
 
   const fetchAcls = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dns/resolver/acls", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<{ data?: AccessListEntry[] }>("/api/v1/dns/resolver/acls");
       setAcls(body.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load access lists");
@@ -121,12 +110,7 @@ export default function DnsAclsPage() {
       };
       if (form.description.trim()) payload.description = form.description.trim();
 
-      const res = await fetch("/api/v1/dns/resolver/acls", {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.post("/api/v1/dns/resolver/acls", payload);
 
       showFeedback("success", "Access list entry created");
       setForm(defaultForm);
@@ -140,11 +124,7 @@ export default function DnsAclsPage() {
 
   const handleDelete = async (id: string) => {
     try {
-      const res = await fetch(`/api/v1/dns/resolver/acls/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(`/api/v1/dns/resolver/acls/${id}`);
       showFeedback("success", "Access list entry deleted");
       setDeleteId(null);
       await fetchAcls();

--- a/aifw-ui/src/app/dns/blocklists/page.tsx
+++ b/aifw-ui/src/app/dns/blocklists/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState, useCallback } from "react";
 import Help, { HelpBanner } from "../Help";
+import { api } from "@/lib/api";
 
 /* ---------- Types ---------- */
 
@@ -47,26 +48,6 @@ const CATEGORIES = ["ads", "tracking", "malware", "phishing", "crypto", "adult",
 
 /* ---------- Helpers ---------- */
 
-function authHeaders(): HeadersInit {
-  const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") || "" : "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-async function api<T>(method: string, path: string, body?: unknown): Promise<T> {
-  const res = await fetch(path, {
-    method,
-    headers: authHeaders(),
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
-  if (res.status === 204) return undefined as T;
-  if (!res.ok) {
-    const txt = await res.text();
-    throw new Error(`${res.status}: ${txt || res.statusText}`);
-  }
-  const ct = res.headers.get("content-type") || "";
-  return ct.includes("application/json") ? res.json() : (undefined as T);
-}
-
 function fmtTime(t: number | null): string {
   if (!t) return "never";
   return new Date(t * 1000).toLocaleString();
@@ -109,7 +90,7 @@ export default function BlocklistsPage() {
 
   const loadMaster = useCallback(async () => {
     try {
-      const s = await api<BlocklistSchedule>("GET", "/api/v1/dns/blocklists/schedule");
+      const s = await api.get<BlocklistSchedule>("/api/v1/dns/blocklists/schedule");
       setMasterEnabled(s.enabled);
     } catch (e) {
       setMasterError(String(e));
@@ -123,7 +104,7 @@ export default function BlocklistsPage() {
     setMasterBusy(true);
     setMasterError(null);
     try {
-      await api("PUT", "/api/v1/dns/blocklists/enabled", { enabled: next });
+      await api.put("/api/v1/dns/blocklists/enabled", { enabled: next });
       setMasterEnabled(next);
     } catch (e) {
       setMasterError(String(e));
@@ -243,7 +224,7 @@ function SourcesTab() {
   const reload = useCallback(async () => {
     setLoading(true);
     try {
-      const data = await api<BlocklistSource[]>("GET", "/api/v1/dns/blocklists");
+      const data = await api.get<BlocklistSource[]>("/api/v1/dns/blocklists");
       setSources(data);
     } finally {
       setLoading(false);
@@ -259,7 +240,7 @@ function SourcesTab() {
 
   async function toggleEnabled(s: BlocklistSource) {
     try {
-      await api("PUT", `/api/v1/dns/blocklists/${s.id}`, { enabled: !s.enabled });
+      await api.put(`/api/v1/dns/blocklists/${s.id}`, { enabled: !s.enabled });
       await reload();
     } catch (e) {
       showToast(String(e), false);
@@ -270,7 +251,7 @@ function SourcesTab() {
     try {
       const body: Record<string, unknown> = { action };
       if (action === "redirect" && !s.redirect_ip) body.redirect_ip = "0.0.0.0";
-      await api("PUT", `/api/v1/dns/blocklists/${s.id}`, body);
+      await api.put(`/api/v1/dns/blocklists/${s.id}`, body);
       await reload();
     } catch (e) {
       showToast(String(e), false);
@@ -280,7 +261,7 @@ function SourcesTab() {
   async function refreshOne(id: number) {
     setRefreshingId(id);
     try {
-      const out = await api<RefreshOutcome>("POST", `/api/v1/dns/blocklists/${id}/refresh`);
+      const out = await api.post<RefreshOutcome>(`/api/v1/dns/blocklists/${id}/refresh`);
       showToast(out.ok ? `Refreshed: ${fmtNum(out.rule_count)} rules` : `Failed: ${out.error}`, out.ok);
       await reload();
     } catch (e) {
@@ -293,7 +274,7 @@ function SourcesTab() {
   async function refreshAll() {
     setRefreshingAll(true);
     try {
-      const outs = await api<RefreshOutcome[]>("POST", "/api/v1/dns/blocklists/refresh-all");
+      const outs = await api.post<RefreshOutcome[]>("/api/v1/dns/blocklists/refresh-all");
       const ok = outs.filter((o) => o.ok).length;
       showToast(`Refreshed ${ok}/${outs.length} sources`, ok === outs.length);
       await reload();
@@ -307,7 +288,7 @@ function SourcesTab() {
   async function remove(s: BlocklistSource) {
     if (!confirm(`Delete "${s.name}"?`)) return;
     try {
-      await api("DELETE", `/api/v1/dns/blocklists/${s.id}`);
+      await api.delete(`/api/v1/dns/blocklists/${s.id}`);
       await reload();
     } catch (e) {
       showToast(String(e), false);
@@ -459,7 +440,7 @@ function AddSourceModal({ onClose, onCreated }: { onClose: () => void; onCreated
     setBusy(true);
     setErr(null);
     try {
-      await api("POST", "/api/v1/dns/blocklists", {
+      await api.post("/api/v1/dns/blocklists", {
         name: name.trim(),
         category,
         url: url.trim(),
@@ -562,7 +543,7 @@ function PatternsTab({ kind, title, hint }: { kind: "whitelist" | "customblocks"
   const [err, setErr] = useState<string | null>(null);
 
   const reload = useCallback(async () => {
-    const data = await api<PatternEntry[]>("GET", `/api/v1/dns/${kind}`);
+    const data = await api.get<PatternEntry[]>(`/api/v1/dns/${kind}`);
     setItems(data);
   }, [kind]);
 
@@ -575,7 +556,7 @@ function PatternsTab({ kind, title, hint }: { kind: "whitelist" | "customblocks"
     setBusy(true);
     setErr(null);
     try {
-      await api("POST", `/api/v1/dns/${kind}`, { pattern: pattern.trim(), note: note.trim() || null });
+      await api.post(`/api/v1/dns/${kind}`, { pattern: pattern.trim(), note: note.trim() || null });
       setPattern("");
       setNote("");
       await reload();
@@ -589,7 +570,7 @@ function PatternsTab({ kind, title, hint }: { kind: "whitelist" | "customblocks"
   async function remove(id: number) {
     if (!confirm("Delete this entry?")) return;
     try {
-      await api("DELETE", `/api/v1/dns/${kind}/${id}`);
+      await api.delete(`/api/v1/dns/${kind}/${id}`);
       await reload();
     } catch (e) {
       setErr(String(e));
@@ -670,7 +651,7 @@ function ScheduleTab() {
   const [okMsg, setOkMsg] = useState<string | null>(null);
 
   useEffect(() => {
-    (async () => setSched(await api<BlocklistSchedule>("GET", "/api/v1/dns/blocklists/schedule")))();
+    (async () => setSched(await api.get<BlocklistSchedule>("/api/v1/dns/blocklists/schedule")))();
   }, []);
 
   if (!sched) return <div className="text-[var(--text-muted)]">Loading…</div>;
@@ -685,7 +666,7 @@ function ScheduleTab() {
     setErr(null);
     setOkMsg(null);
     try {
-      const next = await api<BlocklistSchedule>("PUT", "/api/v1/dns/blocklists/schedule", sched);
+      const next = await api.put<BlocklistSchedule>("/api/v1/dns/blocklists/schedule", sched);
       setSched(next);
       setOkMsg("Saved");
       setTimeout(() => setOkMsg(null), 2000);
@@ -700,7 +681,7 @@ function ScheduleTab() {
     setSaving(true);
     setErr(null);
     try {
-      await api("POST", "/api/v1/dns/blocklists/refresh-all");
+      await api.post("/api/v1/dns/blocklists/refresh-all");
       setOkMsg("Refresh kicked off");
       setTimeout(() => setOkMsg(null), 2000);
     } catch (e) {

--- a/aifw-ui/src/app/dns/domains/page.tsx
+++ b/aifw-ui/src/app/dns/domains/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -28,16 +29,6 @@ const defaultForm: DomainForm = {
 };
 
 /* -- Helpers --------------------------------------------------------- */
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
 
 function fmtDate(iso: string): string {
   if (!iso) return "-";
@@ -73,9 +64,7 @@ export default function DnsDomainsPage() {
 
   const fetchDomains = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dns/resolver/domains", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<{ data?: DomainOverride[] }>("/api/v1/dns/resolver/domains");
       setDomains(body.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load domain overrides");
@@ -129,17 +118,11 @@ export default function DnsDomainsPage() {
       };
       if (form.description.trim()) payload.description = form.description.trim();
 
-      const url = editingId
-        ? `/api/v1/dns/resolver/domains/${editingId}`
-        : "/api/v1/dns/resolver/domains";
-      const method = editingId ? "PUT" : "POST";
-
-      const res = await fetch(url, {
-        method,
-        headers: authHeaders(),
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      if (editingId) {
+        await api.put(`/api/v1/dns/resolver/domains/${editingId}`, payload);
+      } else {
+        await api.post("/api/v1/dns/resolver/domains", payload);
+      }
 
       showFeedback("success", editingId ? "Domain override updated" : "Domain override created");
       closeModal();
@@ -153,11 +136,7 @@ export default function DnsDomainsPage() {
 
   const handleDelete = async (id: string) => {
     try {
-      const res = await fetch(`/api/v1/dns/resolver/domains/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(`/api/v1/dns/resolver/domains/${id}`);
       showFeedback("success", "Domain override deleted");
       setDeleteId(null);
       await fetchDomains();
@@ -168,12 +147,7 @@ export default function DnsDomainsPage() {
 
   const toggleEnabled = async (d: DomainOverride) => {
     try {
-      const res = await fetch(`/api/v1/dns/resolver/domains/${d.id}`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({ ...d, enabled: !d.enabled }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.put(`/api/v1/dns/resolver/domains/${d.id}`, { ...d, enabled: !d.enabled });
       await fetchDomains();
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to toggle domain override");

--- a/aifw-ui/src/app/dns/forwarding/page.tsx
+++ b/aifw-ui/src/app/dns/forwarding/page.tsx
@@ -1,17 +1,16 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
-/* -- Helpers --------------------------------------------------------- */
+/* -- Types ----------------------------------------------------------- */
 
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
+interface ForwardingConfig extends Record<string, unknown> {
+  forwarding_enabled?: boolean;
+  use_system_nameservers?: boolean;
+  forwarding_servers?: string[];
+  dot_enabled?: boolean;
+  dot_upstream?: string[];
 }
 
 /* -- Page ------------------------------------------------------------ */
@@ -41,9 +40,7 @@ export default function DnsForwardingPage() {
 
   const fetchConfig = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dns/resolver/config", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const c = await res.json();
+      const c = await api.get<ForwardingConfig>("/api/v1/dns/resolver/config");
       setFullConfig(c);
       setForwardingEnabled(c.forwarding_enabled ?? false);
       setUseSystemNs(c.use_system_nameservers ?? false);
@@ -68,22 +65,17 @@ export default function DnsForwardingPage() {
   const handleSave = async () => {
     setSaving(true);
     try {
-      const res = await fetch("/api/v1/dns/resolver/config", {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({
-          ...fullConfig,
-          forwarding_enabled: forwardingEnabled,
-          forwarding_servers: servers.filter(s => s.trim()),
-          use_system_nameservers: useSystemNs,
-          dot_enabled: dotEnabled,
-          dot_upstream: dotUpstream.filter(s => s.trim()),
-        }),
+      await api.put("/api/v1/dns/resolver/config", {
+        ...fullConfig,
+        forwarding_enabled: forwardingEnabled,
+        forwarding_servers: servers.filter(s => s.trim()),
+        use_system_nameservers: useSystemNs,
+        dot_enabled: dotEnabled,
+        dot_upstream: dotUpstream.filter(s => s.trim()),
       });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
       showFeedback("success", "Forwarding configuration saved");
       // Apply config
-      await fetch("/api/v1/dns/resolver/apply", { method: "POST", headers: authHeaders() });
+      await api.post("/api/v1/dns/resolver/apply");
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Save failed");
     } finally {

--- a/aifw-ui/src/app/dns/hosts/page.tsx
+++ b/aifw-ui/src/app/dns/hosts/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { isValidHostname, isValidIPv4, isValidIPv6, isValidDomain } from "@/lib/validate";
+import { api } from "@/lib/api";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -40,16 +41,6 @@ const defaultForm: HostForm = {
 const RECORD_TYPES = ["A", "AAAA", "MX", "CNAME", "TXT"];
 
 /* -- Helpers --------------------------------------------------------- */
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
 
 function fmtDate(iso: string): string {
   if (!iso) return "-";
@@ -99,9 +90,7 @@ export default function DnsHostsPage() {
 
   const fetchHosts = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dns/resolver/hosts", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<{ data?: HostOverride[] }>("/api/v1/dns/resolver/hosts");
       setHosts(body.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load host overrides");
@@ -174,17 +163,11 @@ export default function DnsHostsPage() {
       }
       if (form.description.trim()) payload.description = form.description.trim();
 
-      const url = editingId
-        ? `/api/v1/dns/resolver/hosts/${editingId}`
-        : "/api/v1/dns/resolver/hosts";
-      const method = editingId ? "PUT" : "POST";
-
-      const res = await fetch(url, {
-        method,
-        headers: authHeaders(),
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      if (editingId) {
+        await api.put(`/api/v1/dns/resolver/hosts/${editingId}`, payload);
+      } else {
+        await api.post("/api/v1/dns/resolver/hosts", payload);
+      }
 
       showFeedback("success", editingId ? "Host override updated" : "Host override created");
       closeModal();
@@ -198,11 +181,7 @@ export default function DnsHostsPage() {
 
   const handleDelete = async (id: string) => {
     try {
-      const res = await fetch(`/api/v1/dns/resolver/hosts/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(`/api/v1/dns/resolver/hosts/${id}`);
       showFeedback("success", "Host override deleted");
       setDeleteId(null);
       await fetchHosts();
@@ -213,12 +192,7 @@ export default function DnsHostsPage() {
 
   const toggleEnabled = async (host: HostOverride) => {
     try {
-      const res = await fetch(`/api/v1/dns/resolver/hosts/${host.id}`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({ ...host, enabled: !host.enabled }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.put(`/api/v1/dns/resolver/hosts/${host.id}`, { ...host, enabled: !host.enabled });
       await fetchHosts();
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to toggle host override");

--- a/aifw-ui/src/app/dns/logs/page.tsx
+++ b/aifw-ui/src/app/dns/logs/page.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
+import { api } from "@/lib/api";
 
 export default function DnsLogsPage() {
   const [logs, setLogs] = useState<string[]>([]);
@@ -17,8 +13,7 @@ export default function DnsLogsPage() {
   const [backend, setBackend] = useState<"rdns" | "unbound">("rdns");
 
   useEffect(() => {
-    fetch(`/api/v1/dns/resolver/config`, { headers: authHeaders() })
-      .then((r) => (r.ok ? r.json() : null))
+    api.get<{ backend?: string }>(`/api/v1/dns/resolver/config`)
       .then((c) => { if (c?.backend === "unbound" || c?.backend === "rdns") setBackend(c.backend); })
       .catch(() => {});
   }, []);
@@ -27,9 +22,7 @@ export default function DnsLogsPage() {
     try {
       const params = new URLSearchParams({ lines: String(lines) });
       if (search) params.set("search", search);
-      const res = await fetch(`/api/v1/dns/resolver/logs?${params}`, { headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.get<{ data?: string[] }>(`/api/v1/dns/resolver/logs?${params}`);
       setLogs(data.data || []);
       setError(null);
     } catch (err) {

--- a/aifw-ui/src/app/dns/page.tsx
+++ b/aifw-ui/src/app/dns/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -75,16 +76,6 @@ interface NetInterface {
 }
 
 /* -- Helpers --------------------------------------------------------- */
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
 
 const defaultConfig: ResolverConfig = {
   backend: "rdns",
@@ -172,9 +163,7 @@ export default function DnsResolverPage() {
 
   const fetchStatus = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dns/resolver/status", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setStatus(await res.json());
+      setStatus(await api.get<DnsStatus>("/api/v1/dns/resolver/status"));
     } catch {
       /* silent */
     }
@@ -182,9 +171,7 @@ export default function DnsResolverPage() {
 
   const fetchConfig = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/dns/resolver/config", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data: ResolverConfig = await res.json();
+      const data = await api.get<ResolverConfig>("/api/v1/dns/resolver/config");
       setConfigRaw(data);
     } catch {
       /* silent */
@@ -193,9 +180,7 @@ export default function DnsResolverPage() {
 
   const fetchInterfaces = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/interfaces", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<{ data?: NetInterface[] }>("/api/v1/interfaces");
       const names = (body.data || [])
         .map((i: NetInterface) => i.name)
         .filter((n: string) => !n.startsWith("lo") && !n.startsWith("pflog"));
@@ -229,11 +214,8 @@ export default function DnsResolverPage() {
   const serviceAction = async (action: "start" | "stop" | "restart") => {
     setActionLoading(action);
     try {
-      const res = await fetch(`/api/v1/dns/resolver/${action}`, {
-        method: "POST",
-        headers: authHeaders(),
-      });
-      const data: ApplyReport | { message?: string } = await res.json().catch(() => ({}));
+      const data: ApplyReport | { message?: string } =
+        (await api.post<ApplyReport | { message?: string }>(`/api/v1/dns/resolver/${action}`)) ?? {};
       if ("probe_udp" in data) {
         reportToFeedback(data as ApplyReport, `DNS Resolver ${action} completed`);
       } else {
@@ -251,12 +233,7 @@ export default function DnsResolverPage() {
   const saveConfig = async () => {
     setSaving(true);
     try {
-      const res = await fetch("/api/v1/dns/resolver/config", {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify(config),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.put("/api/v1/dns/resolver/config", config);
       showFeedback("success", "DNS Resolver settings saved");
       setIsDirty(false);
       await fetchConfig();
@@ -271,19 +248,9 @@ export default function DnsResolverPage() {
     setApplying(true);
     try {
       // Save config first, then apply
-      const saveRes = await fetch("/api/v1/dns/resolver/config", {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify(config),
-      });
-      if (!saveRes.ok) throw new Error(`Save failed: HTTP ${saveRes.status}`);
+      await api.put("/api/v1/dns/resolver/config", config);
 
-      const res = await fetch("/api/v1/dns/resolver/apply", {
-        method: "POST",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`Apply failed: HTTP ${res.status}`);
-      const data: ApplyReport = await res.json();
+      const data = await api.post<ApplyReport>("/api/v1/dns/resolver/apply");
       reportToFeedback(data, "Configuration applied");
       setIsDirty(false);
       // If server rolled back, the persisted backend may have flipped —

--- a/aifw-ui/src/app/geoip/page.tsx
+++ b/aifw-ui/src/app/geoip/page.tsx
@@ -1,18 +1,9 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 import Card from "@/components/Card";
 import StatusBadge from "@/components/StatusBadge";
-
-const API = "";
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${token}`,
-  };
-}
 
 interface GeoIpRule {
   id: string;
@@ -85,9 +76,7 @@ export default function GeoIpPage() {
   // ── Fetch all rules ──
   const fetchRules = useCallback(async () => {
     try {
-      const res = await fetch(`${API}/api/v1/geoip`, { headers: authHeaders() });
-      if (!res.ok) throw new Error(`Failed to fetch rules: ${res.status}`);
-      const json = await res.json();
+      const json = await api.get<{ data?: GeoIpRule[] }>("/api/v1/geoip");
       setRules(json.data || []);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Failed to load rules";
@@ -110,15 +99,7 @@ export default function GeoIpPage() {
     setAdding(true);
     setFeedback(null);
     try {
-      const res = await fetch(`${API}/api/v1/geoip`, {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify({ country_code: code, action: newAction }),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `Create failed: ${res.status}`);
-      }
+      await api.post("/api/v1/geoip", { country_code: code, action: newAction });
       setNewCountryCode("");
       setFeedback({ type: "success", message: `Rule for ${code} created` });
       clearFeedback();
@@ -137,19 +118,11 @@ export default function GeoIpPage() {
     setSaving(true);
     setFeedback(null);
     try {
-      const res = await fetch(`${API}/api/v1/geoip/${id}`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({
-          country_code: editCountryCode.trim().toUpperCase(),
-          action: editAction,
-          status: editStatus,
-        }),
+      await api.put(`/api/v1/geoip/${id}`, {
+        country_code: editCountryCode.trim().toUpperCase(),
+        action: editAction,
+        status: editStatus,
       });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `Update failed: ${res.status}`);
-      }
       setEditingId(null);
       setFeedback({ type: "success", message: "Rule updated" });
       clearFeedback();
@@ -169,19 +142,11 @@ export default function GeoIpPage() {
     setTogglingId(rule.id);
     setFeedback(null);
     try {
-      const res = await fetch(`${API}/api/v1/geoip/${rule.id}`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({
-          country_code: rule.country_code,
-          action: rule.action,
-          status: newStatus,
-        }),
+      await api.put(`/api/v1/geoip/${rule.id}`, {
+        country_code: rule.country_code,
+        action: rule.action,
+        status: newStatus,
       });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `Toggle failed: ${res.status}`);
-      }
       setFeedback({ type: "success", message: `${rule.country_code} ${newStatus}` });
       clearFeedback();
       await fetchRules();
@@ -201,14 +166,7 @@ export default function GeoIpPage() {
     setDeletingId(id);
     setFeedback(null);
     try {
-      const res = await fetch(`${API}/api/v1/geoip/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `Delete failed: ${res.status}`);
-      }
+      await api.delete(`/api/v1/geoip/${id}`);
       setFeedback({ type: "success", message: `Rule for ${countryCode} deleted` });
       clearFeedback();
       await fetchRules();
@@ -240,14 +198,7 @@ export default function GeoIpPage() {
 
     setLookupLoading(true);
     try {
-      const res = await fetch(`${API}/api/v1/geoip/lookup/${encodeURIComponent(trimmed)}`, {
-        headers: authHeaders(),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `Lookup failed: ${res.status}`);
-      }
-      const data: LookupResult = await res.json();
+      const data = await api.get<LookupResult>(`/api/v1/geoip/lookup/${encodeURIComponent(trimmed)}`);
       setLookupResult(data);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Lookup failed";

--- a/aifw-ui/src/app/ids/alerts/page.tsx
+++ b/aifw-ui/src/app/ids/alerts/page.tsx
@@ -1,16 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-
-const API = "";
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${token}`,
-  };
-}
+import { api } from "@/lib/api";
 
 interface IdsAlert {
   id: string;
@@ -105,11 +96,10 @@ export default function IdsAlertsPage() {
       if (srcIpFilter.trim()) params.set("src_ip", srcIpFilter.trim());
       if (ackFilter) params.set("acknowledged", ackFilter);
 
-      const res = await fetch(`${API}/api/v1/ids/alerts?${params.toString()}`, {
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`Failed to fetch alerts: ${res.status}`);
-      const json = await res.json();
+      type AlertsPayload = IdsAlert[] & { alerts?: IdsAlert[]; total?: number };
+      const json = await api.get<AlertsPayload & { data?: AlertsPayload }>(
+        `/api/v1/ids/alerts?${params.toString()}`,
+      );
       const d = json.data || json;
       setAlerts(d.alerts || d || []);
       setTotal(d.total ?? (d.alerts || d || []).length);
@@ -133,14 +123,7 @@ export default function IdsAlertsPage() {
     setAckingId(id);
     setFeedback(null);
     try {
-      const res = await fetch(`${API}/api/v1/ids/alerts/${id}/acknowledge`, {
-        method: "PUT",
-        headers: authHeaders(),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `Acknowledge failed: ${res.status}`);
-      }
+      await api.put(`/api/v1/ids/alerts/${id}/acknowledge`);
       setFeedback({ type: "success", message: "Alert acknowledged" });
       clearFeedback();
       await fetchAlerts();

--- a/aifw-ui/src/app/ids/page.tsx
+++ b/aifw-ui/src/app/ids/page.tsx
@@ -2,16 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Card from "@/components/Card";
-
-const API = "";
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${token}`,
-  };
-}
+import { api } from "@/lib/api";
 
 interface IdsStats {
   packets_inspected: number;
@@ -84,9 +75,7 @@ export default function IdsDashboardPage() {
 
   const fetchStats = useCallback(async () => {
     try {
-      const res = await fetch(`${API}/api/v1/ids/stats`, { headers: authHeaders() });
-      if (!res.ok) throw new Error(`Failed to fetch stats: ${res.status}`);
-      const json = await res.json();
+      const json = await api.get<StatsResponse & { data?: StatsResponse }>("/api/v1/ids/stats");
       setData(json.data || json);
     } catch (err: unknown) {
       if (loading) {
@@ -109,15 +98,7 @@ export default function IdsDashboardPage() {
     setModeChanging(true);
     setFeedback(null);
     try {
-      const res = await fetch(`${API}/api/v1/ids/config`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({ mode: newMode }),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `Failed to change mode: ${res.status}`);
-      }
+      await api.put("/api/v1/ids/config", { mode: newMode });
       setFeedback({ type: "success", message: `Mode changed to ${newMode.toUpperCase()}` });
       clearFeedback();
       await fetchStats();

--- a/aifw-ui/src/app/ids/rules/page.tsx
+++ b/aifw-ui/src/app/ids/rules/page.tsx
@@ -1,16 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-
-const API = "";
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${token}`,
-  };
-}
+import { api } from "@/lib/api";
 
 interface IdsRule {
   id: string;
@@ -85,11 +76,10 @@ export default function IdsRulesPage() {
       if (search.trim()) params.set("search", search.trim());
       if (enabledFilter) params.set("enabled", enabledFilter);
 
-      const res = await fetch(`${API}/api/v1/ids/rules?${params.toString()}`, {
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`Failed to fetch rules: ${res.status}`);
-      const json = await res.json();
+      type RulesPayload = IdsRule[] & { rules?: IdsRule[]; total?: number };
+      const json = await api.get<RulesPayload & { data?: RulesPayload }>(
+        `/api/v1/ids/rules?${params.toString()}`,
+      );
       const d = json.data || json;
       setRules(d.rules || d || []);
       setTotal(d.total ?? (d.rules || d || []).length);
@@ -113,18 +103,10 @@ export default function IdsRulesPage() {
     setUpdatingId(rule.id);
     setFeedback(null);
     try {
-      const res = await fetch(`${API}/api/v1/ids/rules/${rule.id}`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({
-          enabled: !rule.enabled,
-          action_override: rule.action_override,
-        }),
+      await api.put(`/api/v1/ids/rules/${rule.id}`, {
+        enabled: !rule.enabled,
+        action_override: rule.action_override,
       });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `Toggle failed: ${res.status}`);
-      }
       setFeedback({
         type: "success",
         message: `SID ${rule.sid} ${!rule.enabled ? "enabled" : "disabled"}`,
@@ -145,18 +127,10 @@ export default function IdsRulesPage() {
     setFeedback(null);
     try {
       const override_action = newAction === "alert" && !rule.action_override ? null : newAction;
-      const res = await fetch(`${API}/api/v1/ids/rules/${rule.id}`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({
-          enabled: rule.enabled,
-          action_override: override_action,
-        }),
+      await api.put(`/api/v1/ids/rules/${rule.id}`, {
+        enabled: rule.enabled,
+        action_override: override_action,
       });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `Override failed: ${res.status}`);
-      }
       setFeedback({
         type: "success",
         message: `SID ${rule.sid} action set to ${newAction}`,

--- a/aifw-ui/src/app/ids/rulesets/page.tsx
+++ b/aifw-ui/src/app/ids/rulesets/page.tsx
@@ -1,16 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-
-const API = "";
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${token}`,
-  };
-}
+import { api } from "@/lib/api";
 
 interface Ruleset {
   id: string;
@@ -74,9 +65,10 @@ export default function IdsRulesetsPage() {
 
   const fetchRulesets = useCallback(async () => {
     try {
-      const res = await fetch(`${API}/api/v1/ids/rulesets`, { headers: authHeaders() });
-      if (!res.ok) throw new Error(`Failed to fetch rulesets: ${res.status}`);
-      const json = await res.json();
+      type RulesetsPayload = Ruleset[] & { rulesets?: Ruleset[] };
+      const json = await api.get<RulesetsPayload & { data?: RulesetsPayload }>(
+        "/api/v1/ids/rulesets",
+      );
       const d = json.data || json;
       setRulesets(d.rulesets || d || []);
     } catch (err: unknown) {
@@ -98,21 +90,13 @@ export default function IdsRulesetsPage() {
     setAdding(true);
     setFeedback(null);
     try {
-      const res = await fetch(`${API}/api/v1/ids/rulesets`, {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify({
-          name: newName.trim(),
-          source_url: newUrl.trim(),
-          rule_format: newFormat,
-          enabled: true,
-          auto_update: newAutoUpdate,
-        }),
+      await api.post("/api/v1/ids/rulesets", {
+        name: newName.trim(),
+        source_url: newUrl.trim(),
+        rule_format: newFormat,
+        enabled: true,
+        auto_update: newAutoUpdate,
       });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `Create failed: ${res.status}`);
-      }
       setFeedback({ type: "success", message: `Ruleset "${newName.trim()}" created` });
       clearFeedback();
       setNewName("");
@@ -134,16 +118,10 @@ export default function IdsRulesetsPage() {
     setTogglingId(ruleset.id);
     setFeedback(null);
     try {
-      const res = await fetch(`${API}/api/v1/ids/rulesets/${ruleset.id}`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({ enabled: !ruleset.enabled }),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `Toggle failed: ${res.status}`);
-      }
-      const data = await res.json().catch(() => ({}));
+      const data = await api.put<{ data?: Ruleset } | undefined>(
+        `/api/v1/ids/rulesets/${ruleset.id}`,
+        { enabled: !ruleset.enabled },
+      );
       const updated = data?.data;
       const action = !ruleset.enabled ? "enabled" : "disabled";
       const ruleCount = updated?.rule_count ?? ruleset.rule_count;
@@ -172,14 +150,7 @@ export default function IdsRulesetsPage() {
     setDeletingId(ruleset.id);
     setFeedback(null);
     try {
-      const res = await fetch(`${API}/api/v1/ids/rulesets/${ruleset.id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `Delete failed: ${res.status}`);
-      }
+      await api.delete(`/api/v1/ids/rulesets/${ruleset.id}`);
       setFeedback({ type: "success", message: `Ruleset "${ruleset.name}" deleted` });
       clearFeedback();
       await fetchRulesets();

--- a/aifw-ui/src/app/ids/settings/page.tsx
+++ b/aifw-ui/src/app/ids/settings/page.tsx
@@ -1,16 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-
-const API = "";
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${token}`,
-  };
-}
+import { api } from "@/lib/api";
 
 interface IdsConfig {
   mode: string;
@@ -83,9 +74,9 @@ export default function IdsSettingsPage() {
 
   const fetchConfig = useCallback(async () => {
     try {
-      const res = await fetch(`${API}/api/v1/ids/config`, { headers: authHeaders() });
-      if (!res.ok) throw new Error(`Failed to fetch config: ${res.status}`);
-      const json = await res.json();
+      const json = await api.get<Partial<IdsConfig> & { data?: Partial<IdsConfig> }>(
+        "/api/v1/ids/config",
+      );
       const d = json.data || json;
       setConfig({
         mode: d.mode || "disabled",
@@ -114,9 +105,7 @@ export default function IdsSettingsPage() {
     // Fetch available system interfaces
     (async () => {
       try {
-        const res = await fetch(`${API}/api/v1/interfaces`, { headers: authHeaders() });
-        if (!res.ok) return;
-        const data = await res.json();
+        const data = await api.get<{ data?: { name: string }[] }>("/api/v1/interfaces");
         const ifaces: string[] = (data.data || [])
           .map((i: { name: string }) => i.name)
           .filter((n: string) => !n.startsWith("lo") && !n.startsWith("pflog"));
@@ -129,15 +118,7 @@ export default function IdsSettingsPage() {
     setSaving(true);
     setFeedback(null);
     try {
-      const res = await fetch(`${API}/api/v1/ids/config`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify(config),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `Save failed: ${res.status}`);
-      }
+      await api.put("/api/v1/ids/config", config);
       setFeedback({ type: "success", message: "Configuration saved" });
       clearFeedback();
     } catch (err: unknown) {

--- a/aifw-ui/src/app/interfaces/page.tsx
+++ b/aifw-ui/src/app/interfaces/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, useRef } from "react";
+import { api } from "@/lib/api";
 
 interface InterfaceDetail {
   name: string;
@@ -82,14 +83,6 @@ function hexMaskToCidr(hex: string | null): number | null {
   return bits;
 }
 
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token");
-  return {
-    "Content-Type": "application/json",
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  };
-}
-
 function formatBytes(bytes: number): string {
   if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`;
   if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MB`;
@@ -114,11 +107,7 @@ export default function InterfacesPage() {
 
   const fetchInterfaces = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/interfaces/detailed", {
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error("Failed to fetch interfaces");
-      const json = await res.json();
+      const json = await api.get<{ data?: InterfaceDetail[] }>("/api/v1/interfaces/detailed");
       const filtered = (json.data || []).filter(
         (i: InterfaceDetail) => !i.name.startsWith("lo")
       );
@@ -188,19 +177,11 @@ export default function InterfacesPage() {
     }
 
     try {
-      const res = await fetch(
+      const data = await api.put<{ message?: string } | undefined>(
         `/api/v1/interfaces/config/${encodeURIComponent(editingName)}`,
-        {
-          method: "PUT",
-          headers: authHeaders(),
-          body: JSON.stringify(body),
-        }
+        body
       );
-      const data = await res.json().catch(() => ({ message: "" }));
-      if (!res.ok) {
-        throw new Error(data?.message || "Failed to update interface");
-      }
-      showFeedback("success", data.message || `Interface ${editingName} configured`);
+      showFeedback("success", data?.message || `Interface ${editingName} configured`);
       closeEdit();
       // Wait briefly for changes to take effect before refreshing
       setTimeout(() => fetchInterfaces(), 1500);

--- a/aifw-ui/src/app/login/page.tsx
+++ b/aifw-ui/src/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
+import { api } from "@/lib/api";
 
 export default function LoginPage() {
   const [username, setUsername] = useState("");
@@ -18,13 +19,13 @@ export default function LoginPage() {
     setError("");
     setLoading(true);
     try {
-      const res = await fetch("/api/v1/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username, password }),
-      });
-      if (!res.ok) throw new Error("Invalid credentials");
-      const data = await res.json();
+      // noAuthRedirect: a 401 here means bad credentials, not an expired
+      // session — redirecting to /login would just loop.
+      const data = await api.post<{ tokens?: { access_token?: string }; totp_required?: boolean }>(
+        "/api/v1/auth/login",
+        { username, password },
+        { noAuthRedirect: true },
+      );
       const token = data.tokens?.access_token;
       if (token) {
         localStorage.setItem("aifw_token", token);
@@ -44,13 +45,11 @@ export default function LoginPage() {
     setError("");
     setLoading(true);
     try {
-      const res = await fetch("/api/v1/auth/totp/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username, password, totp_code: totpCode }),
-      });
-      if (!res.ok) throw new Error("Invalid code");
-      const data = await res.json();
+      const data = await api.post<{ access_token?: string }>(
+        "/api/v1/auth/totp/login",
+        { username, password, totp_code: totpCode },
+        { noAuthRedirect: true },
+      );
       const token = data.access_token;
       if (token) {
         localStorage.setItem("aifw_token", token);

--- a/aifw-ui/src/app/logs/page.tsx
+++ b/aifw-ui/src/app/logs/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 interface AuditEntry {
   id: string;
@@ -31,12 +32,7 @@ export default function LogsPage() {
 
   const fetchLogs = useCallback(async () => {
     try {
-      const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
-      const res = await fetch("/api/v1/logs", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`Failed to fetch logs (${res.status})`);
-      const json = await res.json();
+      const json = await api.get<{ data?: AuditEntry[] }>("/api/v1/logs");
       setEntries(json.data || []);
       setError(null);
     } catch (err) {

--- a/aifw-ui/src/app/metrics/page.tsx
+++ b/aifw-ui/src/app/metrics/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState, useCallback } from "react";
+import { api } from "@/lib/api";
 
 type Range = { label: string; secs: number };
 const RANGES: Range[] = [
@@ -17,11 +18,6 @@ interface SeriesResponse {
   tier: string;
   interval_secs: number;
   points: SeriesPoint[];
-}
-
-function authHeaders(): HeadersInit {
-  const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
-  return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
 /** Human-friendly metric value formatter. Picks units by magnitude. */
@@ -134,9 +130,7 @@ export default function MetricsPage() {
 
   const fetchList = useCallback(async () => {
     try {
-      const r = await fetch("/api/v1/metrics/list", { headers: authHeaders() });
-      if (!r.ok) throw new Error(`list failed (${r.status})`);
-      const j = await r.json();
+      const j = await api.get<{ names?: string[] }>("/api/v1/metrics/list");
       const n: string[] = j.names || [];
       setNames(n);
       if (!selected && n.length) setSelected(n[0]);
@@ -149,12 +143,10 @@ export default function MetricsPage() {
     if (!selected) return;
     setLoading(true);
     try {
-      const u = new URL(`/api/v1/metrics/series`, window.location.origin);
-      u.searchParams.set("name", selected);
-      u.searchParams.set("range_secs", String(rangeSecs));
-      const r = await fetch(u.toString(), { headers: authHeaders() });
-      if (!r.ok) throw new Error(`series failed (${r.status})`);
-      const j: SeriesResponse = await r.json();
+      const params = new URLSearchParams();
+      params.set("name", selected);
+      params.set("range_secs", String(rangeSecs));
+      const j = await api.get<SeriesResponse>(`/api/v1/metrics/series?${params.toString()}`);
       setData(j);
       setError(null);
     } catch (e) {

--- a/aifw-ui/src/app/multi-wan/lib.ts
+++ b/aifw-ui/src/app/multi-wan/lib.ts
@@ -1,29 +1,28 @@
 // Shared helpers for Multi-WAN UI pages.
 
-export function authHeaders(): HeadersInit {
-  const token = (typeof window !== "undefined" && localStorage.getItem("aifw_token")) || "";
-  return {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${token}`,
-  };
-}
+import { api as client } from "@/lib/api";
 
+/// Thin method-string shim over the central api client (`@/lib/api`) so the
+/// multi-wan pages' existing `api("VERB", path, body)` call sites keep working.
 export async function api<T>(
   method: string,
   path: string,
   body?: unknown,
 ): Promise<T> {
-  const res = await fetch(path, {
-    method,
-    headers: authHeaders(),
-    body: body === undefined ? undefined : JSON.stringify(body),
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(text || `${method} ${path} → ${res.status}`);
+  switch (method.toUpperCase()) {
+    case "GET":
+      return client.get<T>(path);
+    case "POST":
+      return client.post<T>(path, body);
+    case "PUT":
+      return client.put<T>(path, body);
+    case "PATCH":
+      return client.patch<T>(path, body);
+    case "DELETE":
+      return client.delete<T>(path);
+    default:
+      throw new Error(`Unsupported method: ${method}`);
   }
-  if (res.status === 204) return undefined as T;
-  return (await res.json()) as T;
 }
 
 export interface RoutingInstance {

--- a/aifw-ui/src/app/nat/outbound/page.tsx
+++ b/aifw-ui/src/app/nat/outbound/page.tsx
@@ -60,8 +60,7 @@ export default function OutboundNatPage() {
     [reordered[idx], reordered[targetIdx]] = [reordered[targetIdx], reordered[idx]];
     setRules(reordered);
     try {
-      const t = localStorage.getItem("aifw_token");
-      await fetch("/api/v1/nat/reorder", { method: "PUT", headers: { Authorization: `Bearer ${t}`, "Content-Type": "application/json" }, body: JSON.stringify({ rule_ids: reordered.map(x => x.id) }) });
+      await api.put("/api/v1/nat/reorder", { rule_ids: reordered.map(x => x.id) });
     } catch { setError("Failed to save order"); }
   };
 
@@ -572,19 +571,14 @@ function PfNatOutput() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const token = localStorage.getItem("aifw_token") || "";
-    fetch("/api/v1/rules/system", { headers: { Authorization: `Bearer ${token}` } })
-      .then(r => r.json())
+    api.get<unknown>("/api/v1/rules/system")
       .then(d => {
         // Also fetch NAT rules from pf anchor
-        return fetch("/api/v1/status", { headers: { Authorization: `Bearer ${token}` } })
-          .then(r => r.json())
-          .then(() => d);
+        return api.get<unknown>("/api/v1/status").then(() => d);
       })
       .then(() => {
         // Fetch pf nat rules directly
-        fetch("/api/v1/nat/pf-output", { headers: { Authorization: `Bearer ${token}` } })
-          .then(r => r.ok ? r.json() : { data: [] })
+        api.get<{ data?: string[] }>("/api/v1/nat/pf-output")
           .then(d => setOutput(d.data || []))
           .catch(() => {});
       })

--- a/aifw-ui/src/app/nat/port-forward/page.tsx
+++ b/aifw-ui/src/app/nat/port-forward/page.tsx
@@ -55,7 +55,7 @@ export default function PortForwardPage() {
     const reordered = [...rules];
     [reordered[idx], reordered[targetIdx]] = [reordered[targetIdx], reordered[idx]];
     setRules(reordered);
-    try { const t = localStorage.getItem("aifw_token"); await fetch("/api/v1/nat/reorder", { method: "PUT", headers: { Authorization: `Bearer ${t}`, "Content-Type": "application/json" }, body: JSON.stringify({ rule_ids: reordered.map(x => x.id) }) }); } catch { setError("Failed to save order"); }
+    try { await api.put("/api/v1/nat/reorder", { rule_ids: reordered.map(x => x.id) }); } catch { setError("Failed to save order"); }
   };
 
   const fetchRules = useCallback(async () => {
@@ -239,8 +239,7 @@ export default function PortForwardPage() {
             <button
               onClick={async () => {
                 try {
-                  const token = localStorage.getItem("aifw_token");
-                  await fetch("/api/v1/reload", { method: "POST", headers: { Authorization: `Bearer ${token}` } });
+                  await api.post("/api/v1/reload");
                   setPendingChanges(false); setError(null);
                 } catch { setError("Failed to apply changes"); }
               }}
@@ -536,9 +535,7 @@ function PfNatOutput() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const token = localStorage.getItem("aifw_token") || "";
-    fetch("/api/v1/nat/pf-output", { headers: { Authorization: `Bearer ${token}` } })
-      .then(r => r.ok ? r.json() : { data: [] })
+    api.get<{ data?: string[] }>("/api/v1/nat/pf-output")
       .then(d => setOutput(d.data || []))
       .catch(() => {})
       .finally(() => setLoading(false));

--- a/aifw-ui/src/app/page.tsx
+++ b/aifw-ui/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useRef, useMemo } from "react";
 import { useWs } from "@/context/WsContext";
+import { api } from "@/lib/api";
 
 interface StatusData {
   pf_running: boolean; pf_states: number; pf_rules: number;
@@ -338,17 +339,16 @@ export default function Dashboard() {
   useEffect(() => {
     const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
     if (!token) return;
-    const headers = { Authorization: `Bearer ${token}` };
     const fetchSvc = async () => {
       const [dnsRes, dhcpRes, timeRes] = await Promise.allSettled([
-        fetch("/api/v1/dns/resolver/status", { headers }).then(r => r.ok ? r.json() : null),
-        fetch("/api/v1/dhcp/status", { headers }).then(r => r.ok ? r.json() : null),
-        fetch("/api/v1/time/status", { headers }).then(r => r.ok ? r.json() : null),
+        api.get<{ running: boolean; version: string; total_hosts: number; total_domains: number; total_acls: number; queries_total: number; cache_hits: number; cache_misses: number }>("/api/v1/dns/resolver/status"),
+        api.get<{ running: boolean; version: string; total_subnets: number; active_leases: number; total_reservations: number }>("/api/v1/dhcp/status"),
+        api.get<{ running: boolean; version: string; sources_count: number }>("/api/v1/time/status"),
       ]);
       setSvcStatus({
-        dns: dnsRes.status === "fulfilled" ? dnsRes.value : null,
-        dhcp: dhcpRes.status === "fulfilled" ? dhcpRes.value : null,
-        time: timeRes.status === "fulfilled" ? timeRes.value : null,
+        dns: dnsRes.status === "fulfilled" ? dnsRes.value ?? null : null,
+        dhcp: dhcpRes.status === "fulfilled" ? dhcpRes.value ?? null : null,
+        time: timeRes.status === "fulfilled" ? timeRes.value ?? null : null,
       });
     };
     fetchSvc();
@@ -360,9 +360,8 @@ export default function Dashboard() {
   useEffect(() => {
     const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
     if (!token) return;
-    fetch("/api/v1/cluster/status", { headers: { Authorization: `Bearer ${token}` } })
-      .then(r => r.ok ? r.json() : null)
-      .then((s: { role?: string; peer_reachable?: boolean } | null) => {
+    api.get<{ role?: string; peer_reachable?: boolean }>("/api/v1/cluster/status")
+      .then((s) => {
         if (s && s.role && s.role !== "standalone") {
           setHaStatus({ role: s.role, peer_reachable: s.peer_reachable ?? false });
         }

--- a/aifw-ui/src/app/plugins/page.tsx
+++ b/aifw-ui/src/app/plugins/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 interface PluginEntry {
   name: string;
@@ -17,15 +18,6 @@ interface PluginConfig {
   settings: Record<string, unknown>;
 }
 
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
-
 export default function PluginsPage() {
   const [plugins, setPlugins] = useState<PluginEntry[]>([]);
   const [total, setTotal] = useState(0);
@@ -39,13 +31,12 @@ export default function PluginsPage() {
 
   const fetchPlugins = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/plugins", { headers: authHeadersPlain() });
-      if (res.ok) {
-        const data = await res.json();
-        setPlugins(data.plugins || []);
-        setTotal(data.total || 0);
-        setRunning(data.running || 0);
-      }
+      const data = await api.get<{ plugins?: PluginEntry[]; total?: number; running?: number }>(
+        "/api/v1/plugins",
+      );
+      setPlugins(data.plugins || []);
+      setTotal(data.total || 0);
+      setRunning(data.running || 0);
     } catch { /* silent */ }
     setLoading(false);
   }, []);
@@ -54,15 +45,12 @@ export default function PluginsPage() {
 
   const togglePlugin = async (name: string, enabled: boolean) => {
     try {
-      const res = await fetch("/api/v1/plugins/toggle", {
-        method: "POST", headers: authHeaders(),
-        body: JSON.stringify({ name, enabled }),
+      const data = await api.post<{ message?: string }>("/api/v1/plugins/toggle", {
+        name,
+        enabled,
       });
-      if (res.ok) {
-        const data = await res.json();
-        setActionMsg(data.message || "Done");
-        fetchPlugins();
-      }
+      setActionMsg(data.message || "Done");
+      fetchPlugins();
     } catch { setActionMsg("Failed"); }
     setTimeout(() => setActionMsg(""), 3000);
   };
@@ -70,12 +58,9 @@ export default function PluginsPage() {
   const openConfig = async (name: string) => {
     setSelectedPlugin(name);
     try {
-      const res = await fetch(`/api/v1/plugins/${name}/config`, { headers: authHeadersPlain() });
-      if (res.ok) {
-        const data = await res.json();
-        setPluginConfig(data);
-        setConfigJson(JSON.stringify(data.settings || {}, null, 2));
-      }
+      const data = await api.get<PluginConfig>(`/api/v1/plugins/${name}/config`);
+      setPluginConfig(data);
+      setConfigJson(JSON.stringify(data.settings || {}, null, 2));
     } catch { /* */ }
   };
 
@@ -84,14 +69,11 @@ export default function PluginsPage() {
     setSavingConfig(true);
     try {
       const settings = JSON.parse(configJson);
-      const res = await fetch(`/api/v1/plugins/${selectedPlugin}/config`, {
-        method: "PUT", headers: authHeaders(),
-        body: JSON.stringify({ settings }),
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setActionMsg(data.message || "Saved");
-      }
+      const data = await api.put<{ message?: string }>(
+        `/api/v1/plugins/${selectedPlugin}/config`,
+        { settings },
+      );
+      setActionMsg(data.message || "Saved");
     } catch (e) {
       setActionMsg("Invalid JSON or save failed");
     }

--- a/aifw-ui/src/app/profile/page.tsx
+++ b/aifw-ui/src/app/profile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
 
 interface UserProfile {
   id: string;
@@ -15,11 +16,6 @@ interface TotpSetup {
   secret: string;
   provisioning_uri: string;
   recovery_codes: string[];
-}
-
-function authHeaders(): HeadersInit {
-  const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
-  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
 }
 
 export default function ProfilePage() {
@@ -60,8 +56,7 @@ export default function ProfilePage() {
   useEffect(() => {
     const userId = getUserId();
     if (!userId) return;
-    fetch(`/api/v1/auth/users/${userId}`, { headers: authHeaders() })
-      .then((r) => r.ok ? r.json() : Promise.reject())
+    api.get<{ data: UserProfile }>(`/api/v1/auth/users/${userId}`)
       .then((d) => setUser(d.data))
       .catch(() => showFeedback("error", "Failed to load profile"))
       .finally(() => setLoading(false));
@@ -79,24 +74,17 @@ export default function ProfilePage() {
     }
     setChangingPassword(true);
     try {
-      // Verify current password by attempting login
-      const loginRes = await fetch("/api/v1/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username: user?.username, password: currentPassword }),
-      });
-      if (!loginRes.ok) {
+      // Verify current password by attempting login. A 401 here means
+      // "wrong password", not an expired session — skip the auth redirect.
+      try {
+        await api.post("/api/v1/auth/login", { username: user?.username, password: currentPassword }, { noAuthRedirect: true });
+      } catch {
         showFeedback("error", "Current password is incorrect");
         return;
       }
 
       const userId = getUserId();
-      const res = await fetch(`/api/v1/auth/users/${userId}`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({ password: newPassword }),
-      });
-      if (!res.ok) throw new Error();
+      await api.put(`/api/v1/auth/users/${userId}`, { password: newPassword });
       showFeedback("success", "Password changed successfully");
       setCurrentPassword("");
       setNewPassword("");
@@ -111,12 +99,7 @@ export default function ProfilePage() {
   const handleSetupTotp = async () => {
     setSettingUpTotp(true);
     try {
-      const res = await fetch("/api/v1/auth/totp/setup", {
-        method: "POST",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error();
-      const data = await res.json();
+      const data = await api.post<TotpSetup>("/api/v1/auth/totp/setup");
       setTotpSetup(data);
       setRecoveryCodes(data.recovery_codes);
     } catch {
@@ -129,12 +112,9 @@ export default function ProfilePage() {
   const handleVerifyTotp = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await fetch("/api/v1/auth/totp/verify", {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify({ code: totpCode }),
-      });
-      if (!res.ok) throw new Error();
+      // The API answers 401 for a wrong TOTP code — expected input error,
+      // not session expiry, so skip the auth redirect.
+      await api.post("/api/v1/auth/totp/verify", { code: totpCode }, { noAuthRedirect: true });
       showFeedback("success", "MFA enabled successfully");
       setTotpSetup(null);
       setTotpCode("");
@@ -148,12 +128,8 @@ export default function ProfilePage() {
     e.preventDefault();
     setDisablingTotp(true);
     try {
-      const res = await fetch("/api/v1/auth/totp/disable", {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify({ code: disableCode }),
-      });
-      if (!res.ok) throw new Error();
+      // 401 here means "wrong code" — keep the local error, no redirect.
+      await api.post("/api/v1/auth/totp/disable", { code: disableCode }, { noAuthRedirect: true });
       showFeedback("success", "MFA disabled");
       setShowDisable(false);
       setDisableCode("");

--- a/aifw-ui/src/app/reboot/page.tsx
+++ b/aifw-ui/src/app/reboot/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { api } from "@/lib/api";
 
 type Mode = "reboot" | "shutdown";
 
@@ -16,18 +17,12 @@ export default function RebootPage() {
     setBusy(true);
     setFeedback(null);
     try {
-      const token = localStorage.getItem("aifw_token") || "";
       const path = mode === "reboot" ? "/api/v1/updates/reboot" : "/api/v1/updates/shutdown";
-      const res = await fetch(path, {
-        method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json().catch(() => ({}));
+      const data = await api.post<{ message?: string }>(path);
       setFeedback({
         type: "success",
         msg:
-          data.message ||
+          data?.message ||
           (mode === "reboot"
             ? "System rebooting in 10 seconds..."
             : "System shutting down in 10 seconds..."),

--- a/aifw-ui/src/app/reverse-proxy/entrypoints/page.tsx
+++ b/aifw-ui/src/app/reverse-proxy/entrypoints/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -53,16 +54,6 @@ const defaultForm: EntryPointForm = {
 };
 
 /* -- Helpers --------------------------------------------------------- */
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
 
 function fmtDate(iso: string): string {
   if (!iso) return "-";
@@ -214,9 +205,7 @@ export default function EntrypointsPage() {
 
   const fetchEntrypoints = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/entrypoints", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<EntryPoint[] | { data?: EntryPoint[] }>("/api/v1/reverse-proxy/entrypoints");
       setEntrypoints(Array.isArray(body) ? body : body.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load entrypoints");
@@ -274,19 +263,10 @@ export default function EntrypointsPage() {
         enabled: form.enabled,
       };
 
-      const url = editingId
-        ? `/api/v1/reverse-proxy/entrypoints/${editingId}`
-        : "/api/v1/reverse-proxy/entrypoints";
-      const method = editingId ? "PUT" : "POST";
-
-      const res = await fetch(url, {
-        method,
-        headers: authHeaders(),
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `HTTP ${res.status}`);
+      if (editingId) {
+        await api.put(`/api/v1/reverse-proxy/entrypoints/${editingId}`, payload);
+      } else {
+        await api.post("/api/v1/reverse-proxy/entrypoints", payload);
       }
 
       showFeedback("success", editingId ? "Entrypoint updated" : "Entrypoint created");
@@ -301,11 +281,7 @@ export default function EntrypointsPage() {
 
   const handleDelete = async (id: string) => {
     try {
-      const res = await fetch(`/api/v1/reverse-proxy/entrypoints/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(`/api/v1/reverse-proxy/entrypoints/${id}`);
       showFeedback("success", "Entrypoint deleted");
       setDeleteId(null);
       await fetchEntrypoints();

--- a/aifw-ui/src/app/reverse-proxy/http/middlewares/page.tsx
+++ b/aifw-ui/src/app/reverse-proxy/http/middlewares/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 /* ── Types ────────────────────────────────────────────────────── */
 
@@ -19,16 +20,6 @@ interface Feedback {
 }
 
 /* ── Helpers ──────────────────────────────────────────────────── */
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
 
 function fmtDate(iso: string): string {
   if (!iso) return "-";
@@ -218,9 +209,7 @@ export default function HttpMiddlewaresPage() {
 
   const fetchMiddlewares = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/http/middlewares", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.get<HttpMiddleware[] | { data?: HttpMiddleware[] }>("/api/v1/reverse-proxy/http/middlewares");
       setMiddlewares(Array.isArray(data) ? data : data.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load middlewares");
@@ -279,14 +268,10 @@ export default function HttpMiddlewaresPage() {
         config_json: JSON.stringify(formConfig),
         enabled: formEnabled,
       };
-      const url = editingId
-        ? `/api/v1/reverse-proxy/http/middlewares/${editingId}`
-        : "/api/v1/reverse-proxy/http/middlewares";
-      const method = editingId ? "PUT" : "POST";
-      const res = await fetch(url, { method, headers: authHeaders(), body: JSON.stringify(body) });
-      if (!res.ok) {
-        const errBody = await res.json().catch(() => ({}));
-        throw new Error(errBody.error || errBody.message || `HTTP ${res.status}`);
+      if (editingId) {
+        await api.put(`/api/v1/reverse-proxy/http/middlewares/${editingId}`, body);
+      } else {
+        await api.post("/api/v1/reverse-proxy/http/middlewares", body);
       }
       showFeedback("success", editingId ? "Middleware updated" : "Middleware created");
       closeModal();
@@ -302,14 +287,7 @@ export default function HttpMiddlewaresPage() {
     if (!confirm(`Delete middleware "${mw.name}"?`)) return;
     setDeletingId(mw.id);
     try {
-      const res = await fetch(`/api/v1/reverse-proxy/http/middlewares/${mw.id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) {
-        const errBody = await res.json().catch(() => ({}));
-        throw new Error(errBody.error || errBody.message || `HTTP ${res.status}`);
-      }
+      await api.delete(`/api/v1/reverse-proxy/http/middlewares/${mw.id}`);
       showFeedback("success", `Middleware "${mw.name}" deleted`);
       await fetchMiddlewares();
     } catch (err) {
@@ -327,12 +305,7 @@ export default function HttpMiddlewaresPage() {
         config_json: mw.config_json,
         enabled: !mw.enabled,
       };
-      const res = await fetch(`/api/v1/reverse-proxy/http/middlewares/${mw.id}`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.put(`/api/v1/reverse-proxy/http/middlewares/${mw.id}`, body);
       setMiddlewares((prev) =>
         prev.map((m) => (m.id === mw.id ? { ...m, enabled: !mw.enabled } : m))
       );

--- a/aifw-ui/src/app/reverse-proxy/http/routers/page.tsx
+++ b/aifw-ui/src/app/reverse-proxy/http/routers/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -48,16 +49,6 @@ interface Feedback {
 }
 
 /* -- Helpers --------------------------------------------------------- */
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
 
 function parseJsonArray(raw: string): string[] {
   try {
@@ -236,9 +227,7 @@ export default function HttpRoutersPage() {
 
   const fetchRouters = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/http/routers", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.get<HttpRouter[] | { data?: HttpRouter[] }>("/api/v1/reverse-proxy/http/routers");
       setRouters(Array.isArray(data) ? data : data.data || []);
     } catch {
       showFeedback("error", "Failed to load HTTP routers");
@@ -249,27 +238,21 @@ export default function HttpRoutersPage() {
 
   const fetchEntrypoints = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/entrypoints", { headers: authHeadersPlain() });
-      if (!res.ok) return;
-      const data = await res.json();
+      const data = await api.get<Entrypoint[] | { data?: Entrypoint[] }>("/api/v1/reverse-proxy/entrypoints");
       setEntrypoints(Array.isArray(data) ? data : data.data || []);
     } catch { /* silent */ }
   }, []);
 
   const fetchServices = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/http/services", { headers: authHeadersPlain() });
-      if (!res.ok) return;
-      const data = await res.json();
+      const data = await api.get<HttpService[] | { data?: HttpService[] }>("/api/v1/reverse-proxy/http/services");
       setServices(Array.isArray(data) ? data : data.data || []);
     } catch { /* silent */ }
   }, []);
 
   const fetchMiddlewares = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/http/middlewares", { headers: authHeadersPlain() });
-      if (!res.ok) return;
-      const data = await res.json();
+      const data = await api.get<HttpMiddleware[] | { data?: HttpMiddleware[] }>("/api/v1/reverse-proxy/http/middlewares");
       setMiddlewares(Array.isArray(data) ? data : data.data || []);
     } catch { /* silent */ }
   }, []);
@@ -373,19 +356,10 @@ export default function HttpRoutersPage() {
         enabled: formEnabled,
       };
 
-      const url = editingId
-        ? `/api/v1/reverse-proxy/http/routers/${editingId}`
-        : "/api/v1/reverse-proxy/http/routers";
-      const method = editingId ? "PUT" : "POST";
-
-      const res = await fetch(url, {
-        method,
-        headers: authHeaders(),
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) {
-        const errData = await res.json().catch(() => ({ message: `HTTP ${res.status}` }));
-        throw new Error(errData.message || errData.error || `HTTP ${res.status}`);
+      if (editingId) {
+        await api.put(`/api/v1/reverse-proxy/http/routers/${editingId}`, body);
+      } else {
+        await api.post("/api/v1/reverse-proxy/http/routers", body);
       }
 
       showFeedback("success", editingId ? "Router updated" : "Router created");
@@ -401,11 +375,7 @@ export default function HttpRoutersPage() {
   const handleDelete = async (id: string) => {
     setDeletingId(id);
     try {
-      const res = await fetch(`/api/v1/reverse-proxy/http/routers/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(`/api/v1/reverse-proxy/http/routers/${id}`);
       showFeedback("success", "Router deleted");
       setRouters((prev) => prev.filter((r) => r.id !== id));
     } catch (err) {
@@ -417,12 +387,7 @@ export default function HttpRoutersPage() {
 
   const handleToggleEnabled = async (router: HttpRouter) => {
     try {
-      const res = await fetch(`/api/v1/reverse-proxy/http/routers/${router.id}`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({ ...router, enabled: !router.enabled }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.put(`/api/v1/reverse-proxy/http/routers/${router.id}`, { ...router, enabled: !router.enabled });
       setRouters((prev) =>
         prev.map((r) => (r.id === router.id ? { ...r, enabled: !r.enabled } : r))
       );

--- a/aifw-ui/src/app/reverse-proxy/http/services/page.tsx
+++ b/aifw-ui/src/app/reverse-proxy/http/services/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 /* ────────────────────────── Types ────────────────────────── */
 
@@ -70,11 +71,6 @@ interface FailoverConfig {
 }
 
 /* ────────────────────────── Helpers ────────────────────────── */
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
 
 const defaultLbConfig: LbConfig = {
   servers: [{ url: "http://10.0.0.1:8080", weight: 1 }],
@@ -651,9 +647,7 @@ export default function HttpServicesPage() {
   const fetchServices = useCallback(async () => {
     try {
       setError(null);
-      const res = await fetch("/api/v1/reverse-proxy/http/services", { headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const json = await res.json();
+      const json = await api.get<HttpService[] | { data?: HttpService[] }>("/api/v1/reverse-proxy/http/services");
       setServices(Array.isArray(json) ? json : json.data || []);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load services");
@@ -716,18 +710,10 @@ export default function HttpServicesPage() {
     };
 
     try {
-      const url = editingId
-        ? `/api/v1/reverse-proxy/http/services/${editingId}`
-        : "/api/v1/reverse-proxy/http/services";
-      const method = editingId ? "PUT" : "POST";
-      const res = await fetch(url, {
-        method,
-        headers: authHeaders(),
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) {
-        const errBody = await res.json().catch(() => null);
-        throw new Error(errBody?.message || errBody?.error || `Failed to ${editingId ? "update" : "create"} service`);
+      if (editingId) {
+        await api.put(`/api/v1/reverse-proxy/http/services/${editingId}`, body);
+      } else {
+        await api.post("/api/v1/reverse-proxy/http/services", body);
       }
       closeModal();
       await fetchServices();
@@ -742,11 +728,7 @@ export default function HttpServicesPage() {
     if (!confirm("Delete this service? This action cannot be undone.")) return;
     setError(null);
     try {
-      const res = await fetch(`/api/v1/reverse-proxy/http/services/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error("Failed to delete service");
+      await api.delete(`/api/v1/reverse-proxy/http/services/${id}`);
       await fetchServices();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Delete failed");
@@ -756,17 +738,12 @@ export default function HttpServicesPage() {
   async function handleToggleEnabled(svc: HttpService) {
     setError(null);
     try {
-      const res = await fetch(`/api/v1/reverse-proxy/http/services/${svc.id}`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({
-          name: svc.name,
-          service_type: svc.service_type,
-          config_json: svc.config_json,
-          enabled: !svc.enabled,
-        }),
+      await api.put(`/api/v1/reverse-proxy/http/services/${svc.id}`, {
+        name: svc.name,
+        service_type: svc.service_type,
+        config_json: svc.config_json,
+        enabled: !svc.enabled,
       });
-      if (!res.ok) throw new Error("Failed to toggle service");
       setServices((prev) => prev.map((s) => (s.id === svc.id ? { ...s, enabled: !s.enabled } : s)));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Toggle failed");

--- a/aifw-ui/src/app/reverse-proxy/logs/page.tsx
+++ b/aifw-ui/src/app/reverse-proxy/logs/page.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
+import { api } from "@/lib/api";
 
 type LogType = "server" | "access";
 
@@ -22,9 +18,7 @@ export default function ReverseProxyLogsPage() {
     try {
       const params = new URLSearchParams({ lines: String(lines), log_type: logType });
       if (search) params.set("search", search);
-      const res = await fetch(`/api/v1/reverse-proxy/logs?${params}`, { headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.get<string[]>(`/api/v1/reverse-proxy/logs?${params}`);
       setLogs(data || []);
       setError(null);
     } catch (err) {

--- a/aifw-ui/src/app/reverse-proxy/page.tsx
+++ b/aifw-ui/src/app/reverse-proxy/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -31,16 +32,6 @@ interface Feedback {
 }
 
 /* -- Helpers --------------------------------------------------------- */
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
 
 const defaultConfig: GlobalConfig = {
   enabled: false,
@@ -76,9 +67,7 @@ export default function ReverseProxyPage() {
 
   const fetchStatus = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/status", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setStatus(await res.json());
+      setStatus(await api.get<ReverseProxyStatus>("/api/v1/reverse-proxy/status"));
     } catch {
       /* silent */
     }
@@ -86,9 +75,7 @@ export default function ReverseProxyPage() {
 
   const fetchConfig = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/config", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data: GlobalConfig = await res.json();
+      const data = await api.get<GlobalConfig>("/api/v1/reverse-proxy/config");
       setConfigRaw(data);
     } catch {
       /* silent */
@@ -108,12 +95,8 @@ export default function ReverseProxyPage() {
   const serviceAction = async (action: "start" | "stop" | "restart") => {
     setActionLoading(action);
     try {
-      const res = await fetch(`/api/v1/reverse-proxy/${action}`, {
-        method: "POST",
-        headers: authHeaders(),
-      });
-      const data = await res.json().catch(() => ({ message: "" }));
-      const msg = data.message || `Reverse proxy ${action} completed`;
+      const data = await api.post<{ message?: string }>(`/api/v1/reverse-proxy/${action}`);
+      const msg = data?.message || `Reverse proxy ${action} completed`;
       if (msg.toLowerCase().includes("fail") || msg.toLowerCase().includes("error")) {
         showFeedback("error", msg);
       } else {
@@ -130,12 +113,7 @@ export default function ReverseProxyPage() {
   const handleSave = async () => {
     setSaving(true);
     try {
-      const res = await fetch("/api/v1/reverse-proxy/config", {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify(config),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.put("/api/v1/reverse-proxy/config", config);
       showFeedback("success", "Global settings saved");
       setIsDirty(false);
       await fetchConfig();
@@ -149,11 +127,7 @@ export default function ReverseProxyPage() {
   const handleApply = async () => {
     setApplying(true);
     try {
-      const res = await fetch("/api/v1/reverse-proxy/apply", {
-        method: "POST",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.post("/api/v1/reverse-proxy/apply");
       showFeedback("success", "Configuration applied and service restarted");
       setIsDirty(false);
       await fetchStatus();
@@ -167,13 +141,8 @@ export default function ReverseProxyPage() {
   const handleValidate = async () => {
     setValidating(true);
     try {
-      const res = await fetch("/api/v1/reverse-proxy/validate", {
-        method: "POST",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
-      showFeedback("success", data.message || "Configuration is valid");
+      const data = await api.post<{ message?: string }>("/api/v1/reverse-proxy/validate");
+      showFeedback("success", data?.message || "Configuration is valid");
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Configuration validation failed");
     } finally {

--- a/aifw-ui/src/app/reverse-proxy/tcp/page.tsx
+++ b/aifw-ui/src/app/reverse-proxy/tcp/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -94,16 +95,6 @@ const defaultServiceForm: ServiceForm = {
 };
 
 /* -- Helpers --------------------------------------------------------- */
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
 
 function buildTlsJson(form: RouterForm): string | null {
   if (!form.tlsPassthrough && !form.tlsCertResolver.trim()) return null;
@@ -232,9 +223,7 @@ export default function TcpPage() {
 
   const fetchRouters = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/tcp/routers", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<TcpRouter[] | { data?: TcpRouter[] }>("/api/v1/reverse-proxy/tcp/routers");
       setRouters(Array.isArray(body) ? body : body.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load TCP routers");
@@ -243,9 +232,7 @@ export default function TcpPage() {
 
   const fetchServices = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/tcp/services", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<TcpService[] | { data?: TcpService[] }>("/api/v1/reverse-proxy/tcp/services");
       setServices(Array.isArray(body) ? body : body.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load TCP services");
@@ -254,9 +241,7 @@ export default function TcpPage() {
 
   const fetchEntrypoints = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/entrypoints", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<EntryPoint[] | { data?: EntryPoint[] }>("/api/v1/reverse-proxy/entrypoints");
       setEntrypoints(Array.isArray(body) ? body : body.data || []);
     } catch {
       /* silent */
@@ -317,14 +302,10 @@ export default function TcpPage() {
         tls_json: buildTlsJson(routerForm),
         enabled: routerForm.enabled,
       };
-      const url = editingRouterId
-        ? `/api/v1/reverse-proxy/tcp/routers/${editingRouterId}`
-        : "/api/v1/reverse-proxy/tcp/routers";
-      const method = editingRouterId ? "PUT" : "POST";
-      const res = await fetch(url, { method, headers: authHeaders(), body: JSON.stringify(payload) });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `HTTP ${res.status}`);
+      if (editingRouterId) {
+        await api.put(`/api/v1/reverse-proxy/tcp/routers/${editingRouterId}`, payload);
+      } else {
+        await api.post("/api/v1/reverse-proxy/tcp/routers", payload);
       }
       showFeedback("success", editingRouterId ? "TCP router updated" : "TCP router created");
       closeRouterModal();
@@ -338,11 +319,7 @@ export default function TcpPage() {
 
   const handleDeleteRouter = async (id: string) => {
     try {
-      const res = await fetch(`/api/v1/reverse-proxy/tcp/routers/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(`/api/v1/reverse-proxy/tcp/routers/${id}`);
       showFeedback("success", "TCP router deleted");
       setDeleteRouterId(null);
       await fetchRouters();
@@ -395,14 +372,10 @@ export default function TcpPage() {
         config_json: buildServiceConfigJson(serviceForm),
         enabled: serviceForm.enabled,
       };
-      const url = editingServiceId
-        ? `/api/v1/reverse-proxy/tcp/services/${editingServiceId}`
-        : "/api/v1/reverse-proxy/tcp/services";
-      const method = editingServiceId ? "PUT" : "POST";
-      const res = await fetch(url, { method, headers: authHeaders(), body: JSON.stringify(payload) });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `HTTP ${res.status}`);
+      if (editingServiceId) {
+        await api.put(`/api/v1/reverse-proxy/tcp/services/${editingServiceId}`, payload);
+      } else {
+        await api.post("/api/v1/reverse-proxy/tcp/services", payload);
       }
       showFeedback("success", editingServiceId ? "TCP service updated" : "TCP service created");
       closeServiceModal();
@@ -416,11 +389,7 @@ export default function TcpPage() {
 
   const handleDeleteService = async (id: string) => {
     try {
-      const res = await fetch(`/api/v1/reverse-proxy/tcp/services/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(`/api/v1/reverse-proxy/tcp/services/${id}`);
       showFeedback("success", "TCP service deleted");
       setDeleteServiceId(null);
       await fetchServices();

--- a/aifw-ui/src/app/reverse-proxy/tls/page.tsx
+++ b/aifw-ui/src/app/reverse-proxy/tls/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -118,16 +119,6 @@ const caServerPresets: Record<string, string> = {
 };
 
 /* -- Helpers --------------------------------------------------------- */
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
 
 function buildTlsOptionJson(form: TlsOptionForm): string {
   const cfg: Record<string, unknown> = {};
@@ -308,9 +299,7 @@ export default function TlsCertsPage() {
 
   const fetchCerts = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/tls/certs", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<TlsCert[] | { data?: TlsCert[] }>("/api/v1/reverse-proxy/tls/certs");
       setCerts(Array.isArray(body) ? body : body.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load certificates");
@@ -319,9 +308,7 @@ export default function TlsCertsPage() {
 
   const fetchOptions = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/tls/options", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<TlsOption[] | { data?: TlsOption[] }>("/api/v1/reverse-proxy/tls/options");
       setTlsOptions(Array.isArray(body) ? body : body.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load TLS options");
@@ -330,9 +317,7 @@ export default function TlsCertsPage() {
 
   const fetchResolvers = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/cert-resolvers", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<CertResolver[] | { data?: CertResolver[] }>("/api/v1/reverse-proxy/cert-resolvers");
       setResolvers(Array.isArray(body) ? body : body.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load cert resolvers");
@@ -379,14 +364,10 @@ export default function TlsCertsPage() {
         cert_file: certForm.certFile.trim(),
         key_file: certForm.keyFile.trim(),
       };
-      const url = editingCertId
-        ? `/api/v1/reverse-proxy/tls/certs/${editingCertId}`
-        : "/api/v1/reverse-proxy/tls/certs";
-      const method = editingCertId ? "PUT" : "POST";
-      const res = await fetch(url, { method, headers: authHeaders(), body: JSON.stringify(payload) });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `HTTP ${res.status}`);
+      if (editingCertId) {
+        await api.put(`/api/v1/reverse-proxy/tls/certs/${editingCertId}`, payload);
+      } else {
+        await api.post("/api/v1/reverse-proxy/tls/certs", payload);
       }
       showFeedback("success", editingCertId ? "Certificate updated" : "Certificate created");
       closeCertModal();
@@ -430,14 +411,10 @@ export default function TlsCertsPage() {
         name: optionForm.name.trim(),
         config_json: buildTlsOptionJson(optionForm),
       };
-      const url = editingOptionId
-        ? `/api/v1/reverse-proxy/tls/options/${editingOptionId}`
-        : "/api/v1/reverse-proxy/tls/options";
-      const method = editingOptionId ? "PUT" : "POST";
-      const res = await fetch(url, { method, headers: authHeaders(), body: JSON.stringify(payload) });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `HTTP ${res.status}`);
+      if (editingOptionId) {
+        await api.put(`/api/v1/reverse-proxy/tls/options/${editingOptionId}`, payload);
+      } else {
+        await api.post("/api/v1/reverse-proxy/tls/options", payload);
       }
       showFeedback("success", editingOptionId ? "TLS option updated" : "TLS option created");
       closeOptionModal();
@@ -481,14 +458,10 @@ export default function TlsCertsPage() {
         name: resolverForm.name.trim(),
         config_json: buildCertResolverJson(resolverForm),
       };
-      const url = editingResolverId
-        ? `/api/v1/reverse-proxy/cert-resolvers/${editingResolverId}`
-        : "/api/v1/reverse-proxy/cert-resolvers";
-      const method = editingResolverId ? "PUT" : "POST";
-      const res = await fetch(url, { method, headers: authHeaders(), body: JSON.stringify(payload) });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `HTTP ${res.status}`);
+      if (editingResolverId) {
+        await api.put(`/api/v1/reverse-proxy/cert-resolvers/${editingResolverId}`, payload);
+      } else {
+        await api.post("/api/v1/reverse-proxy/cert-resolvers", payload);
       }
       showFeedback("success", editingResolverId ? "Cert resolver updated" : "Cert resolver created");
       closeResolverModal();
@@ -511,8 +484,7 @@ export default function TlsCertsPage() {
     else url = `/api/v1/reverse-proxy/cert-resolvers/${id}`;
 
     try {
-      const res = await fetch(url, { method: "DELETE", headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(url);
       const labels = { cert: "Certificate", option: "TLS option", resolver: "Cert resolver" };
       showFeedback("success", `${labels[type]} deleted`);
       setDeleteTarget(null);

--- a/aifw-ui/src/app/reverse-proxy/udp/page.tsx
+++ b/aifw-ui/src/app/reverse-proxy/udp/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -90,16 +91,6 @@ const defaultServiceForm: ServiceForm = {
 };
 
 /* -- Helpers --------------------------------------------------------- */
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
 
 function buildServiceConfigJson(form: ServiceForm): string {
   if (form.service_type === "weighted") {
@@ -208,9 +199,7 @@ export default function UdpPage() {
 
   const fetchRouters = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/udp/routers", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<UdpRouter[] | { data?: UdpRouter[] }>("/api/v1/reverse-proxy/udp/routers");
       setRouters(Array.isArray(body) ? body : body.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load UDP routers");
@@ -219,9 +208,7 @@ export default function UdpPage() {
 
   const fetchServices = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/udp/services", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<UdpService[] | { data?: UdpService[] }>("/api/v1/reverse-proxy/udp/services");
       setServices(Array.isArray(body) ? body : body.data || []);
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to load UDP services");
@@ -230,9 +217,7 @@ export default function UdpPage() {
 
   const fetchEntrypoints = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/reverse-proxy/entrypoints", { headers: authHeadersPlain() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
+      const body = await api.get<EntryPoint[] | { data?: EntryPoint[] }>("/api/v1/reverse-proxy/entrypoints");
       setEntrypoints(Array.isArray(body) ? body : body.data || []);
     } catch {
       /* silent */
@@ -289,14 +274,10 @@ export default function UdpPage() {
         priority: parseInt(routerForm.priority, 10) || 0,
         enabled: routerForm.enabled,
       };
-      const url = editingRouterId
-        ? `/api/v1/reverse-proxy/udp/routers/${editingRouterId}`
-        : "/api/v1/reverse-proxy/udp/routers";
-      const method = editingRouterId ? "PUT" : "POST";
-      const res = await fetch(url, { method, headers: authHeaders(), body: JSON.stringify(payload) });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `HTTP ${res.status}`);
+      if (editingRouterId) {
+        await api.put(`/api/v1/reverse-proxy/udp/routers/${editingRouterId}`, payload);
+      } else {
+        await api.post("/api/v1/reverse-proxy/udp/routers", payload);
       }
       showFeedback("success", editingRouterId ? "UDP router updated" : "UDP router created");
       closeRouterModal();
@@ -310,11 +291,7 @@ export default function UdpPage() {
 
   const handleDeleteRouter = async (id: string) => {
     try {
-      const res = await fetch(`/api/v1/reverse-proxy/udp/routers/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(`/api/v1/reverse-proxy/udp/routers/${id}`);
       showFeedback("success", "UDP router deleted");
       setDeleteRouterId(null);
       await fetchRouters();
@@ -368,14 +345,10 @@ export default function UdpPage() {
         config_json: buildServiceConfigJson(serviceForm),
         enabled: serviceForm.enabled,
       };
-      const url = editingServiceId
-        ? `/api/v1/reverse-proxy/udp/services/${editingServiceId}`
-        : "/api/v1/reverse-proxy/udp/services";
-      const method = editingServiceId ? "PUT" : "POST";
-      const res = await fetch(url, { method, headers: authHeaders(), body: JSON.stringify(payload) });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || body.message || `HTTP ${res.status}`);
+      if (editingServiceId) {
+        await api.put(`/api/v1/reverse-proxy/udp/services/${editingServiceId}`, payload);
+      } else {
+        await api.post("/api/v1/reverse-proxy/udp/services", payload);
       }
       showFeedback("success", editingServiceId ? "UDP service updated" : "UDP service created");
       closeServiceModal();
@@ -389,11 +362,7 @@ export default function UdpPage() {
 
   const handleDeleteService = async (id: string) => {
     try {
-      const res = await fetch(`/api/v1/reverse-proxy/udp/services/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(`/api/v1/reverse-proxy/udp/services/${id}`);
       showFeedback("success", "UDP service deleted");
       setDeleteServiceId(null);
       await fetchServices();

--- a/aifw-ui/src/app/routes/page.tsx
+++ b/aifw-ui/src/app/routes/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { api } from "@/lib/api";
 import { validateCIDR, validateIP } from "@/lib/validate";
 
 interface StaticRoute {
@@ -57,14 +58,6 @@ const emptyForm: RouteForm = {
   fib: 0,
 };
 
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token");
-  return {
-    "Content-Type": "application/json",
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  };
-}
-
 export default function RoutesPage() {
   const [staticRoutes, setStaticRoutes] = useState<StaticRoute[]>([]);
   const [systemRoutes, setSystemRoutes] = useState<SystemRoute[]>([]);
@@ -79,9 +72,7 @@ export default function RoutesPage() {
 
   const fetchStaticRoutes = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/routes", { headers: authHeaders() });
-      if (!res.ok) throw new Error("Failed to fetch static routes");
-      const json = await res.json();
+      const json = await api.get<{ data: StaticRoute[] }>("/api/v1/routes");
       setStaticRoutes(json.data);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to fetch static routes");
@@ -90,9 +81,7 @@ export default function RoutesPage() {
 
   const fetchSystemRoutes = useCallback(async (fib: number = systemFib) => {
     try {
-      const res = await fetch(`/api/v1/routes/system?fib=${fib}`, { headers: authHeaders() });
-      if (!res.ok) throw new Error("Failed to fetch system routes");
-      const json = await res.json();
+      const json = await api.get<{ data: SystemRoute[] }>(`/api/v1/routes/system?fib=${fib}`);
       setSystemRoutes(json.data);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to fetch system routes");
@@ -101,9 +90,7 @@ export default function RoutesPage() {
 
   const fetchInterfaces = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/interfaces", { headers: authHeaders() });
-      if (!res.ok) throw new Error("Failed to fetch interfaces");
-      const json = await res.json();
+      const json = await api.get<{ data: InterfaceInfo[] }>("/api/v1/interfaces");
       setInterfaces(json.data);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to fetch interfaces");
@@ -112,11 +99,9 @@ export default function RoutesPage() {
 
   const fetchInstances = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/multiwan/instances", { headers: authHeaders() });
-      if (!res.ok) return; // gracefully handle users without multiwan:read
-      const json = await res.json();
+      const json = await api.get<{ data?: RoutingInstance[] }>("/api/v1/multiwan/instances");
       setInstances(json.data || []);
-    } catch { /* optional */ }
+    } catch { /* optional — gracefully handle users without multiwan:read */ }
   }, []);
 
   const fetchAll = useCallback(async () => {
@@ -156,16 +141,10 @@ export default function RoutesPage() {
     if (form.description) body.description = form.description;
 
     try {
-      const url = editingId ? `/api/v1/routes/${editingId}` : "/api/v1/routes";
-      const method = editingId ? "PUT" : "POST";
-      const res = await fetch(url, {
-        method,
-        headers: authHeaders(),
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) {
-        const errBody = await res.json().catch(() => null);
-        throw new Error(errBody?.message || `Failed to ${editingId ? "update" : "create"} route`);
+      if (editingId) {
+        await api.put(`/api/v1/routes/${editingId}`, body);
+      } else {
+        await api.post("/api/v1/routes", body);
       }
       setForm({ ...emptyForm });
       setEditingId(null);
@@ -199,11 +178,7 @@ export default function RoutesPage() {
     if (!confirm("Delete this static route?")) return;
     setError(null);
     try {
-      const res = await fetch(`/api/v1/routes/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error("Failed to delete route");
+      await api.delete(`/api/v1/routes/${id}`);
       await fetchStaticRoutes();
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Delete failed");
@@ -213,12 +188,7 @@ export default function RoutesPage() {
   async function toggleEnabled(route: StaticRoute) {
     setError(null);
     try {
-      const res = await fetch(`/api/v1/routes/${route.id}`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({ ...route, enabled: !route.enabled }),
-      });
-      if (!res.ok) throw new Error("Failed to toggle route");
+      await api.put(`/api/v1/routes/${route.id}`, { ...route, enabled: !route.enabled });
       await fetchStaticRoutes();
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Toggle failed");

--- a/aifw-ui/src/app/rules/page.tsx
+++ b/aifw-ui/src/app/rules/page.tsx
@@ -142,13 +142,8 @@ export default function RulesPage() {
     [reordered[idx], reordered[targetIdx]] = [reordered[targetIdx], reordered[idx]];
     setRules(reordered);
     try {
-      const token = localStorage.getItem("aifw_token");
-      const res = await fetch("/api/v1/rules/reorder", {
-        method: "PUT",
-        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-        body: JSON.stringify({ rule_ids: reordered.map(r => r.id) }),
-      });
-      if (res.ok) setPendingChanges(true);
+      await api.put("/api/v1/rules/reorder", { rule_ids: reordered.map(r => r.id) });
+      setPendingChanges(true);
     } catch { setError("Failed to save rule order"); }
   };
 
@@ -179,17 +174,10 @@ export default function RulesPage() {
   };
 
   const applyBlockLogging = async () => {
-    const token = localStorage.getItem("aifw_token") || "";
     try {
-      const res = await fetch("/api/v1/rules/block-logging", {
-        method: "POST",
-        headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-        body: JSON.stringify({ enabled: blockLogging }),
-      });
-      if (res.ok) {
-        setBlockLoggingPending(false);
-        fetchRules();
-      }
+      await api.post("/api/v1/rules/block-logging", { enabled: blockLogging });
+      setBlockLoggingPending(false);
+      fetchRules();
     } catch { /* silent */ }
   };
 

--- a/aifw-ui/src/app/rules/schedules/page.tsx
+++ b/aifw-ui/src/app/rules/schedules/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { api } from "@/lib/api";
 
 interface Schedule {
   id: string;
@@ -31,23 +32,6 @@ const defaultForm: ScheduleForm = {
   enabled: true,
 };
 
-async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
-  const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  };
-  const res = await fetch(path, { ...options, headers });
-  if (!res.ok) {
-    if (res.status === 401 && typeof window !== "undefined") {
-      localStorage.removeItem("aifw_token");
-      window.location.href = "/login";
-    }
-    throw new Error(`API ${res.status}: ${res.statusText}`);
-  }
-  return res.json();
-}
-
 export default function SchedulesPage() {
   const [schedules, setSchedules] = useState<Schedule[]>([]);
   const [loading, setLoading] = useState(true);
@@ -60,7 +44,7 @@ export default function SchedulesPage() {
   const fetchSchedules = useCallback(async () => {
     try {
       setError(null);
-      const res = await apiFetch<{ data: Record<string, unknown>[] }>("/api/v1/schedules");
+      const res = await api.get<{ data: Record<string, unknown>[] }>("/api/v1/schedules");
       // Normalize: API returns time_ranges/days_of_week as comma-separated strings
       const normalized: Schedule[] = (res.data || []).map((s) => ({
         ...s,
@@ -98,9 +82,9 @@ export default function SchedulesPage() {
       };
 
       if (editingId) {
-        await apiFetch(`/api/v1/schedules/${editingId}`, { method: "PUT", body: JSON.stringify(body) });
+        await api.put(`/api/v1/schedules/${editingId}`, body);
       } else {
-        await apiFetch("/api/v1/schedules", { method: "POST", body: JSON.stringify(body) });
+        await api.post("/api/v1/schedules", body);
       }
 
       setForm(defaultForm);
@@ -130,7 +114,7 @@ export default function SchedulesPage() {
     if (!confirm("Delete this schedule?")) return;
     setError(null);
     try {
-      await apiFetch(`/api/v1/schedules/${id}`, { method: "DELETE" });
+      await api.delete(`/api/v1/schedules/${id}`);
       await fetchSchedules();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to delete schedule");
@@ -140,15 +124,12 @@ export default function SchedulesPage() {
   const handleToggleEnabled = async (schedule: Schedule) => {
     setError(null);
     try {
-      await apiFetch(`/api/v1/schedules/${schedule.id}`, {
-        method: "PUT",
-        body: JSON.stringify({
-          name: schedule.name,
-          description: schedule.description || undefined,
-          time_ranges: schedule.time_ranges,
-          days_of_week: schedule.days_of_week,
-          enabled: !schedule.enabled,
-        }),
+      await api.put(`/api/v1/schedules/${schedule.id}`, {
+        name: schedule.name,
+        description: schedule.description || undefined,
+        time_ranges: schedule.time_ranges,
+        days_of_week: schedule.days_of_week,
+        enabled: !schedule.enabled,
       });
       await fetchSchedules();
     } catch (err) {

--- a/aifw-ui/src/app/settings/page.tsx
+++ b/aifw-ui/src/app/settings/page.tsx
@@ -2,8 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
-
-const API = "";
+import { api } from "@/lib/api";
 
 // Settings categories. `key` matches the `?cat=` URL param; `sections` lists
 // the section <h2> labels that belong to the category. The render below uses
@@ -18,18 +17,6 @@ const CATEGORIES: { key: string; label: string; sections: string[] }[] = [
   { key: "backup",  label: "Backup & History", sections: ["Config History", "S3 Backup Sync", "Email Notifications (SMTP)"] },
   { key: "ai",      label: "AI / LLM",        sections: ["AI / LLM Providers"] },
 ];
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${token}`,
-  };
-}
-
-async function authFetch(url: string, options?: RequestInit): Promise<Response> {
-  return fetch(url, { ...options, headers: { ...authHeaders(), ...options?.headers } });
-}
 
 interface SectionFeedback {
   type: "success" | "error";
@@ -230,11 +217,7 @@ export default function SettingsPage() {
   useEffect(() => {
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/dns`, {
-          headers: authHeaders(),
-        });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json();
+        const data = await api.get<{ servers?: string[] }>("/api/v1/dns");
         setDnsServers(data.servers || []);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : "Unknown error";
@@ -249,11 +232,7 @@ export default function SettingsPage() {
   useEffect(() => {
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/auth/settings`, {
-          headers: authHeaders(),
-        });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json();
+        const data = await api.get<{ access_token_expiry_mins?: number; require_totp?: boolean }>("/api/v1/auth/settings");
         if (data.access_token_expiry_mins !== undefined) setSessionTimeout(data.access_token_expiry_mins);
         if (data.require_totp !== undefined) setRequireMfa(data.require_totp);
       } catch (err: unknown) {
@@ -267,9 +246,7 @@ export default function SettingsPage() {
     // Fetch Valkey settings
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/settings/valkey`, { headers: authHeaders() });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json();
+        const data = await api.get<{ enabled?: boolean; url?: string; retention_minutes?: number; status?: string }>("/api/v1/settings/valkey");
         if (data.enabled !== undefined) setValkeyEnabled(data.enabled);
         if (data.url) setValkeyUrl(data.url);
         if (data.retention_minutes) setMetricsRetention(data.retention_minutes);
@@ -284,9 +261,7 @@ export default function SettingsPage() {
     // Fetch Dashboard History settings
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/settings/dashboard-history`, { headers: authHeaders() });
-        if (!res.ok) return;
-        const data = await res.json();
+        const data = await api.get<{ mode?: string; history_seconds?: number; current_entries?: number; estimated_ram_mb?: number; ram_limit_mb?: number }>("/api/v1/settings/dashboard-history");
         if (data.mode === "duration" || data.mode === "ram") setHistoryMode(data.mode);
         if (data.history_seconds) setHistoryMinutes(Math.round(data.history_seconds / 60));
         if (data.current_entries !== undefined) setHistoryEntries(data.current_entries);
@@ -302,9 +277,7 @@ export default function SettingsPage() {
     // Fetch pf state-table tuning
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/settings/pf-tuning`, { headers: authHeaders() });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const d = await res.json();
+        const d = await api.get<{ configured_max_states?: number; live_max_states?: number; current_states?: number; min_states?: number; max_states?: number }>("/api/v1/settings/pf-tuning");
         if (typeof d.configured_max_states === "number") {
           setPfConfigured(d.configured_max_states);
           setPfMaxStates(d.configured_max_states);
@@ -320,9 +293,7 @@ export default function SettingsPage() {
     // Fetch Config History retention
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/config/retention`, { headers: authHeaders() });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json();
+        const data = await api.get<{ max_versions?: number; current_count?: number }>("/api/v1/config/retention");
         if (typeof data.max_versions === "number") setCfgMaxVersions(data.max_versions);
         if (typeof data.current_count === "number") setCfgCurrentCount(data.current_count);
       } catch {
@@ -335,9 +306,7 @@ export default function SettingsPage() {
     // Fetch S3 backup config
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/backup/s3/config`, { headers: authHeaders() });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const d = await res.json();
+        const d = await api.get<{ enabled?: boolean; bucket?: string; region?: string; endpoint?: string; prefix?: string; path_style?: boolean; access_key_id?: string; has_secret?: boolean }>("/api/v1/backup/s3/config");
         setS3Enabled(!!d.enabled);
         setS3Bucket(d.bucket || "");
         setS3Region(d.region || "us-east-1");
@@ -355,9 +324,7 @@ export default function SettingsPage() {
     // Fetch SMTP config
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/notify/smtp/config`, { headers: authHeaders() });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const d = await res.json();
+        const d = await api.get<{ enabled?: boolean; host?: string; port?: number | string; tls?: string; username?: string; has_password?: boolean; from_address?: string; recipients?: string; enabled_events?: string[] }>("/api/v1/notify/smtp/config");
         setSmtpEnabled(!!d.enabled);
         setSmtpHost(d.host || "");
         setSmtpPort(Number(d.port) || 587);
@@ -376,9 +343,7 @@ export default function SettingsPage() {
     // Fetch IDS Alert Buffer settings
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/settings/ids-alerts`, { headers: authHeaders() });
-        if (!res.ok) return;
-        const data = await res.json();
+        const data = await api.get<{ max_mb?: number; max_age_secs?: number; stats?: NonNullable<typeof idsStats> }>("/api/v1/settings/ids-alerts");
         if (data.max_mb) setIdsMaxMb(data.max_mb);
         if (data.max_age_secs) setIdsMaxAge(data.max_age_secs);
         if (data.stats) setIdsStats(data.stats);
@@ -388,9 +353,7 @@ export default function SettingsPage() {
     // Fetch AI provider settings
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/settings/ai`, { headers: authHeaders() });
-        if (!res.ok) return;
-        const data = await res.json();
+        const data = await api.get<{ enabled?: boolean; active_provider?: string; providers?: typeof aiProviders }>("/api/v1/settings/ai");
         if (data.enabled !== undefined) setAiEnabled(data.enabled);
         if (data.active_provider) setAiActiveProvider(data.active_provider);
         if (data.providers) setAiProviders(data.providers);
@@ -401,9 +364,7 @@ export default function SettingsPage() {
     // Fetch TLS policy settings
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/settings/tls`, { headers: authHeaders() });
-        if (!res.ok) return;
-        const data = await res.json();
+        const data = await api.get<{ min_version?: string; block_expired?: boolean; block_weak_keys?: boolean }>("/api/v1/settings/tls");
         if (data.min_version) setMinTlsVersion(data.min_version);
         if (data.block_expired !== undefined) setBlockExpired(data.block_expired);
         if (data.block_weak_keys !== undefined) setBlockWeakKeys(data.block_weak_keys);
@@ -415,9 +376,7 @@ export default function SettingsPage() {
     // Fetch System General
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/system/general`, { headers: authHeaders() });
-        if (!res.ok) return;
-        const d = await res.json();
+        const d = await api.get<{ hostname?: string; domain?: string; timezone?: string }>("/api/v1/system/general");
         setSysHostname(d.hostname || "");
         setSysDomain(d.domain || "");
         setSysTimezone(d.timezone || "UTC");
@@ -427,9 +386,7 @@ export default function SettingsPage() {
     // Fetch timezone list
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/system/timezones`, { headers: authHeaders() });
-        if (!res.ok) return;
-        const d = await res.json();
+        const d = await api.get<string[]>("/api/v1/system/timezones");
         setTimezoneList(Array.isArray(d) ? d : ["UTC"]);
       } catch { setTimezoneList(["UTC"]); }
     })();
@@ -437,9 +394,7 @@ export default function SettingsPage() {
     // Fetch System Banner
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/system/banner`, { headers: authHeaders() });
-        if (!res.ok) return;
-        const d = await res.json();
+        const d = await api.get<{ login_banner?: string; motd?: string }>("/api/v1/system/banner");
         setLoginBanner(d.login_banner || "");
         setMotdBody(d.motd || "");
       } catch { /* silent */ }
@@ -448,9 +403,7 @@ export default function SettingsPage() {
     // Fetch System SSH
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/system/ssh`, { headers: authHeaders() });
-        if (!res.ok) return;
-        const d = await res.json();
+        const d = await api.get<{ enabled?: boolean; port?: number; password_auth?: boolean; permit_root_login?: boolean }>("/api/v1/system/ssh");
         if (d.enabled !== undefined) setSshEnabled(d.enabled);
         if (d.port !== undefined) setSshPort(d.port);
         if (d.password_auth !== undefined) setSshPasswordAuth(d.password_auth);
@@ -461,9 +414,7 @@ export default function SettingsPage() {
     // Fetch System Console
     (async () => {
       try {
-        const res = await authFetch(`${API}/api/v1/system/console`, { headers: authHeaders() });
-        if (!res.ok) return;
-        const d = await res.json();
+        const d = await api.get<{ kind?: "video" | "serial" | "dual"; baud?: number }>("/api/v1/system/console");
         if (d.kind) setConsoleKind(d.kind);
         if (d.baud) setConsoleBaud(d.baud);
       } catch { /* silent */ }
@@ -476,17 +427,12 @@ export default function SettingsPage() {
     setMetricsSaving(true);
     setMetricsFeedback(null);
     try {
-      const res = await authFetch(`${API}/api/v1/settings/metrics`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({
-          backend: metricsBackend,
-          postgres_url: metricsBackend === "postgres" ? postgresUrl : undefined,
-          collection_interval: Number(collectionInterval),
-          retention_days: Number(retentionDays),
-        }),
+      await api.put("/api/v1/settings/metrics", {
+        backend: metricsBackend,
+        postgres_url: metricsBackend === "postgres" ? postgresUrl : undefined,
+        collection_interval: Number(collectionInterval),
+        retention_days: Number(retentionDays),
       });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
       setFeedbackWithTimeout(setMetricsFeedback, { type: "success", message: "Metrics settings saved." });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Unknown error";
@@ -500,16 +446,11 @@ export default function SettingsPage() {
     setApiSaving(true);
     setApiFeedback(null);
     try {
-      const res = await authFetch(`${API}/api/v1/settings/api`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({
-          port: Number(apiPort),
-          cors_origins: corsOrigins,
-          jwt_secret: jwtSecret,
-        }),
+      await api.put("/api/v1/settings/api", {
+        port: Number(apiPort),
+        cors_origins: corsOrigins,
+        jwt_secret: jwtSecret,
       });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
       setFeedbackWithTimeout(setApiFeedback, { type: "success", message: "API settings saved." });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Unknown error";
@@ -523,16 +464,11 @@ export default function SettingsPage() {
     setTlsSaving(true);
     setTlsFeedback(null);
     try {
-      const res = await authFetch(`${API}/api/v1/settings/tls`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({
-          min_version: minTlsVersion,
-          block_expired: blockExpired,
-          block_weak_keys: blockWeakKeys,
-        }),
+      await api.put("/api/v1/settings/tls", {
+        min_version: minTlsVersion,
+        block_expired: blockExpired,
+        block_weak_keys: blockWeakKeys,
       });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
       setFeedbackWithTimeout(setTlsFeedback, { type: "success", message: "TLS policy saved." });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Unknown error";
@@ -546,12 +482,7 @@ export default function SettingsPage() {
     setDnsSaving(true);
     setDnsFeedback(null);
     try {
-      const res = await authFetch(`${API}/api/v1/dns`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({ servers: dnsServers }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.put("/api/v1/dns", { servers: dnsServers });
       setFeedbackWithTimeout(setDnsFeedback, { type: "success", message: "DNS servers saved." });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Unknown error";
@@ -565,15 +496,10 @@ export default function SettingsPage() {
     setAuthSaving(true);
     setAuthFeedback(null);
     try {
-      const res = await authFetch(`${API}/api/v1/auth/settings`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({
-          access_token_expiry_mins: sessionTimeout,
-          require_totp: requireMfa,
-        }),
+      await api.put("/api/v1/auth/settings", {
+        access_token_expiry_mins: sessionTimeout,
+        require_totp: requireMfa,
       });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
       setFeedbackWithTimeout(setAuthFeedback, { type: "success", message: "Auth settings saved." });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Unknown error";
@@ -587,12 +513,7 @@ export default function SettingsPage() {
     setIdsSaving(true);
     setIdsFeedback(null);
     try {
-      const res = await authFetch(`${API}/api/v1/settings/ids-alerts`, {
-        method: "PUT", headers: authHeaders(),
-        body: JSON.stringify({ max_mb: idsMaxMb, max_age_secs: idsMaxAge }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.put<{ stats?: NonNullable<typeof idsStats> }>("/api/v1/settings/ids-alerts", { max_mb: idsMaxMb, max_age_secs: idsMaxAge });
       if (data.stats) setIdsStats(data.stats);
       setFeedbackWithTimeout(setIdsFeedback, { type: "success", message: "IDS alert settings saved." });
     } catch (err: unknown) {
@@ -609,13 +530,7 @@ export default function SettingsPage() {
         historyMode === "ram"
           ? { mode: "ram", ram_limit_mb: historyRamMb }
           : { mode: "duration", history_seconds: Math.max(5, historyMinutes) * 60 };
-      const res = await authFetch(`${API}/api/v1/settings/dashboard-history`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.put<{ estimated_ram_mb?: number; history_seconds?: number }>("/api/v1/settings/dashboard-history", body);
       if (data.estimated_ram_mb !== undefined) setHistoryEstRamMb(data.estimated_ram_mb);
       if (data.history_seconds) setHistoryMinutes(Math.round(data.history_seconds / 60));
       setFeedbackWithTimeout(setHistoryFeedback, { type: "success", message: "Dashboard history updated. Takes effect immediately." });
@@ -631,16 +546,7 @@ export default function SettingsPage() {
     setCfgRetSaving(true);
     setCfgRetFeedback(null);
     try {
-      const res = await authFetch(`${API}/api/v1/config/retention`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({ max_versions: cfgMaxVersions }),
-      });
-      if (!res.ok) {
-        const txt = await res.text().catch(() => "");
-        throw new Error(txt || `HTTP ${res.status}`);
-      }
-      const data = await res.json();
+      const data = await api.put<{ max_versions?: number; current_count?: number }>("/api/v1/config/retention", { max_versions: cfgMaxVersions });
       if (typeof data.max_versions === "number") setCfgMaxVersions(data.max_versions);
       if (typeof data.current_count === "number") setCfgCurrentCount(data.current_count);
       setFeedbackWithTimeout(setCfgRetFeedback, { type: "success", message: "Config history retention saved." });
@@ -656,16 +562,7 @@ export default function SettingsPage() {
     setPfSaving(true);
     setPfFeedback(null);
     try {
-      const res = await authFetch(`${API}/api/v1/settings/pf-tuning`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({ max_states: pfMaxStates }),
-      });
-      if (!res.ok) {
-        const txt = await res.text().catch(() => "");
-        throw new Error(txt || `HTTP ${res.status}`);
-      }
-      const d = await res.json();
+      const d = await api.put<{ configured_max_states: number; live_max_states: number | null }>("/api/v1/settings/pf-tuning", { max_states: pfMaxStates });
       setPfConfigured(d.configured_max_states);
       setPfLive(d.live_max_states);
       setFeedbackWithTimeout(setPfFeedback, { type: "success", message: "pf state-table limit applied (no reload of rules required)." });
@@ -695,16 +592,7 @@ export default function SettingsPage() {
     setS3Saving(true);
     setS3Feedback(null);
     try {
-      const res = await authFetch(`${API}/api/v1/backup/s3/config`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify(buildS3Payload()),
-      });
-      if (!res.ok) {
-        const txt = await res.text().catch(() => "");
-        throw new Error(txt || `HTTP ${res.status}`);
-      }
-      const d = await res.json();
+      const d = await api.put<{ has_secret?: boolean }>("/api/v1/backup/s3/config", buildS3Payload());
       setS3HasSecret(!!d.has_secret);
       setS3Secret("");
       setFeedbackWithTimeout(setS3Feedback, { type: "success", message: "S3 settings saved." });
@@ -720,13 +608,7 @@ export default function SettingsPage() {
     setS3Testing(true);
     setS3TestResult(null);
     try {
-      const res = await authFetch(`${API}/api/v1/backup/s3/test`, {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify(buildS3Payload()),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const d = await res.json();
+      const d = await api.post<{ ok?: boolean; message?: string; write?: boolean; read?: boolean; delete?: boolean }>("/api/v1/backup/s3/test", buildS3Payload());
       setS3TestResult({
         ok: !!d.ok,
         message: d.message || "",
@@ -758,16 +640,7 @@ export default function SettingsPage() {
     setSmtpSaving(true);
     setSmtpFeedback(null);
     try {
-      const res = await authFetch(`${API}/api/v1/notify/smtp/config`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify(buildSmtpPayload()),
-      });
-      if (!res.ok) {
-        const txt = await res.text().catch(() => "");
-        throw new Error(txt || `HTTP ${res.status}`);
-      }
-      const d = await res.json();
+      const d = await api.put<{ has_password?: boolean }>("/api/v1/notify/smtp/config", buildSmtpPayload());
       setSmtpHasPass(!!d.has_password);
       setSmtpPass("");
       setFeedbackWithTimeout(setSmtpFeedback, { type: "success", message: "SMTP settings saved." });
@@ -783,13 +656,7 @@ export default function SettingsPage() {
     setSmtpTesting(true);
     setSmtpFeedback(null);
     try {
-      const res = await authFetch(`${API}/api/v1/notify/smtp/test`, {
-        method: "POST",
-        headers: authHeaders(),
-        body: JSON.stringify(buildSmtpPayload()),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const d = await res.json();
+      const d = await api.post<{ ok?: boolean; message?: string }>("/api/v1/notify/smtp/test", buildSmtpPayload());
       setFeedbackWithTimeout(setSmtpFeedback, {
         type: d.ok ? "success" : "error",
         message: d.message || (d.ok ? "Test email sent." : "Test failed."),
@@ -812,16 +679,13 @@ export default function SettingsPage() {
       if (aiEditEndpoint) body.endpoint = aiEditEndpoint;
       if (aiEditModel) body.model = aiEditModel;
       body.tls_insecure = aiEditTlsInsecure;
-      const res = await authFetch(`${API}/api/v1/settings/ai`, {
-        method: "PUT", headers: authHeaders(), body: JSON.stringify(body),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.put("/api/v1/settings/ai", body);
       setFeedbackWithTimeout(setAiFeedback, { type: "success", message: `${provider} settings saved.` });
       setAiEditingProvider(null);
       setAiEditKey("");
-      // Refresh
-      const r2 = await authFetch(`${API}/api/v1/settings/ai`, { headers: authHeaders() });
-      if (r2.ok) { const d = await r2.json(); setAiProviders(d.providers || []); setAiActiveProvider(d.active_provider || ""); setAiEnabled(d.enabled); }
+      // Refresh (best-effort — a failed refresh shouldn't flag the save as failed)
+      const d = await api.get<{ providers?: typeof aiProviders; active_provider?: string; enabled: boolean }>("/api/v1/settings/ai").catch(() => null);
+      if (d) { setAiProviders(d.providers || []); setAiActiveProvider(d.active_provider || ""); setAiEnabled(d.enabled); }
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Unknown error";
       setFeedbackWithTimeout(setAiFeedback, { type: "error", message: `Save failed: ${msg}` });
@@ -833,9 +697,7 @@ export default function SettingsPage() {
     try {
       const body: Record<string, unknown> = { enabled };
       if (active) body.active_provider = active;
-      await authFetch(`${API}/api/v1/settings/ai`, {
-        method: "PUT", headers: authHeaders(), body: JSON.stringify(body),
-      });
+      await api.put("/api/v1/settings/ai", body);
       setAiEnabled(enabled);
       if (active) setAiActiveProvider(active);
       setFeedbackWithTimeout(setAiFeedback, { type: "success", message: enabled ? "AI analysis enabled." : "AI analysis disabled." });
@@ -847,11 +709,8 @@ export default function SettingsPage() {
     setAiModelsLoading(true);
     setAiModels([]);
     try {
-      const res = await authFetch(`${API}/api/v1/settings/ai/models?provider=${provider}`, { headers: authHeaders() });
-      if (res.ok) {
-        const data = await res.json();
-        setAiModels(data.models || []);
-      }
+      const data = await api.get<{ models?: string[] }>(`/api/v1/settings/ai/models?provider=${provider}`);
+      setAiModels(data.models || []);
     } catch { /* ignore */ }
     finally { setAiModelsLoading(false); }
   };
@@ -864,15 +723,8 @@ export default function SettingsPage() {
       if (aiEditEndpoint) body.endpoint = aiEditEndpoint;
       if (aiEditKey) body.api_key = aiEditKey;
       body.tls_insecure = aiEditTlsInsecure;
-      const res = await authFetch(`${API}/api/v1/settings/ai/test`, {
-        method: "POST", headers: authHeaders(), body: JSON.stringify(body),
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setAiTestResult({ success: data.success, status_code: data.status_code });
-      } else {
-        setAiTestResult({ success: false, status_code: "error" });
-      }
+      const data = await api.post<{ success: boolean; status_code: string }>("/api/v1/settings/ai/test", body);
+      setAiTestResult({ success: data.success, status_code: data.status_code });
     } catch {
       setAiTestResult({ success: false, status_code: "error" });
     } finally { setAiTesting(false); }
@@ -881,13 +733,7 @@ export default function SettingsPage() {
   const saveGeneral = async () => {
     setGeneralSaving(true); setGeneralFeedback(null);
     try {
-      const r = await authFetch(`${API}/api/v1/system/general`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({ hostname: sysHostname, domain: sysDomain, timezone: sysTimezone }),
-      });
-      if (!r.ok) throw new Error(await r.text());
-      const res = await r.json();
+      const res = await api.put<{ warning?: string }>("/api/v1/system/general", { hostname: sysHostname, domain: sysDomain, timezone: sysTimezone });
       const msg = res.warning ? `Saved (warning: ${res.warning})` : "Saved.";
       setGeneralFeedback({ type: res.warning ? "error" : "success", message: msg });
     } catch (e) { setGeneralFeedback({ type: "error", message: String(e) }); }
@@ -897,12 +743,7 @@ export default function SettingsPage() {
   const saveBanner = async () => {
     setBannerSaving(true); setBannerFeedback(null);
     try {
-      const r = await authFetch(`${API}/api/v1/system/banner`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({ login_banner: loginBanner, motd: motdBody }),
-      });
-      if (!r.ok) throw new Error(await r.text());
+      await api.put("/api/v1/system/banner", { login_banner: loginBanner, motd: motdBody });
       setBannerFeedback({ type: "success", message: "Saved." });
     } catch (e) { setBannerFeedback({ type: "error", message: String(e) }); }
     finally { setBannerSaving(false); }
@@ -911,12 +752,7 @@ export default function SettingsPage() {
   const saveSsh = async () => {
     setSshSaving(true); setSshFeedback(null);
     try {
-      const r = await authFetch(`${API}/api/v1/system/ssh`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({ enabled: sshEnabled, port: sshPort, password_auth: sshPasswordAuth, permit_root_login: sshPermitRoot }),
-      });
-      if (!r.ok) throw new Error(await r.text());
+      await api.put("/api/v1/system/ssh", { enabled: sshEnabled, port: sshPort, password_auth: sshPasswordAuth, permit_root_login: sshPermitRoot });
       setSshFeedback({ type: "success", message: `Saved. sshd reloading${sshPort !== 22 ? ` — reconnect on port ${sshPort}` : ""}.` });
     } catch (e) { setSshFeedback({ type: "error", message: String(e) }); }
     finally { setSshSaving(false); }
@@ -925,12 +761,7 @@ export default function SettingsPage() {
   const saveConsole = async () => {
     setConsoleSaving(true); setConsoleFeedback(null);
     try {
-      const r = await authFetch(`${API}/api/v1/system/console`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({ kind: consoleKind, baud: consoleBaud }),
-      });
-      if (!r.ok) throw new Error(await r.text());
+      await api.put("/api/v1/system/console", { kind: consoleKind, baud: consoleBaud });
       setConsoleFeedback({ type: "success", message: "Saved. Reboot required. Verify console access before rebooting." });
       setConsoleConfirm(false);
     } catch (e) { setConsoleFeedback({ type: "error", message: String(e) }); }
@@ -941,17 +772,11 @@ export default function SettingsPage() {
     setValkeySaving(true);
     setValkeyFeedback(null);
     try {
-      const res = await authFetch(`${API}/api/v1/settings/valkey`, {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify({
-          enabled: valkeyEnabled,
-          url: valkeyUrl,
-          retention_minutes: metricsRetention,
-        }),
+      const data = await api.put<{ status?: string }>("/api/v1/settings/valkey", {
+        enabled: valkeyEnabled,
+        url: valkeyUrl,
+        retention_minutes: metricsRetention,
       });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
       if (data.status) setValkeyStatus(data.status);
       setFeedbackWithTimeout(setValkeyFeedback, { type: "success", message: "Valkey settings saved." });
     } catch (err: unknown) {
@@ -2272,8 +2097,7 @@ function SystemActions() {
     setRebooting(true);
     setFeedback(null);
     try {
-      const res = await authFetch("/api/v1/updates/reboot", { method: "POST" });
-      const data = await res.json();
+      const data = await api.post<{ message?: string }>("/api/v1/updates/reboot");
       setFeedback({ type: "success", message: data.message || "System rebooting..." });
       setConfirmReboot(false);
     } catch {

--- a/aifw-ui/src/app/system/info/page.tsx
+++ b/aifw-ui/src/app/system/info/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { api } from "@/lib/api";
 
 interface SysInfo {
   hostname: string; domain: string;
@@ -11,11 +12,6 @@ interface SysInfo {
   mem_total_bytes: number; mem_used_bytes: number;
   disk_total_bytes: number; disk_used_bytes: number;
   temperatures_c: { core: number; celsius: number }[];
-}
-
-function authFetch(url: string): Promise<Response> {
-  const token = typeof window !== "undefined" ? (localStorage.getItem("aifw_token") || "") : "";
-  return fetch(url, { headers: { Authorization: `Bearer ${token}` } });
 }
 
 function fmtDuration(secs: number): string {
@@ -43,9 +39,7 @@ export default function SystemInfoPage() {
     async function tick() {
       if (document.visibilityState !== "visible") return;
       try {
-        const r = await authFetch("/api/v1/system/info");
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        const d = await r.json();
+        const d = await api.get<SysInfo>("/api/v1/system/info");
         if (!cancelled) { setInfo(d); setErr(null); }
       } catch (e) {
         if (!cancelled) setErr(String(e));

--- a/aifw-ui/src/app/threats/page.tsx
+++ b/aifw-ui/src/app/threats/page.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-
-const API = "";
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
+import { api, ApiError } from "@/lib/api";
 
 interface IdsAlert {
   id: string;
@@ -92,12 +86,17 @@ export default function ThreatsPage() {
   const fetchAlerts = useCallback(async () => {
     try {
       // Fetch latest alerts + AI-reviewed alerts (may overlap, deduplicate by id)
-      const [latestRes, reviewedRes] = await Promise.all([
-        fetch(`${API}/api/v1/ids/alerts?limit=200`, { headers: authHeaders() }),
-        fetch(`${API}/api/v1/ids/alerts?limit=300&classification=reviewed`, { headers: authHeaders() }),
+      // HTTP errors are treated as an empty list (as before); network errors surface below.
+      const emptyOnHttpError = (err: unknown): { data?: IdsAlert[] } => {
+        if (err instanceof ApiError) return {};
+        throw err;
+      };
+      const [latestJson, reviewedJson] = await Promise.all([
+        api.get<{ data?: IdsAlert[] }>("/api/v1/ids/alerts?limit=200").catch(emptyOnHttpError),
+        api.get<{ data?: IdsAlert[] }>("/api/v1/ids/alerts?limit=300&classification=reviewed").catch(emptyOnHttpError),
       ]);
-      const latest = latestRes.ok ? (await latestRes.json()).data || [] : [];
-      const reviewed = reviewedRes.ok ? (await reviewedRes.json()).data || [] : [];
+      const latest = latestJson.data || [];
+      const reviewed = reviewedJson.data || [];
       // Merge and deduplicate
       const byId = new Map<string, IdsAlert>();
       for (const a of [...reviewed, ...latest]) byId.set(a.id, a);
@@ -120,31 +119,25 @@ export default function ThreatsPage() {
   const runAiAnalysis = async () => {
     setAiRunning(true);
     try {
-      const res = await fetch(`${API}/api/v1/ai/analyze`, { method: "POST", headers: authHeaders() });
-      if (res.ok) {
-        const data = await res.json();
-        if (data.classified > 0) await fetchAlerts();
-      }
+      const data = await api.post<{ classified: number }>("/api/v1/ai/analyze");
+      if (data.classified > 0) await fetchAlerts();
     } catch { /* ignore */ }
     finally { setAiRunning(false); }
   };
 
   const fetchAiLog = async () => {
     try {
-      const res = await fetch(`${API}/api/v1/ai/audit-log?limit=30`, { headers: authHeaders() });
-      if (res.ok) {
-        const data = await res.json();
-        setAiLog(data.entries || []);
-      }
+      const data = await api.get<{ entries?: typeof aiLog }>("/api/v1/ai/audit-log?limit=30");
+      setAiLog(data.entries || []);
     } catch { /* ignore */ }
   };
 
   const handleClassify = async (id: string, classification: string) => {
     setClassifying(id);
     try {
-      await fetch(`${API}/api/v1/ids/alerts/${id}/classify`, {
-        method: "PUT", headers: authHeaders(),
-        body: JSON.stringify({ classification, notes: noteText || null }),
+      await api.put(`/api/v1/ids/alerts/${id}/classify`, {
+        classification,
+        notes: noteText || null,
       });
       setNoteText("");
       await fetchAlerts();

--- a/aifw-ui/src/app/time/logs/page.tsx
+++ b/aifw-ui/src/app/time/logs/page.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
+import { api } from "@/lib/api";
 
 export default function TimeLogsPage() {
   const [logs, setLogs] = useState<string[]>([]);
@@ -19,9 +15,7 @@ export default function TimeLogsPage() {
     try {
       const params = new URLSearchParams({ lines: String(lines) });
       if (search) params.set("search", search);
-      const res = await fetch(`/api/v1/time/logs?${params}`, { headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.get<{ data?: string[] }>(`/api/v1/time/logs?${params}`);
       setLogs(data.data || []);
       setError(null);
     } catch (err) {

--- a/aifw-ui/src/app/time/page.tsx
+++ b/aifw-ui/src/app/time/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { api } from "@/lib/api";
 
 interface TimeConfig {
   enabled: boolean;
@@ -47,15 +48,6 @@ interface TimeStatus {
 
 interface NetInterface { name: string; }
 
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
-function authHeadersPlain(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { Authorization: `Bearer ${token}` };
-}
-
 const defaultConfig: TimeConfig = {
   enabled: false, log_level: "info",
   clock_discipline: true, clock_step_threshold_ms: 128, clock_panic_threshold_ms: 1000,
@@ -101,32 +93,27 @@ export default function TimeServicePage() {
 
   const fetchStatus = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/time/status", { headers: authHeadersPlain() });
-      if (res.ok) setStatus(await res.json());
+      setStatus(await api.get<TimeStatus>("/api/v1/time/status"));
     } catch { /* */ }
   }, []);
 
   const fetchConfig = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/time/config", { headers: authHeadersPlain() });
-      if (res.ok) setConfigRaw(await res.json());
+      setConfigRaw(await api.get<TimeConfig>("/api/v1/time/config"));
     } catch { /* */ }
   }, []);
 
   const fetchSources = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/time/sources", { headers: authHeadersPlain() });
-      if (res.ok) { const body = await res.json(); setSources(body.data || []); }
+      const body = await api.get<{ data?: NtpSource[] }>("/api/v1/time/sources");
+      setSources(body.data || []);
     } catch { /* */ }
   }, []);
 
   const fetchInterfaces = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/interfaces", { headers: authHeadersPlain() });
-      if (res.ok) {
-        const body = await res.json();
-        setInterfaces((body.data || []).map((i: NetInterface) => i.name).filter((n: string) => !n.startsWith("lo") && !n.startsWith("pflog")));
-      }
+      const body = await api.get<{ data?: NetInterface[] }>("/api/v1/interfaces");
+      setInterfaces((body.data || []).map((i: NetInterface) => i.name).filter((n: string) => !n.startsWith("lo") && !n.startsWith("pflog")));
     } catch { /* */ }
   }, []);
 
@@ -158,8 +145,7 @@ export default function TimeServicePage() {
     if (!validate()) return;
     setSaving(true);
     try {
-      const res = await fetch("/api/v1/time/config", { method: "PUT", headers: authHeaders(), body: JSON.stringify(config) });
-      const body = await res.json();
+      const body = await api.put<{ message?: string }>("/api/v1/time/config", config);
       setActionMsg(body.message || "Saved");
       setIsDirty(false);
     } catch { setActionMsg("Save failed"); }
@@ -171,9 +157,8 @@ export default function TimeServicePage() {
     if (!validate()) return;
     setApplying(true);
     try {
-      await fetch("/api/v1/time/config", { method: "PUT", headers: authHeaders(), body: JSON.stringify(config) });
-      const res = await fetch("/api/v1/time/apply", { method: "POST", headers: authHeaders() });
-      const body = await res.json();
+      await api.put("/api/v1/time/config", config);
+      const body = await api.post<{ message?: string }>("/api/v1/time/apply");
       setActionMsg(body.message || "Applied");
       setIsDirty(false);
       fetchStatus();
@@ -185,8 +170,7 @@ export default function TimeServicePage() {
   const serviceAction = async (action: string) => {
     setActionLoading(action);
     try {
-      const res = await fetch(`/api/v1/time/${action}`, { method: "POST", headers: authHeaders() });
-      const body = await res.json();
+      const body = await api.post<{ message?: string }>(`/api/v1/time/${action}`);
       setActionMsg(body.message || action);
       fetchStatus();
     } catch { setActionMsg(`${action} failed`); }
@@ -199,10 +183,7 @@ export default function TimeServicePage() {
     const pollErr = validatePollRange(newMinPoll, newMaxPoll);
     if (pollErr) { setErrors({ ...errors, newSource: pollErr }); return; }
     try {
-      await fetch("/api/v1/time/sources", {
-        method: "POST", headers: authHeaders(),
-        body: JSON.stringify({ address: newAddr, nts: newNts, min_poll: newMinPoll, max_poll: newMaxPoll, enabled: true }),
-      });
+      await api.post("/api/v1/time/sources", { address: newAddr, nts: newNts, min_poll: newMinPoll, max_poll: newMaxPoll, enabled: true });
       setNewAddr(""); setNewNts(false); setNewMinPoll(4); setNewMaxPoll(10);
       setErrors({});
       fetchSources();
@@ -210,15 +191,12 @@ export default function TimeServicePage() {
   };
 
   const deleteSource = async (id: string) => {
-    await fetch(`/api/v1/time/sources/${id}`, { method: "DELETE", headers: authHeaders() });
+    await api.delete(`/api/v1/time/sources/${id}`).catch(() => {});
     fetchSources();
   };
 
   const toggleSourceEnabled = async (s: NtpSource) => {
-    await fetch(`/api/v1/time/sources/${s.id}`, {
-      method: "PUT", headers: authHeaders(),
-      body: JSON.stringify({ address: s.address, nts: s.nts, min_poll: s.min_poll, max_poll: s.max_poll, enabled: !s.enabled }),
-    });
+    await api.put(`/api/v1/time/sources/${s.id}`, { address: s.address, nts: s.nts, min_poll: s.min_poll, max_poll: s.max_poll, enabled: !s.enabled }).catch(() => {});
     fetchSources();
   };
 

--- a/aifw-ui/src/app/updates/page.tsx
+++ b/aifw-ui/src/app/updates/page.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
-}
+import { api } from "@/lib/api";
 
 interface UpdateStatus {
   os_version: string;
@@ -132,9 +128,7 @@ export default function UpdatesPage() {
 
   const fetchStatus = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/updates/status", { headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data: UpdateStatus = await res.json();
+      const data = await api.get<UpdateStatus>("/api/v1/updates/status");
       setStatus(data);
       if (data.checking) setChecking(true);
       else setChecking(false);
@@ -147,9 +141,7 @@ export default function UpdatesPage() {
 
   const fetchSchedule = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/updates/schedule", { headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data: MaintenanceWindow = await res.json();
+      const data = await api.get<MaintenanceWindow>("/api/v1/updates/schedule");
       setSchedule(data);
     } catch {
       // use defaults
@@ -158,9 +150,7 @@ export default function UpdatesPage() {
 
   const fetchAifwStatus = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/updates/aifw/status", { headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data: AifwUpdateInfo = await res.json();
+      const data = await api.get<AifwUpdateInfo>("/api/v1/updates/aifw/status");
       setAifwInfo(data);
     } catch {
       // silent
@@ -169,9 +159,7 @@ export default function UpdatesPage() {
 
   const fetchHistory = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/updates/history", { headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.get<{ data?: UpdateHistoryEntry[] }>("/api/v1/updates/history");
       setHistory((data.data || []).slice(0, 50));
     } catch {
       // silent
@@ -197,9 +185,7 @@ export default function UpdatesPage() {
   const handleCheck = async () => {
     setChecking(true);
     try {
-      const res = await fetch("/api/v1/updates/check", { method: "POST", headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.post<{ message?: string }>("/api/v1/updates/check");
       showFeedback("success", data.message || "Update check complete");
       setChecking(false);
       fetchStatus();
@@ -213,9 +199,7 @@ export default function UpdatesPage() {
   const handleInstall = async () => {
     setInstalling(true);
     try {
-      const res = await fetch("/api/v1/updates/install", { method: "POST", headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.post<{ message?: string }>("/api/v1/updates/install");
       showFeedback("success", data.message || "Updates installed");
       setInstalling(false);
       fetchStatus();
@@ -230,9 +214,7 @@ export default function UpdatesPage() {
     setRebooting(true);
     setRebootConfirm(false);
     try {
-      const res = await fetch("/api/v1/updates/reboot", { method: "POST", headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.post<{ message?: string }>("/api/v1/updates/reboot");
       showFeedback("success", data.message || "Reboot scheduled");
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to schedule reboot");
@@ -244,12 +226,7 @@ export default function UpdatesPage() {
   const handleSaveSchedule = async () => {
     setSavingSchedule(true);
     try {
-      const res = await fetch("/api/v1/updates/schedule", {
-        method: "PUT",
-        headers: authHeaders(),
-        body: JSON.stringify(schedule),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.put("/api/v1/updates/schedule", schedule);
       showFeedback("success", "Maintenance window saved");
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Failed to save schedule");
@@ -261,9 +238,7 @@ export default function UpdatesPage() {
   const handleAifwCheck = async () => {
     setAifwChecking(true);
     try {
-      const res = await fetch("/api/v1/updates/aifw/check", { method: "POST", headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data: AifwUpdateInfo = await res.json();
+      const data = await api.post<AifwUpdateInfo>("/api/v1/updates/aifw/check");
       setAifwInfo(data);
       showFeedback("success", data.update_available
         ? `AiFw v${data.latest_version} is available`
@@ -279,12 +254,7 @@ export default function UpdatesPage() {
     // Optimistic — reflect the toggle immediately, revert on failure.
     setAifwInfo((prev) => (prev ? { ...prev, include_prereleases: enabled } : prev));
     try {
-      const res = await fetch("/api/v1/updates/aifw/prerelease", {
-        method: "POST",
-        headers: { ...authHeaders(), "Content-Type": "application/json" },
-        body: JSON.stringify({ enabled }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.post("/api/v1/updates/aifw/prerelease", { enabled });
       showFeedback("success", `Pre-release channel ${enabled ? "enabled" : "disabled"}`);
       // Re-check against the new channel so the available version updates.
       await handleAifwCheck();
@@ -329,17 +299,15 @@ export default function UpdatesPage() {
     while (Date.now() - pollStart < 120000) {
       await new Promise((r) => setTimeout(r, 2000));
       try {
-        const probe = await fetch("/api/v1/status", {
-          headers: authHeaders(),
+        await api.get("/api/v1/status", {
+          noAuthRedirect: true,
           signal: AbortSignal.timeout(3000),
         });
-        if (probe.ok) {
-          clearInterval(countdownInterval);
-          setRestartCountdown(0);
-          await new Promise((r) => setTimeout(r, 500));
-          window.location.reload();
-          return;
-        }
+        clearInterval(countdownInterval);
+        setRestartCountdown(0);
+        await new Promise((r) => setTimeout(r, 500));
+        window.location.reload();
+        return;
       } catch {
         // API not back yet — keep polling
       }
@@ -351,9 +319,7 @@ export default function UpdatesPage() {
   const handleAifwInstall = async () => {
     setAifwInstalling(true);
     try {
-      const res = await fetch("/api/v1/updates/aifw/install", { method: "POST", headers: authHeaders() });
-      if (!res.ok) throw new Error((await res.text().catch(() => "")) || `HTTP ${res.status}`);
-      const data: UpdateInstallResponse = await res.json();
+      const data = await api.post<UpdateInstallResponse>("/api/v1/updates/aifw/install");
       setAifwInstalling(false);
 
       if (data.restart_required) {
@@ -380,9 +346,7 @@ export default function UpdatesPage() {
   const handleAifwRollback = async () => {
     setAifwRollingBack(true);
     try {
-      const res = await fetch("/api/v1/updates/aifw/rollback", { method: "POST", headers: authHeaders() });
-      if (!res.ok) throw new Error((await res.text().catch(() => "")) || `HTTP ${res.status}`);
-      const data: UpdateInstallResponse = await res.json();
+      const data = await api.post<UpdateInstallResponse>("/api/v1/updates/aifw/rollback");
       setAifwRollingBack(false);
 
       if (data.restart_required) {
@@ -406,9 +370,7 @@ export default function UpdatesPage() {
   // and switches to the bounce overlay.
   const handleConfirmRestart = async () => {
     try {
-      const res = await fetch("/api/v1/updates/aifw/restart", { method: "POST", headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      await res.json();
+      await api.post("/api/v1/updates/aifw/restart");
       setRestartPrompt(null);
       watchRestart();
     } catch (err) {
@@ -421,9 +383,7 @@ export default function UpdatesPage() {
   // overlay countdown is longer than the service-restart path.
   const handleConfirmReboot = async () => {
     try {
-      const res = await fetch("/api/v1/updates/aifw/reboot", { method: "POST", headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      await res.json();
+      await api.post("/api/v1/updates/aifw/reboot");
       setRestartPrompt(null);
       setAifwRebooting(true);
     } catch (err) {

--- a/aifw-ui/src/app/users/page.tsx
+++ b/aifw-ui/src/app/users/page.tsx
@@ -3,8 +3,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { PERMISSION_CATEGORIES } from "@/lib/permissions";
-
-const API = "";
+import { api } from "@/lib/api";
 
 interface User {
   id: string;
@@ -39,11 +38,6 @@ interface AuditEntry {
 interface Feedback {
   type: "success" | "error";
   message: string;
-}
-
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token") || "";
-  return { "Content-Type": "application/json", Authorization: `Bearer ${token}` };
 }
 
 function getCurrentUserId(): string | null {
@@ -238,9 +232,7 @@ export default function UsersPage() {
 
   const fetchUsers = useCallback(async () => {
     try {
-      const res = await fetch(`${API}/api/v1/auth/users`, { headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.get<{ data?: User[] }>("/api/v1/auth/users");
       setUsers(data.data || []);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Unknown error";
@@ -253,9 +245,7 @@ export default function UsersPage() {
   const fetchAudit = useCallback(async () => {
     setAuditLoading(true);
     try {
-      const res = await fetch(`${API}/api/v1/auth/audit`, { headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await api.get<{ data?: AuditEntry[] }>("/api/v1/auth/audit");
       setAuditEntries(data.data || []);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Unknown error";
@@ -267,9 +257,7 @@ export default function UsersPage() {
 
   const fetchRoles = useCallback(async () => {
     try {
-      const res = await fetch(`${API}/api/v1/auth/roles`, { headers: authHeaders() });
-      if (!res.ok) return;
-      const data = await res.json();
+      const data = await api.get<{ roles?: Role[] }>("/api/v1/auth/roles");
       setRoles(data.roles || []);
     } catch { /* ignore */ }
   }, []);
@@ -287,11 +275,7 @@ export default function UsersPage() {
     if (!newUsername.trim() || !newPassword.trim()) return;
     setAdding(true);
     try {
-      const res = await fetch(`${API}/api/v1/auth/users`, {
-        method: "POST", headers: authHeaders(),
-        body: JSON.stringify({ username: newUsername.trim(), password: newPassword, role: newRole }),
-      });
-      if (!res.ok) { const b = await res.json().catch(() => ({})); throw new Error(b.error || b.message || `HTTP ${res.status}`); }
+      await api.post("/api/v1/auth/users", { username: newUsername.trim(), password: newPassword, role: newRole });
       setFeedbackWithTimeout({ type: "success", message: `User "${newUsername.trim()}" created.` });
       setNewUsername(""); setNewPassword(""); setNewRole("viewer"); setShowAddForm(false);
       await fetchUsers();
@@ -309,8 +293,7 @@ export default function UsersPage() {
     try {
       const body: Record<string, unknown> = { username: editUsername.trim(), role: editRole, enabled: editEnabled };
       if (editPassword.trim()) body.password = editPassword;
-      const res = await fetch(`${API}/api/v1/auth/users/${editingId}`, { method: "PUT", headers: authHeaders(), body: JSON.stringify(body) });
-      if (!res.ok) { const d = await res.json().catch(() => ({})); throw new Error(d.error || d.message || `HTTP ${res.status}`); }
+      await api.put(`/api/v1/auth/users/${editingId}`, body);
       setFeedbackWithTimeout({ type: "success", message: "User updated." }); setEditingId(null); await fetchUsers();
     } catch (err: unknown) {
       setFeedbackWithTimeout({ type: "error", message: `Failed: ${err instanceof Error ? err.message : "Unknown"}` });
@@ -319,16 +302,14 @@ export default function UsersPage() {
 
   const handleToggleEnabled = async (u: User) => {
     try {
-      const res = await fetch(`${API}/api/v1/auth/users/${u.id}`, { method: "PUT", headers: authHeaders(), body: JSON.stringify({ enabled: !u.enabled }) });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.put(`/api/v1/auth/users/${u.id}`, { enabled: !u.enabled });
       setFeedbackWithTimeout({ type: "success", message: `${u.username} ${!u.enabled ? "enabled" : "disabled"}.` }); await fetchUsers();
     } catch (err: unknown) { setFeedbackWithTimeout({ type: "error", message: `Failed: ${err instanceof Error ? err.message : "Unknown"}` }); }
   };
 
   const handleDelete = async (u: User) => {
     try {
-      const res = await fetch(`${API}/api/v1/auth/users/${u.id}`, { method: "DELETE", headers: authHeaders() });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.delete(`/api/v1/auth/users/${u.id}`);
       setFeedbackWithTimeout({ type: "success", message: `User "${u.username}" deleted.` }); setDeletingId(null); await fetchUsers();
     } catch (err: unknown) { setFeedbackWithTimeout({ type: "error", message: `Failed: ${err instanceof Error ? err.message : "Unknown"}` }); }
   };
@@ -338,11 +319,7 @@ export default function UsersPage() {
     if (!newRoleName.trim()) return;
     setRoleSaving(true);
     try {
-      const res = await fetch(`${API}/api/v1/auth/roles`, {
-        method: "POST", headers: authHeaders(),
-        body: JSON.stringify({ name: newRoleName.trim(), permissions: Array.from(newRolePerms), description: newRoleDesc.trim() || null }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await api.post("/api/v1/auth/roles", { name: newRoleName.trim(), permissions: Array.from(newRolePerms), description: newRoleDesc.trim() || null });
       setFeedbackWithTimeout({ type: "success", message: `Role "${newRoleName.trim()}" created` });
       setShowRoleForm(false); setNewRoleName(""); setNewRoleDesc(""); setNewRolePerms(new Set()); await fetchRoles();
     } catch (err: unknown) { setFeedbackWithTimeout({ type: "error", message: `Failed: ${err instanceof Error ? err.message : "Unknown"}` }); }
@@ -357,11 +334,7 @@ export default function UsersPage() {
     if (!editingRoleId) return;
     setRoleSaving(true);
     try {
-      const res = await fetch(`${API}/api/v1/auth/roles/${editingRoleId}`, {
-        method: "PUT", headers: authHeaders(),
-        body: JSON.stringify({ name: editRoleName.trim() || undefined, permissions: Array.from(editRolePerms), description: editRoleDesc.trim() || null }),
-      });
-      if (!res.ok) { const b = await res.json().catch(() => ({})); throw new Error(b.message || `HTTP ${res.status}`); }
+      await api.put(`/api/v1/auth/roles/${editingRoleId}`, { name: editRoleName.trim() || undefined, permissions: Array.from(editRolePerms), description: editRoleDesc.trim() || null });
       setFeedbackWithTimeout({ type: "success", message: "Role updated" }); setEditingRoleId(null); await fetchRoles();
     } catch (err: unknown) { setFeedbackWithTimeout({ type: "error", message: `Failed: ${err instanceof Error ? err.message : "Unknown"}` }); }
     finally { setRoleSaving(false); }
@@ -371,8 +344,7 @@ export default function UsersPage() {
     if (!confirm(`Delete role "${r.name}"? Users assigned to this role will need to be reassigned.`)) return;
     setDeletingRoleId(r.id);
     try {
-      const res = await fetch(`${API}/api/v1/auth/roles/${r.id}`, { method: "DELETE", headers: authHeaders() });
-      if (!res.ok) { const b = await res.json().catch(() => ({})); throw new Error(b.message || `HTTP ${res.status}`); }
+      await api.delete(`/api/v1/auth/roles/${r.id}`);
       setFeedbackWithTimeout({ type: "success", message: `Role "${r.name}" deleted` }); await fetchRoles();
     } catch (err: unknown) { setFeedbackWithTimeout({ type: "error", message: `Failed: ${err instanceof Error ? err.message : "Unknown"}` }); }
     finally { setDeletingRoleId(null); }

--- a/aifw-ui/src/app/vlans/page.tsx
+++ b/aifw-ui/src/app/vlans/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { api } from "@/lib/api";
 import { validateCIDR, isValidIP, isValidCIDR } from "@/lib/validate";
 
 type FieldErrors = Partial<Record<
@@ -48,14 +49,6 @@ const emptyForm: VlanForm = {
   description: "",
 };
 
-function authHeaders(): HeadersInit {
-  const token = localStorage.getItem("aifw_token");
-  return {
-    "Content-Type": "application/json",
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  };
-}
-
 export default function VlansPage() {
   const [vlans, setVlans] = useState<VlanConfig[]>([]);
   const [physicalInterfaces, setPhysicalInterfaces] = useState<string[]>([]);
@@ -69,9 +62,7 @@ export default function VlansPage() {
 
   const fetchVlans = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/vlans", { headers: authHeaders() });
-      if (!res.ok) throw new Error("Failed to fetch VLANs");
-      const json = await res.json();
+      const json = await api.get<{ data?: VlanConfig[] }>("/api/v1/vlans");
       setVlans(json.data || []);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to fetch VLANs");
@@ -80,11 +71,7 @@ export default function VlansPage() {
 
   const fetchInterfaces = useCallback(async () => {
     try {
-      const res = await fetch("/api/v1/interfaces/detailed", {
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error("Failed to fetch interfaces");
-      const json = await res.json();
+      const json = await api.get<{ data?: InterfaceInfo[] }>("/api/v1/interfaces/detailed");
       const physical = (json.data || [])
         .filter((i: InterfaceInfo) => !i.is_vlan && !i.name.startsWith("lo"))
         .map((i: InterfaceInfo) => i.name);
@@ -197,19 +184,10 @@ export default function VlansPage() {
     }
 
     try {
-      const url = editingId ? `/api/v1/vlans/${editingId}` : "/api/v1/vlans";
-      const method = editingId ? "PUT" : "POST";
-      const res = await fetch(url, {
-        method,
-        headers: authHeaders(),
-        body: JSON.stringify(body),
-      });
-      if (!res.ok) {
-        const errBody = await res.json().catch(() => null);
-        throw new Error(
-          errBody?.message ||
-            `Failed to ${editingId ? "update" : "create"} VLAN`
-        );
+      if (editingId) {
+        await api.put(`/api/v1/vlans/${editingId}`, body);
+      } else {
+        await api.post("/api/v1/vlans", body);
       }
       closeModal();
       await fetchVlans();
@@ -224,11 +202,7 @@ export default function VlansPage() {
     if (!confirm("Delete this VLAN? This action cannot be undone.")) return;
     setError(null);
     try {
-      const res = await fetch(`/api/v1/vlans/${id}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-      });
-      if (!res.ok) throw new Error("Failed to delete VLAN");
+      await api.delete(`/api/v1/vlans/${id}`);
       await fetchVlans();
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Delete failed");

--- a/aifw-ui/src/app/vpn/page.tsx
+++ b/aifw-ui/src/app/vpn/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useWs } from "@/context/WsContext";
+import { api } from "@/lib/api";
 import Help, { HelpBanner } from "./Help";
 
 /* ────────────────────────── Types ────────────────────────── */
@@ -60,23 +61,6 @@ function fmtDuration(secs: number): string {
   if (secs < 60) return `${secs}s ago`;
   if (secs < 3600) return `${Math.floor(secs/60)}m ago`;
   return `${Math.floor(secs/3600)}h ${Math.floor((secs%3600)/60)}m ago`;
-}
-
-function authHeaders(): Record<string, string> {
-  const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
-  return {
-    "Content-Type": "application/json",
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  };
-}
-
-async function apiFetch<T>(url: string, opts?: RequestInit): Promise<T> {
-  const res = await fetch(url, { ...opts, headers: { ...authHeaders(), ...opts?.headers } });
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(body || `Request failed (${res.status})`);
-  }
-  return res.json();
 }
 
 /* ────────────────────────── Default form values ────────────────────────── */
@@ -244,7 +228,7 @@ export default function VpnPage() {
 
   const fetchTunnels = useCallback(async () => {
     try {
-      const res = await apiFetch<{ data: WgTunnel[] }>("/api/v1/vpn/wg");
+      const res = await api.get<{ data: WgTunnel[] }>("/api/v1/vpn/wg");
       setTunnels(res.data);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load WireGuard tunnels");
@@ -255,7 +239,7 @@ export default function VpnPage() {
 
   const fetchPeers = useCallback(async (tunnelId: string) => {
     try {
-      const res = await apiFetch<{ data: WgPeer[] }>(`/api/v1/vpn/wg/${tunnelId}/peers`);
+      const res = await api.get<{ data: WgPeer[] }>(`/api/v1/vpn/wg/${tunnelId}/peers`);
       setPeersByTunnel((prev) => ({ ...prev, [tunnelId]: res.data }));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load peers");
@@ -264,7 +248,7 @@ export default function VpnPage() {
 
   const fetchIpsec = useCallback(async () => {
     try {
-      const res = await apiFetch<{ data: IpsecSa[] }>("/api/v1/vpn/ipsec");
+      const res = await api.get<{ data: IpsecSa[] }>("/api/v1/vpn/ipsec");
       setIpsecSas(res.data);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load IPsec SAs");
@@ -277,7 +261,7 @@ export default function VpnPage() {
     queueMicrotask(() => {
       fetchTunnels();
       fetchIpsec();
-      apiFetch<{ data: { name: string; role?: string }[] }>("/api/v1/interfaces")
+      api.get<{ data: { name: string; role?: string }[] }>("/api/v1/interfaces")
         .then(res => setInterfaces(res.data || []))
         .catch(() => {});
     });
@@ -320,15 +304,9 @@ export default function VpnPage() {
       }
 
       if (editingWgId) {
-        await apiFetch(`/api/v1/vpn/wg/${editingWgId}`, {
-          method: "PUT",
-          body: JSON.stringify(body),
-        });
+        await api.put(`/api/v1/vpn/wg/${editingWgId}`, body);
       } else {
-        await apiFetch("/api/v1/vpn/wg", {
-          method: "POST",
-          body: JSON.stringify(body),
-        });
+        await api.post("/api/v1/vpn/wg", body);
       }
       setWgForm(defaultWgForm);
       setEditingWgId(null);
@@ -359,7 +337,7 @@ export default function VpnPage() {
   const handleDeleteWg = async (id: string) => {
     setError(null);
     try {
-      await apiFetch(`/api/v1/vpn/wg/${id}`, { method: "DELETE" });
+      await api.delete(`/api/v1/vpn/wg/${id}`);
       setTunnels((prev) => prev.filter((t) => t.id !== id));
       setPeersByTunnel((prev) => {
         const next = { ...prev };
@@ -381,7 +359,7 @@ export default function VpnPage() {
   const handleStartTunnel = async (id: string) => {
     setError(null);
     try {
-      await apiFetch(`/api/v1/vpn/wg/${id}/start`, { method: "POST" });
+      await api.post(`/api/v1/vpn/wg/${id}/start`);
       await fetchTunnels();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to start tunnel");
@@ -391,7 +369,7 @@ export default function VpnPage() {
   const handleStopTunnel = async (id: string) => {
     setError(null);
     try {
-      await apiFetch(`/api/v1/vpn/wg/${id}/stop`, { method: "POST" });
+      await api.post(`/api/v1/vpn/wg/${id}/stop`);
       await fetchTunnels();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to stop tunnel");
@@ -400,7 +378,7 @@ export default function VpnPage() {
 
   const handleAutoAssignIp = async (tunnelId: string) => {
     try {
-      const res = await apiFetch<{ next_ip: string }>(`/api/v1/vpn/wg/${tunnelId}/peers/next-ip`);
+      const res = await api.get<{ next_ip: string }>(`/api/v1/vpn/wg/${tunnelId}/peers/next-ip`);
       setPeerForm((f) => ({ ...f, allowed_ips: res.next_ip }));
     } catch {
       setError("No free IPs in tunnel subnet");
@@ -429,10 +407,7 @@ export default function VpnPage() {
       if (peerForm.preshared_key.trim()) {
         body.preshared_key = peerForm.preshared_key.trim();
       }
-      await apiFetch(`/api/v1/vpn/wg/${tunnelId}/peers`, {
-        method: "POST",
-        body: JSON.stringify(body),
-      });
+      await api.post(`/api/v1/vpn/wg/${tunnelId}/peers`, body);
       setPeerForm(defaultPeerForm);
       setShowPeerForm(null);
       await fetchPeers(tunnelId);
@@ -445,7 +420,7 @@ export default function VpnPage() {
 
   const handleShowConfig = async (tunnelId: string, peer: WgPeer) => {
     try {
-      const res = await apiFetch<{ full_tunnel: string; split_tunnel: string }>(`/api/v1/vpn/wg/${tunnelId}/peers/${peer.id}/config`);
+      const res = await api.get<{ full_tunnel: string; split_tunnel: string }>(`/api/v1/vpn/wg/${tunnelId}/peers/${peer.id}/config`);
       setConfigModal({ peerName: peer.name || peer.public_key.slice(0, 12), fullTunnel: res.full_tunnel, splitTunnel: res.split_tunnel });
       setConfigTab("full");
       setConfigCopied(false);
@@ -466,7 +441,7 @@ export default function VpnPage() {
   const handleDeletePeer = async (tunnelId: string, peerId: string) => {
     setError(null);
     try {
-      await apiFetch(`/api/v1/vpn/wg/${tunnelId}/peers/${peerId}`, { method: "DELETE" });
+      await api.delete(`/api/v1/vpn/wg/${tunnelId}/peers/${peerId}`);
       setPeersByTunnel((prev) => ({
         ...prev,
         [tunnelId]: (prev[tunnelId] || []).filter((p) => p.id !== peerId),
@@ -484,15 +459,12 @@ export default function VpnPage() {
     setIpsecSubmitting(true);
     setError(null);
     try {
-      await apiFetch("/api/v1/vpn/ipsec", {
-        method: "POST",
-        body: JSON.stringify({
-          name: ipsecForm.name.trim(),
-          local_addr: ipsecForm.local_addr.trim(),
-          remote_addr: ipsecForm.remote_addr.trim(),
-          protocol: ipsecForm.protocol,
-          mode: ipsecForm.mode,
-        }),
+      await api.post("/api/v1/vpn/ipsec", {
+        name: ipsecForm.name.trim(),
+        local_addr: ipsecForm.local_addr.trim(),
+        remote_addr: ipsecForm.remote_addr.trim(),
+        protocol: ipsecForm.protocol,
+        mode: ipsecForm.mode,
       });
       setIpsecForm(defaultIpsecForm);
       setShowIpsecForm(false);
@@ -507,7 +479,7 @@ export default function VpnPage() {
   const handleDeleteIpsec = async (id: string) => {
     setError(null);
     try {
-      await apiFetch(`/api/v1/vpn/ipsec/${id}`, { method: "DELETE" });
+      await api.delete(`/api/v1/vpn/ipsec/${id}`);
       setIpsecSas((prev) => prev.filter((sa) => sa.id !== id));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to delete IPsec SA");

--- a/aifw-ui/src/components/PendingBanner.tsx
+++ b/aifw-ui/src/components/PendingBanner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { getWsTicket } from "@/lib/api";
+import { api, getWsTicket } from "@/lib/api";
 
 interface PendingState {
   firewall: boolean;
@@ -22,10 +22,7 @@ export default function PendingBanner() {
     const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
     if (!token) return;
     try {
-      const res = await fetch("/api/v1/pending", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (res.ok) setPending(await res.json());
+      setPending(await api.get<PendingState>("/api/v1/pending"));
     } catch { /* silent */ }
   }, []);
 
@@ -77,21 +74,12 @@ export default function PendingBanner() {
   const applyChanges = async () => {
     setApplying(true);
     setFeedback(null);
-    const token = localStorage.getItem("aifw_token") || "";
     try {
       if (pending.firewall || pending.nat) {
-        const res = await fetch("/api/v1/reload", {
-          method: "POST",
-          headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-        });
-        if (!res.ok) throw new Error(`Reload failed: HTTP ${res.status}`);
+        await api.post("/api/v1/reload");
       }
       if (pending.dns) {
-        const res = await fetch("/api/v1/dns/resolver/apply", {
-          method: "POST",
-          headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-        });
-        if (!res.ok) throw new Error(`DNS apply failed: HTTP ${res.status}`);
+        await api.post("/api/v1/dns/resolver/apply");
       }
       setPending({ firewall: false, nat: false, dns: false });
       setFeedback("Changes applied successfully");

--- a/aifw-ui/src/components/Sidebar.tsx
+++ b/aifw-ui/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useState, useEffect } from "react";
 import { useAuth } from "@/context/AuthContext";
+import { api } from "@/lib/api";
 
 interface NavChild { href: string; label: string; permission?: string; }
 interface NavItem {
@@ -188,12 +189,12 @@ export default function Sidebar({ onClose, width }: { onClose?: () => void; widt
   useEffect(() => {
     const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
     if (!token) return;
-    fetch("/api/v1/interfaces", { headers: { Authorization: `Bearer ${token}` } })
-      .then((r) => r.ok ? r.json() : { data: [] })
+    api
+      .get<{ data?: { name: string; role?: string }[] }>("/api/v1/interfaces")
       .then((d) => {
         const ifaces = (d.data || [])
-          .filter((i: { name: string }) => !i.name.startsWith("lo") && !i.name.startsWith("pflog"))
-          .map((i: { name: string; role?: string }) => ({ name: i.name, role: i.role }));
+          .filter((i) => !i.name.startsWith("lo") && !i.name.startsWith("pflog"))
+          .map((i) => ({ name: i.name, role: i.role }));
         setInterfaces(ifaces);
       })
       .catch(() => {});

--- a/aifw-ui/src/lib/api.ts
+++ b/aifw-ui/src/lib/api.ts
@@ -1,24 +1,132 @@
 const API_BASE = "";
+const TOKEN_KEY = "aifw_token";
 
-export async function fetchApi<T>(path: string, options?: RequestInit): Promise<T> {
-  const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
+/// Error thrown for any non-2xx response. `message` carries the
+/// server-provided error/message body field when one exists, so call
+/// sites can show it directly: `err instanceof Error ? err.message : ...`.
+export class ApiError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+export interface RequestOptions {
+  /// Skip the automatic token-clear + redirect to /login on 401.
+  /// Needed by the login/TOTP flow, where 401 means "bad credentials".
+  noAuthRedirect?: boolean;
+  /// Extra headers merged over the defaults.
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+}
+
+function authToken(): string | null {
+  return typeof window !== "undefined" ? localStorage.getItem(TOKEN_KEY) : null;
+}
+
+/// Pull a human-readable message out of an error response. The API mostly
+/// returns `{ "error": ... }` or `{ "message": ... }` JSON bodies.
+async function errorMessage(res: Response): Promise<string> {
+  try {
+    const body = await res.clone().json();
+    if (body && typeof body === "object") {
+      const m = (body as Record<string, unknown>).error ?? (body as Record<string, unknown>).message;
+      if (typeof m === "string" && m) return m;
+    }
+  } catch {
+    /* not JSON */
+  }
+  try {
+    const text = await res.text();
+    if (text && text.length <= 512) return text;
+  } catch {
+    /* unreadable body */
+  }
+  return `API ${res.status}: ${res.statusText || "request failed"}`;
+}
+
+/// Core request: attaches the Bearer token, JSON-encodes plain bodies
+/// (FormData passes through untouched so the browser sets the multipart
+/// boundary), centralizes the 401 → /login redirect, and throws ApiError
+/// with the server's error message on any non-2xx status.
+async function request(
+  method: string,
+  path: string,
+  body?: unknown,
+  opts: RequestOptions = {},
+): Promise<Response> {
+  const token = authToken();
+  const isForm = typeof FormData !== "undefined" && body instanceof FormData;
+  // Strings are passed through as-is (already-serialized JSON from legacy
+  // fetchApi callers); FormData passes through so the browser sets the
+  // multipart boundary; anything else is JSON-encoded.
+  const rawBody: BodyInit | undefined = isForm
+    ? (body as FormData)
+    : typeof body === "string"
+      ? body
+      : body !== undefined
+        ? JSON.stringify(body)
+        : undefined;
   const headers: Record<string, string> = {
-    "Content-Type": "application/json",
+    ...(body !== undefined && !isForm ? { "Content-Type": "application/json" } : {}),
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(opts.headers ?? {}),
   };
 
-  const res = await fetch(`${API_BASE}${path}`, { ...options, headers });
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers,
+    body: rawBody,
+    signal: opts.signal,
+  });
+
   if (!res.ok) {
-    if (res.status === 401 && typeof window !== "undefined") {
-      localStorage.removeItem("aifw_token");
+    if (res.status === 401 && !opts.noAuthRedirect && typeof window !== "undefined") {
+      localStorage.removeItem(TOKEN_KEY);
       window.location.href = "/login";
     }
-    throw new Error(`API ${res.status}: ${res.statusText}`);
+    throw new ApiError(res.status, await errorMessage(res));
   }
-  return res.json();
+  return res;
+}
+
+/// Parse a JSON body, tolerating empty responses (204 / empty 200).
+async function parseJson<T>(res: Response): Promise<T> {
+  const text = await res.text();
+  return (text ? JSON.parse(text) : undefined) as T;
+}
+
+/// Back-compat JSON wrapper used by the named `api.*` methods below.
+/// Prefer the `api.get/post/...` verbs for new code (#429).
+export async function fetchApi<T>(path: string, options?: RequestInit): Promise<T> {
+  const res = await request(options?.method ?? "GET", path, options?.body ?? undefined, {});
+  return parseJson<T>(res);
 }
 
 export const api = {
+  // ---- Generic verbs (#429): the one true way to call the API. ----
+  get: <T>(path: string, opts?: RequestOptions) =>
+    request("GET", path, undefined, opts).then((r) => parseJson<T>(r)),
+  post: <T>(path: string, body?: unknown, opts?: RequestOptions) =>
+    request("POST", path, body, opts).then((r) => parseJson<T>(r)),
+  put: <T>(path: string, body?: unknown, opts?: RequestOptions) =>
+    request("PUT", path, body, opts).then((r) => parseJson<T>(r)),
+  patch: <T>(path: string, body?: unknown, opts?: RequestOptions) =>
+    request("PATCH", path, body, opts).then((r) => parseJson<T>(r)),
+  delete: <T>(path: string, opts?: RequestOptions) =>
+    request("DELETE", path, undefined, opts).then((r) => parseJson<T>(r)),
+  // Raw-body variants for PEM/config exports and file downloads.
+  getText: (path: string, opts?: RequestOptions) =>
+    request("GET", path, undefined, opts).then((r) => r.text()),
+  postText: (path: string, body?: unknown, opts?: RequestOptions) =>
+    request("POST", path, body, opts).then((r) => r.text()),
+  getBlob: (path: string, opts?: RequestOptions) =>
+    request("GET", path, undefined, opts).then((r) => r.blob()),
+  postBlob: (path: string, body?: unknown, opts?: RequestOptions) =>
+    request("POST", path, body, opts).then((r) => r.blob()),
   // Auth
   login: (username: string, password: string) =>
     fetchApi<{ token: string }>("/api/v1/auth/login", {


### PR DESCRIPTION
Closes #429 (QUAL-H9).

## What

`lib/api.ts` is promoted to a real client, and all ~285 ad-hoc `fetch()` call sites across 62 files are migrated onto it. Net **−1,225 lines**.

### The client
- `api.get/post/put/patch/delete<T>` returning parsed JSON, plus `getText`/`postText`/`getBlob`/`postBlob` for PEM/config exports and file downloads.
- Bearer token attached automatically; plain objects JSON-encoded; `FormData` passed through so the browser sets the multipart boundary.
- **Centralized 401 handling**: clears the token and redirects to `/login`. `{ noAuthRedirect: true }` opts out where 401 is a meaningful answer (login/TOTP flows, wrong-password/wrong-code checks in profile, reboot-tolerant pollers).
- **`ApiError`** carries the server's `error`/`message` body (or short text body) as `.message` plus `.status` — existing `err.message` catch blocks keep working and now show the real server error instead of hand-rolled `HTTP <status>` strings.
- Legacy `fetchApi` + named `api.*` methods kept working (4 files still use them).

### The migration
- 62 files migrated; ~50 duplicated `authHeaders()` helpers, `const API = ""` consts, and three local per-page fetch wrappers (schedules, ddns/acme/vpn, dns/blocklists) deleted — two of which had their own divergent 401-redirect copies.
- `app/multi-wan/lib.ts` internals rebased onto the client with its exported `api(method, path, body)` signature byte-identical, so its 7 consumer pages needed no changes.
- Silent best-effort calls keep their silence; sites that showed server error bodies still do (via ApiError); EventSource/WebSocket ticket flows untouched.

### Intentionally left as-is
- `updates/page.tsx` reboot **down-probe**: raw `fetch` semantics (resolve on any HTTP status, reject only on network failure) are load-bearing for detecting "API went down".
- `updates/page.tsx` tarball upload: stays `XMLHttpRequest` for `xhr.upload` progress events driving the progress bar.

## Verification
- `npx tsc --noEmit` clean, `npm run lint` clean, `npm run build` (static export) succeeds.
- Residual scan: zero raw `fetch()` outside `lib/api.ts` and the documented down-probe; zero `authHeaders` remnants.

## Notes for review
A handful of call sites previously *ignored* non-2xx responses entirely (no `res.ok` check) and now surface errors through their existing catch blocks — each was a deliberate judgment call toward honest error reporting (e.g. DNS/reverse-proxy `serviceAction` no longer shows a success toast on HTTP 500; `saveAiGlobal` in settings no longer optimistically reports success on 4xx/5xx).