### PR TITLE
perf(ui): pause page polling in hidden tabs via shared usePolling hook (PERF-H22 #366)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.98.3"
+version = "5.98.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.98.3",
+  "version": "5.98.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/src/app/backup/page.tsx
+++ b/aifw-ui/src/app/backup/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -419,11 +420,7 @@ export default function BackupPage() {
   };
 
   // Poll commit confirm status
-  useEffect(() => {
-    queueMicrotask(fetchCommitStatus);
-    const t = setInterval(fetchCommitStatus, 5000);
-    return () => clearInterval(t);
-  }, [fetchCommitStatus]);
+  usePolling(fetchCommitStatus, 5000);
 
   /* -- Render -------------------------------------------------------- */
 

--- a/aifw-ui/src/app/cluster/components/StatusBanner.tsx
+++ b/aifw-ui/src/app/cluster/components/StatusBanner.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 type Status = {
   role: string;
@@ -13,23 +14,16 @@ type Status = {
 export default function StatusBanner() {
   const [s, setS] = useState<Status | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-    const fetchStatus = async () => {
-      try {
-        // Tolerant poller: failures (incl. 401) just leave the banner hidden,
-        // so don't bounce to /login from here.
-        const j = await api.get<Status>("/api/v1/cluster/status", { noAuthRedirect: true });
-        if (!cancelled) setS(j);
-      } catch {}
-    };
-    fetchStatus();
-    const id = setInterval(fetchStatus, 5000);
-    return () => {
-      cancelled = true;
-      clearInterval(id);
-    };
+  const fetchStatus = useCallback(async () => {
+    try {
+      // Tolerant poller: failures (incl. 401) just leave the banner hidden,
+      // so don't bounce to /login from here.
+      const j = await api.get<Status>("/api/v1/cluster/status", { noAuthRedirect: true });
+      setS(j);
+    } catch {}
   }, []);
+
+  usePolling(fetchStatus, 5000);
 
   if (!s) return null;
   const isMaster = s.role === "primary";

--- a/aifw-ui/src/app/dhcp/leases/page.tsx
+++ b/aifw-ui/src/app/dhcp/leases/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useCallback } from "react";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 /* -- Types ---------------------------------------------------------- */
 
@@ -55,7 +56,6 @@ export default function DhcpLeasesPage() {
   const [feedback, setFeedback] = useState<{ type: "success" | "error"; msg: string } | null>(null);
   const [search, setSearch] = useState("");
   const [releaseIp, setReleaseIp] = useState<string | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const showFeedback = (type: "success" | "error", msg: string) => {
     setFeedback({ type, msg });
@@ -70,22 +70,13 @@ export default function DhcpLeasesPage() {
       setLeases(body.data || []);
     } catch {
       /* silent on auto-refresh failures */
+    } finally {
+      setLoading(false);
     }
   }, []);
 
-  useEffect(() => {
-    (async () => {
-      setLoading(true);
-      await fetchLeases();
-      setLoading(false);
-    })();
-
-    // Auto-refresh every 5 seconds
-    intervalRef.current = setInterval(fetchLeases, 5000);
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [fetchLeases]);
+  // Auto-refresh every 5 seconds (paused while the tab is hidden)
+  usePolling(fetchLeases, 5000);
 
   /* -- Actions ------------------------------------------------------ */
 

--- a/aifw-ui/src/app/dhcp/logs/page.tsx
+++ b/aifw-ui/src/app/dhcp/logs/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 export default function DhcpLogsPage() {
   const [logs, setLogs] = useState<string[]>([]);
@@ -25,12 +26,11 @@ export default function DhcpLogsPage() {
     }
   }, [lines, search]);
 
+  // Fetch on mount / filter change even when auto-refresh is off.
   useEffect(() => {
-    queueMicrotask(fetchLogs);
-    if (!autoRefresh) return;
-    const interval = setInterval(fetchLogs, 5000);
-    return () => clearInterval(interval);
+    if (!autoRefresh) queueMicrotask(fetchLogs);
   }, [fetchLogs, autoRefresh]);
+  usePolling(fetchLogs, 5000, autoRefresh);
 
   const getLogLevel = (line: string): string => {
     if (line.includes("ERROR") || line.includes("FATAL")) return "error";

--- a/aifw-ui/src/app/dhcp/metrics/page.tsx
+++ b/aifw-ui/src/app/dhcp/metrics/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 interface PoolStats {
   subnet: string;
@@ -17,7 +18,6 @@ export default function DhcpMetricsPage() {
   const [loading, setLoading] = useState(true);
   const [showRaw, setShowRaw] = useState(false);
   const [autoRefresh, setAutoRefresh] = useState(true);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const fetchStats = useCallback(async () => {
     try {
@@ -38,24 +38,14 @@ export default function DhcpMetricsPage() {
 
   const fetchAll = useCallback(async () => {
     await Promise.all([fetchStats(), fetchRawMetrics()]);
+    setLoading(false);
   }, [fetchStats, fetchRawMetrics]);
 
+  // Fetch on mount even when auto-refresh is off.
   useEffect(() => {
-    (async () => {
-      setLoading(true);
-      await fetchAll();
-      setLoading(false);
-    })();
-  }, [fetchAll]);
-
-  useEffect(() => {
-    if (!autoRefresh) {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-      return;
-    }
-    intervalRef.current = setInterval(fetchAll, 5000);
-    return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
-  }, [autoRefresh, fetchAll]);
+    if (!autoRefresh) queueMicrotask(fetchAll);
+  }, [fetchAll, autoRefresh]);
+  usePolling(fetchAll, 5000, autoRefresh);
 
   const utilizationColor = (pct: number) => {
     if (pct >= 90) return "text-red-400";

--- a/aifw-ui/src/app/dns/logs/page.tsx
+++ b/aifw-ui/src/app/dns/logs/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 export default function DnsLogsPage() {
   const [logs, setLogs] = useState<string[]>([]);
@@ -32,12 +33,11 @@ export default function DnsLogsPage() {
     }
   }, [lines, search]);
 
+  // Fetch on mount / filter change even when auto-refresh is off.
   useEffect(() => {
-    queueMicrotask(fetchLogs);
-    if (!autoRefresh) return;
-    const interval = setInterval(fetchLogs, 5000);
-    return () => clearInterval(interval);
+    if (!autoRefresh) queueMicrotask(fetchLogs);
   }, [fetchLogs, autoRefresh]);
+  usePolling(fetchLogs, 5000, autoRefresh);
 
   const getLogLevel = (line: string): string => {
     if (line.includes("error") || line.includes("ERROR") || line.includes("FATAL")) return "error";

--- a/aifw-ui/src/app/ids/page.tsx
+++ b/aifw-ui/src/app/ids/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import Card from "@/components/Card";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 interface IdsStats {
   packets_inspected: number;
@@ -88,11 +89,7 @@ export default function IdsDashboardPage() {
     }
   }, [loading, clearFeedback]);
 
-  useEffect(() => {
-    queueMicrotask(fetchStats);
-    const interval = setInterval(fetchStats, 5000);
-    return () => clearInterval(interval);
-  }, [fetchStats]);
+  usePolling(fetchStats, 5000);
 
   async function handleModeChange(newMode: string) {
     setModeChanging(true);

--- a/aifw-ui/src/app/interfaces/page.tsx
+++ b/aifw-ui/src/app/interfaces/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef } from "react";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 interface InterfaceDetail {
   name: string;
@@ -123,11 +124,7 @@ export default function InterfacesPage() {
     }
   }, []);
 
-  useEffect(() => {
-    queueMicrotask(fetchInterfaces);
-    const interval = setInterval(fetchInterfaces, 10000);
-    return () => clearInterval(interval);
-  }, [fetchInterfaces]);
+  usePolling(fetchInterfaces, 10000);
 
   function openEdit(iface: InterfaceDetail) {
     setEditingName(iface.name);

--- a/aifw-ui/src/app/logs/page.tsx
+++ b/aifw-ui/src/app/logs/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 interface AuditEntry {
   id: string;
@@ -42,11 +43,7 @@ export default function LogsPage() {
     }
   }, []);
 
-  useEffect(() => {
-    queueMicrotask(fetchLogs);
-    const interval = setInterval(fetchLogs, 10_000);
-    return () => clearInterval(interval);
-  }, [fetchLogs]);
+  usePolling(fetchLogs, 10_000);
 
   const actions = [...new Set(entries.map((e) => e.action))];
 

--- a/aifw-ui/src/app/metrics/page.tsx
+++ b/aifw-ui/src/app/metrics/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState, useCallback } from "react";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 type Range = { label: string; secs: number };
 const RANGES: Range[] = [
@@ -157,11 +158,7 @@ export default function MetricsPage() {
   }, [selected, rangeSecs]);
 
   useEffect(() => { queueMicrotask(fetchList); }, [fetchList]);
-  useEffect(() => {
-    queueMicrotask(fetchSeries);
-    const id = setInterval(fetchSeries, refreshMs);
-    return () => clearInterval(id);
-  }, [fetchSeries, refreshMs]);
+  usePolling(fetchSeries, refreshMs);
 
   const latest = data && data.points.length > 0 ? data.points[data.points.length - 1] : null;
 

--- a/aifw-ui/src/app/multi-wan/flows/page.tsx
+++ b/aifw-ui/src/app/multi-wan/flows/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import Help, { HelpBanner } from "../Help";
 import { api, FlowSummary } from "../lib";
+import { usePolling } from "@/lib/usePolling";
 
 function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;
@@ -37,12 +38,11 @@ export default function FlowsPage() {
     }
   }, []);
 
+  // Fetch on mount even when live refresh is off.
   useEffect(() => {
-    queueMicrotask(refresh);
-    if (!liveRefresh) return;
-    const t = setInterval(refresh, 3000);
-    return () => clearInterval(t);
+    if (!liveRefresh) queueMicrotask(refresh);
   }, [refresh, liveRefresh]);
+  usePolling(refresh, 3000, liveRefresh);
 
   async function migrateLabel(label: string) {
     if (!confirm(`Kill pf states with label "${label}"? Clients will reconnect.`))

--- a/aifw-ui/src/app/multi-wan/gateways/page.tsx
+++ b/aifw-ui/src/app/multi-wan/gateways/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import Help, { HelpBanner } from "../Help";
+import { usePolling } from "@/lib/usePolling";
 import {
   api,
   Gateway,
@@ -87,11 +88,7 @@ export default function GatewaysPage() {
     }
   }, []);
 
-  useEffect(() => {
-    queueMicrotask(refresh);
-    const t = setInterval(refresh, 5000);
-    return () => clearInterval(t);
-  }, [refresh]);
+  usePolling(refresh, 5000);
 
   function validate(): boolean {
     const e: Record<string, string> = {};

--- a/aifw-ui/src/app/multi-wan/groups/page.tsx
+++ b/aifw-ui/src/app/multi-wan/groups/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import Help, { HelpBanner } from "../Help";
+import { usePolling } from "@/lib/usePolling";
 import {
   api,
   Gateway,
@@ -87,11 +88,7 @@ export default function GroupsPage() {
     }
   }, []);
 
-  useEffect(() => {
-    queueMicrotask(refresh);
-    const t = setInterval(refresh, 10_000);
-    return () => clearInterval(t);
-  }, [refresh]);
+  usePolling(refresh, 10_000);
 
   function validateForm() {
     const errs: Record<string, string> = {};

--- a/aifw-ui/src/app/multi-wan/policies/page.tsx
+++ b/aifw-ui/src/app/multi-wan/policies/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo } from "react";
 import Help, { HelpBanner } from "../Help";
+import { usePolling } from "@/lib/usePolling";
 import {
   api,
   Gateway,
@@ -167,11 +168,7 @@ export default function PoliciesPage() {
     }
   }, []);
 
-  useEffect(() => {
-    queueMicrotask(refresh);
-    const t = setInterval(refresh, 15_000);
-    return () => clearInterval(t);
-  }, [refresh]);
+  usePolling(refresh, 15_000);
 
   /* ────────── validation ────────── */
 

--- a/aifw-ui/src/app/nat/flows/page.tsx
+++ b/aifw-ui/src/app/nat/flows/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState, useMemo, useRef } from "react";
+import { useEffect, useState, useMemo, useRef, useCallback } from "react";
 import { useWs } from "@/context/WsContext";
 import { fetchApi } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 function formatBytes(b: number): string {
   if (b >= 1e9) return `${(b/1e9).toFixed(1)} GB`; if (b >= 1e6) return `${(b/1e6).toFixed(1)} MB`;
@@ -223,33 +224,29 @@ export default function NatFlowsPage() {
   // even though that subnet shares no prefix with wg0's own /24.
   const [wgRoutes, setWgRoutes] = useState<Route[]>([]);
 
-  useEffect(() => {
-    let cancelled = false;
-    async function loadRoutes() {
-      try {
-        const tRes = await fetchApi<{ data: WgTunnelLite[] }>("/api/v1/vpn/wg");
-        const routes: Route[] = [];
-        for (const t of tRes.data || []) {
-          if (!t.interface) continue;
-          const add = (cidr: string) => {
-            const c = parseCidr(cidr);
-            if (c) routes.push({ iface: t.interface, base: c.base, prefix: c.prefix });
-          };
-          if (t.address) add(t.address);
-          if (t.split_routes) for (const r of t.split_routes.split(/[,\s]+/)) if (r) add(r);
-          try {
-            const pRes = await fetchApi<{ data: WgPeerLite[] }>(`/api/v1/vpn/wg/${t.id}/peers`);
-            for (const p of pRes.data || [])
-              for (const a of (p.allowed_ips || "").split(/[,\s]+/)) if (a) add(a);
-          } catch { /* peers are optional — address/split_routes already cover the interface */ }
-        }
-        if (!cancelled) setWgRoutes(routes);
-      } catch { /* VPN endpoint unavailable — fall back to local-subnet matching only */ }
-    }
-    loadRoutes();
-    const iv = setInterval(loadRoutes, 30000);
-    return () => { cancelled = true; clearInterval(iv); };
+  const loadRoutes = useCallback(async () => {
+    try {
+      const tRes = await fetchApi<{ data: WgTunnelLite[] }>("/api/v1/vpn/wg");
+      const routes: Route[] = [];
+      for (const t of tRes.data || []) {
+        if (!t.interface) continue;
+        const add = (cidr: string) => {
+          const c = parseCidr(cidr);
+          if (c) routes.push({ iface: t.interface, base: c.base, prefix: c.prefix });
+        };
+        if (t.address) add(t.address);
+        if (t.split_routes) for (const r of t.split_routes.split(/[,\s]+/)) if (r) add(r);
+        try {
+          const pRes = await fetchApi<{ data: WgPeerLite[] }>(`/api/v1/vpn/wg/${t.id}/peers`);
+          for (const p of pRes.data || [])
+            for (const a of (p.allowed_ips || "").split(/[,\s]+/)) if (a) add(a);
+        } catch { /* peers are optional — address/split_routes already cover the interface */ }
+      }
+      setWgRoutes(routes);
+    } catch { /* VPN endpoint unavailable — fall back to local-subnet matching only */ }
   }, []);
+
+  usePolling(loadRoutes, 30000);
 
   const ifaces = ws.interfaces as Iface[];
   const connections = ws.connections as Conn[];

--- a/aifw-ui/src/app/page.tsx
+++ b/aifw-ui/src/app/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState, useRef, useMemo } from "react";
+import { useEffect, useState, useRef, useMemo, useCallback } from "react";
 import { useWs } from "@/context/WsContext";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 interface StatusData {
   pf_running: boolean; pf_states: number; pf_rules: number;
@@ -335,26 +336,23 @@ export default function Dashboard() {
     [ifaces]
   );
 
-  // Fetch DNS/DHCP/Time status on mount + every 30s
-  useEffect(() => {
+  // Fetch DNS/DHCP/Time status on mount + every 30s (paused while hidden)
+  const fetchSvc = useCallback(async () => {
     const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
     if (!token) return;
-    const fetchSvc = async () => {
-      const [dnsRes, dhcpRes, timeRes] = await Promise.allSettled([
-        api.get<{ running: boolean; version: string; total_hosts: number; total_domains: number; total_acls: number; queries_total: number; cache_hits: number; cache_misses: number }>("/api/v1/dns/resolver/status"),
-        api.get<{ running: boolean; version: string; total_subnets: number; active_leases: number; total_reservations: number }>("/api/v1/dhcp/status"),
-        api.get<{ running: boolean; version: string; sources_count: number }>("/api/v1/time/status"),
-      ]);
-      setSvcStatus({
-        dns: dnsRes.status === "fulfilled" ? dnsRes.value ?? null : null,
-        dhcp: dhcpRes.status === "fulfilled" ? dhcpRes.value ?? null : null,
-        time: timeRes.status === "fulfilled" ? timeRes.value ?? null : null,
-      });
-    };
-    fetchSvc();
-    const iv = setInterval(fetchSvc, 30000);
-    return () => clearInterval(iv);
+    const [dnsRes, dhcpRes, timeRes] = await Promise.allSettled([
+      api.get<{ running: boolean; version: string; total_hosts: number; total_domains: number; total_acls: number; queries_total: number; cache_hits: number; cache_misses: number }>("/api/v1/dns/resolver/status"),
+      api.get<{ running: boolean; version: string; total_subnets: number; active_leases: number; total_reservations: number }>("/api/v1/dhcp/status"),
+      api.get<{ running: boolean; version: string; sources_count: number }>("/api/v1/time/status"),
+    ]);
+    setSvcStatus({
+      dns: dnsRes.status === "fulfilled" ? dnsRes.value ?? null : null,
+      dhcp: dhcpRes.status === "fulfilled" ? dhcpRes.value ?? null : null,
+      time: timeRes.status === "fulfilled" ? timeRes.value ?? null : null,
+    });
   }, []);
+
+  usePolling(fetchSvc, 30000);
 
   // Fetch HA status once on mount — only show card when HA is configured
   useEffect(() => {

--- a/aifw-ui/src/app/reverse-proxy/logs/page.tsx
+++ b/aifw-ui/src/app/reverse-proxy/logs/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 type LogType = "server" | "access";
 
@@ -28,15 +29,15 @@ export default function ReverseProxyLogsPage() {
     }
   }, [lines, search, logType]);
 
+  // Show the spinner on mount / log-type change, and fetch even when
+  // auto-refresh is off (the polling hook handles the auto-refresh case).
   useEffect(() => {
     queueMicrotask(() => {
       setLoading(true);
-      fetchLogs();
+      if (!autoRefresh) fetchLogs();
     });
-    if (!autoRefresh) return;
-    const interval = setInterval(fetchLogs, 5000);
-    return () => clearInterval(interval);
   }, [fetchLogs, autoRefresh]);
+  usePolling(fetchLogs, 5000, autoRefresh);
 
   const getLogLevel = (line: string): string => {
     if (line.includes("ERROR") || line.includes("FATAL")) return "error";

--- a/aifw-ui/src/app/system/info/page.tsx
+++ b/aifw-ui/src/app/system/info/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useCallback } from "react";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 interface SysInfo {
   hostname: string; domain: string;
@@ -34,21 +35,17 @@ export default function SystemInfoPage() {
   const [info, setInfo] = useState<SysInfo | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-    async function tick() {
-      if (document.visibilityState !== "visible") return;
-      try {
-        const d = await api.get<SysInfo>("/api/v1/system/info");
-        if (!cancelled) { setInfo(d); setErr(null); }
-      } catch (e) {
-        if (!cancelled) setErr(String(e));
-      }
+  const tick = useCallback(async () => {
+    try {
+      const d = await api.get<SysInfo>("/api/v1/system/info");
+      setInfo(d);
+      setErr(null);
+    } catch (e) {
+      setErr(String(e));
     }
-    tick();
-    const id = setInterval(tick, 5000);
-    return () => { cancelled = true; clearInterval(id); };
   }, []);
+
+  usePolling(tick, 5000);
 
   if (err) return <div className="p-6 text-red-400">Failed: {err}</div>;
   if (!info) return <div className="p-6 text-[var(--text-muted)]">Loading…</div>;

--- a/aifw-ui/src/app/threats/page.tsx
+++ b/aifw-ui/src/app/threats/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import { api, ApiError } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 interface IdsAlert {
   id: string;
@@ -110,11 +111,7 @@ export default function ThreatsPage() {
     }
   }, []);
 
-  useEffect(() => {
-    queueMicrotask(fetchAlerts);
-    const interval = setInterval(fetchAlerts, 15_000);
-    return () => clearInterval(interval);
-  }, [fetchAlerts]);
+  usePolling(fetchAlerts, 15_000);
 
   const runAiAnalysis = async () => {
     setAiRunning(true);

--- a/aifw-ui/src/app/time/logs/page.tsx
+++ b/aifw-ui/src/app/time/logs/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 export default function TimeLogsPage() {
   const [logs, setLogs] = useState<string[]>([]);
@@ -25,12 +26,11 @@ export default function TimeLogsPage() {
     }
   }, [lines, search]);
 
+  // Fetch on mount / filter change even when auto-refresh is off.
   useEffect(() => {
-    queueMicrotask(fetchLogs);
-    if (!autoRefresh) return;
-    const interval = setInterval(fetchLogs, 5000);
-    return () => clearInterval(interval);
+    if (!autoRefresh) queueMicrotask(fetchLogs);
   }, [fetchLogs, autoRefresh]);
+  usePolling(fetchLogs, 5000, autoRefresh);
 
   const getLogLevel = (line: string): string => {
     if (line.includes("ERROR") || line.includes("FATAL")) return "error";

--- a/aifw-ui/src/app/time/page.tsx
+++ b/aifw-ui/src/app/time/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 interface TimeConfig {
   enabled: boolean;
@@ -117,8 +118,8 @@ export default function TimeServicePage() {
     } catch { /* */ }
   }, []);
 
-  useEffect(() => { queueMicrotask(() => { fetchStatus(); fetchConfig(); fetchSources(); fetchInterfaces(); }); }, [fetchStatus, fetchConfig, fetchSources, fetchInterfaces]);
-  useEffect(() => { const t = setInterval(fetchStatus, 5000); return () => clearInterval(t); }, [fetchStatus]);
+  useEffect(() => { queueMicrotask(() => { fetchConfig(); fetchSources(); fetchInterfaces(); }); }, [fetchConfig, fetchSources, fetchInterfaces]);
+  usePolling(fetchStatus, 5000);
 
   const validate = (): boolean => {
     const e: Record<string, string> = {};

--- a/aifw-ui/src/app/updates/page.tsx
+++ b/aifw-ui/src/app/updates/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { api } from "@/lib/api";
+import { usePolling } from "@/lib/usePolling";
 
 interface UpdateStatus {
   os_version: string;
@@ -176,11 +177,7 @@ export default function UpdatesPage() {
   }, [fetchStatus, fetchSchedule, fetchHistory, fetchAifwStatus]);
 
   // Poll status while checking or installing
-  useEffect(() => {
-    if (!checking && !installing) return;
-    const interval = setInterval(fetchStatus, 3000);
-    return () => clearInterval(interval);
-  }, [checking, installing, fetchStatus]);
+  usePolling(fetchStatus, 3000, checking || installing);
 
   const handleCheck = async () => {
     setChecking(true);

--- a/aifw-ui/src/lib/usePolling.ts
+++ b/aifw-ui/src/lib/usePolling.ts
@@ -1,0 +1,81 @@
+import { useEffect } from "react";
+
+/// How long after the last poll a window-focus event may trigger an early
+/// refresh. Prevents rapid focus/blur cycles from spamming the API.
+const FOCUS_THROTTLE_MS = 5_000;
+
+/// Runs `fn` immediately, then every `intervalMs` — but only while the page
+/// is visible (PERF-H22 #366). Background tabs stop polling entirely; when
+/// the tab becomes visible (or the window regains focus) the data is
+/// refreshed right away and the interval restarts.
+///
+/// Overlapping runs are deduplicated: if the previous `fn` call is still in
+/// flight when the next tick fires, that tick is skipped.
+///
+/// `fn` must be referentially stable (wrap it in `useCallback`); a new
+/// identity restarts polling with an immediate refresh, mirroring the old
+/// per-page `useEffect` + `setInterval` behavior. Pass `enabled: false` to
+/// suspend polling (no initial call either), e.g. while a modal owns the
+/// screen or the poll target doesn't exist yet.
+export function usePolling(
+  fn: () => void | Promise<void>,
+  intervalMs: number,
+  enabled: boolean = true,
+): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    let timer: ReturnType<typeof setInterval> | null = null;
+    let inFlight = false;
+    let lastTick = 0;
+
+    const tick = () => {
+      if (inFlight) return;
+      inFlight = true;
+      lastTick = Date.now();
+      Promise.resolve()
+        .then(fn)
+        .catch(() => {
+          /* poll errors are handled (or ignored) inside `fn` */
+        })
+        .finally(() => {
+          inFlight = false;
+        });
+    };
+
+    const start = () => {
+      if (timer === null) timer = setInterval(tick, intervalMs);
+    };
+    const stop = () => {
+      if (timer !== null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        tick();
+        start();
+      } else {
+        stop();
+      }
+    };
+
+    const onFocus = () => {
+      if (document.visibilityState !== "visible") return;
+      if (Date.now() - lastTick >= FOCUS_THROTTLE_MS) tick();
+    };
+
+    tick();
+    if (document.visibilityState === "visible") start();
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("focus", onFocus);
+
+    return () => {
+      stop();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [fn, intervalMs, enabled]);
+}


### PR DESCRIPTION
Closes #366

## Problem

19 pages each ran their own `useEffect` + `setInterval` poll loop (3–30s cadence). An idle background tab kept issuing 4–8 GET requests per minute indefinitely, each paying the auth-middleware DB cost. No visibility awareness, no in-flight dedup.

## Fix

New shared hook `aifw-ui/src/lib/usePolling.ts`:

- polls immediately + on interval **only while `document.visibilityState` is visible**; hidden tabs stop polling entirely
- refreshes immediately and restarts the interval when the tab becomes visible again
- revalidates on window `focus` (5s throttle, mirroring SWR's default)
- skips a tick if the previous fetch is still in flight
- `enabled` flag suspends polling — used by the auto/live-refresh toggles (dns/dhcp/time/reverse-proxy logs, dhcp metrics, multi-wan flows) and the updates page's poll-while-`checking || installing`

All 19 poll sites migrated onto it. Untouched: `blocked/page.tsx` (local clock tick, no network) and the updates-page restart countdown (local timer).

### Why not SWR / react-query (the issue's suggested fix)

The measured impact is idle-tab polling, which the hook eliminates. Each page polls distinct endpoints and only one page is mounted at a time, so a shared cross-component cache buys almost nothing here — while migrating 19 pages' state management onto SWR would be a much larger, riskier diff right after the central api-client consolidation (#429). The hook still provides the SWR behaviors that matter for this finding: visibility-aware pause, focus revalidation, and request dedup.

## Verification (live app, headful Chrome via CDP)

Ran `aifw-api` (mock pf, scratch DB) serving the built UI; observed `/api/v1/logs` on the audit-log page (10s cadence) via `performance` resource timings:

- visible: requests at exactly 0s / 10s / 20s / …
- hidden for 32s: **0 requests** (previously 3)
- visible again: 1 immediate refresh, cadence resumes
- window focus >5s after last tick: 1 early refresh; second focus 0.8s later: throttled, 0
- DNS logs page auto-refresh toggle off: no requests for 14s; changing the lines filter still fired exactly one fetch

`npm run lint`, `npm run build`, `cargo check` (zero warnings), `cargo test` (all 28 suites pass).