### PR TITLE
perf(ui): virtualize alert/log/connection lists (PERF-H24 #368)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.98.4"
+version = "5.98.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "aifw-ui",
-  "version": "5.96.20",
+  "version": "5.98.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.96.20",
+      "version": "5.98.5",
       "dependencies": {
+        "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",
         "next": "^16.2.9",
         "react": "^19.2.7",
@@ -1668,6 +1669,33 @@
         "@tailwindcss/oxide": "4.3.1",
         "postcss": "8.5.15",
         "tailwindcss": "4.3.1"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.6.tgz",
+      "integrity": "sha512-4+Uq8m0/gzO4kMCHUEpTtGX1RnONK0C+g88b2ltwPMWUBiaVarBuWKoPJaz7gj1cKCVRAdyu+U8GcKhwCc2beA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.4.tgz",
+      "integrity": "sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.98.4",
+  "version": "5.98.5",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -9,6 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@tanstack/react-virtual": "^3.14.6",
     "lucide-react": "^1.20.0",
     "next": "^16.2.9",
     "react": "^19.2.7",

--- a/aifw-ui/src/app/connections/page.tsx
+++ b/aifw-ui/src/app/connections/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
+import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import Card from "@/components/Card";
+import { useDocumentOffset } from "@/lib/useDocumentOffset";
 import StatusBadge from "@/components/StatusBadge";
 import { useWs } from "@/context/WsContext";
 
@@ -136,6 +138,23 @@ export default function ConnectionsPage() {
   const totalPacketsIn = connections.reduce((sum, c) => sum + c.packets_in, 0);
   const totalPacketsOut = connections.reduce((sum, c) => sum + c.packets_out, 0);
 
+  // Virtualize table rows (PERF-H24 #368): spacer <tr>s stand in for
+  // off-screen rows so the table only mounts rows near the viewport.
+  const tbodyRef = useRef<HTMLTableSectionElement | null>(null);
+  const tbodyOffset = useDocumentOffset(tbodyRef);
+  const rowVirtualizer = useWindowVirtualizer({
+    count: sortedConnections.length,
+    estimateSize: () => 38,
+    overscan: 15,
+    scrollMargin: tbodyOffset,
+  });
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const scrollMargin = rowVirtualizer.options.scrollMargin;
+  const paddingTop = virtualRows.length > 0 ? virtualRows[0].start - scrollMargin : 0;
+  const paddingBottom = virtualRows.length > 0
+    ? rowVirtualizer.getTotalSize() - (virtualRows[virtualRows.length - 1].end - scrollMargin)
+    : 0;
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -210,8 +229,14 @@ export default function ConnectionsPage() {
                   <SortHeader label="Bytes In/Out" sortKey="bytes" currentSort={sortKey} currentDir={sortDir} onSort={handleSort} className="w-32 text-left" />
                 </tr>
               </thead>
-              <tbody>
-                {sortedConnections.map((conn) => {
+              <tbody ref={tbodyRef}>
+                {paddingTop > 0 && (
+                  <tr aria-hidden="true">
+                    <td colSpan={7} style={{ height: paddingTop, padding: 0 }} />
+                  </tr>
+                )}
+                {virtualRows.map((virtualRow) => {
+                  const conn = sortedConnections[virtualRow.index];
                   const colors: Record<string, string> = {
                     tcp: "text-blue-400",
                     udp: "text-purple-400",
@@ -257,6 +282,11 @@ export default function ConnectionsPage() {
                     </tr>
                   );
                 })}
+                {paddingBottom > 0 && (
+                  <tr aria-hidden="true">
+                    <td colSpan={7} style={{ height: paddingBottom, padding: 0 }} />
+                  </tr>
+                )}
               </tbody>
             </table>
           </div>

--- a/aifw-ui/src/app/logs/page.tsx
+++ b/aifw-ui/src/app/logs/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
+import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { api } from "@/lib/api";
 import { usePolling } from "@/lib/usePolling";
+import { useDocumentOffset } from "@/lib/useDocumentOffset";
 
 interface AuditEntry {
   id: string;
@@ -57,6 +59,24 @@ export default function LogsPage() {
       return false;
     return true;
   });
+
+  // Virtualize table rows (PERF-H24 #368): spacer <tr>s stand in for
+  // off-screen rows so the table only mounts rows near the viewport.
+  const tbodyRef = useRef<HTMLTableSectionElement | null>(null);
+  const tbodyOffset = useDocumentOffset(tbodyRef);
+  const rowVirtualizer = useWindowVirtualizer({
+    count: filtered.length,
+    estimateSize: () => 38,
+    overscan: 15,
+    scrollMargin: tbodyOffset,
+    getItemKey: (index) => filtered[index]?.id ?? index,
+  });
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const scrollMargin = rowVirtualizer.options.scrollMargin;
+  const paddingTop = virtualRows.length > 0 ? virtualRows[0].start - scrollMargin : 0;
+  const paddingBottom = virtualRows.length > 0
+    ? rowVirtualizer.getTotalSize() - (virtualRows[virtualRows.length - 1].end - scrollMargin)
+    : 0;
 
   if (loading) {
     return (
@@ -128,7 +148,7 @@ export default function LogsPage() {
                 <th className="text-left py-3 px-3 text-xs font-medium text-gray-400 uppercase tracking-wider">Source</th>
               </tr>
             </thead>
-            <tbody>
+            <tbody ref={tbodyRef}>
               {filtered.length === 0 ? (
                 <tr>
                   <td colSpan={5} className="py-8 text-center text-gray-500">
@@ -136,7 +156,15 @@ export default function LogsPage() {
                   </td>
                 </tr>
               ) : (
-                filtered.map((entry) => (
+                <>
+                  {paddingTop > 0 && (
+                    <tr aria-hidden="true">
+                      <td colSpan={5} style={{ height: paddingTop, padding: 0 }} />
+                    </tr>
+                  )}
+                  {virtualRows.map((virtualRow) => {
+                    const entry = filtered[virtualRow.index];
+                    return (
                   <tr
                     key={entry.id}
                     className="border-b border-gray-700 hover:bg-gray-700/50 transition-colors"
@@ -169,7 +197,14 @@ export default function LogsPage() {
                       {entry.source}
                     </td>
                   </tr>
-                ))
+                    );
+                  })}
+                  {paddingBottom > 0 && (
+                    <tr aria-hidden="true">
+                      <td colSpan={5} style={{ height: paddingBottom, padding: 0 }} />
+                    </tr>
+                  )}
+                </>
               )}
             </tbody>
           </table>

--- a/aifw-ui/src/app/threats/page.tsx
+++ b/aifw-ui/src/app/threats/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
+import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { api, ApiError } from "@/lib/api";
 import { usePolling } from "@/lib/usePolling";
+import { useDocumentOffset } from "@/lib/useDocumentOffset";
 
 interface IdsAlert {
   id: string;
@@ -172,6 +174,18 @@ export default function ThreatsPage() {
     investigating: alerts.filter(a => a.classification === "investigating").length,
   };
 
+  // Virtualize the alert list (PERF-H24 #368): only rows near the viewport
+  // are mounted instead of up to 500 complex cards at once.
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const listOffset = useDocumentOffset(listRef);
+  const rowVirtualizer = useWindowVirtualizer({
+    count: filtered.length,
+    estimateSize: () => 68,
+    overscan: 10,
+    scrollMargin: listOffset,
+    getItemKey: (index) => filtered[index]?.id ?? index,
+  });
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -338,14 +352,22 @@ export default function ThreatsPage() {
           </p>
         </div>
       ) : (
-        <div className="space-y-2">
-          {filtered.map(alert => {
+        <div ref={listRef} className="relative" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
+          {rowVirtualizer.getVirtualItems().map(virtualRow => {
+            const alert = filtered[virtualRow.index];
             const sev = SEV_META[alert.severity] || SEV_META[4];
             const cls = CLASS_META[alert.classification] || CLASS_META.unreviewed;
             const isExpanded = expandedId === alert.id;
 
             return (
-              <div key={alert.id} className={`bg-[var(--bg-card)] border rounded-lg overflow-hidden transition-all ${
+              <div
+                key={alert.id}
+                data-index={virtualRow.index}
+                ref={rowVirtualizer.measureElement}
+                className="absolute top-0 left-0 w-full pb-2"
+                style={{ transform: `translateY(${virtualRow.start - rowVirtualizer.options.scrollMargin}px)` }}
+              >
+              <div className={`bg-[var(--bg-card)] border rounded-lg overflow-hidden transition-all ${
                 alert.classification === "confirmed" ? "border-red-500/30" :
                 alert.classification === "false_positive" ? "border-green-500/20 opacity-60" :
                 alert.classification === "investigating" ? "border-yellow-500/30" :
@@ -483,6 +505,7 @@ export default function ThreatsPage() {
                     </div>
                   </div>
                 )}
+              </div>
               </div>
             );
           })}

--- a/aifw-ui/src/lib/useDocumentOffset.ts
+++ b/aifw-ui/src/lib/useDocumentOffset.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState, type RefObject } from "react";
+
+/// Distance in pixels from the top of the document to `ref`'s element,
+/// for use as `scrollMargin` on a window virtualizer (PERF-H24 #368).
+///
+/// Re-measured whenever the document body resizes, so banners or panels
+/// above the element toggling open/closed don't skew the virtualizer's
+/// visible-range calculation.
+export function useDocumentOffset(ref: RefObject<HTMLElement | null>): number {
+  const [offset, setOffset] = useState(0);
+
+  useEffect(() => {
+    const measure = () => {
+      setOffset(
+        ref.current
+          ? ref.current.getBoundingClientRect().top + window.scrollY
+          : 0,
+      );
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(document.body);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return offset;
+}


### PR DESCRIPTION
Closes #368

## What

Adds list virtualization via `@tanstack/react-virtual` so only rows near the viewport are mounted, instead of up to 500 complex cards / unbounded table rows:

- **`threats/page.tsx`** — window virtualizer with dynamic row measurement (`measureElement`), since cards expand/collapse in place. ~11–17 cards mounted instead of 500.
- **`connections/page.tsx`** and **`logs/page.tsx`** — window virtualizer with spacer-`<tr>` rows, preserving native `<table>` semantics (column sizing, sticky-free layout, a11y).
- **`src/lib/useDocumentOffset.ts`** (new) — shared hook that measures a list's document offset for `scrollMargin`, re-measuring via a `ResizeObserver` on `document.body` so banners/panels toggling above the list (error banner, AI log panel) don't skew the visible-range calculation.

## Why no changes to `ids/*`

The finding also listed `ids/page.tsx`, but that dashboard renders only top-10 signature/source tables, and `ids/alerts` + `ids/rules` are already server-side paginated (25/50 rows per page) — nothing there mounts a large list.

## Verification

Verified end-to-end on Linux/WSL (mock pf backend) with seeded data — 500 IDS alerts, 1,000 audit entries:

- threats: 11–17 mounted cards out of 200 rendered alerts; scroll to top/middle/bottom shows correct rows with no gaps; expanding a card mid-list (72px → 504px) re-measures and shifts rows correctly
- logs: 20 mounted rows out of 100; last entry reachable; spacer rows collapse when not needed
- connections: renders cleanly (empty state on mock backend; table uses the same spacer-row path as logs)
- no new console errors; `npm run lint`, `npm run build`, `cargo check`, and `cargo test` all pass

Version bumped 5.98.4 → 5.98.5.