### PR TITLE
perf(ui): keep WS history in a ref instead of React state (PERF-H23 #367)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.98.5"
+version = "5.98.6"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.98.5",
+  "version": "5.98.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.98.5",
+      "version": "5.98.6",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.98.5",
+  "version": "5.98.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/src/app/page.tsx
+++ b/aifw-ui/src/app/page.tsx
@@ -219,13 +219,12 @@ export default function Dashboard() {
   const prevIfaceData = useRef<Record<string, { bytes_in: number; bytes_out: number }>>({});
   const prevT = useRef(0);
   const historyProcessed = useRef(false);
-  const lastHistoryLen = useRef(0);
 
-  const pickNic = (name: string) => {
+  const pickNic = useCallback((name: string) => {
     setSelectedNic(name);
     selectedNicRef.current = name;
     localStorage.setItem("aifw_dashboard_nic", name);
-  };
+  }, []);
 
   const pickTimeframe = (tf: string) => {
     setTimeframe(tf);
@@ -234,18 +233,20 @@ export default function Dashboard() {
 
   const tfPoints = TIMEFRAMES.find(t => t.key === timeframe)?.points ?? 300;
 
-  // Process history from context on mount / when history changes
-  useEffect(() => {
-    if (!ws.historyLoaded) return;
-    if (ws.history.length === 0) { historyProcessed.current = true; return; }
-    // Only reprocess full history once, or when NIC changes
-    if (historyProcessed.current && ws.history.length === lastHistoryLen.current) return;
+  const { historyLoaded: wsHistoryLoaded, getHistory: wsGetHistory } = ws;
 
-    const rawHistory = ws.history as Record<string, unknown>[];
+  // Seed the chart from the buffered history once it has loaded, and
+  // rebuild when the NIC changes. History lives behind ws.getHistory()
+  // (not state), so per-frame appends never re-run this (PERF-H23 #367).
+  useEffect(() => {
+    if (!wsHistoryLoaded) return;
+    const rawHistory = wsGetHistory();
+    if (rawHistory.length === 0) { historyProcessed.current = true; return; }
+
     const points: HistoryPoint[] = [];
     const prevByIf: Record<string, { bytes_in: number; bytes_out: number }> = {};
     let prevTs = 0;
-    let nic = selectedNicRef.current;
+    let nic = selectedNic;
 
     for (let idx = 0; idx < rawHistory.length; idx++) {
       const entry = rawHistory[idx];
@@ -279,21 +280,14 @@ export default function Dashboard() {
       });
     }
 
-    if (!selectedNicRef.current && nic) pickNic(nic);
     Object.assign(prevIfaceData.current, prevByIf);
     prevT.current = Date.now();
-    lastHistoryLen.current = ws.history.length;
     historyProcessed.current = true;
-    setHistory(points.slice(-MAX_PTS));
-  }, [ws.historyLoaded, ws.history, ws.history.length]);
-
-  // Reset history processing when NIC changes so it recomputes rates
-  useEffect(() => {
-    if (historyProcessed.current) {
-      historyProcessed.current = false;
-      lastHistoryLen.current = 0;
-    }
-  }, [selectedNic]);
+    queueMicrotask(() => {
+      if (!selectedNic && nic) pickNic(nic);
+      setHistory(points.slice(-MAX_PTS));
+    });
+  }, [wsHistoryLoaded, wsGetHistory, selectedNic, pickNic]);
 
   // Process live updates from ws.status/ws.interfaces changes
   useEffect(() => {

--- a/aifw-ui/src/app/traffic/page.tsx
+++ b/aifw-ui/src/app/traffic/page.tsx
@@ -124,15 +124,16 @@ export default function TrafficPage() {
   const visibleNics = allSelected ? ifaceNames.map(i => i.name) : [...selectedNics].filter(n => ifaceNames.some(i => i.name === n));
 
   const historyProcessed = useRef(false);
-  const lastHistoryLen = useRef(0);
+  const { historyLoaded: wsHistoryLoaded, getHistory: wsGetHistory } = ws;
 
-  // Pre-populate rate histories from WebSocket history (same pattern as dashboard)
+  // Seed rate histories from the buffered WS history once it has loaded
+  // (same pattern as dashboard). History lives behind ws.getHistory(), so
+  // per-frame appends never re-run this (PERF-H23 #367).
   useEffect(() => {
-    if (!ws.historyLoaded) return;
-    if (ws.history.length === 0) { historyProcessed.current = true; return; }
-    if (historyProcessed.current && ws.history.length === lastHistoryLen.current) return;
+    if (!wsHistoryLoaded || historyProcessed.current) return;
+    const rawHistory = wsGetHistory();
+    if (rawHistory.length === 0) { historyProcessed.current = true; return; }
 
-    const rawHistory = ws.history as Record<string, unknown>[];
     const prevByIf: Record<string, { bytes_in: number; bytes_out: number }> = {};
     const histories: Record<string, RatePoint[]> = {};
     let prevTs = 0;
@@ -165,9 +166,7 @@ export default function TrafficPage() {
     }
     Object.assign(prevIface.current, prevByIf);
     prevTime.current = Date.now();
-    lastHistoryLen.current = ws.history.length;
     historyProcessed.current = true;
-    setRateHistories(histories);
 
     // Set current rates from the last computed points
     const rates: Record<string, { in: number; out: number }> = {};
@@ -177,8 +176,11 @@ export default function TrafficPage() {
         rates[name] = { in: last.bpsIn, out: last.bpsOut };
       }
     }
-    setCurrentRates(rates);
-  }, [ws.historyLoaded, ws.history, ws.history.length]);
+    queueMicrotask(() => {
+      setRateHistories(histories);
+      setCurrentRates(rates);
+    });
+  }, [wsHistoryLoaded, wsGetHistory]);
 
   // Process live updates — all interfaces
   useEffect(() => {

--- a/aifw-ui/src/context/WsContext.tsx
+++ b/aifw-ui/src/context/WsContext.tsx
@@ -12,13 +12,21 @@ interface WsData {
   services: Record<string, unknown>[];
   ids: Record<string, unknown> | null;
   connected: boolean;
-  history: Record<string, unknown>[];
+  /// Snapshot of the rolling status-update history (up to 1800 entries,
+  /// ~30 min at 1 Hz). Exposed as an imperative getter — not state — so
+  /// per-frame appends don't re-render every useWs() consumer
+  /// (PERF-H23 #367). Read it once when `historyLoaded` flips true and
+  /// build chart data incrementally from live updates afterwards.
+  getHistory: () => Record<string, unknown>[];
   historyLoaded: boolean;
 }
 
+/// Cap on buffered status-update frames (1 Hz → ~30 minutes).
+const HISTORY_MAX = 1800;
+
 const WsContext = createContext<WsData>({
   status: null, system: null, connections: [], interfaces: [], blocked: [], services: [],
-  ids: null, connected: false, history: [], historyLoaded: false,
+  ids: null, connected: false, getHistory: () => [], historyLoaded: false,
 });
 
 export function useWs() { return useContext(WsContext); }
@@ -32,7 +40,6 @@ export function WsProvider({ children }: { children: ReactNode }) {
   const [services, setServices] = useState<Record<string, unknown>[]>([]);
   const [ids, setIds] = useState<Record<string, unknown> | null>(null);
   const [connected, setConnected] = useState(false);
-  const [history, setHistory] = useState<Record<string, unknown>[]>([]);
   const [historyLoaded, setHistoryLoaded] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
   const reconRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -63,7 +70,6 @@ export function WsProvider({ children }: { children: ReactNode }) {
 
         if (msg.type === "history" && Array.isArray(msg.data)) {
           histBuf.current = msg.data;
-          setHistory(msg.data);
           setHistoryLoaded(true);
           const last = msg.data[msg.data.length - 1];
           if (last?.status) setStatus(last.status);
@@ -84,8 +90,10 @@ export function WsProvider({ children }: { children: ReactNode }) {
           if (msg.blocked) setBlocked(msg.blocked);
           if (msg.services) setServices(msg.services);
           if (msg.ids) setIds(msg.ids);
-          histBuf.current = [...histBuf.current, msg].slice(-1800);
-          setHistory(histBuf.current);
+          // Append in place — no per-frame reallocation and no state update,
+          // so history growth never triggers React re-renders (PERF-H23 #367).
+          histBuf.current.push(msg);
+          if (histBuf.current.length > HISTORY_MAX) histBuf.current.shift();
         }
       } catch { /* ignore */ }
     };
@@ -108,8 +116,12 @@ export function WsProvider({ children }: { children: ReactNode }) {
     };
   }, [connect]);
 
+  // Stable identity; returns a copy so consumers can't mutate the buffer.
+  // Called rarely (chart seeding on mount / NIC change), never per frame.
+  const getHistory = useCallback(() => histBuf.current.slice(), []);
+
   return (
-    <WsContext.Provider value={{ status, system, connections, interfaces, blocked, services, ids, connected, history, historyLoaded }}>
+    <WsContext.Provider value={{ status, system, connections, interfaces, blocked, services, ids, connected, getHistory, historyLoaded }}>
       {children}
     </WsContext.Provider>
   );


### PR DESCRIPTION
Closes #367

## Problem

`WsContext` reallocated the 1800-entry history array on every WebSocket frame (`[...histBuf.current, msg].slice(-1800)`) and pushed it through `setState`, so every `useWs()` consumer re-rendered every second with a fresh array identity. On top of that, the dashboard and traffic pages' `length === lastHistoryLen` guard only stops reprocessing once the buffer hits the 1800 cap — until then (the first 30 minutes of a session) both pages re-parsed the **entire** history array every single frame.

## Fix

Follows the issue's recommended direction (ref + non-reactive access):

- **`WsContext.tsx`** — history is appended in place into the existing ref (`push`/`shift`, no per-frame allocation) and never touches React state. Consumers get a stable `getHistory()` getter plus the existing one-shot `historyLoaded` flag. Per-frame history growth now triggers zero re-renders and zero allocations beyond the pushed frame itself.
- **`app/page.tsx` (dashboard)** — seeds its chart from `getHistory()` when history loads or when the selected NIC changes (now an explicit effect dependency); the `lastHistoryLen` / reset-effect machinery is gone.
- **`app/traffic/page.tsx`** — seeds rate histories once when history loads.

Both pages already build chart data incrementally from live `ws.status` updates, so nothing needs reactive history — full reprocessing now happens exactly twice per visit at most (initial load + NIC pick) instead of once per second.

## Verification

Ran the app locally (mock pf backend) and drove it in Chrome with an instrumented WebSocket:

- history frame (600 entries) received → dashboard chart seeded from it (single large SVG path rendered from the full buffer)
- live `status_update` frames arrive at 1 Hz and flow into the existing incremental chart-update path
- dashboard, traffic, and connections pages all render with no new console errors (the only error is the pre-existing `/api/v1/interfaces` 500 on the mock backend)
- `npm run lint` (zero warnings), `npm run build`, `cargo check`, `cargo test` all pass

Version bumped 5.98.5 → 5.98.6.