### PR TITLE
fix: log or justify every silent 'let _ =' in the top-5 offending files (QUAL-H1 #421)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.1"
+version = "5.99.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -485,8 +485,11 @@ pub(crate) async fn commit_confirm_arm_with_snapshot(
                 tracing::warn!("Commit confirm expired after {timeout_secs}s — rolling back");
                 if let Some(inner) = store.write().await.take()
                     && let Ok(config) = serde_json::from_str::<FirewallConfig>(&inner.rollback_config) {
-                        let _ = apply_firewall_config(&rollback_state, &config, &InterfaceMap::new()).await;
-                        tracing::info!("Config rolled back successfully");
+                        if let Err(e) = apply_firewall_config(&rollback_state, &config, &InterfaceMap::new()).await {
+                            tracing::warn!(error = %e, "commit confirm rollback: apply_firewall_config failed");
+                        } else {
+                            tracing::info!("Config rolled back successfully");
+                        }
                     }
             }
             _ = cancel_rx => {
@@ -504,6 +507,8 @@ pub(crate) async fn commit_confirm_arm_with_snapshot(
 pub async fn commit_confirm_accept() -> Result<Json<MessageResponse>, StatusCode> {
     let mut store = commit_store().write().await;
     if let Some(inner) = store.take() {
+        // Safely ignorable: oneshot send only fails if the rollback timer task
+        // already exited (timer fired or task dropped) — nothing left to cancel.
         let _ = inner.cancel_tx.send(()); // Cancel the rollback timer
         Ok(Json(MessageResponse {
             message: "Configuration confirmed and accepted permanently.".to_string(),
@@ -1705,31 +1710,44 @@ pub(crate) async fn apply_firewall_config(
             .map(|s| format!("nameserver {s}"))
             .collect::<Vec<_>>()
             .join("\n");
-        let _ = tokio::fs::write("/etc/resolv.conf", &content).await;
+        if let Err(e) = tokio::fs::write("/etc/resolv.conf", &content).await {
+            tracing::warn!(error = %e, "import: /etc/resolv.conf write failed");
+        }
     }
 
     let auth = &config.auth;
-    let _ = sqlx::query(
+    if let Err(e) = sqlx::query(
         "INSERT OR REPLACE INTO auth_config (key, value) VALUES ('access_token_expiry_mins', ?1)",
     )
     .bind(auth.access_token_expiry_mins.to_string())
     .execute(&state.pool)
-    .await;
-    let _ = sqlx::query(
+    .await
+    {
+        tracing::warn!(key = "access_token_expiry_mins", error = %e, "import: auth config restore failed");
+    }
+    if let Err(e) = sqlx::query(
         "INSERT OR REPLACE INTO auth_config (key, value) VALUES ('refresh_token_expiry_days', ?1)",
     )
     .bind(auth.refresh_token_expiry_days.to_string())
     .execute(&state.pool)
-    .await;
-    let _ =
+    .await
+    {
+        tracing::warn!(key = "refresh_token_expiry_days", error = %e, "import: auth config restore failed");
+    }
+    if let Err(e) =
         sqlx::query("INSERT OR REPLACE INTO auth_config (key, value) VALUES ('require_totp', ?1)")
             .bind(if auth.require_totp { "true" } else { "false" })
             .execute(&state.pool)
-            .await;
+            .await
+    {
+        tracing::warn!(key = "require_totp", error = %e, "import: auth config restore failed");
+    }
 
     // Traffic shaping: queues + per-IP rate limits
     let shaping = aifw_core::shaping::ShapingEngine::new(state.pool.clone(), state.pf.clone());
-    let _ = shaping.migrate().await;
+    if let Err(e) = shaping.migrate().await {
+        tracing::warn!(error = %e, "import: shaping migrate failed");
+    }
     for table in ["queues", "rate_limits"] {
         if let Err(e) = sqlx::query(sqlx::AssertSqlSafe(format!("DELETE FROM {table}")))
             .execute(&state.pool)
@@ -1744,8 +1762,10 @@ pub(crate) async fn apply_firewall_config(
         };
         let mut qc = qc.clone();
         qc.interface = mapped;
-        if let Some(q) = queue_from_config(&qc) {
-            let _ = shaping.add_queue(q).await;
+        if let Some(q) = queue_from_config(&qc)
+            && let Err(e) = shaping.add_queue(q).await
+        {
+            tracing::warn!(queue = %qc.name, error = %e, "import: shaping queue restore failed");
         }
     }
     for rc in &config.rate_limits {
@@ -1758,16 +1778,24 @@ pub(crate) async fn apply_firewall_config(
         };
         let mut rc = rc.clone();
         rc.interface = iface_after;
-        if let Some(r) = rate_limit_from_config(&rc) {
-            let _ = shaping.add_rate_limit(r).await;
+        if let Some(r) = rate_limit_from_config(&rc)
+            && let Err(e) = shaping.add_rate_limit(r).await
+        {
+            tracing::warn!(error = %e, "import: rate limit restore failed");
         }
     }
-    let _ = shaping.apply_queues().await;
-    let _ = shaping.apply_rate_limits().await;
+    if let Err(e) = shaping.apply_queues().await {
+        tracing::warn!(error = %e, "import: shaping queues apply failed");
+    }
+    if let Err(e) = shaping.apply_rate_limits().await {
+        tracing::warn!(error = %e, "import: rate limits apply failed");
+    }
 
     // TLS: SNI rules + JA3 blocklist
     let tls_engine = aifw_core::tls::TlsEngine::new(state.pool.clone(), state.pf.clone());
-    let _ = tls_engine.migrate().await;
+    if let Err(e) = tls_engine.migrate().await {
+        tracing::warn!(error = %e, "import: tls migrate failed");
+    }
     for table in ["sni_rules", "ja3_blocklist"] {
         if let Err(e) = sqlx::query(sqlx::AssertSqlSafe(format!("DELETE FROM {table}")))
             .execute(&state.pool)
@@ -1777,17 +1805,23 @@ pub(crate) async fn apply_firewall_config(
         }
     }
     for sc in &config.tls.sni_rules {
-        if let Some(sni) = sni_rule_from_config(sc) {
-            let _ = tls_engine.add_sni_rule(sni).await;
+        if let Some(sni) = sni_rule_from_config(sc)
+            && let Err(e) = tls_engine.add_sni_rule(sni).await
+        {
+            tracing::warn!(pattern = %sc.pattern, error = %e, "import: sni rule restore failed");
         }
     }
     for hash in &config.tls.blocked_ja3 {
-        let _ = tls_engine.add_ja3_block(hash, "restored from backup").await;
+        if let Err(e) = tls_engine.add_ja3_block(hash, "restored from backup").await {
+            tracing::warn!(hash = %hash, error = %e, "import: ja3 block restore failed");
+        }
     }
 
     // HA: CARP VIPs + pfsync + cluster nodes
     let ha_engine = aifw_core::ha::ClusterEngine::new(state.pool.clone(), state.pf.clone());
-    let _ = ha_engine.migrate().await;
+    if let Err(e) = ha_engine.migrate().await {
+        tracing::warn!(error = %e, "import: ha migrate failed");
+    }
     for table in ["carp_vips", "pfsync_config", "cluster_nodes"] {
         if let Err(e) = sqlx::query(sqlx::AssertSqlSafe(format!("DELETE FROM {table}")))
             .execute(&state.pool)
@@ -1802,8 +1836,10 @@ pub(crate) async fn apply_firewall_config(
         };
         let mut vc = vc.clone();
         vc.interface = mapped;
-        if let Some(vip) = carp_vip_from_config(&vc) {
-            let _ = ha_engine.add_carp_vip(vip).await;
+        if let Some(vip) = carp_vip_from_config(&vc)
+            && let Err(e) = ha_engine.add_carp_vip(vip).await
+        {
+            tracing::warn!(vip = %vc.virtual_ip, error = %e, "import: carp vip restore failed");
         }
     }
     if let Some(pc) = &config.ha.pfsync
@@ -1811,13 +1847,17 @@ pub(crate) async fn apply_firewall_config(
     {
         let mut pc = pc.clone();
         pc.sync_interface = mapped_sync;
-        if let Some(pfsync) = pfsync_from_config(&pc) {
-            let _ = ha_engine.set_pfsync(pfsync).await;
+        if let Some(pfsync) = pfsync_from_config(&pc)
+            && let Err(e) = ha_engine.set_pfsync(pfsync).await
+        {
+            tracing::warn!(error = %e, "import: pfsync restore failed");
         }
     }
     for nc in &config.ha.nodes {
-        if let Some(node) = cluster_node_from_config(nc) {
-            let _ = ha_engine.add_node(node).await;
+        if let Some(node) = cluster_node_from_config(nc)
+            && let Err(e) = ha_engine.add_node(node).await
+        {
+            tracing::warn!(error = %e, "import: cluster node restore failed");
         }
     }
 
@@ -1826,8 +1866,9 @@ pub(crate) async fn apply_firewall_config(
         if t.enabled
             && t.key == "pf.max_states"
             && let Ok(val) = t.value.parse::<u64>()
+            && let Err(e) = aifw_core::pf_tuning::set_max_states(&state.pool, val).await
         {
-            let _ = aifw_core::pf_tuning::set_max_states(&state.pool, val).await;
+            tracing::warn!(value = val, error = %e, "import: pf.max_states restore failed");
         }
     }
 
@@ -1837,9 +1878,15 @@ pub(crate) async fn apply_firewall_config(
     if let Ok(vpn_rules) = state.vpn_engine.collect_vpn_rules().await {
         state.rule_engine.set_extra_rules(vpn_rules).await;
     }
-    let _ = state.rule_engine.apply_rules().await;
-    let _ = state.nat_engine.apply_rules().await;
-    let _ = state.geoip_engine.apply_rules().await;
+    if let Err(e) = state.rule_engine.apply_rules().await {
+        tracing::warn!(error = %e, "import: firewall rules apply failed");
+    }
+    if let Err(e) = state.nat_engine.apply_rules().await {
+        tracing::warn!(error = %e, "import: nat rules apply failed");
+    }
+    if let Err(e) = state.geoip_engine.apply_rules().await {
+        tracing::warn!(error = %e, "import: geoip rules apply failed");
+    }
 
     Ok(())
 }
@@ -1847,21 +1894,20 @@ pub(crate) async fn apply_firewall_config(
 async fn apply_dhcp_section(state: &AppState, dhcp: &aifw_core::config::DhcpSection) {
     // Wipe + re-insert for a clean restore. `auto_apply` at the end regenerates
     // the rDHCP TOML config and restarts the service.
-    let _ = sqlx::query("DELETE FROM dhcp_subnets")
-        .execute(&state.pool)
-        .await;
-    let _ = sqlx::query("DELETE FROM dhcp_reservations")
-        .execute(&state.pool)
-        .await;
-    let _ = sqlx::query("DELETE FROM dhcp_config")
-        .execute(&state.pool)
-        .await;
-    let _ = sqlx::query("DELETE FROM dhcp_ddns_config")
-        .execute(&state.pool)
-        .await;
-    let _ = sqlx::query("DELETE FROM dhcp_ha_config")
-        .execute(&state.pool)
-        .await;
+    for table in [
+        "dhcp_subnets",
+        "dhcp_reservations",
+        "dhcp_config",
+        "dhcp_ddns_config",
+        "dhcp_ha_config",
+    ] {
+        if let Err(e) = sqlx::query(sqlx::AssertSqlSafe(format!("DELETE FROM {table}")))
+            .execute(&state.pool)
+            .await
+        {
+            tracing::warn!(table, error = %e, "dhcp restore: DELETE failed before restore");
+        }
+    }
 
     // --- global ----------------------------------------------
     let g = &dhcp.global;
@@ -1910,11 +1956,15 @@ async fn apply_dhcp_section(state: &AppState, dhcp: &aifw_core::config::DhcpSect
         ),
         ("relay_rate_limit_pps", g.relay_rate_limit_pps.to_string()),
     ] {
-        let _ = sqlx::query("INSERT OR REPLACE INTO dhcp_config (key, value) VALUES (?1, ?2)")
-            .bind(k)
-            .bind(v)
-            .execute(&state.pool)
-            .await;
+        if let Err(e) =
+            sqlx::query("INSERT OR REPLACE INTO dhcp_config (key, value) VALUES (?1, ?2)")
+                .bind(k)
+                .bind(v)
+                .execute(&state.pool)
+                .await
+        {
+            tracing::warn!(key = k, error = %e, "dhcp restore: config insert failed");
+        }
     }
 
     // --- subnets ---------------------------------------------
@@ -1961,7 +2011,7 @@ async fn apply_dhcp_section(state: &AppState, dhcp: &aifw_core::config::DhcpSect
         }
         let options_json =
             serde_json::to_string(&safe_options).unwrap_or_else(|_| "[]".to_string());
-        let _ = sqlx::query(
+        if let Err(e) = sqlx::query(
             "INSERT INTO dhcp_subnets \
              (id, network, pool_start, pool_end, gateway, dns_servers, domain_name, \
               lease_time, max_lease_time, renewal_time, rebinding_time, preferred_time, \
@@ -1990,18 +2040,24 @@ async fn apply_dhcp_section(state: &AppState, dhcp: &aifw_core::config::DhcpSect
         .bind(&options_json)
         .bind(&s.created_at)
         .execute(&state.pool)
-        .await;
+        .await
+        {
+            tracing::warn!(network = %s.network, error = %e, "dhcp restore: subnet insert failed");
+        }
     }
 
     // --- reservations ----------------------------------------
     for r in &dhcp.reservations {
-        let _ = sqlx::query(
+        if let Err(e) = sqlx::query(
             "INSERT INTO dhcp_reservations (id, subnet_id, mac_address, ip_address, hostname, client_id, description, created_at) \
              VALUES (?1,?2,?3,?4,?5,?6,?7,?8)"
         )
         .bind(&r.id).bind(&r.subnet_id).bind(&r.mac_address).bind(&r.ip_address)
         .bind(&r.hostname).bind(&r.client_id).bind(&r.description).bind(&r.created_at)
-        .execute(&state.pool).await;
+        .execute(&state.pool).await
+        {
+            tracing::warn!(ip = %r.ip_address, error = %e, "dhcp restore: reservation insert failed");
+        }
     }
 
     // --- DDNS ------------------------------------------------
@@ -2024,11 +2080,15 @@ async fn apply_dhcp_section(state: &AppState, dhcp: &aifw_core::config::DhcpSect
         ("tsig_secret", d.tsig_secret.clone()),
         ("ttl", d.ttl.to_string()),
     ] {
-        let _ = sqlx::query("INSERT OR REPLACE INTO dhcp_ddns_config (key, value) VALUES (?1, ?2)")
-            .bind(k)
-            .bind(v)
-            .execute(&state.pool)
-            .await;
+        if let Err(e) =
+            sqlx::query("INSERT OR REPLACE INTO dhcp_ddns_config (key, value) VALUES (?1, ?2)")
+                .bind(k)
+                .bind(v)
+                .execute(&state.pool)
+                .await
+        {
+            tracing::warn!(key = k, error = %e, "dhcp restore: ddns config insert failed");
+        }
     }
 
     // --- DHCP HA ---------------------------------------------
@@ -2060,11 +2120,15 @@ async fn apply_dhcp_section(state: &AppState, dhcp: &aifw_core::config::DhcpSect
         ("tls_key", h.tls_key.clone().unwrap_or_default()),
         ("tls_ca", h.tls_ca.clone().unwrap_or_default()),
     ] {
-        let _ = sqlx::query("INSERT OR REPLACE INTO dhcp_ha_config (key, value) VALUES (?1, ?2)")
-            .bind(k)
-            .bind(v)
-            .execute(&state.pool)
-            .await;
+        if let Err(e) =
+            sqlx::query("INSERT OR REPLACE INTO dhcp_ha_config (key, value) VALUES (?1, ?2)")
+                .bind(k)
+                .bind(v)
+                .execute(&state.pool)
+                .await
+        {
+            tracing::warn!(key = k, error = %e, "dhcp restore: ha config insert failed");
+        }
     }
 
     // Regenerate rDHCP TOML + restart service so the restored config takes effect.
@@ -2425,7 +2489,9 @@ pub async fn auto_snapshot_middleware(
             }
         };
         let mgr = ConfigManager::new(bg_state.pool.clone());
-        let _ = mgr.migrate().await;
+        if let Err(e) = mgr.migrate().await {
+            tracing::warn!(error = %e, "auto-snapshot: config manager migrate failed");
+        }
         let version = match mgr
             .save_if_changed(&cfg, &bg_actor, Some(&bg_comment))
             .await
@@ -2639,27 +2705,32 @@ pub(crate) async fn apply_cluster_snapshot(state: &AppState, body: &str) -> anyh
 
     // Restore local per-peer credentials wiped by apply_firewall_config.
     for (id, key, hash) in &saved_keys {
-        if key.is_some() || hash.is_some() {
-            let _ = sqlx::query(
+        if (key.is_some() || hash.is_some())
+            && let Err(e) = sqlx::query(
                 "UPDATE cluster_nodes SET peer_api_key = ?1, peer_api_key_hash = ?2 WHERE id = ?3",
             )
             .bind(key)
             .bind(hash)
             .bind(id)
             .execute(&state.pool)
-            .await;
+            .await
+        {
+            tracing::warn!(node = %id, error = %e, "cluster snapshot: peer api key restore failed");
         }
     }
 
     // Sync IDS rule overrides: apply enabled/action_override to ids_rules rows
     for ov in &payload.ids_rule_overrides {
-        let _ =
+        if let Err(e) =
             sqlx::query("UPDATE ids_rules SET enabled = ?1, action_override = ?2 WHERE id = ?3")
                 .bind(ov.enabled)
                 .bind(&ov.action_override)
                 .bind(&ov.id)
                 .execute(&state.pool)
-                .await;
+                .await
+        {
+            tracing::warn!(rule = %ov.id, error = %e, "cluster snapshot: ids rule override sync failed");
+        }
     }
 
     // Sync IDS suppressions: wipe and re-insert atomically so the IDS daemon
@@ -2682,7 +2753,9 @@ pub(crate) async fn apply_cluster_snapshot(state: &AppState, body: &str) -> anyh
     tx.commit().await?;
 
     // Reload IDS config so suppressions take effect
-    let _ = state.ids_client.reload().await;
+    if let Err(e) = state.ids_client.reload().await {
+        tracing::warn!(error = %e, "cluster snapshot: ids reload failed");
+    }
 
     Ok(())
 }

--- a/aifw-api/src/dhcp.rs
+++ b/aifw-api/src/dhcp.rs
@@ -21,8 +21,27 @@ async fn reload_aifw_anchor(state: &AppState) {
     if let Ok(vpn_rules) = state.vpn_engine.collect_vpn_rules().await {
         state.rule_engine.set_extra_rules(vpn_rules).await;
     }
-    let _ = state.rule_engine.apply_rules().await;
-    let _ = state.nat_engine.apply_rules().await;
+    if let Err(e) = state.rule_engine.apply_rules().await {
+        tracing::warn!(error = %e, "dhcp: firewall rule reload failed during anchor reload");
+    }
+    if let Err(e) = state.nat_engine.apply_rules().await {
+        tracing::warn!(error = %e, "dhcp: NAT rule reload failed during anchor reload");
+    }
+}
+
+/// Log a warning if a sudo helper call failed to spawn or exited non-zero.
+/// DHCP service control is best-effort — failures must be visible but never fatal.
+fn warn_on_cmd_fail(what: &str, res: &std::io::Result<std::process::Output>) {
+    match res {
+        Err(e) => tracing::warn!(error = %e, "dhcp: {} failed to run", what),
+        Ok(o) if !o.status.success() => tracing::warn!(
+            status = %o.status,
+            stderr = %String::from_utf8_lossy(&o.stderr).trim(),
+            "dhcp: {} failed",
+            what
+        ),
+        Ok(_) => {}
+    }
 }
 const RDHCP_LEASE_DB: &str = "/var/db/rdhcpd/leases";
 const RDHCP_LOG_PATH: &str = "/var/log/rdhcpd/rdhcpd.log";
@@ -384,13 +403,15 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
         .fetch_one(pool)
         .await
         .unwrap_or(0);
-        if check == 0 {
-            let _ = sqlx::query(sqlx::AssertSqlSafe(format!(
+        if check == 0
+            && let Err(e) = sqlx::query(sqlx::AssertSqlSafe(format!(
                 "ALTER TABLE dhcp_subnets ADD COLUMN {}",
                 col
             )))
             .execute(pool)
-            .await;
+            .await
+        {
+            tracing::warn!(error = %e, column = col_name, "dhcp: dhcp_subnets column migration failed");
         }
     }
 
@@ -418,10 +439,12 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     .fetch_one(pool)
     .await
     .unwrap_or(0);
-    if check == 0 {
-        let _ = sqlx::query("ALTER TABLE dhcp_reservations ADD COLUMN client_id TEXT")
+    if check == 0
+        && let Err(e) = sqlx::query("ALTER TABLE dhcp_reservations ADD COLUMN client_id TEXT")
             .execute(pool)
-            .await;
+            .await
+    {
+        tracing::warn!(error = %e, "dhcp: dhcp_reservations client_id column migration failed");
     }
 
     sqlx::query(
@@ -521,11 +544,14 @@ async fn load_global_config(pool: &SqlitePool) -> DhcpGlobalConfig {
 }
 
 async fn save_config_key(pool: &SqlitePool, key: &str, value: &str) {
-    let _ = sqlx::query("INSERT OR REPLACE INTO dhcp_config (key, value) VALUES (?1, ?2)")
+    if let Err(e) = sqlx::query("INSERT OR REPLACE INTO dhcp_config (key, value) VALUES (?1, ?2)")
         .bind(key)
         .bind(value)
         .execute(pool)
-        .await;
+        .await
+    {
+        tracing::warn!(error = %e, key, "dhcp: config key write failed");
+    }
 }
 
 async fn load_ddns_config(pool: &SqlitePool) -> DdnsConfig {
@@ -552,11 +578,15 @@ async fn load_ddns_config(pool: &SqlitePool) -> DdnsConfig {
 }
 
 async fn save_ddns_key(pool: &SqlitePool, key: &str, value: &str) {
-    let _ = sqlx::query("INSERT OR REPLACE INTO dhcp_ddns_config (key, value) VALUES (?1, ?2)")
-        .bind(key)
-        .bind(value)
-        .execute(pool)
-        .await;
+    if let Err(e) =
+        sqlx::query("INSERT OR REPLACE INTO dhcp_ddns_config (key, value) VALUES (?1, ?2)")
+            .bind(key)
+            .bind(value)
+            .execute(pool)
+            .await
+    {
+        tracing::warn!(error = %e, key, "dhcp: DDNS config key write failed");
+    }
 }
 
 async fn load_ha_config(pool: &SqlitePool) -> HaConfig {
@@ -597,11 +627,15 @@ async fn load_ha_config(pool: &SqlitePool) -> HaConfig {
 }
 
 async fn save_ha_key(pool: &SqlitePool, key: &str, value: &str) {
-    let _ = sqlx::query("INSERT OR REPLACE INTO dhcp_ha_config (key, value) VALUES (?1, ?2)")
-        .bind(key)
-        .bind(value)
-        .execute(pool)
-        .await;
+    if let Err(e) =
+        sqlx::query("INSERT OR REPLACE INTO dhcp_ha_config (key, value) VALUES (?1, ?2)")
+            .bind(key)
+            .bind(value)
+            .execute(pool)
+            .await
+    {
+        tracing::warn!(error = %e, key, "dhcp: HA config key write failed");
+    }
 }
 
 async fn list_subnets_db(pool: &SqlitePool) -> Vec<DhcpSubnet> {
@@ -1189,7 +1223,10 @@ pub async fn dhcp_status(State(state): State<AppState>) -> Result<Json<DhcpStatu
 async fn run_rdhcp_service(action: &str) -> Json<MessageResponse> {
     // Ensure rdhcpd is enabled in rc.conf before start/restart
     if action == "start" || action == "restart" {
-        let _ = aifw_core::sudo::sysrc(&["rdhcpd_enable=YES"]).await;
+        warn_on_cmd_fail(
+            "sysrc rdhcpd_enable=YES",
+            &aifw_core::sudo::sysrc(&["rdhcpd_enable=YES"]).await,
+        );
     }
     let output = aifw_core::sudo::service("rdhcpd", action).await;
     match output {
@@ -1238,10 +1275,14 @@ async fn ensure_config(pool: &SqlitePool) {
     let config_exists = tokio::fs::metadata(RDHCP_CONFIG_PATH).await.is_ok();
     if !config_exists {
         let toml_config = generate_rdhcp_config(pool).await;
-        let _ = tokio::fs::create_dir_all("/usr/local/etc/rdhcpd").await;
-        let _ = tokio::fs::create_dir_all(RDHCP_LEASE_DB).await;
-        let _ = tokio::fs::create_dir_all("/var/log/rdhcpd").await;
-        let _ = tokio::fs::write(RDHCP_CONFIG_PATH, &toml_config).await;
+        for dir in ["/usr/local/etc/rdhcpd", RDHCP_LEASE_DB, "/var/log/rdhcpd"] {
+            if let Err(e) = tokio::fs::create_dir_all(dir).await {
+                tracing::warn!(error = %e, dir, "dhcp: create_dir_all failed");
+            }
+        }
+        if let Err(e) = tokio::fs::write(RDHCP_CONFIG_PATH, &toml_config).await {
+            tracing::warn!(error = %e, path = RDHCP_CONFIG_PATH, "dhcp: initial config write failed");
+        }
     }
 }
 
@@ -1955,9 +1996,11 @@ pub async fn apply_config(
     let toml_config = generate_rdhcp_config(&state.pool).await;
 
     // Create directories
-    let _ = tokio::fs::create_dir_all("/usr/local/etc/rdhcpd").await;
-    let _ = tokio::fs::create_dir_all(RDHCP_LEASE_DB).await;
-    let _ = tokio::fs::create_dir_all("/var/log/rdhcpd").await;
+    for dir in ["/usr/local/etc/rdhcpd", RDHCP_LEASE_DB, "/var/log/rdhcpd"] {
+        if let Err(e) = tokio::fs::create_dir_all(dir).await {
+            tracing::warn!(error = %e, dir, "dhcp: create_dir_all failed");
+        }
+    }
 
     // Write TOML config
     tokio::fs::write(RDHCP_CONFIG_PATH, &toml_config)
@@ -1965,13 +2008,19 @@ pub async fn apply_config(
         .map_err(|_| internal())?;
 
     // Fix ownership
-    let _ = aifw_core::sudo::chown_r("aifw:aifw", "/usr/local/etc/rdhcpd").await;
-    let _ = aifw_core::sudo::chown_r("aifw:aifw", RDHCP_LEASE_DB).await;
-    let _ = aifw_core::sudo::chown_r("aifw:aifw", "/var/log/rdhcpd").await;
+    for path in ["/usr/local/etc/rdhcpd", RDHCP_LEASE_DB, "/var/log/rdhcpd"] {
+        warn_on_cmd_fail("chown", &aifw_core::sudo::chown_r("aifw:aifw", path).await);
+    }
 
     if config.enabled {
-        let _ = aifw_core::sudo::sysrc(&["rdhcpd_enable=YES"]).await;
-        let _ = aifw_core::sudo::service("rdhcpd", "restart").await;
+        warn_on_cmd_fail(
+            "sysrc rdhcpd_enable=YES",
+            &aifw_core::sudo::sysrc(&["rdhcpd_enable=YES"]).await,
+        );
+        warn_on_cmd_fail(
+            "service rdhcpd restart",
+            &aifw_core::sudo::service("rdhcpd", "restart").await,
+        );
 
         // Reload all aifw anchor rules (includes user rules + service rules)
         // This preserves existing firewall rules while adding DHCP pass rules
@@ -1981,8 +2030,14 @@ pub async fn apply_config(
             message: "DHCP config applied and rDHCP restarted".to_string(),
         }))
     } else {
-        let _ = aifw_core::sudo::service("rdhcpd", "stop").await;
-        let _ = aifw_core::sudo::sysrc(&["rdhcpd_enable=NO"]).await;
+        warn_on_cmd_fail(
+            "service rdhcpd stop",
+            &aifw_core::sudo::service("rdhcpd", "stop").await,
+        );
+        warn_on_cmd_fail(
+            "sysrc rdhcpd_enable=NO",
+            &aifw_core::sudo::sysrc(&["rdhcpd_enable=NO"]).await,
+        );
         // Reload anchor to remove DHCP rules
         reload_aifw_anchor(&state).await;
         Ok(Json(MessageResponse {
@@ -2001,13 +2056,21 @@ pub(crate) async fn auto_apply(state: &AppState) {
     }
 
     let toml_config = generate_rdhcp_config(&state.pool).await;
-    let _ = tokio::fs::create_dir_all("/usr/local/etc/rdhcpd").await;
+    if let Err(e) = tokio::fs::create_dir_all("/usr/local/etc/rdhcpd").await {
+        tracing::warn!(error = %e, "dhcp: create_dir_all /usr/local/etc/rdhcpd failed");
+    }
     if tokio::fs::write(RDHCP_CONFIG_PATH, &toml_config)
         .await
         .is_ok()
     {
-        let _ = aifw_core::sudo::chown_r("aifw:aifw", "/usr/local/etc/rdhcpd").await;
-        let _ = aifw_core::sudo::service("rdhcpd", "restart").await;
+        warn_on_cmd_fail(
+            "chown",
+            &aifw_core::sudo::chown_r("aifw:aifw", "/usr/local/etc/rdhcpd").await,
+        );
+        warn_on_cmd_fail(
+            "service rdhcpd restart",
+            &aifw_core::sudo::service("rdhcpd", "restart").await,
+        );
         tracing::info!("DHCP config auto-applied");
     }
 
@@ -2064,10 +2127,13 @@ async fn ensure_dhcp_pf_rules(config: &DhcpGlobalConfig) {
         .await
         .is_ok()
     {
-        let _ = Command::new("/usr/local/bin/sudo")
-            .args(["/sbin/pfctl", "-f", pf_path])
-            .output()
-            .await;
+        warn_on_cmd_fail(
+            "pfctl -f pf.conf",
+            &Command::new("/usr/local/bin/sudo")
+                .args(["/sbin/pfctl", "-f", pf_path])
+                .output()
+                .await,
+        );
         tracing::info!("DHCP pf rules added");
     } else {
         tracing::warn!("aifw-sudo-write failed to update pf.conf for DHCP rules");

--- a/aifw-api/src/iface.rs
+++ b/aifw-api/src/iface.rs
@@ -133,15 +133,21 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
                     && let Some(iface) = rest.strip_suffix('"')
                 {
                     let now = chrono::Utc::now().to_rfc3339();
-                    let _ = sqlx::query("INSERT OR IGNORE INTO interface_roles (interface_name, role, updated_at) VALUES (?1, 'WAN', ?2)")
-                            .bind(iface).bind(&now).execute(pool).await;
+                    if let Err(e) = sqlx::query("INSERT OR IGNORE INTO interface_roles (interface_name, role, updated_at) VALUES (?1, 'WAN', ?2)")
+                            .bind(iface).bind(&now).execute(pool).await
+                    {
+                        tracing::warn!(error = %e, iface, "WAN role seed insert failed");
+                    }
                 }
                 if let Some(rest) = line.strip_prefix("lan_if = \"")
                     && let Some(iface) = rest.strip_suffix('"')
                 {
                     let now = chrono::Utc::now().to_rfc3339();
-                    let _ = sqlx::query("INSERT OR IGNORE INTO interface_roles (interface_name, role, updated_at) VALUES (?1, 'LAN', ?2)")
-                            .bind(iface).bind(&now).execute(pool).await;
+                    if let Err(e) = sqlx::query("INSERT OR IGNORE INTO interface_roles (interface_name, role, updated_at) VALUES (?1, 'LAN', ?2)")
+                            .bind(iface).bind(&now).execute(pool).await
+                    {
+                        tracing::warn!(error = %e, iface, "LAN role seed insert failed");
+                    }
                 }
             }
         }
@@ -309,10 +315,6 @@ pub(crate) async fn parse_ifconfig() -> Vec<InterfaceDetail> {
     }
 
     // Get traffic stats via netstat
-    let stats_out = Command::new("netstat")
-        .args(["-I", "", "-b", "-n", "--libxo", "json"])
-        .output()
-        .await;
     for iface in &mut interfaces {
         if let Ok(output) = Command::new("netstat")
             .args(["-I", &iface.name, "-b", "-n"])
@@ -348,8 +350,37 @@ pub(crate) async fn parse_ifconfig() -> Vec<InterfaceDetail> {
     interfaces.retain(|i| {
         !i.name.starts_with("pflog") && !i.name.starts_with("pfsync") && !i.name.starts_with("enc")
     });
-    let _ = stats_out;
     interfaces
+}
+
+/// Log a failed best-effort system command (sudo helper or direct spawn)
+/// at warn level — non-zero exit or spawn error. Interface configuration
+/// is intentionally non-fatal (apply as much as possible), but failures
+/// must be visible for diagnosis.
+fn warn_on_fail(res: std::io::Result<std::process::Output>, what: &str, iface: &str) {
+    match res {
+        Ok(out) if out.status.success() => {}
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            tracing::warn!(iface = %iface, status = %out.status, stderr = %stderr.trim(), "{} failed", what);
+        }
+        Err(e) => tracing::warn!(iface = %iface, error = %e, "{} failed to run", what),
+    }
+}
+
+/// Like [`warn_on_fail`] but at debug level — for commands whose failure
+/// is expected in normal operation (pkill with no matching dhclient,
+/// deleting an address/route/rcvar that isn't set, creating a VLAN device
+/// that already exists) yet still worth a trace.
+fn debug_on_fail(res: std::io::Result<std::process::Output>, what: &str, iface: &str) {
+    match res {
+        Ok(out) if out.status.success() => {}
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            tracing::debug!(iface = %iface, status = %out.status, stderr = %stderr.trim(), "{} failed", what);
+        }
+        Err(e) => tracing::debug!(iface = %iface, error = %e, "{} failed to run", what),
+    }
 }
 
 /// Load interface roles from DB — returns HashMap<name, role>.
@@ -482,13 +513,21 @@ pub async fn configure_interface(
 
     // Handle enable/disable
     if let Some(enabled) = req.enabled {
-        let _ = aifw_core::sudo::ifconfig(&name, if enabled { "up" } else { "down" }, &[]).await;
+        warn_on_fail(
+            aifw_core::sudo::ifconfig(&name, if enabled { "up" } else { "down" }, &[]).await,
+            "ifconfig up/down toggle",
+            &name,
+        );
     }
 
     // Handle MTU
     if let Some(mtu) = req.mtu {
         let mtu_s = mtu.to_string();
-        let _ = aifw_core::sudo::ifconfig(&name, "mtu", &[&mtu_s]).await;
+        warn_on_fail(
+            aifw_core::sudo::ifconfig(&name, "mtu", &[&mtu_s]).await,
+            "ifconfig mtu set",
+            &name,
+        );
     }
 
     // Handle IPv4 mode change
@@ -496,18 +535,38 @@ pub async fn configure_interface(
         match mode.as_str() {
             "dhcp" => {
                 // Kill any existing dhclient, remove static address, then start dhclient
-                let _ = aifw_core::sudo::pkill_dhclient(&name).await;
-                let _ = aifw_core::sudo::ifconfig(&name, "delete", &[]).await;
-                let _ = aifw_core::sudo::dhclient(&[&name]).await;
+                debug_on_fail(
+                    aifw_core::sudo::pkill_dhclient(&name).await,
+                    "dhclient kill",
+                    &name,
+                );
+                debug_on_fail(
+                    aifw_core::sudo::ifconfig(&name, "delete", &[]).await,
+                    "ifconfig address delete",
+                    &name,
+                );
+                warn_on_fail(
+                    aifw_core::sudo::dhclient(&[&name]).await,
+                    "dhclient start",
+                    &name,
+                );
                 // Persist
                 let kv = format!("ifconfig_{}=DHCP", name);
-                let _ = aifw_core::sudo::sysrc(&[&kv]).await;
+                warn_on_fail(
+                    aifw_core::sudo::sysrc(&[&kv]).await,
+                    "sysrc ifconfig persist",
+                    &name,
+                );
                 // Remove static defaultrouter if we're switching to DHCP (DHCP will set it)
                 msgs.push("Set to DHCP".to_string());
             }
             "static" => {
                 // Kill dhclient first so it doesn't overwrite our static IP
-                let _ = aifw_core::sudo::pkill_dhclient(&name).await;
+                debug_on_fail(
+                    aifw_core::sudo::pkill_dhclient(&name).await,
+                    "dhclient kill",
+                    &name,
+                );
                 // Brief pause for dhclient to fully exit
                 tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
@@ -516,15 +575,31 @@ pub async fn configure_interface(
                     // FreeBSD ifconfig won't replace — it adds aliases. Must delete first.
                     let current = get_iface_ipv4s(&name).await;
                     for old_ip in &current {
-                        let _ = aifw_core::sudo::ifconfig(&name, "inet", &[old_ip, "-alias"]).await;
+                        warn_on_fail(
+                            aifw_core::sudo::ifconfig(&name, "inet", &[old_ip, "-alias"]).await,
+                            "ifconfig old alias remove",
+                            &name,
+                        );
                     }
                     // Set the new static IP
-                    let _ = aifw_core::sudo::ifconfig(&name, "inet", &[addr]).await;
-                    let _ = aifw_core::sudo::ifconfig(&name, "up", &[]).await;
+                    warn_on_fail(
+                        aifw_core::sudo::ifconfig(&name, "inet", &[addr]).await,
+                        "ifconfig static ip set",
+                        &name,
+                    );
+                    warn_on_fail(
+                        aifw_core::sudo::ifconfig(&name, "up", &[]).await,
+                        "ifconfig up",
+                        &name,
+                    );
 
                     // Persist in rc.conf
                     let kv = format!("ifconfig_{}=inet {}", name, addr);
-                    let _ = aifw_core::sudo::sysrc(&[&kv]).await;
+                    warn_on_fail(
+                        aifw_core::sudo::sysrc(&[&kv]).await,
+                        "sysrc ifconfig persist",
+                        &name,
+                    );
                     msgs.push(format!("Set static IP {}", addr));
                 }
 
@@ -537,10 +612,23 @@ pub async fn configure_interface(
                         let owns_default =
                             cur_gw_iface.as_deref() == Some(&name) || cur_gw_iface.is_none();
                         if owns_default {
-                            let _ = aifw_core::sudo::route(&["delete", "default"]).await;
-                            let _ = aifw_core::sudo::route(&["add", "default", gw]).await;
+                            // Delete may fail when no default route exists yet — expected.
+                            debug_on_fail(
+                                aifw_core::sudo::route(&["delete", "default"]).await,
+                                "route delete default",
+                                &name,
+                            );
+                            warn_on_fail(
+                                aifw_core::sudo::route(&["add", "default", gw]).await,
+                                "route add default",
+                                &name,
+                            );
                             let kv = format!("defaultrouter={}", gw);
-                            let _ = aifw_core::sudo::sysrc(&[&kv]).await;
+                            warn_on_fail(
+                                aifw_core::sudo::sysrc(&[&kv]).await,
+                                "sysrc defaultrouter persist",
+                                &name,
+                            );
                             msgs.push(format!("Gateway set to {}", gw));
                         } else {
                             msgs.push(format!(
@@ -555,18 +643,40 @@ pub async fn configure_interface(
                     else {
                         let (_, cur_gw_iface) = get_default_gateway().await;
                         if cur_gw_iface.as_deref() == Some(&name) {
-                            let _ = aifw_core::sudo::route(&["delete", "default"]).await;
-                            let _ = aifw_core::sudo::sysrc(&["-x", "defaultrouter"]).await;
+                            warn_on_fail(
+                                aifw_core::sudo::route(&["delete", "default"]).await,
+                                "route delete default",
+                                &name,
+                            );
+                            // Unset may fail when defaultrouter isn't in rc.conf (DHCP-set route) — expected.
+                            debug_on_fail(
+                                aifw_core::sudo::sysrc(&["-x", "defaultrouter"]).await,
+                                "sysrc defaultrouter unset",
+                                &name,
+                            );
                             msgs.push("Default gateway removed".to_string());
                         }
                     }
                 }
             }
             "none" => {
-                let _ = aifw_core::sudo::pkill_dhclient(&name).await;
-                let _ = aifw_core::sudo::ifconfig(&name, "delete", &[]).await;
+                debug_on_fail(
+                    aifw_core::sudo::pkill_dhclient(&name).await,
+                    "dhclient kill",
+                    &name,
+                );
+                debug_on_fail(
+                    aifw_core::sudo::ifconfig(&name, "delete", &[]).await,
+                    "ifconfig address delete",
+                    &name,
+                );
                 let key = format!("ifconfig_{}", name);
-                let _ = aifw_core::sudo::sysrc(&["-x", &key]).await;
+                // Unset may fail when the rcvar was never set — expected.
+                debug_on_fail(
+                    aifw_core::sudo::sysrc(&["-x", &key]).await,
+                    "sysrc ifconfig unset",
+                    &name,
+                );
                 msgs.push("Removed IP configuration".to_string());
             }
             _ => {}
@@ -578,10 +688,23 @@ pub async fn configure_interface(
         if !gw.is_empty() {
             let owns_default = cur_gw_iface.as_deref() == Some(&name) || cur_gw_iface.is_none();
             if owns_default {
-                let _ = aifw_core::sudo::route(&["delete", "default"]).await;
-                let _ = aifw_core::sudo::route(&["add", "default", gw]).await;
+                // Delete may fail when no default route exists yet — expected.
+                debug_on_fail(
+                    aifw_core::sudo::route(&["delete", "default"]).await,
+                    "route delete default",
+                    &name,
+                );
+                warn_on_fail(
+                    aifw_core::sudo::route(&["add", "default", gw]).await,
+                    "route add default",
+                    &name,
+                );
                 let kv = format!("defaultrouter={}", gw);
-                let _ = aifw_core::sudo::sysrc(&[&kv]).await;
+                warn_on_fail(
+                    aifw_core::sudo::sysrc(&[&kv]).await,
+                    "sysrc defaultrouter persist",
+                    &name,
+                );
                 msgs.push(format!("Gateway set to {}", gw));
             } else {
                 msgs.push(format!(
@@ -591,8 +714,17 @@ pub async fn configure_interface(
                 ));
             }
         } else if cur_gw_iface.as_deref() == Some(&name) {
-            let _ = aifw_core::sudo::route(&["delete", "default"]).await;
-            let _ = aifw_core::sudo::sysrc(&["-x", "defaultrouter"]).await;
+            warn_on_fail(
+                aifw_core::sudo::route(&["delete", "default"]).await,
+                "route delete default",
+                &name,
+            );
+            // Unset may fail when defaultrouter isn't in rc.conf (DHCP-set route) — expected.
+            debug_on_fail(
+                aifw_core::sudo::sysrc(&["-x", "defaultrouter"]).await,
+                "sysrc defaultrouter unset",
+                &name,
+            );
             msgs.push("Default gateway removed".to_string());
         }
     }
@@ -600,11 +732,19 @@ pub async fn configure_interface(
     if let Some(ref ipv6) = req.ipv6_address
         && !ipv6.is_empty()
     {
-        let _ = aifw_core::sudo::ifconfig(&name, "inet6", &[ipv6]).await;
+        warn_on_fail(
+            aifw_core::sudo::ifconfig(&name, "inet6", &[ipv6]).await,
+            "ifconfig inet6 set",
+            &name,
+        );
     }
 
     if let Some(ref desc) = req.description {
-        let _ = aifw_core::sudo::ifconfig(&name, "description", &[desc]).await;
+        warn_on_fail(
+            aifw_core::sudo::ifconfig(&name, "description", &[desc]).await,
+            "ifconfig description set",
+            &name,
+        );
     }
 
     let summary = if msgs.is_empty() {
@@ -705,38 +845,74 @@ pub async fn apply_vlans(pool: &SqlitePool) -> Result<(), String> {
         let vlan_name = format!("vlan{}", vid);
 
         if *enabled {
-            // Create if not exists
-            let _ = aifw_core::sudo::ifconfig(&vlan_name, "create", &[]).await;
+            // Create if not exists — fails with "File exists" on re-apply, expected.
+            debug_on_fail(
+                aifw_core::sudo::ifconfig(&vlan_name, "create", &[]).await,
+                "vlan create",
+                &vlan_name,
+            );
             let vid_s = vid.to_string();
-            let _ =
-                aifw_core::sudo::ifconfig(&vlan_name, "vlan", &[&vid_s, "vlandev", parent]).await;
+            warn_on_fail(
+                aifw_core::sudo::ifconfig(&vlan_name, "vlan", &[&vid_s, "vlandev", parent]).await,
+                "vlan vlandev config",
+                &vlan_name,
+            );
             let mtu_s = mtu.to_string();
-            let _ = aifw_core::sudo::ifconfig(&vlan_name, "mtu", &[&mtu_s]).await;
+            warn_on_fail(
+                aifw_core::sudo::ifconfig(&vlan_name, "mtu", &[&mtu_s]).await,
+                "vlan mtu set",
+                &vlan_name,
+            );
 
             if mode == "static" {
                 if let Some(addr) = ip_addr {
-                    let _ = aifw_core::sudo::ifconfig(&vlan_name, "inet", &[addr]).await;
+                    warn_on_fail(
+                        aifw_core::sudo::ifconfig(&vlan_name, "inet", &[addr]).await,
+                        "vlan inet set",
+                        &vlan_name,
+                    );
                 }
             } else if mode == "dhcp" {
-                let _ = Command::new("/usr/local/bin/sudo")
-                    .args(["/sbin/dhclient", &vlan_name])
-                    .output()
-                    .await;
+                warn_on_fail(
+                    Command::new("/usr/local/bin/sudo")
+                        .args(["/sbin/dhclient", &vlan_name])
+                        .output()
+                        .await,
+                    "vlan dhclient start",
+                    &vlan_name,
+                );
             }
-            let _ = aifw_core::sudo::ifconfig(&vlan_name, "up", &[]).await;
+            warn_on_fail(
+                aifw_core::sudo::ifconfig(&vlan_name, "up", &[]).await,
+                "vlan ifconfig up",
+                &vlan_name,
+            );
 
             // Persist in rc.conf
             let vlans_kv = format!("vlans_{}={}", parent, vid);
-            let _ = aifw_core::sudo::sysrc(&[&vlans_kv]).await;
+            warn_on_fail(
+                aifw_core::sudo::sysrc(&[&vlans_kv]).await,
+                "sysrc vlans persist",
+                &vlan_name,
+            );
             let rc_val = match mode.as_str() {
                 "dhcp" => "DHCP".to_string(),
                 "static" => format!("inet {}", ip_addr.as_deref().unwrap_or("")),
                 _ => "up".to_string(),
             };
             let ifconfig_kv = format!("ifconfig_{}={}", vlan_name, rc_val);
-            let _ = aifw_core::sudo::sysrc(&[&ifconfig_kv]).await;
+            warn_on_fail(
+                aifw_core::sudo::sysrc(&[&ifconfig_kv]).await,
+                "sysrc ifconfig persist",
+                &vlan_name,
+            );
         } else {
-            let _ = aifw_core::sudo::ifconfig(&vlan_name, "down", &[]).await;
+            // Down may fail when a disabled VLAN was never created — expected.
+            debug_on_fail(
+                aifw_core::sudo::ifconfig(&vlan_name, "down", &[]).await,
+                "vlan ifconfig down",
+                &vlan_name,
+            );
         }
     }
 
@@ -753,9 +929,18 @@ pub async fn apply_vlans(pool: &SqlitePool) -> Result<(), String> {
         .collect();
     for iface in iface_list.split_whitespace() {
         if iface.starts_with("vlan") && !db_vlan_names.contains(&iface.to_string()) {
-            let _ = aifw_core::sudo::ifconfig(iface, "destroy", &[]).await;
+            warn_on_fail(
+                aifw_core::sudo::ifconfig(iface, "destroy", &[]).await,
+                "stale vlan destroy",
+                iface,
+            );
             let key = format!("ifconfig_{}", iface);
-            let _ = aifw_core::sudo::sysrc(&["-x", &key]).await;
+            // Unset may fail when the rcvar was never set — expected.
+            debug_on_fail(
+                aifw_core::sudo::sysrc(&["-x", &key]).await,
+                "sysrc ifconfig unset",
+                iface,
+            );
         }
     }
 

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 const GITHUB_API_URL: &str = "https://api.github.com/repos/ZerosAndOnesLLC/AiFw/releases/latest";
 // Lists releases newest-first INCLUDING pre-releases (and drafts), unlike
@@ -168,6 +168,25 @@ fn all_binaries() -> Vec<String> {
         bins.extend(repo.binaries.iter().cloned());
     }
     bins
+}
+
+/// Describe a failed best-effort privileged step, or `None` on success.
+///
+/// The `crate::sudo::*` wrappers (and raw `Command::output()`) return
+/// `Ok(Output)` even when the command exits non-zero, so a bare
+/// `let _ =` used to hide both spawn errors and failed commands
+/// (QUAL-H1 #421). Callers log the returned description and continue —
+/// these steps stay non-fatal by design.
+fn step_failure(result: &std::io::Result<std::process::Output>) -> Option<String> {
+    match result {
+        Ok(o) if o.status.success() => None,
+        Ok(o) => Some(format!(
+            "exit {}: {}",
+            o.status,
+            String::from_utf8_lossy(&o.stderr).trim()
+        )),
+        Err(e) => Some(format!("spawn failed: {e}")),
+    }
 }
 
 /// Failures from the self-update flow (release check, download, verify,
@@ -417,8 +436,17 @@ pub async fn install_from_path(
     const EXTRACT_DIR: &str = "/tmp/aifw-update-extract";
     // Scrub current + legacy staging. Root-owned, so the sudo helper is
     // required; best-effort because a clean run has nothing to remove.
-    let _ = crate::sudo::rm(&["-rf", EXTRACT_DIR]).await;
-    let _ = crate::sudo::rm(&["-rf", "/tmp/aifw-update/extracted"]).await;
+    if let Some(err) = step_failure(&crate::sudo::rm(&["-rf", EXTRACT_DIR]).await) {
+        debug!(path = EXTRACT_DIR, error = %err, "update: staging dir scrub failed");
+    }
+    if let Some(err) = step_failure(&crate::sudo::rm(&["-rf", "/tmp/aifw-update/extracted"]).await)
+    {
+        debug!(
+            path = "/tmp/aifw-update/extracted",
+            error = %err,
+            "update: legacy staging dir scrub failed"
+        );
+    }
     let extract_dir = std::path::PathBuf::from(EXTRACT_DIR);
     tokio::fs::create_dir_all(&extract_dir)
         .await
@@ -551,7 +579,13 @@ pub async fn install_from_path(
     let ui_src = update_dir.join("ui");
     if ui_src.exists() {
         info!("Installing UI...");
-        let _ = crate::sudo::rm(&["-rf", UI_DIR]).await;
+        if let Some(err) = step_failure(&crate::sudo::rm(&["-rf", UI_DIR]).await) {
+            warn!(
+                path = UI_DIR,
+                error = %err,
+                "update: failed to remove old UI dir — stale UI files may remain"
+            );
+        }
         let ui_src_str = ui_src
             .to_str()
             .ok_or_else(|| UpdaterError::Install("ui_src path is not UTF-8".into()))?;
@@ -583,7 +617,9 @@ pub async fn install_from_path(
         let pkg_installed = check.map(|o| o.status.success()).unwrap_or(false);
         if !pkg_installed {
             info!(package = pkg, "Installing missing dependency");
-            let _ = crate::sudo::pkg("install", &["-y", pkg]).await;
+            if let Some(err) = step_failure(&crate::sudo::pkg("install", &["-y", pkg]).await) {
+                warn!(package = pkg, error = %err, "update: dependency install failed");
+            }
         }
     }
 
@@ -615,7 +651,11 @@ pub async fn install_from_path(
                 let src_str = src
                     .to_str()
                     .expect("src path is utf-8 (file_name validated above)");
-                let _ = crate::sudo::install(Some("755"), None, None, src_str, &dst).await;
+                if let Some(err) = step_failure(
+                    &crate::sudo::install(Some("755"), None, None, src_str, &dst).await,
+                ) {
+                    warn!(script = %name, dest = %dst, error = %err, "update: rc.d script install failed");
+                }
             }
         }
     }
@@ -627,7 +667,9 @@ pub async fn install_from_path(
     let libexec_src = update_dir.join("libexec");
     if libexec_src.exists() {
         info!("Installing libexec scripts...");
-        let _ = crate::sudo::mkdir(&["-p", "/usr/local/libexec"]).await;
+        if let Some(err) = step_failure(&crate::sudo::mkdir(&["-p", "/usr/local/libexec"]).await) {
+            warn!(error = %err, "update: mkdir /usr/local/libexec failed");
+        }
         if let Ok(mut entries) = tokio::fs::read_dir(&libexec_src).await {
             while let Ok(Some(entry)) = entries.next_entry().await {
                 if !entry
@@ -647,7 +689,11 @@ pub async fn install_from_path(
                 let src_str = src
                     .to_str()
                     .expect("src path is utf-8 (file_name validated above)");
-                let _ = crate::sudo::install(Some("755"), None, None, src_str, &dst).await;
+                if let Some(err) = step_failure(
+                    &crate::sudo::install(Some("755"), None, None, src_str, &dst).await,
+                ) {
+                    warn!(script = %name, dest = %dst, error = %err, "update: libexec script install failed");
+                }
             }
         }
     }
@@ -676,14 +722,20 @@ pub async fn install_from_path(
                 let src_str = src
                     .to_str()
                     .expect("src path is utf-8 (file_name validated above)");
-                let _ = crate::sudo::install(Some("755"), None, None, src_str, &dst).await;
+                if let Some(err) = step_failure(
+                    &crate::sudo::install(Some("755"), None, None, src_str, &dst).await,
+                ) {
+                    warn!(script = %name, dest = %dst, error = %err, "update: utility script install failed");
+                }
             }
         }
     }
 
     // Ensure required directories exist (new services may need them)
     for dir in &manifest.directories {
-        let _ = crate::sudo::mkdir(&["-p", dir]).await;
+        if let Some(err) = step_failure(&crate::sudo::mkdir(&["-p", dir]).await) {
+            warn!(path = %dir, error = %err, "update: required directory create failed");
+        }
     }
 
     // Read the installed version from the tarball's version file
@@ -719,24 +771,32 @@ pub async fn install_from_path(
     // edits MOTD via the UI.
     #[cfg(target_os = "freebsd")]
     {
-        let _ = Command::new("/usr/local/libexec/aifw-motd-cleanup.sh")
+        let result = Command::new("/usr/local/libexec/aifw-motd-cleanup.sh")
             .output()
             .await;
+        if let Some(err) = step_failure(&result) {
+            debug!(error = %err, "update: motd cleanup script failed");
+        }
     }
 
     // One-shot migration: enforce password-protected console login on
     // existing installs that were shipped with autologin. Idempotent.
     #[cfg(target_os = "freebsd")]
     {
-        let _ = Command::new("/usr/local/libexec/aifw-login-migrate.sh")
+        let result = Command::new("/usr/local/libexec/aifw-login-migrate.sh")
             .output()
             .await;
+        if let Some(err) = step_failure(&result) {
+            warn!(error = %err, "update: console login migration script failed — autologin may remain enabled");
+        }
     }
 
     // Cleanup extract dir. Contents are root-owned (sudo-tar), so std fs
     // remove_dir_all would fail silently and leak staging across updates —
     // exactly what let stale dirs pile up before. Use the sudo helper.
-    let _ = crate::sudo::rm(&["-rf", EXTRACT_DIR]).await;
+    if let Some(err) = step_failure(&crate::sudo::rm(&["-rf", EXTRACT_DIR]).await) {
+        debug!(path = EXTRACT_DIR, error = %err, "update: staging dir cleanup failed");
+    }
 
     let version_display = if installed_version.is_empty() {
         "unknown".to_string()
@@ -759,8 +819,12 @@ pub async fn download_and_install(info: &AifwUpdateInfo) -> Result<String, Updat
     let tarball_path = std::path::PathBuf::from(format!("{}/update.tar.xz", tmp_dir));
     let checksum_path = format!("{}/update.tar.xz.sha256", tmp_dir);
 
-    // Clean and create temp dir
-    let _ = tokio::fs::remove_dir_all(tmp_dir).await;
+    // Clean and create temp dir. NotFound is the normal clean-run case.
+    if let Err(e) = tokio::fs::remove_dir_all(tmp_dir).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        debug!(path = tmp_dir, error = %e, "update: temp dir scrub failed");
+    }
     tokio::fs::create_dir_all(tmp_dir)
         .await
         .map_err(|e| UpdaterError::Install(format!("Failed to create temp dir: {}", e)))?;
@@ -783,7 +847,11 @@ pub async fn download_and_install(info: &AifwUpdateInfo) -> Result<String, Updat
     let version = install_from_path(&tarball_path, Some(&expected_hash)).await?;
 
     // Cleanup temp dir
-    let _ = tokio::fs::remove_dir_all(tmp_dir).await;
+    if let Err(e) = tokio::fs::remove_dir_all(tmp_dir).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        debug!(path = tmp_dir, error = %e, "update: temp dir cleanup failed");
+    }
 
     let new_ver = if version.is_empty() {
         info.latest_version.clone()
@@ -870,7 +938,9 @@ async fn write_embedded_script(name: &str, content: &str) {
         warn!(name, "failed to stage embedded script");
         return;
     }
-    let _ = crate::sudo::mkdir(&["-p", "/usr/local/libexec"]).await;
+    if let Some(err) = step_failure(&crate::sudo::mkdir(&["-p", "/usr/local/libexec"]).await) {
+        warn!(name, error = %err, "bootstrap: mkdir /usr/local/libexec failed");
+    }
     // Prefer the narrow `aifw-sudo-install` helper when it's already on
     // disk. Otherwise fall back to direct `sudo /usr/bin/install`, which
     // the broad pre-#204 sudoers grant permits. This is the bootstrap path
@@ -886,7 +956,9 @@ async fn write_embedded_script(name: &str, content: &str) {
             .output()
             .await
     };
-    let _ = tokio::fs::remove_file(&tmp).await;
+    if let Err(e) = tokio::fs::remove_file(&tmp).await {
+        debug!(name, path = %tmp, error = %e, "failed to remove staged bootstrap script");
+    }
     match result {
         Ok(o) if o.status.success() => info!(name, "libexec script bootstrapped"),
         Ok(o) => warn!(name, stderr = %String::from_utf8_lossy(&o.stderr), "install failed"),
@@ -924,7 +996,9 @@ async fn is_executable(path: &str) -> bool {
 pub async fn ensure_rcvars() {
     for var in OWNED_RCVARS {
         let arg = format!("{}=YES", var);
-        let _ = crate::sudo::sysrc(&[&arg]).await;
+        if let Some(err) = step_failure(&crate::sudo::sysrc(&[&arg]).await) {
+            warn!(rcvar = var, error = %err, "failed to set rcvar — service restart may be a silent no-op");
+        }
     }
 }
 
@@ -1025,7 +1099,14 @@ pub async fn schedule_reboot() -> Result<(), UpdaterError> {
         .spawn();
     match result {
         Ok(mut child) => {
-            let _ = child.wait().await;
+            match child.wait().await {
+                Ok(status) if !status.success() => warn!(
+                    %status,
+                    "shutdown exited non-zero — reboot may not be scheduled"
+                ),
+                Err(e) => warn!(error = %e, "failed to reap shutdown command"),
+                Ok(_) => {}
+            }
             info!("reboot scheduled (+1 min)");
             Ok(())
         }
@@ -1070,7 +1151,11 @@ pub async fn rollback() -> Result<String, UpdaterError> {
         let src = format!("{}/bin/{}", BACKUP_DIR, bin);
         if std::path::Path::new(&src).exists() {
             let dst = format!("{}/{}", BIN_DIR, bin);
-            let _ = crate::sudo::install(Some("755"), None, None, &src, &dst).await;
+            if let Some(err) =
+                step_failure(&crate::sudo::install(Some("755"), None, None, &src, &dst).await)
+            {
+                warn!(binary = %bin, error = %err, "rollback: binary restore failed");
+            }
         }
     }
 
@@ -1080,19 +1165,29 @@ pub async fn rollback() -> Result<String, UpdaterError> {
         let src = format!("{}/rc.d/{}", BACKUP_DIR, script);
         if std::path::Path::new(&src).exists() {
             let dst = format!("/usr/local/etc/rc.d/{}", script);
-            let _ = crate::sudo::install(Some("755"), None, None, &src, &dst).await;
+            if let Some(err) =
+                step_failure(&crate::sudo::install(Some("755"), None, None, &src, &dst).await)
+            {
+                warn!(script = %script, error = %err, "rollback: rc.d script restore failed");
+            }
         }
     }
 
     // Restore UI
     let backup_ui = format!("{}/ui", BACKUP_DIR);
     if std::path::Path::new(&backup_ui).exists() {
-        let _ = crate::sudo::rm(&["-rf", UI_DIR]).await;
-        let _ = crate::sudo::cp(&["-a", &backup_ui, UI_DIR]).await;
+        if let Some(err) = step_failure(&crate::sudo::rm(&["-rf", UI_DIR]).await) {
+            warn!(path = UI_DIR, error = %err, "rollback: failed to remove current UI dir");
+        }
+        if let Some(err) = step_failure(&crate::sudo::cp(&["-a", &backup_ui, UI_DIR]).await) {
+            warn!(path = UI_DIR, error = %err, "rollback: UI restore failed");
+        }
     }
 
     // Restore version file
-    let _ = crate::sudo::cp(&[&backup_ver, VERSION_FILE]).await;
+    if let Some(err) = step_failure(&crate::sudo::cp(&[&backup_ver, VERSION_FILE]).await) {
+        warn!(path = VERSION_FILE, error = %err, "rollback: version file restore failed");
+    }
 
     info!("Rolled back to v{}", version);
     Ok(format!("Rolled back to v{}", version))
@@ -1101,16 +1196,26 @@ pub async fn rollback() -> Result<String, UpdaterError> {
 // --- Private helpers ---
 
 async fn backup_current() -> Result<(), UpdaterError> {
-    let _ = crate::sudo::rm(&["-rf", BACKUP_DIR]).await;
+    if let Some(err) = step_failure(&crate::sudo::rm(&["-rf", BACKUP_DIR]).await) {
+        warn!(path = BACKUP_DIR, error = %err, "backup: failed to clear old backup dir");
+    }
     // The mkdir helper takes exactly one target, so create each dir
     // separately (rather than one mkdir with two operands).
-    let _ = crate::sudo::mkdir(&["-p", &format!("{}/bin", BACKUP_DIR)]).await;
-    let _ = crate::sudo::mkdir(&["-p", &format!("{}/rc.d", BACKUP_DIR)]).await;
+    for sub in ["bin", "rc.d"] {
+        let dir = format!("{}/{}", BACKUP_DIR, sub);
+        if let Some(err) = step_failure(&crate::sudo::mkdir(&["-p", &dir]).await) {
+            warn!(path = %dir, error = %err, "backup: failed to create backup dir");
+        }
+    }
 
     for bin in &all_binaries() {
         let src = format!("{}/{}", BIN_DIR, bin);
-        if std::path::Path::new(&src).exists() {
-            let _ = crate::sudo::cp(&["-p", &src, &format!("{}/bin/{}", BACKUP_DIR, bin)]).await;
+        if std::path::Path::new(&src).exists()
+            && let Some(err) = step_failure(
+                &crate::sudo::cp(&["-p", &src, &format!("{}/bin/{}", BACKUP_DIR, bin)]).await,
+            )
+        {
+            warn!(binary = %bin, error = %err, "backup: binary copy failed — rollback may be incomplete");
         }
     }
 
@@ -1118,18 +1223,28 @@ async fn backup_current() -> Result<(), UpdaterError> {
     let manifest = load_manifest();
     for script in &manifest.rc_scripts {
         let src = format!("/usr/local/etc/rc.d/{}", script);
-        if std::path::Path::new(&src).exists() {
-            let _ =
-                crate::sudo::cp(&["-p", &src, &format!("{}/rc.d/{}", BACKUP_DIR, script)]).await;
+        if std::path::Path::new(&src).exists()
+            && let Some(err) = step_failure(
+                &crate::sudo::cp(&["-p", &src, &format!("{}/rc.d/{}", BACKUP_DIR, script)]).await,
+            )
+        {
+            warn!(script = %script, error = %err, "backup: rc.d script copy failed");
         }
     }
 
-    if std::path::Path::new(UI_DIR).exists() {
-        let _ = crate::sudo::cp(&["-a", UI_DIR, &format!("{}/ui", BACKUP_DIR)]).await;
+    if std::path::Path::new(UI_DIR).exists()
+        && let Some(err) =
+            step_failure(&crate::sudo::cp(&["-a", UI_DIR, &format!("{}/ui", BACKUP_DIR)]).await)
+    {
+        warn!(path = UI_DIR, error = %err, "backup: UI copy failed — rollback may be incomplete");
     }
 
-    if std::path::Path::new(VERSION_FILE).exists() {
-        let _ = crate::sudo::cp(&[VERSION_FILE, &format!("{}/version", BACKUP_DIR)]).await;
+    if std::path::Path::new(VERSION_FILE).exists()
+        && let Some(err) = step_failure(
+            &crate::sudo::cp(&[VERSION_FILE, &format!("{}/version", BACKUP_DIR)]).await,
+        )
+    {
+        warn!(path = VERSION_FILE, error = %err, "backup: version file copy failed — rollback will report no backup");
     }
 
     Ok(())

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -33,9 +33,7 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
     // 3b. Fix DB ownership (DB was created as root, aifw user needs write access)
     #[cfg(target_os = "freebsd")]
     {
-        let _ = std::process::Command::new("chown")
-            .args(["-R", "aifw:aifw", "/var/db/aifw"])
-            .output();
+        run_best_effort("chown", &["-R", "aifw:aifw", "/var/db/aifw"]);
     }
 
     // 4. Generate pf rules
@@ -90,21 +88,31 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
     #[cfg(target_os = "freebsd")]
     {
         let sudoers_path = "/usr/local/etc/sudoers.d/aifw";
-        let _ = std::fs::create_dir_all("/usr/local/etc/sudoers.d");
-        let _ = std::fs::write(sudoers_path, sudoers_content());
+        warn_on_err(
+            "mkdir /usr/local/etc/sudoers.d",
+            std::fs::create_dir_all("/usr/local/etc/sudoers.d"),
+        );
+        warn_on_err(
+            "write sudoers grants",
+            std::fs::write(sudoers_path, sudoers_content()),
+        );
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(sudoers_path, std::fs::Permissions::from_mode(0o440));
+            warn_on_err(
+                "chmod sudoers to 0440",
+                std::fs::set_permissions(sudoers_path, std::fs::Permissions::from_mode(0o440)),
+            );
         }
     }
 
     // 5c. Setup unbound directory
     console::info("Configuring Unbound DNS resolver...");
-    let _ = std::fs::create_dir_all("/var/unbound");
-    let _ = std::process::Command::new("chown")
-        .args(["-R", "unbound:unbound", "/var/unbound"])
-        .status();
+    warn_on_err(
+        "mkdir /var/unbound",
+        std::fs::create_dir_all("/var/unbound"),
+    );
+    run_best_effort("chown", &["-R", "unbound:unbound", "/var/unbound"]);
     console::success("Unbound configured");
 
     // 5c2. Setup rDHCP directories
@@ -114,17 +122,11 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
         "/var/log/rdhcpd",
         "/usr/local/etc/rdhcpd",
     ] {
-        let _ = std::fs::create_dir_all(dir);
+        warn_on_err(&format!("mkdir {dir}"), std::fs::create_dir_all(dir));
     }
-    let _ = std::process::Command::new("chown")
-        .args(["-R", "aifw:aifw", "/var/db/rdhcpd"])
-        .status();
-    let _ = std::process::Command::new("chown")
-        .args(["-R", "aifw:aifw", "/var/log/rdhcpd"])
-        .status();
-    let _ = std::process::Command::new("chown")
-        .args(["-R", "aifw:aifw", "/usr/local/etc/rdhcpd"])
-        .status();
+    run_best_effort("chown", &["-R", "aifw:aifw", "/var/db/rdhcpd"]);
+    run_best_effort("chown", &["-R", "aifw:aifw", "/var/log/rdhcpd"]);
+    run_best_effort("chown", &["-R", "aifw:aifw", "/usr/local/etc/rdhcpd"]);
     console::success("rDHCP configured");
 
     // 5c3. Setup rDNS directories and user
@@ -135,43 +137,38 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
         "/var/run/rdns",
         "/var/log/rdns",
     ] {
-        let _ = std::fs::create_dir_all(dir);
+        warn_on_err(&format!("mkdir {dir}"), std::fs::create_dir_all(dir));
     }
     // Create rdns user if not exists
-    let _ = std::process::Command::new("pw")
+    let rdns_exists = std::process::Command::new("pw")
         .args(["user", "show", "rdns"])
         .status()
-        .and_then(|s| {
-            if !s.success() {
-                std::process::Command::new("pw")
-                    .args([
-                        "useradd",
-                        "rdns",
-                        "-d",
-                        "/nonexistent",
-                        "-s",
-                        "/usr/sbin/nologin",
-                        "-c",
-                        "rDNS DNS Server",
-                    ])
-                    .status()
-            } else {
-                Ok(s)
-            }
-        });
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !rdns_exists {
+        run_best_effort(
+            "pw",
+            &[
+                "useradd",
+                "rdns",
+                "-d",
+                "/nonexistent",
+                "-s",
+                "/usr/sbin/nologin",
+                "-c",
+                "rDNS DNS Server",
+            ],
+        );
+    }
     console::success("rDNS configured");
 
     // 5c4. Setup rTIME directories
     console::info("Configuring rTIME time service...");
     for dir in ["/usr/local/etc/rtime", "/var/run/rtime", "/var/log/rtime"] {
-        let _ = std::fs::create_dir_all(dir);
+        warn_on_err(&format!("mkdir {dir}"), std::fs::create_dir_all(dir));
     }
-    let _ = std::process::Command::new("chown")
-        .args(["-R", "aifw:aifw", "/usr/local/etc/rtime"])
-        .status();
-    let _ = std::process::Command::new("chown")
-        .args(["-R", "aifw:aifw", "/var/log/rtime"])
-        .status();
+    run_best_effort("chown", &["-R", "aifw:aifw", "/usr/local/etc/rtime"]);
+    run_best_effort("chown", &["-R", "aifw:aifw", "/var/log/rtime"]);
     console::success("rTIME configured");
 
     // 5d. Configure devfs rules for /dev/pf and /dev/bpf* access
@@ -242,42 +239,39 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
         // WAN interface
         match config.wan_mode {
             crate::config::WanMode::Dhcp => {
-                let _ = Command::new("sysrc")
-                    .args([&format!("ifconfig_{}=DHCP", config.wan_interface)])
-                    .output();
+                run_best_effort(
+                    "sysrc",
+                    &[&format!("ifconfig_{}=DHCP", config.wan_interface)],
+                );
             }
             crate::config::WanMode::Static => {
                 if let Some(ref ip) = config.wan_ip {
-                    let _ = Command::new("sysrc")
-                        .args([&format!("ifconfig_{}=inet {}", config.wan_interface, ip)])
-                        .output();
+                    run_best_effort(
+                        "sysrc",
+                        &[&format!("ifconfig_{}=inet {}", config.wan_interface, ip)],
+                    );
                 }
                 if let Some(ref gw) = config.wan_gateway {
-                    let _ = Command::new("sysrc")
-                        .args([&format!("defaultrouter={}", gw)])
-                        .output();
+                    run_best_effort("sysrc", &[&format!("defaultrouter={}", gw)]);
                 }
             }
             crate::config::WanMode::Pppoe => {
-                let _ = Command::new("sysrc")
-                    .args([&format!("ifconfig_{}=DHCP", config.wan_interface)])
-                    .output();
+                run_best_effort(
+                    "sysrc",
+                    &[&format!("ifconfig_{}=DHCP", config.wan_interface)],
+                );
             }
         }
 
         // LAN interface
         if let (Some(iface), Some(ip)) = (&config.lan_interface, &config.lan_ip) {
-            let _ = Command::new("sysrc")
-                .args([&format!("ifconfig_{}=inet {}", iface, ip)])
-                .output();
+            run_best_effort("sysrc", &[&format!("ifconfig_{}=inet {}", iface, ip)]);
             // Apply immediately
-            let _ = Command::new("ifconfig")
-                .args([iface.as_str(), "inet", ip])
-                .output();
+            run_best_effort("ifconfig", &[iface.as_str(), "inet", ip]);
         }
 
         // Gateway forwarding
-        let _ = Command::new("sysrc").args(["gateway_enable=YES"]).output();
+        run_best_effort("sysrc", &["gateway_enable=YES"]);
 
         console::success("Network interfaces configured");
     }
@@ -295,9 +289,10 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
         // keep re-applying over the daemon's DB-driven updates (v5.57.3 fix).
 
         // Load pf rules
-        let _ = Command::new("pfctl")
-            .args(["-f", &format!("{}/pf.conf.aifw", config.config_dir)])
-            .output();
+        run_best_effort(
+            "pfctl",
+            &["-f", &format!("{}/pf.conf.aifw", config.config_dir)],
+        );
         console::success("pf rules loaded");
 
         // sysrc-enable AiFw services so existing-install upgrades and
@@ -305,26 +300,25 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
         // added in v5.76.0). aifw_firstboot also does this, but only on
         // first boot — running aifw-setup on an existing appliance never
         // hits firstboot, so we belt-and-braces it here too.
-        let _ = Command::new("sysrc")
-            .args(["aifw_daemon_enable=YES"])
-            .output();
-        let _ = Command::new("sysrc").args(["aifw_ids_enable=YES"]).output();
-        let _ = Command::new("sysrc").args(["aifw_api_enable=YES"]).output();
-        let _ = Command::new("sysrc")
-            .args(["aifw_watchdog_enable=YES"])
-            .output();
+        run_best_effort("sysrc", &["aifw_daemon_enable=YES"]);
+        run_best_effort("sysrc", &["aifw_ids_enable=YES"]);
+        run_best_effort("sysrc", &["aifw_api_enable=YES"]);
+        run_best_effort("sysrc", &["aifw_watchdog_enable=YES"]);
 
         // HA cluster rc.conf keys
         let cluster_enabled = config.cluster.is_some();
-        let _ = run_sysrc(
-            "aifw_cluster_enabled",
-            if cluster_enabled { "YES" } else { "NO" },
+        warn_on_err(
+            "",
+            run_sysrc(
+                "aifw_cluster_enabled",
+                if cluster_enabled { "YES" } else { "NO" },
+            ),
         );
         if let Some(c) = &config.cluster {
-            let _ = run_sysrc("aifw_cluster_role", &c.role.to_string());
-            let _ = run_sysrc("pfsync_enable", "YES");
+            warn_on_err("", run_sysrc("aifw_cluster_role", &c.role.to_string()));
+            warn_on_err("", run_sysrc("pfsync_enable", "YES"));
             let pfsync_args = format!("syncdev {} defer up", c.pfsync_iface);
-            let _ = run_sysrc("ifconfig_pfsync0", &pfsync_args);
+            warn_on_err("", run_sysrc("ifconfig_pfsync0", &pfsync_args));
             // Setup writes Conservative timing to rc.conf as the boot-time default.
             // At runtime, aifw-daemon's recover_kernel_state_for_role re-applies
             // the actual stored profile via ifconfig, so any operator change via
@@ -344,35 +338,31 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
                     vip.virtual_ip,
                     vip.prefix,
                 );
-                let _ = run_sysrc_append(&key, &alias);
+                warn_on_err("", run_sysrc_append(&key, &alias));
             }
-            let _ = run_sysrc("aifw_carp_demote_enable", "YES");
-            let _ = run_sysrc("aifw_demote_on_shutdown_enable", "YES");
+            warn_on_err("", run_sysrc("aifw_carp_demote_enable", "YES"));
+            warn_on_err("", run_sysrc("aifw_demote_on_shutdown_enable", "YES"));
         } else {
-            let _ = run_sysrc("aifw_cluster_role", "standalone");
+            warn_on_err("", run_sysrc("aifw_cluster_role", "standalone"));
         }
 
         // Start core services
-        let _ = Command::new("service")
-            .args(["aifw_daemon", "start"])
-            .output();
+        run_best_effort("service", &["aifw_daemon", "start"]);
         // aifw_ids must come up before aifw_api (aifw_api REQUIREs aifw_ids)
-        let _ = Command::new("service").args(["aifw_ids", "start"]).output();
-        let _ = Command::new("service").args(["aifw_api", "start"]).output();
+        run_best_effort("service", &["aifw_ids", "start"]);
+        run_best_effort("service", &["aifw_api", "start"]);
         // Watchdog last so it doesn't observe the others mid-startup and
         // try to "heal" them.
-        let _ = Command::new("service")
-            .args(["aifw_watchdog", "start"])
-            .output();
+        run_best_effort("service", &["aifw_watchdog", "start"]);
         console::success("AiFw daemon, IDS, API, and watchdog started");
 
         // Start rDNS
-        let _ = Command::new("service").args(["rdns", "start"]).output();
+        run_best_effort("service", &["rdns", "start"]);
         console::success("rDNS started");
 
         // Start rDHCP if enabled
         if config.dhcp_enabled {
-            let _ = Command::new("service").args(["rdhcpd", "start"]).output();
+            run_best_effort("service", &["rdhcpd", "start"]);
             console::success("rDHCP started");
         }
     }
@@ -422,9 +412,7 @@ fn create_service_user() -> Result<(), String> {
             }
         }
         // Create group
-        let _ = Command::new("pw")
-            .args(["groupadd", "aifw", "-g", "470"])
-            .output();
+        run_best_effort("pw", &["groupadd", "aifw", "-g", "470"]);
         // Create user: no login shell, no home, system account
         let out = Command::new("pw")
             .args([
@@ -476,12 +464,10 @@ fn configure_devfs() -> Result<(), String> {
         }
 
         // Enable the ruleset in rc.conf
-        let _ = Command::new("sysrc")
-            .args(["devfs_system_ruleset=aifw_devfs"])
-            .output();
+        run_best_effort("sysrc", &["devfs_system_ruleset=aifw_devfs"]);
 
         // Apply immediately
-        let _ = Command::new("service").args(["devfs", "restart"]).output();
+        run_best_effort("service", &["devfs", "restart"]);
     }
     Ok(())
 }
@@ -528,13 +514,12 @@ fn generate_tls_cert() -> Result<(), String> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(key_path, std::fs::Permissions::from_mode(0o640));
-        let _ = std::process::Command::new("chown")
-            .args(["root:aifw", key_path])
-            .output();
-        let _ = std::process::Command::new("chown")
-            .args(["root:aifw", cert_path])
-            .output();
+        warn_on_err(
+            "chmod jwt key to 0640",
+            std::fs::set_permissions(key_path, std::fs::Permissions::from_mode(0o640)),
+        );
+        run_best_effort("chown", &["root:aifw", key_path]);
+        run_best_effort("chown", &["root:aifw", cert_path]);
     }
 
     Ok(())
@@ -556,10 +541,16 @@ fn configure_ssh(config: &SetupConfig) -> Result<(), String> {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(ssh_dir, std::fs::Permissions::from_mode(0o700));
-            let _ = std::fs::set_permissions(
-                format!("{ssh_dir}/authorized_keys"),
-                std::fs::Permissions::from_mode(0o600),
+            warn_on_err(
+                "chmod ssh dir to 0700",
+                std::fs::set_permissions(ssh_dir, std::fs::Permissions::from_mode(0o700)),
+            );
+            warn_on_err(
+                "chmod authorized_keys to 0600",
+                std::fs::set_permissions(
+                    format!("{ssh_dir}/authorized_keys"),
+                    std::fs::Permissions::from_mode(0o600),
+                ),
             );
         }
     }
@@ -600,19 +591,17 @@ fn configure_ssh(config: &SetupConfig) -> Result<(), String> {
             .map_err(|e| format!("failed to write sshd_config: {e}"))?;
 
         // Enable sshd at boot
-        let _ = std::process::Command::new("sysrc")
-            .args(["sshd_enable=YES"])
-            .output();
+        run_best_effort("sysrc", &["sshd_enable=YES"]);
 
         // Restart sshd to apply config
-        let _ = std::process::Command::new("service")
-            .args(["sshd", "restart"])
-            .output();
+        run_best_effort("service", &["sshd", "restart"]);
     }
 
     #[cfg(not(target_os = "freebsd"))]
     {
-        let _ = sshd_config; // suppress unused warning on non-FreeBSD
+        // Not fallible: consumes the built string to suppress the unused
+        // warning on non-FreeBSD dev builds.
+        let _ = sshd_config;
     }
 
     Ok(())
@@ -628,24 +617,14 @@ fn create_dirs(config: &SetupConfig) -> Result<(), String> {
     {
         use std::process::Command;
         // Config dir: root owns, aifw group can read
-        let _ = Command::new("chown")
-            .args(["root:aifw", &config.config_dir])
-            .output();
-        let _ = Command::new("chmod")
-            .args(["750", &config.config_dir])
-            .output();
+        run_best_effort("chown", &["root:aifw", &config.config_dir]);
+        run_best_effort("chmod", &["750", &config.config_dir]);
         // DB dir: aifw owns (API needs write access)
-        let _ = Command::new("chown")
-            .args(["-R", "aifw:aifw", "/var/db/aifw"])
-            .output();
-        let _ = Command::new("chmod").args(["750", "/var/db/aifw"]).output();
+        run_best_effort("chown", &["-R", "aifw:aifw", "/var/db/aifw"]);
+        run_best_effort("chmod", &["750", "/var/db/aifw"]);
         // Log dir: aifw owns
-        let _ = Command::new("chown")
-            .args(["-R", "aifw:aifw", "/var/log/aifw"])
-            .output();
-        let _ = Command::new("chmod")
-            .args(["750", "/var/log/aifw"])
-            .output();
+        run_best_effort("chown", &["-R", "aifw:aifw", "/var/log/aifw"]);
+        run_best_effort("chmod", &["750", "/var/log/aifw"]);
     }
 
     Ok(())
@@ -653,6 +632,38 @@ fn create_dirs(config: &SetupConfig) -> Result<(), String> {
 
 fn write_file(path: &str, content: &str) -> Result<(), String> {
     std::fs::write(path, content).map_err(|e| format!("failed to write {path}: {e}"))
+}
+
+/// Run a best-effort setup command, printing a visible warning on spawn
+/// failure or non-zero exit instead of silently swallowing it (QUAL-H1 #421).
+/// First-boot steps intentionally continue past individual failures — the
+/// operator sees the warning in the wizard output and can fix up afterwards.
+#[cfg_attr(not(target_os = "freebsd"), allow(dead_code))]
+fn run_best_effort(cmd: &str, args: &[&str]) {
+    match std::process::Command::new(cmd).args(args).output() {
+        Ok(out) if out.status.success() => {}
+        Ok(out) => console::warn(&format!(
+            "{cmd} {} exited with {}: {}",
+            args.join(" "),
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        )),
+        Err(e) => console::warn(&format!("failed to run {cmd} {}: {e}", args.join(" "))),
+    }
+}
+
+/// Print a fallible best-effort step's failure instead of dropping it
+/// (QUAL-H1 #421). Pass an empty `desc` when the error already carries
+/// full context.
+#[cfg_attr(not(target_os = "freebsd"), allow(dead_code))]
+fn warn_on_err<T, E: std::fmt::Display>(desc: &str, res: Result<T, E>) {
+    if let Err(e) = res {
+        if desc.is_empty() {
+            console::warn(&format!("{e}"));
+        } else {
+            console::warn(&format!("{desc}: {e}"));
+        }
+    }
 }
 
 /// Write a single sysrc key=value pair (FreeBSD only).
@@ -810,11 +821,17 @@ async fn init_database(config: &SetupConfig) -> Result<(), String> {
         .map_err(|e| format!("interface_roles table: {e}"))?;
 
     let now = chrono::Utc::now().to_rfc3339();
-    let _ = sqlx::query("INSERT OR REPLACE INTO interface_roles (interface_name, role, updated_at) VALUES (?1, 'WAN', ?2)")
-        .bind(&config.wan_interface).bind(&now).execute(&pool).await;
+    warn_on_err(
+        "seed WAN interface role",
+        sqlx::query("INSERT OR REPLACE INTO interface_roles (interface_name, role, updated_at) VALUES (?1, 'WAN', ?2)")
+            .bind(&config.wan_interface).bind(&now).execute(&pool).await,
+    );
     if let Some(ref lan) = config.lan_interface {
-        let _ = sqlx::query("INSERT OR REPLACE INTO interface_roles (interface_name, role, updated_at) VALUES (?1, 'LAN', ?2)")
-            .bind(lan).bind(&now).execute(&pool).await;
+        warn_on_err(
+            "seed LAN interface role",
+            sqlx::query("INSERT OR REPLACE INTO interface_roles (interface_name, role, updated_at) VALUES (?1, 'LAN', ?2)")
+                .bind(lan).bind(&now).execute(&pool).await,
+        );
     }
 
     // Seed DNS resolver config — rDNS enabled by default with forwarding to user's DNS servers
@@ -842,18 +859,24 @@ async fn init_database(config: &SetupConfig) -> Result<(), String> {
             ("rebind_protection", "true"),
         ];
         for (k, v) in &dns_defaults {
-            let _ = sqlx::query(
-                "INSERT OR IGNORE INTO dns_resolver_config (key, value) VALUES (?1, ?2)",
-            )
-            .bind(k)
-            .bind(v)
-            .execute(&pool)
-            .await;
+            warn_on_err(
+                &format!("seed dns config {k}"),
+                sqlx::query(
+                    "INSERT OR IGNORE INTO dns_resolver_config (key, value) VALUES (?1, ?2)",
+                )
+                .bind(k)
+                .bind(v)
+                .execute(&pool)
+                .await,
+            );
         }
         // Forward to user's configured DNS servers
         if !config.dns_servers.is_empty() {
-            let _ = sqlx::query("INSERT OR IGNORE INTO dns_resolver_config (key, value) VALUES ('forwarding_servers', ?1)")
-                .bind(config.dns_servers.join(",")).execute(&pool).await;
+            warn_on_err(
+                "seed dns forwarding servers",
+                sqlx::query("INSERT OR IGNORE INTO dns_resolver_config (key, value) VALUES ('forwarding_servers', ?1)")
+                    .bind(config.dns_servers.join(",")).execute(&pool).await,
+            );
         }
     }
 
@@ -909,19 +932,21 @@ rate_limit = 1000
         fwd = fwd_servers
     );
 
-    let _ = std::fs::create_dir_all("/usr/local/etc/rdns");
-    let _ = std::fs::write("/usr/local/etc/rdns/rdns.toml", &rdns_conf);
+    warn_on_err(
+        "mkdir /usr/local/etc/rdns",
+        std::fs::create_dir_all("/usr/local/etc/rdns"),
+    );
+    warn_on_err(
+        "write rdns.toml",
+        std::fs::write("/usr/local/etc/rdns/rdns.toml", &rdns_conf),
+    );
 
     // Enable rDNS at boot
     #[cfg(target_os = "freebsd")]
     {
-        let _ = std::process::Command::new("sysrc")
-            .args(["rdns_enable=YES"])
-            .status();
+        run_best_effort("sysrc", &["rdns_enable=YES"]);
         // Disable unbound to avoid port conflict
-        let _ = std::process::Command::new("sysrc")
-            .args(["local_unbound_enable=NO"])
-            .status();
+        run_best_effort("sysrc", &["local_unbound_enable=NO"]);
     }
 
     // Seed DNS ACL entries — allow LAN subnet and localhost
@@ -937,8 +962,11 @@ rate_limit = 1000
     if acl_count.0 == 0 {
         let now = chrono::Utc::now().to_rfc3339();
         // Allow localhost
-        let _ = sqlx::query("INSERT INTO dns_access_lists (id, network, action, description, created_at) VALUES (?1, '127.0.0.0/8', 'allow', 'Localhost', ?2)")
-            .bind(uuid::Uuid::new_v4().to_string()).bind(&now).execute(&pool).await;
+        warn_on_err(
+            "seed localhost dns acl",
+            sqlx::query("INSERT INTO dns_access_lists (id, network, action, description, created_at) VALUES (?1, '127.0.0.0/8', 'allow', 'Localhost', ?2)")
+                .bind(uuid::Uuid::new_v4().to_string()).bind(&now).execute(&pool).await,
+        );
         // Allow LAN subnet if configured
         if let Some(ref lip) = config.lan_ip {
             let octets: Vec<&str> = lip
@@ -949,8 +977,11 @@ rate_limit = 1000
                 .collect();
             if octets.len() == 4 {
                 let subnet = format!("{}.{}.{}.0/24", octets[0], octets[1], octets[2]);
-                let _ = sqlx::query("INSERT INTO dns_access_lists (id, network, action, description, created_at) VALUES (?1, ?2, 'allow', 'LAN subnet', ?3)")
-                    .bind(uuid::Uuid::new_v4().to_string()).bind(&subnet).bind(&now).execute(&pool).await;
+                warn_on_err(
+                    "seed lan dns acl",
+                    sqlx::query("INSERT INTO dns_access_lists (id, network, action, description, created_at) VALUES (?1, ?2, 'allow', 'LAN subnet', ?3)")
+                        .bind(uuid::Uuid::new_v4().to_string()).bind(&subnet).bind(&now).execute(&pool).await,
+                );
             }
         }
     }
@@ -991,9 +1022,12 @@ rate_limit = 1000
         // Delete any pre-existing loopback key so re-running setup always yields
         // a fresh credential. The daemon must be restarted after re-running setup
         // to pick up the new key from rc.conf.
-        let _ = sqlx::query("DELETE FROM api_keys WHERE name = 'aifw-daemon-loopback'")
-            .execute(&pool)
-            .await;
+        warn_on_err(
+            "clear stale loopback api key",
+            sqlx::query("DELETE FROM api_keys WHERE name = 'aifw-daemon-loopback'")
+                .execute(&pool)
+                .await,
+        );
 
         sqlx::query(
             "INSERT INTO api_keys (id, name, key_hash, prefix, user_id, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
@@ -1014,7 +1048,10 @@ rate_limit = 1000
         // AIFW_LOOPBACK_API_KEY into the daemon's environment.
         let key_path = std::path::Path::new("/usr/local/etc/aifw/daemon.key");
         if let Some(parent) = key_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
+            warn_on_err(
+                &format!("mkdir {}", parent.display()),
+                std::fs::create_dir_all(parent),
+            );
         }
         if let Err(e) = std::fs::write(key_path, &loopback_key) {
             tracing::warn!(error = %e, "could not write daemon.key (non-FreeBSD dev env — skipped)");
@@ -1026,22 +1063,22 @@ rate_limit = 1000
                 if let Ok(meta) = std::fs::metadata(key_path) {
                     let mut perms = meta.permissions();
                     perms.set_mode(0o640);
-                    let _ = std::fs::set_permissions(key_path, perms);
+                    warn_on_err(
+                        "chmod daemon api key to 0600",
+                        std::fs::set_permissions(key_path, perms),
+                    );
                 }
             }
             // chown root:aifw — only meaningful on FreeBSD where the aifw user exists.
             #[cfg(target_os = "freebsd")]
             {
-                let _ = std::process::Command::new("chown")
-                    .arg("root:aifw")
-                    .arg(key_path)
-                    .status();
+                run_best_effort("chown", &["root:aifw", "/usr/local/etc/aifw/daemon.key"]);
             }
         }
         // Clear any previously set aifw_daemon_env from rc.conf — the key is
         // now read from daemon.key by the precmd; rc.conf no longer carries it.
         #[cfg(target_os = "freebsd")]
-        let _ = run_sysrc("aifw_daemon_env", "");
+        warn_on_err("", run_sysrc("aifw_daemon_env", ""));
 
         let pf: std::sync::Arc<dyn aifw_pf::PfBackend> =
             std::sync::Arc::from(aifw_pf::create_backend());
@@ -1200,26 +1237,33 @@ async fn seed_dhcp_config(
         ("domain_name", "local"),
     ];
     for (k, v) in &dhcp_defaults {
-        let _ = sqlx::query("INSERT OR IGNORE INTO dhcp_config (key, value) VALUES (?1, ?2)")
-            .bind(k)
-            .bind(v)
-            .execute(pool)
-            .await;
+        warn_on_err(
+            &format!("seed dhcp config {k}"),
+            sqlx::query("INSERT OR IGNORE INTO dhcp_config (key, value) VALUES (?1, ?2)")
+                .bind(k)
+                .bind(v)
+                .execute(pool)
+                .await,
+        );
     }
     // Bind to LAN interface
     if let Some(ref li) = config.lan_interface {
-        let _ =
+        warn_on_err(
+            "seed dhcp interfaces",
             sqlx::query("INSERT OR IGNORE INTO dhcp_config (key, value) VALUES ('interfaces', ?1)")
                 .bind(li)
                 .execute(pool)
-                .await;
+                .await,
+        );
     }
     // DNS for scope = LAN IP (rDNS is on the firewall)
-    let _ =
+    warn_on_err(
+        "seed dhcp dns_servers",
         sqlx::query("INSERT OR IGNORE INTO dhcp_config (key, value) VALUES ('dns_servers', ?1)")
             .bind(lan_ip)
             .execute(pool)
-            .await;
+            .await,
+    );
 
     // Create subnets table and default pool
     sqlx::query(r#"CREATE TABLE IF NOT EXISTS dhcp_subnets (
@@ -1233,7 +1277,7 @@ async fn seed_dhcp_config(
 
     let now = chrono::Utc::now().to_rfc3339();
     let id = uuid::Uuid::new_v4().to_string();
-    let _ = sqlx::query(
+    sqlx::query(
         "INSERT INTO dhcp_subnets (id, network, pool_start, pool_end, gateway, dns_servers, domain_name, \
          lease_time, subnet_type, enabled, description, created_at) \
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'local', 3600, 'address', 1, 'Default LAN pool', ?7)"
@@ -1280,17 +1324,27 @@ enabled = false
         dns = lan_ip
     );
 
-    let _ = std::fs::create_dir_all("/usr/local/etc/rdhcpd");
-    let _ = std::fs::create_dir_all("/var/db/rdhcpd/leases");
-    let _ = std::fs::create_dir_all("/var/log/rdhcpd");
-    let _ = std::fs::write("/usr/local/etc/rdhcpd/config.toml", &rdhcp_conf);
+    warn_on_err(
+        "mkdir /usr/local/etc/rdhcpd",
+        std::fs::create_dir_all("/usr/local/etc/rdhcpd"),
+    );
+    warn_on_err(
+        "mkdir /var/db/rdhcpd/leases",
+        std::fs::create_dir_all("/var/db/rdhcpd/leases"),
+    );
+    warn_on_err(
+        "mkdir /var/log/rdhcpd",
+        std::fs::create_dir_all("/var/log/rdhcpd"),
+    );
+    warn_on_err(
+        "write rdhcpd config.toml",
+        std::fs::write("/usr/local/etc/rdhcpd/config.toml", &rdhcp_conf),
+    );
 
     // Enable rDHCP at boot
     #[cfg(target_os = "freebsd")]
     {
-        let _ = std::process::Command::new("sysrc")
-            .args(["rdhcpd_enable=YES"])
-            .status();
+        run_best_effort("sysrc", &["rdhcpd_enable=YES"]);
     }
 
     Ok(())
@@ -1619,7 +1673,7 @@ async fn seed_default_rules(pool: &sqlx::SqlitePool, config: &SetupConfig) -> Re
                 "any".to_string()
             };
 
-            let _ = sqlx::query(
+            sqlx::query(
                 "INSERT INTO nat_rules (id, nat_type, interface, protocol, src_addr, \
                  src_port_start, src_port_end, dst_addr, dst_port_start, dst_port_end, \
                  redirect_addr, redirect_port_start, redirect_port_end, \
@@ -2320,11 +2374,26 @@ run_rc_command "$1"
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o755);
-        let _ = std::fs::set_permissions(format!("{rcd_dir}/aifw_daemon"), perms.clone());
-        let _ = std::fs::set_permissions(format!("{rcd_dir}/aifw_api"), perms.clone());
-        let _ = std::fs::set_permissions(format!("{rcd_dir}/aifw_ids"), perms.clone());
-        let _ = std::fs::set_permissions(format!("{rcd_dir}/aifw_watchdog"), perms.clone());
-        let _ = std::fs::set_permissions(format!("{rcd_dir}/rdhcpd"), perms);
+        warn_on_err(
+            "chmod rc.d/aifw_daemon to 0755",
+            std::fs::set_permissions(format!("{rcd_dir}/aifw_daemon"), perms.clone()),
+        );
+        warn_on_err(
+            "chmod rc.d/aifw_api to 0755",
+            std::fs::set_permissions(format!("{rcd_dir}/aifw_api"), perms.clone()),
+        );
+        warn_on_err(
+            "chmod rc.d/aifw_ids to 0755",
+            std::fs::set_permissions(format!("{rcd_dir}/aifw_ids"), perms.clone()),
+        );
+        warn_on_err(
+            "chmod rc.d/aifw_watchdog to 0755",
+            std::fs::set_permissions(format!("{rcd_dir}/aifw_watchdog"), perms.clone()),
+        );
+        warn_on_err(
+            "chmod rc.d/rdhcpd to 0755",
+            std::fs::set_permissions(format!("{rcd_dir}/rdhcpd"), perms),
+        );
     }
 
     Ok(())

--- a/aifw-setup/src/tests.rs
+++ b/aifw-setup/src/tests.rs
@@ -365,3 +365,56 @@ mod tests {
         );
     }
 }
+
+/// Discipline gate for QUAL-H1 (#421), mirroring the `sudoers_tests`
+/// pattern: the files swept of silent `let _ = ...` must stay swept.
+/// Every `let _ =` that remains (or is newly added) in these files must
+/// carry a `//` justification comment on the line directly above it —
+/// otherwise the failure it swallows is invisible, which is exactly the
+/// bug class the sweep removed.
+#[cfg(test)]
+mod let_underscore_tests {
+    /// Files cleaned in the #421 sweep, relative to the workspace root.
+    const SWEPT_FILES: &[&str] = &[
+        "aifw-setup/src/apply.rs",
+        "aifw-api/src/iface.rs",
+        "aifw-api/src/backup.rs",
+        "aifw-api/src/dhcp.rs",
+        "aifw-core/src/updater.rs",
+    ];
+
+    #[test]
+    fn let_underscore_requires_justification_comment() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        let mut violations = Vec::new();
+        for rel in SWEPT_FILES {
+            let path = root.join(rel);
+            let content = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("failed to read {rel}: {e}"));
+            let lines: Vec<&str> = content.lines().collect();
+            for (idx, line) in lines.iter().enumerate() {
+                let trimmed = line.trim_start();
+                // Only flag value-discarding `let _ =`, not `let _x =` or
+                // tuple patterns.
+                if !trimmed.starts_with("let _ =") {
+                    continue;
+                }
+                let prev_is_comment = idx
+                    .checked_sub(1)
+                    .map(|i| lines[i].trim_start().starts_with("//"))
+                    .unwrap_or(false);
+                if !prev_is_comment {
+                    violations.push(format!("{rel}:{}: {trimmed}", idx + 1));
+                }
+            }
+        }
+        assert!(
+            violations.is_empty(),
+            "unjustified `let _ =` in swept files (QUAL-H1 #421).\n\
+             Either log the failure (tracing::warn! / console::warn) or add a\n\
+             `//` comment on the line above explaining why it is safe to\n\
+             ignore:\n{}",
+            violations.join("\n")
+        );
+    }
+}

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.1",
+  "version": "5.99.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.1",
+      "version": "5.99.2",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.1",
+  "version": "5.99.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Closes #421

## What

Sweeps the five files the audit flagged as the biggest offenders — 213 `let _ =` sites reviewed individually:

| File | Sites | Now |
|------|-------|-----|
| `aifw-setup/src/apply.rs` | 86 | 85 logged via new `run_best_effort`/`warn_on_err` helpers, 1 justified (non-fallible unused-var suppression) |
| `aifw-api/src/iface.rs` | 40 | 39 logged (26 warn / 13 debug), 1 dead binding deleted |
| `aifw-api/src/backup.rs` | 34 | 33 logged, 1 justified (`cancel_tx.send` — timer may already have fired) |
| `aifw-core/src/updater.rs` | 28 | 28 logged (21 warn / 7 debug) |
| `aifw-api/src/dhcp.rs` | 26 | 26 logged |

Per policy #188, every fallible operation now either logs its failure or carries a justification comment on the line above. **Behavior is unchanged**: all failures stay non-fatal — no new `?`, no early returns.

## Key details

- **Non-zero exits are now visible too.** The `sudo::*` helpers and `Command::output()` return `Ok(Output)` even when the command fails, so a bare `if let Err` would still miss the interesting case. Each file's helper (`run_best_effort`, `warn_on_fail`, `step_failure`, `warn_on_cmd_fail`) logs status + trimmed stderr on non-zero exit.
- **The finding's headline case is fixed**: the silent `chown -R aifw:aifw /var/db/aifw` in first-boot setup now surfaces in the wizard output, as do the sudoers write/0440 chmod and every other security-relevant permission step.
- **Two real bug-adjacent fixes fell out**: the backup commit-confirm rollback logged "Config rolled back successfully" unconditionally (now only on success), and `schedule_reboot()` ignored a non-zero `sudo shutdown` exit (now warns that the reboot may not be scheduled — the sudoers-drift failure class).
- **warn vs debug judgment**: warn is the default; debug only where failure is routine and expected (killing a dhclient that isn't running, `sysrc -x` of an unset key, scrubbing temp dirs that don't exist), each with a comment where non-obvious.
- **Justified keeps** (2 total) carry a `//` comment on the line directly above explaining why the failure is unactionable.

## Regression guard

A workspace-level test in `aifw-setup` (mirroring the `sudoers_tests` discipline pattern, as the finding recommended) reads the five swept files and fails if any `let _ =` appears without a justification comment on the preceding line — so the sweep can't silently regress. The workspace-wide clippy lint suggested in the finding isn't enabled yet since ~335 sites remain in unswept files; the guard covers the cleaned surface until those are done.

## Verification

- `cargo check --workspace --all-targets` zero warnings; clippy clean; `cargo fmt` clean (pre-commit)
- Full `cargo test` passes, including the new guard test
- Version bumped 5.99.1 → 5.99.2