### PR TITLE
perf: fix the 13 open medium performance-audit findings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.3"
+version = "5.99.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/Cargo.toml
+++ b/aifw-api/Cargo.toml
@@ -17,7 +17,7 @@ aifw-plugins = { workspace = true }
 aifw-ids = { workspace = true }
 aifw-ids-ipc = { workspace = true }
 aifw-metrics = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "fs", "process", "time", "sync", "io-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "fs", "process", "time", "sync", "io-util", "signal"] }
 axum = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
@@ -42,6 +42,9 @@ futures-util = "0.3"
 redis = { version = "1.2", features = ["tokio-comp", "connection-manager"] }
 clap = { workspace = true, features = ["env"] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }
+# Already in the tree via tower-http's compression backends; used to
+# deflate metrics-history ring entries (PERF-M5 #373).
+flate2 = "1"
 rcgen = { workspace = true }
 serde_yaml_ng = "0.10"
 time = { workspace = true }

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -2442,10 +2442,16 @@ pub async fn auto_snapshot_middleware(
 
     let response = next.run(request).await;
 
-    if !mutating || should_skip_auto_snapshot(&path) {
+    if !mutating || !response.status().is_success() {
         return response;
     }
-    if !response.status().is_success() {
+    // PERF-M15: any successful mutation may change the exported config —
+    // invalidate the cached cluster snapshot. Done before the skip list so
+    // paths that skip auto-snapshot still invalidate correctly.
+    state
+        .config_generation
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    if should_skip_auto_snapshot(&path) {
         return response;
     }
 

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -44,6 +44,7 @@ use std::sync::Arc;
 use tokio::sync::{RwLock, watch};
 use tower::ServiceBuilder;
 use tower_http::compression::CompressionLayer;
+use tower_http::compression::predicate::SizeAbove;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::services::{ServeDir, ServeFile};
 use tower_http::set_header::SetResponseHeaderLayer;
@@ -135,9 +136,12 @@ async fn over_cap(
     max_attempts: u32,
     window_secs: i64,
 ) -> bool {
+    // PERF-M3: read-only — the window check below already ignores expired
+    // entries, so no prune is needed here. Pruning happens in `bump`, which
+    // is the only place entries are created, so the map stays bounded and
+    // a login storm no longer serializes every check through one write lock.
     let now = chrono::Utc::now();
-    let mut m = map.write().await; // upgraded to write — needed for prune
-    m.retain(|_, (_, since)| (now - *since).num_seconds() <= window_secs);
+    let m = map.read().await;
     matches!(
         m.get(key),
         Some((count, since))
@@ -174,7 +178,11 @@ pub struct AppState {
     /// Never changes without a config write, so a one-shot read is correct.
     pub cluster_enabled: Arc<std::sync::atomic::AtomicBool>,
     pub cluster_events: aifw_common::ClusterEventBus,
-    pub metrics_history: Arc<RwLock<VecDeque<String>>>,
+    /// Ring buffer of deflate-compressed `WsHistoryEntry` JSON frames
+    /// (PERF-M5). ~2-3 KB of repetitive JSON per tick compresses 4-8x, so a
+    /// 1800-entry ring costs ~1 MB instead of ~5 MB. Compress/decompress
+    /// helpers live in `ws.rs`.
+    pub metrics_history: Arc<RwLock<VecDeque<Vec<u8>>>>,
     pub metrics_history_max: Arc<std::sync::atomic::AtomicUsize>,
     pub redis: Option<redis::aio::ConnectionManager>,
     pub pending: Arc<RwLock<PendingChanges>>,
@@ -209,6 +217,24 @@ pub struct AppState {
     /// mutations arriving within the debounce window coalesce into a
     /// single config rebuild + save_if_changed.
     pub auto_snapshot_pending: Arc<tokio::sync::Mutex<backup::AutoSnapshotPending>>,
+    /// Monotonic count of successful mutating API requests, bumped by
+    /// `auto_snapshot_middleware`. Invalidates `cluster_snapshot_cache`
+    /// (PERF-M15).
+    pub config_generation: Arc<std::sync::atomic::AtomicU64>,
+    /// Cache of the last built cluster snapshot, keyed by
+    /// `config_generation` with a max-age safety net (PERF-M15).
+    pub cluster_snapshot_cache: Arc<tokio::sync::Mutex<Option<ClusterSnapshotCache>>>,
+    /// Coalesces multiwan pf-anchor rebuilds so a burst of policy/group
+    /// saves triggers one reload, not one per save (PERF-M12).
+    pub multiwan_apply: Arc<multiwan::ApplyCoalescer>,
+}
+
+/// Cached result of `cluster_snapshot_data` (PERF-M15).
+pub struct ClusterSnapshotCache {
+    generation: u64,
+    built_at: std::time::Instant,
+    json: String,
+    hash: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
@@ -228,8 +254,30 @@ impl AppState {
 
     /// Produces (snapshot_data_json, sha256_hex_hash) for cluster replication.
     /// Includes everything backup exports plus IDS rule overrides + suppressions.
-    /// Hash is sha256 of the JSON bytes.
+    /// Hash is sha256 of the JSON bytes — sha256 (not a faster non-crypto
+    /// hash) deliberately: peers compare hashes across versions, so the
+    /// algorithm can't change without breaking mixed-version clusters.
+    ///
+    /// PERF-M15: the replicator polls this every 10 s; serializing the full
+    /// backup each tick is steady CPU+heap churn even when nothing changed.
+    /// The result is cached until `config_generation` moves (any successful
+    /// mutating API request) or the entry exceeds a 60 s max age — the max
+    /// age bounds staleness for DB writes that bypass the API (daemon/CLI).
     pub async fn cluster_snapshot_data(&self) -> Result<(String, String), aifw_common::AifwError> {
+        const MAX_AGE: std::time::Duration = std::time::Duration::from_secs(60);
+        let generation = self
+            .config_generation
+            .load(std::sync::atomic::Ordering::Relaxed);
+        // Held across the rebuild so concurrent callers don't build the
+        // same snapshot twice.
+        let mut cache = self.cluster_snapshot_cache.lock().await;
+        if let Some(c) = cache.as_ref()
+            && c.generation == generation
+            && c.built_at.elapsed() < MAX_AGE
+        {
+            return Ok((c.json.clone(), c.hash.clone()));
+        }
+
         let payload = crate::backup::cluster_export_payload(self)
             .await
             .map_err(|e| aifw_common::AifwError::Other(format!("export: {e:?}")))?;
@@ -238,6 +286,12 @@ impl AppState {
 
         let hash = aifw_core::sha256_hex(&json);
 
+        *cache = Some(ClusterSnapshotCache {
+            generation,
+            built_at: std::time::Instant::now(),
+            json: json.clone(),
+            hash: hash.clone(),
+        });
         Ok((json, hash))
     }
 }
@@ -516,8 +570,15 @@ pub fn build_router(
                 // Compress JSON responses (dashboards, /logs, /connections,
                 // /ids/alerts) so a slow uplink doesn't starve the UI. br
                 // beats gzip by ~25% on JSON but adds CPU; keep both so
-                // clients negotiate.
-                .layer(CompressionLayer::new().gzip(true).br(true))
+                // clients negotiate. Skip payloads under 1 KiB — they fit in
+                // one packet anyway, so compressing them is pure CPU cost on
+                // a slow appliance (PERF-M22).
+                .layer(
+                    CompressionLayer::new()
+                        .gzip(true)
+                        .br(true)
+                        .compress_when(SizeAbove::new(1024)),
+                )
                 .layer(cors),
         )
         .with_state(state);
@@ -643,73 +704,6 @@ async fn create_state_from_db(
     let pool = db.pool().clone();
     let pf: Arc<dyn PfBackend> = Arc::from(aifw_pf::create_backend());
 
-    // In-memory metrics RRD store + 1s collector tied to pf.
-    // Lives for the lifetime of the process; tier retention is 30 min / 6 h / 7 d / 30 d.
-    let metrics_store = Arc::new(aifw_metrics::MetricsStore::new());
-    let _metrics_task =
-        aifw_metrics::MetricsCollector::new(pf.clone(), metrics_store.clone()).start();
-
-    auth::migrate(&pool).await?;
-
-    let rule_engine = Arc::new(RuleEngine::new(pool.clone(), pf.clone()));
-    let nat_engine =
-        Arc::new(NatEngine::new(pool.clone(), pf.clone()).with_anchor("aifw-nat".to_string()));
-    nat_engine.migrate().await?;
-    let vpn_engine = Arc::new(VpnEngine::new(pool.clone(), pf.clone()));
-    vpn_engine.migrate().await?;
-    let geoip_engine = Arc::new(GeoIpEngine::new(pool.clone(), pf.clone()));
-    geoip_engine.migrate().await?;
-    let multiwan_engine = Arc::new(InstanceEngine::new(pool.clone(), pf.clone()));
-    multiwan_engine
-        .migrate()
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
-    let gateway_engine = Arc::new(GatewayEngine::new(pool.clone()));
-    gateway_engine
-        .migrate()
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
-    let group_engine = Arc::new(GroupEngine::new(pool.clone()));
-    group_engine
-        .migrate()
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
-    let policy_engine = Arc::new(PolicyEngine::new(pool.clone(), pf.clone()));
-    policy_engine
-        .migrate()
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
-    let leak_engine = Arc::new(LeakEngine::new(pool.clone(), pf.clone()));
-    leak_engine
-        .migrate()
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
-    let preflight_engine = Arc::new(PreflightEngine::new(pf.clone()));
-    let sla_engine = Arc::new(SlaEngine::new(pool.clone()));
-    sla_engine.migrate().await.map_err(|e| anyhow::anyhow!(e))?;
-    ca::migrate(&pool).await?;
-    dhcp::migrate(&pool).await?;
-    updates::migrate(&pool).await?;
-    iface::migrate(&pool).await?;
-    dns_resolver::migrate(&pool).await?;
-    dns_blocklists::migrate(&pool).await?;
-    aifw_core::s3_backup::migrate(&pool).await?;
-    aifw_core::smtp_notify::migrate(&pool).await?;
-    aifw_core::acme::migrate(&pool).await?;
-    aifw_core::ddns::migrate(&pool).await?;
-    reverse_proxy::migrate(&pool).await?;
-    system::migrate(&pool).await?;
-    time_service::migrate(&pool).await?;
-    plugins::migrate(&pool).await?;
-    aifw_core::config_manager::ConfigManager::new(pool.clone())
-        .migrate()
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
-    let alias_engine = Arc::new(AliasEngine::new(pool.clone(), pf.clone()));
-    alias_engine
-        .migrate()
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
     let conntrack = Arc::new(
         ConnectionTracker::new(pf.clone()).with_poll_interval(std::time::Duration::from_secs(2)),
     );
@@ -717,18 +711,135 @@ async fn create_state_from_db(
     // request and every WS tick is an atomic ArcSwap load instead of a
     // fresh `pfctl -ss -vv` shell-out + 50k-state clone.
     let _conntrack_poller = conntrack.start_polling();
+
+    // In-memory metrics RRD store + 1s collector tied to pf.
+    // Lives for the lifetime of the process; tier retention is 30 min / 6 h / 7 d / 30 d.
+    // The collector counts connections from the tracker's cached snapshot,
+    // so only one component fetches the full pf state table (PERF-M6).
+    let metrics_store = Arc::new(aifw_metrics::MetricsStore::new());
+    let _metrics_task = aifw_metrics::MetricsCollector::new(pf.clone(), metrics_store.clone())
+        .with_states_source({
+            let tracker = conntrack.clone();
+            move || tracker.snapshot()
+        })
+        .start();
+
+    auth::migrate(&pool).await?;
+
+    let rule_engine = Arc::new(RuleEngine::new(pool.clone(), pf.clone()));
+    let nat_engine =
+        Arc::new(NatEngine::new(pool.clone(), pf.clone()).with_anchor("aifw-nat".to_string()));
+    let vpn_engine = Arc::new(VpnEngine::new(pool.clone(), pf.clone()));
+    let geoip_engine = Arc::new(GeoIpEngine::new(pool.clone(), pf.clone()));
+    let multiwan_engine = Arc::new(InstanceEngine::new(pool.clone(), pf.clone()));
+    let gateway_engine = Arc::new(GatewayEngine::new(pool.clone()));
+    let group_engine = Arc::new(GroupEngine::new(pool.clone()));
+    let policy_engine = Arc::new(PolicyEngine::new(pool.clone(), pf.clone()));
+    let leak_engine = Arc::new(LeakEngine::new(pool.clone(), pf.clone()));
+    let preflight_engine = Arc::new(PreflightEngine::new(pf.clone()));
+    let sla_engine = Arc::new(SlaEngine::new(pool.clone()));
+    let alias_engine = Arc::new(AliasEngine::new(pool.clone(), pf.clone()));
     let cluster_engine = Arc::new(aifw_core::ClusterEngine::new(pool.clone(), pf.clone()));
-    cluster_engine
-        .migrate()
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
     let shaping_engine = Arc::new(ShapingEngine::new(pool.clone(), pf.clone()));
-    shaping_engine
-        .migrate()
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
     let tls_engine = Arc::new(TlsEngine::new(pool.clone(), pf.clone()));
-    tls_engine.migrate().await.map_err(|e| anyhow::anyhow!(e))?;
+
+    // PERF-M17: each migrate() only creates its own tables, so they are
+    // independent — run them concurrently instead of as a 20+ step chain.
+    // SQLite serializes the actual writes (busy_timeout covers contention),
+    // but statement parsing and pool round-trips overlap, cutting cold-boot
+    // latency.
+    tokio::try_join!(
+        async { nat_engine.migrate().await.map_err(anyhow::Error::from) },
+        async { vpn_engine.migrate().await.map_err(anyhow::Error::from) },
+        async { geoip_engine.migrate().await.map_err(anyhow::Error::from) },
+        async {
+            multiwan_engine
+                .migrate()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))
+        },
+        async {
+            gateway_engine
+                .migrate()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))
+        },
+        async { group_engine.migrate().await.map_err(|e| anyhow::anyhow!(e)) },
+        async {
+            policy_engine
+                .migrate()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))
+        },
+        async { leak_engine.migrate().await.map_err(|e| anyhow::anyhow!(e)) },
+        async { sla_engine.migrate().await.map_err(|e| anyhow::anyhow!(e)) },
+        async { ca::migrate(&pool).await.map_err(anyhow::Error::from) },
+        async { dhcp::migrate(&pool).await.map_err(anyhow::Error::from) },
+        async { updates::migrate(&pool).await.map_err(anyhow::Error::from) },
+        async { iface::migrate(&pool).await.map_err(anyhow::Error::from) },
+        async {
+            dns_resolver::migrate(&pool)
+                .await
+                .map_err(anyhow::Error::from)
+        },
+        async {
+            dns_blocklists::migrate(&pool)
+                .await
+                .map_err(anyhow::Error::from)
+        },
+        async {
+            aifw_core::s3_backup::migrate(&pool)
+                .await
+                .map_err(anyhow::Error::from)
+        },
+        async {
+            aifw_core::smtp_notify::migrate(&pool)
+                .await
+                .map_err(anyhow::Error::from)
+        },
+        async {
+            aifw_core::acme::migrate(&pool)
+                .await
+                .map_err(anyhow::Error::from)
+        },
+        async {
+            aifw_core::ddns::migrate(&pool)
+                .await
+                .map_err(anyhow::Error::from)
+        },
+        async {
+            reverse_proxy::migrate(&pool)
+                .await
+                .map_err(anyhow::Error::from)
+        },
+        async { system::migrate(&pool).await.map_err(anyhow::Error::from) },
+        async {
+            time_service::migrate(&pool)
+                .await
+                .map_err(anyhow::Error::from)
+        },
+        async { plugins::migrate(&pool).await.map_err(anyhow::Error::from) },
+        async {
+            aifw_core::config_manager::ConfigManager::new(pool.clone())
+                .migrate()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))
+        },
+        async { alias_engine.migrate().await.map_err(|e| anyhow::anyhow!(e)) },
+        async {
+            cluster_engine
+                .migrate()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))
+        },
+        async {
+            shaping_engine
+                .migrate()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))
+        },
+        async { tls_engine.migrate().await.map_err(|e| anyhow::anyhow!(e)) },
+    )?;
 
     // Read aifw_cluster_enabled once at startup. The flag only changes on
     // config writes, so a cached value is always correct for the process lifetime.
@@ -939,6 +1050,9 @@ async fn create_state_from_db(
         auto_snapshot_pending: Arc::new(tokio::sync::Mutex::new(
             backup::AutoSnapshotPending::default(),
         )),
+        config_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        cluster_snapshot_cache: Arc::new(tokio::sync::Mutex::new(None)),
+        multiwan_apply: Arc::new(multiwan::ApplyCoalescer::new()),
     })
 }
 
@@ -1327,8 +1441,15 @@ async fn main() -> anyhow::Result<()> {
                             .await
                             .unwrap_or_default();
                         if !history.is_empty() {
+                            // Valkey stores plaintext JSON; the in-memory
+                            // ring is deflate-compressed (PERF-M5).
+                            let compressed: Vec<Vec<u8>> = history
+                                .into_iter()
+                                .rev()
+                                .map(|e| ws::compress_history_entry(&e))
+                                .collect();
                             let mut buf = state.metrics_history.write().await;
-                            for entry in history.into_iter().rev() {
+                            for entry in compressed {
                                 buf.push_back(entry);
                             }
                             info!("Loaded {} historical metrics from Valkey", buf.len());
@@ -1536,6 +1657,15 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
+    // Multiwan pf-anchor apply coalescer (PERF-M12): drains the dirty flags
+    // set by policy/group/gateway/leak handlers at most once per second.
+    {
+        let apply_state = state.clone();
+        tokio::spawn(async move {
+            multiwan::run_apply_coalescer(apply_state).await;
+        });
+    }
+
     // Memory-stats heartbeat — logs per-subsystem sizes every 60s so we can
     // isolate which cache/buffer is responsible when RSS grows. Cheap: just reads
     // existing counters; no allocation. Output goes to /var/log/aifw/api.log.
@@ -1648,7 +1778,9 @@ async fn main() -> anyhow::Result<()> {
         }
         let listener = tokio::net::TcpListener::bind(&args.listen).await?;
         info!("AiFw API listening on http://{}", args.listen);
-        axum::serve(listener, app).await?;
+        axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown_signal())
+            .await?;
     } else {
         ensure_tls_cert(&args.tls_cert, &args.tls_key)?;
         let tls_config =
@@ -1656,12 +1788,50 @@ async fn main() -> anyhow::Result<()> {
                 .await?;
         let addr: std::net::SocketAddr = args.listen.parse()?;
         info!("AiFw API listening on https://{}", addr);
+        let handle = axum_server::Handle::new();
+        tokio::spawn({
+            let handle = handle.clone();
+            async move {
+                shutdown_signal().await;
+                // Stop accepting; give in-flight requests a bounded drain
+                // window before the process exits.
+                handle.graceful_shutdown(Some(std::time::Duration::from_secs(10)));
+            }
+        });
         axum_server::bind_rustls(addr, tls_config)
+            .handle(handle)
             .serve(app.into_make_service())
             .await?;
     }
 
     Ok(())
+}
+
+/// Resolves when the process receives SIGTERM or SIGINT (PERF-M13). Lets
+/// both serve paths drain in-flight requests — active uploads, WS pushes,
+/// mid-flight DB writes — instead of dying mid-response on `service stop`.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            warn!("failed to install SIGINT handler: {e}");
+            std::future::pending::<()>().await;
+        }
+    };
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(e) => {
+                warn!("failed to install SIGTERM handler: {e}");
+                std::future::pending::<()>().await;
+            }
+        }
+    };
+    tokio::select! {
+        _ = ctrl_c => info!("SIGINT received; shutting down gracefully"),
+        _ = terminate => info!("SIGTERM received; shutting down gracefully"),
+    }
 }
 
 #[cfg(test)]

--- a/aifw-api/src/multiwan.rs
+++ b/aifw-api/src/multiwan.rs
@@ -31,6 +31,80 @@ fn bad_request() -> StatusCode {
     StatusCode::BAD_REQUEST
 }
 
+/// Coalesces multiwan pf-anchor rebuilds (PERF-M12 #381).
+///
+/// Every policy/group/gateway save used to trigger a full re-fetch of
+/// policies + groups + gateways and a complete `aifw-pbr` anchor reload —
+/// an O(N) pfctl + temp-file dance per save. Handlers now just mark the
+/// affected plane dirty; `run_apply_coalescer` drains the flags at most
+/// once per `COALESCE_WINDOW`, so an admin clicking through edits costs one
+/// rebuild per window instead of one per save. The rebuild was already
+/// fire-and-forget in the handlers (`let _ = apply_all(...)`), so moving it
+/// to a background task preserves the response semantics.
+pub struct ApplyCoalescer {
+    policies_dirty: std::sync::atomic::AtomicBool,
+    leaks_dirty: std::sync::atomic::AtomicBool,
+    notify: tokio::sync::Notify,
+}
+
+impl ApplyCoalescer {
+    pub fn new() -> Self {
+        Self {
+            policies_dirty: std::sync::atomic::AtomicBool::new(false),
+            leaks_dirty: std::sync::atomic::AtomicBool::new(false),
+            notify: tokio::sync::Notify::new(),
+        }
+    }
+
+    /// Request a rebuild of the PBR + reply anchors.
+    pub fn mark_policies_dirty(&self) {
+        self.policies_dirty
+            .store(true, std::sync::atomic::Ordering::Release);
+        self.notify.notify_one();
+    }
+
+    /// Request a rebuild of the route-leak anchor.
+    pub fn mark_leaks_dirty(&self) {
+        self.leaks_dirty
+            .store(true, std::sync::atomic::Ordering::Release);
+        self.notify.notify_one();
+    }
+}
+
+impl Default for ApplyCoalescer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Background task draining `ApplyCoalescer` dirty flags. Spawned once at
+/// boot next to the dashboard producer.
+pub async fn run_apply_coalescer(state: AppState) {
+    use std::sync::atomic::Ordering;
+    const COALESCE_WINDOW: std::time::Duration = std::time::Duration::from_secs(1);
+    loop {
+        state.multiwan_apply.notify.notified().await;
+        // Let a burst of saves land before rebuilding once for all of them.
+        tokio::time::sleep(COALESCE_WINDOW).await;
+        if state
+            .multiwan_apply
+            .policies_dirty
+            .swap(false, Ordering::AcqRel)
+            && let Err(e) = apply_all(&state).await
+        {
+            tracing::warn!(error = %e, "coalesced multiwan policy apply failed");
+        }
+        if state
+            .multiwan_apply
+            .leaks_dirty
+            .swap(false, Ordering::AcqRel)
+            && let Err(e) = apply_leaks(&state).await
+        {
+            tracing::warn!(error = %e, "coalesced route-leak apply failed");
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct CreateInstanceRequest {
     pub name: String,
@@ -768,7 +842,7 @@ pub async fn create_policy(
         .add(p)
         .await
         .map_err(|_| bad_request())?;
-    let _ = apply_all(&state).await;
+    state.multiwan_apply.mark_policies_dirty();
     Ok((StatusCode::CREATED, Json(ApiResponse { data: p })))
 }
 
@@ -789,7 +863,7 @@ pub async fn update_policy(
         .update(p)
         .await
         .map_err(|_| bad_request())?;
-    let _ = apply_all(&state).await;
+    state.multiwan_apply.mark_policies_dirty();
     Ok(Json(ApiResponse { data: p }))
 }
 
@@ -803,7 +877,7 @@ pub async fn delete_policy(
         .delete(uuid)
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
-    let _ = apply_all(&state).await;
+    state.multiwan_apply.mark_policies_dirty();
     Ok(Json(MessageResponse {
         message: format!("policy {id} deleted"),
     }))
@@ -877,7 +951,7 @@ pub async fn create_leak(
         updated_at: now,
     };
     let l = state.leak_engine.add(l).await.map_err(|_| bad_request())?;
-    let _ = apply_leaks(&state).await;
+    state.multiwan_apply.mark_leaks_dirty();
     Ok((StatusCode::CREATED, Json(ApiResponse { data: l })))
 }
 
@@ -891,7 +965,7 @@ pub async fn delete_leak(
         aifw_common::AifwError::NotFound(_) => StatusCode::NOT_FOUND,
         _ => internal(),
     })?;
-    let _ = apply_leaks(&state).await;
+    state.multiwan_apply.mark_leaks_dirty();
     Ok(Json(MessageResponse {
         message: format!("leak {id} deleted"),
     }))
@@ -906,7 +980,7 @@ pub async fn seed_mgmt_escapes(
         .seed_mgmt_escapes(&instances)
         .await
         .map_err(|_| internal())?;
-    let _ = apply_leaks(&state).await;
+    state.multiwan_apply.mark_leaks_dirty();
     Ok(Json(MessageResponse {
         message: "mgmt-escape leaks seeded".into(),
     }))
@@ -1121,8 +1195,8 @@ pub async fn import_config(
             let _ = state.leak_engine.add(l.clone()).await;
         }
     }
-    let _ = apply_all(&state).await;
-    let _ = apply_leaks(&state).await;
+    state.multiwan_apply.mark_policies_dirty();
+    state.multiwan_apply.mark_leaks_dirty();
     Ok(Json(MessageResponse {
         message: format!(
             "imported {} instances, {} gateways, {} groups, {} policies, {} leaks",
@@ -1162,7 +1236,7 @@ pub async fn reorder_policies(
             .await
             .map_err(|_| internal())?;
     }
-    let _ = apply_all(&state).await;
+    state.multiwan_apply.mark_policies_dirty();
     Ok(Json(MessageResponse {
         message: format!("{} policies reordered", req.policy_ids.len()),
     }))
@@ -1222,6 +1296,6 @@ pub async fn toggle_policy(
         .update(p)
         .await
         .map_err(|_| internal())?;
-    let _ = apply_all(&state).await;
+    state.multiwan_apply.mark_policies_dirty();
     Ok(Json(ApiResponse { data: p }))
 }

--- a/aifw-api/src/ws.rs
+++ b/aifw-api/src/ws.rs
@@ -220,6 +220,36 @@ struct IdsHistoryPayload {
     running: bool,
 }
 
+/// Deflate-compress one history JSON frame for the in-memory ring
+/// (PERF-M5). The frames are highly repetitive JSON (~2-3 KB) and compress
+/// 4-8x, cutting the 1800-entry ring from ~5 MB to ~1 MB of process heap.
+pub fn compress_history_entry(json: &str) -> Vec<u8> {
+    use std::io::Write;
+    let mut enc = flate2::write::DeflateEncoder::new(Vec::new(), flate2::Compression::fast());
+    // Writing into a Vec is infallible; finish() only propagates write errors.
+    match enc.write_all(json.as_bytes()).and_then(|_| enc.finish()) {
+        Ok(buf) => buf,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to compress metrics history entry");
+            Vec::new()
+        }
+    }
+}
+
+/// Inverse of `compress_history_entry`. Returns `None` (with a warning) on
+/// corrupt data so one bad entry can't take down the history batch.
+fn decompress_history_entry(data: &[u8]) -> Option<String> {
+    use std::io::Read;
+    let mut out = String::new();
+    match flate2::read::DeflateDecoder::new(data).read_to_string(&mut out) {
+        Ok(_) => Some(out),
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to decompress metrics history entry");
+            None
+        }
+    }
+}
+
 pub async fn ws_handler(State(state): State<AppState>, ws: WebSocketUpgrade) -> Response {
     ws.on_upgrade(move |socket| handle_socket(socket, state))
 }
@@ -233,20 +263,31 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
     // every reconnecting client.
     const INITIAL_HISTORY_SAMPLES: usize = 600; // ~10 minutes at 1 Hz
     {
-        let history = state.metrics_history.read().await;
-        let batch = if history.is_empty() {
+        // Clone the (small) compressed entries under the read lock, then
+        // decompress after releasing it so the producer's write never waits
+        // behind the inflate work (PERF-M5).
+        let compressed: Vec<Vec<u8>> = {
+            let history = state.metrics_history.read().await;
+            let skip = history.len().saturating_sub(INITIAL_HISTORY_SAMPLES);
+            history.iter().skip(skip).cloned().collect()
+        };
+        let batch = if compressed.is_empty() {
             "{\"type\":\"history\",\"data\":[]}".to_string()
         } else {
-            let skip = history.len().saturating_sub(INITIAL_HISTORY_SAMPLES);
-            format!(
-                "{{\"type\":\"history\",\"data\":[{}]}}",
-                history
-                    .iter()
-                    .skip(skip)
-                    .map(|s| s.as_str())
-                    .collect::<Vec<_>>()
-                    .join(",")
-            )
+            let mut out = String::with_capacity(compressed.len() * 2048 + 32);
+            out.push_str("{\"type\":\"history\",\"data\":[");
+            let mut first = true;
+            for entry in &compressed {
+                if let Some(json) = decompress_history_entry(entry) {
+                    if !first {
+                        out.push(',');
+                    }
+                    out.push_str(&json);
+                    first = false;
+                }
+            }
+            out.push_str("]}");
+            out
         };
         let _ = sender.send(Message::Text(batch.into())).await;
     }
@@ -363,17 +404,19 @@ pub async fn run_dashboard_producer(state: AppState) {
                         .query_async(&mut conn)
                         .await;
                 }
-                // PERF-H10 (#354): history_msg moves into the deque — the
+                // PERF-H10 (#354): the entry moves into the deque — the
                 // write() critical section is only O(1) pop/push, so WS
                 // connects reading the history don't stall behind a large
                 // String clone (tokio's fair RwLock queues new readers
-                // behind a waiting writer).
+                // behind a waiting writer). Compression happens before the
+                // lock is taken (PERF-M5).
                 if max > 0 {
+                    let compressed = compress_history_entry(&history_msg);
                     let mut buf = state.metrics_history.write().await;
                     while buf.len() >= max {
                         buf.pop_front();
                     }
-                    buf.push_back(history_msg);
+                    buf.push_back(compressed);
                 }
                 // Live frame to dashboard clients. `send` errors only if
                 // there are no subscribers, which is fine — we wanted to
@@ -755,14 +798,19 @@ async fn collect_system_metrics() -> SystemPayload {
 
     // CPU usage via kern.cp_time delta — native sysctlbyname; no fork.
     let cpu_usage = {
-        use std::sync::Mutex;
-        static PREV_CP: Mutex<Option<[u64; 5]>> = Mutex::new(None);
+        use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+        // PERF-M19: lock-free. Only the single dashboard-producer task
+        // calls this, so relaxed per-cell atomics are plenty — no Mutex,
+        // no poisoning to `.expect()` around.
+        static PREV_CP: [AtomicU64; 5] = [const { AtomicU64::new(0) }; 5];
+        static PREV_INIT: AtomicBool = AtomicBool::new(false);
 
         let cur: Option<[u64; 5]> = sysctl::read_u64_array("kern.cp_time");
         if let Some(cur) = cur {
-            let mut prev_lock = PREV_CP.lock().expect("lock poisoned");
-            let pct = if let Some(prev) = *prev_lock {
-                let d: Vec<u64> = (0..5).map(|i| cur[i].saturating_sub(prev[i])).collect();
+            let pct = if PREV_INIT.load(Ordering::Relaxed) {
+                let d: Vec<u64> = (0..5)
+                    .map(|i| cur[i].saturating_sub(PREV_CP[i].load(Ordering::Relaxed)))
+                    .collect();
                 let total: u64 = d.iter().sum();
                 if total > 0 {
                     ((total - d[4]) as f64 / total as f64) * 100.0
@@ -772,7 +820,10 @@ async fn collect_system_metrics() -> SystemPayload {
             } else {
                 0.0
             };
-            *prev_lock = Some(cur);
+            for (cell, v) in PREV_CP.iter().zip(cur) {
+                cell.store(v, Ordering::Relaxed);
+            }
+            PREV_INIT.store(true, Ordering::Relaxed);
             pct
         } else {
             0.0

--- a/aifw-core/src/audit.rs
+++ b/aifw-core/src/audit.rs
@@ -179,10 +179,14 @@ impl AuditLog {
 
     /// Fetch all audit entries for one firewall rule, newest first
     pub async fn list_for_rule(&self, rule_id: Uuid) -> Result<Vec<AuditEntry>> {
+        // PERF-M9: a long-lived rule accumulates unbounded history; cap the
+        // result so one call can't materialize MBs of rows.
+        const MAX_ROWS: i64 = 500;
         let rows = sqlx::query_as::<_, AuditRow>(sqlx::AssertSqlSafe(format!(
-            "SELECT {AUDIT_LOG_COLUMNS} FROM audit_log WHERE rule_id = ?1 ORDER BY timestamp DESC"
+            "SELECT {AUDIT_LOG_COLUMNS} FROM audit_log WHERE rule_id = ?1 ORDER BY timestamp DESC LIMIT ?2"
         )))
         .bind(rule_id.to_string())
+        .bind(MAX_ROWS)
         .fetch_all(&self.pool)
         .await?;
 

--- a/aifw-ids/src/action.rs
+++ b/aifw-ids/src/action.rs
@@ -123,7 +123,7 @@ mod tests {
         let config = Arc::new(RuntimeConfig::load(&pool).await.unwrap());
 
         // Set IDS mode
-        let mut cfg = config.config();
+        let mut cfg = (*config.config()).clone();
         cfg.mode = IdsMode::Ids;
         config.update(cfg);
 
@@ -149,7 +149,7 @@ mod tests {
 
         let config = Arc::new(RuntimeConfig::load(&pool).await.unwrap());
 
-        let mut cfg = config.config();
+        let mut cfg = (*config.config()).clone();
         cfg.mode = IdsMode::Ips;
         config.update(cfg);
 

--- a/aifw-ids/src/config.rs
+++ b/aifw-ids/src/config.rs
@@ -1,6 +1,7 @@
-use std::sync::RwLock;
+use std::sync::Arc;
 
 use aifw_common::ids::{IdsConfig, IdsMode};
+use arc_swap::ArcSwap;
 use sqlx::SqlitePool;
 
 use crate::Result;
@@ -24,7 +25,7 @@ fn parse_u32_field(field: &str, value: &str) -> Option<u32> {
 /// Runtime configuration for the IDS engine.
 /// Wraps `IdsConfig` with thread-safe interior mutability for hot-reload.
 pub struct RuntimeConfig {
-    inner: RwLock<IdsConfig>,
+    inner: ArcSwap<IdsConfig>,
 }
 
 impl RuntimeConfig {
@@ -32,18 +33,19 @@ impl RuntimeConfig {
     pub async fn load(pool: &SqlitePool) -> Result<Self> {
         let cfg = Self::read_from_db(pool).await?;
         Ok(Self {
-            inner: RwLock::new(cfg),
+            inner: ArcSwap::from_pointee(cfg),
         })
     }
 
-    /// Get a snapshot of the current configuration.
-    pub fn config(&self) -> IdsConfig {
-        self.inner.read().expect("lock poisoned").clone()
+    /// Get a snapshot of the current configuration. O(1) atomic load —
+    /// no lock, no deep clone of the `Vec<String>` fields (PERF-M1).
+    pub fn config(&self) -> Arc<IdsConfig> {
+        self.inner.load_full()
     }
 
     /// Update configuration in memory.
     pub fn update(&self, cfg: IdsConfig) {
-        *self.inner.write().expect("lock poisoned") = cfg;
+        self.inner.store(Arc::new(cfg));
     }
 
     /// Load configuration from the database.
@@ -98,7 +100,7 @@ impl RuntimeConfig {
 
     /// Network variable expansion: resolve `$HOME_NET`, `$EXTERNAL_NET`, etc.
     pub fn expand_var(&self, var: &str) -> Vec<String> {
-        let cfg = self.inner.read().expect("lock poisoned");
+        let cfg = self.inner.load();
         match var {
             "$HOME_NET" | "HOME_NET" => cfg.home_net.clone(),
             "$EXTERNAL_NET" | "EXTERNAL_NET" => {
@@ -310,7 +312,7 @@ mod tests {
         let pool = test_pool().await;
         let config = RuntimeConfig::load(&pool).await.unwrap();
 
-        let mut cfg = config.config();
+        let mut cfg = (*config.config()).clone();
         cfg.mode = IdsMode::Ids;
         cfg.alert_retention_days = 7;
         config.save_to_db(&pool, &cfg).await.unwrap();

--- a/aifw-ids/src/lib.rs
+++ b/aifw-ids/src/lib.rs
@@ -444,7 +444,7 @@ impl IdsEngine {
             // Default: detect all non-loopback/non-pflog interfaces and capture on them.
             // pflog0 only sees blocked/logged pf traffic — we need the real interfaces
             // to inspect all passing traffic.
-            let mut ifaces = detect_network_interfaces();
+            let mut ifaces = detect_network_interfaces().await;
             if ifaces.is_empty() {
                 // Fallback to pflog0 if we can't detect interfaces
                 ifaces.push("pflog0".to_string());
@@ -708,10 +708,17 @@ pub struct RuleRow {
 }
 
 /// Detect network interfaces for packet capture.
-fn detect_network_interfaces() -> Vec<String> {
+///
+/// PERF-M18: async so the `ifconfig` spawn doesn't block a tokio worker
+/// thread during `start()`.
+async fn detect_network_interfaces() -> Vec<String> {
     #[cfg(target_os = "freebsd")]
     {
-        if let Ok(output) = std::process::Command::new("ifconfig").arg("-l").output() {
+        if let Ok(output) = tokio::process::Command::new("ifconfig")
+            .arg("-l")
+            .output()
+            .await
+        {
             let list = String::from_utf8_lossy(&output.stdout);
             return list
                 .split_whitespace()

--- a/aifw-ids/src/output/sqlite.rs
+++ b/aifw-ids/src/output/sqlite.rs
@@ -250,11 +250,12 @@ impl SqliteOutput {
 
     /// Purge alerts older than N days.
     pub async fn purge_old(&self, days: u32) -> Result<u64> {
-        let result = sqlx::query(sqlx::AssertSqlSafe(format!(
-            "DELETE FROM ids_alerts WHERE timestamp < datetime('now', '-{days} days')"
-        )))
-        .execute(&self.pool)
-        .await?;
+        // PERF-M2: bind the modifier so every retention tick reuses one
+        // cached prepared statement instead of compiling a fresh one.
+        let result = sqlx::query("DELETE FROM ids_alerts WHERE timestamp < datetime('now', ?)")
+            .bind(format!("-{days} days"))
+            .execute(&self.pool)
+            .await?;
         Ok(result.rows_affected())
     }
 

--- a/aifw-metrics/src/collector.rs
+++ b/aifw-metrics/src/collector.rs
@@ -76,11 +76,17 @@ pub mod names {
     pub const API_ERRORS: &str = "api.errors";
 }
 
+/// Shared source of the current pf state-table snapshot. Lets the collector
+/// reuse a snapshot another component (the connection tracker) already
+/// fetched instead of shelling out to `pfctl -ss` itself (PERF-M6).
+pub type StatesSource = Box<dyn Fn() -> Arc<Vec<aifw_pf::PfState>> + Send + Sync>;
+
 /// Collects metrics from the pf backend and records them into the store.
 pub struct MetricsCollector {
     pf: Arc<dyn PfBackend>,
     store: Arc<MetricsStore>,
     interval: Duration,
+    states_source: Option<StatesSource>,
     prev_packets_in: u64,
     prev_packets_out: u64,
     prev_bytes_in: u64,
@@ -95,6 +101,7 @@ impl MetricsCollector {
             pf,
             store,
             interval: Duration::from_secs(1),
+            states_source: None,
             prev_packets_in: 0,
             prev_packets_out: 0,
             prev_bytes_in: 0,
@@ -106,6 +113,18 @@ impl MetricsCollector {
     /// for the computed traffic rates.
     pub fn with_interval(mut self, interval: Duration) -> Self {
         self.interval = interval;
+        self
+    }
+
+    /// Builder: count connections from a cached snapshot (e.g. the conntrack
+    /// tracker's ArcSwap) instead of running `pf.get_states()` every tick.
+    /// The snapshot may lag by the provider's own poll interval, which is
+    /// fine for gauge metrics (PERF-M6).
+    pub fn with_states_source(
+        mut self,
+        source: impl Fn() -> Arc<Vec<aifw_pf::PfState>> + Send + Sync + 'static,
+    ) -> Self {
+        self.states_source = Some(Box::new(source));
         self
     }
 
@@ -214,8 +233,14 @@ impl MetricsCollector {
             }
         }
 
-        // Connection breakdown
-        match self.pf.get_states().await {
+        // Connection breakdown. Prefer the shared cached snapshot (one
+        // `pfctl -ss` per poll for the whole process) over a second fetch
+        // of the full state table on the same tick (PERF-M6).
+        let states = match &self.states_source {
+            Some(source) => Ok(source()),
+            None => self.pf.get_states().await.map(Arc::new),
+        };
+        match states {
             Ok(states) => {
                 let total = states.len();
                 let tcp = states.iter().filter(|s| s.protocol == "tcp").count();

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.3",
+  "version": "5.99.4",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Fixes all open MEDIUM findings from the 2026-05-12 performance audit in one sweep.

## Fixes

| Finding | Issue | Change |
|---|---|---|
| PERF-M1 | #369 | `RuntimeConfig` now wraps `ArcSwap<IdsConfig>`; `config()` returns `Arc<IdsConfig>` via an O(1) atomic load instead of deep-cloning the Vec fields on every accessor |
| PERF-M2 | #370 | `purge_old` binds the `-N days` modifier as a parameter, so retention reuses one cached prepared statement |
| PERF-M3 | #371 | `is_blocked` takes only a `read()` lock — the window check already ignores expired entries; pruning stays in `bump()` (the only writer), so the map remains bounded |
| PERF-M5 | #373 | `metrics_history` ring stores deflate-compressed entries (~4-8x smaller, ~5 MB → ~1 MB). Compression happens before the write lock; decompression after releasing the read lock. Valkey still stores plaintext; restore path compresses. Uses `flate2`, which was already in the tree via tower-http |
| PERF-M6 | #374 | `MetricsCollector` gains `with_states_source()`; the API wires it to the conntrack `ArcSwap` snapshot, so only the tracker's 2 s poller runs `pfctl -ss` — the collector no longer does a second full state-table fetch every second |
| PERF-M9 | #377 | `audit.list_for_rule` capped at `LIMIT 500` |
| PERF-M12 | #381 | New `ApplyCoalescer`: policy/group/gateway/leak handlers mark a dirty flag; a background task rebuilds the pf anchors at most once per second. Handlers were already fire-and-forget (`let _ = apply_all(...)`), so response semantics are unchanged; the explicit `POST /multiwan/policies/apply` endpoint remains synchronous |
| PERF-M13 | #382 | Both serve paths get graceful shutdown on SIGTERM/SIGINT: `axum::serve(...).with_graceful_shutdown(...)` and an `axum_server::Handle` with a 10 s drain window for the TLS path |
| PERF-M15 | #384 | `cluster_snapshot_data` caches (json, hash) keyed by a new `config_generation` counter (bumped by the auto-snapshot middleware on every successful mutating request) with a 60 s max age as a safety net for DB writes that bypass the API. Kept sha256 rather than switching to xxh3/blake3 — peers compare hashes across versions, so changing the algorithm would break mixed-version clusters into permanent full-push mode |
| PERF-M17 | #386 | The 28 independent engine/module `migrate()` calls run concurrently via `tokio::try_join!` (SQLite serializes the writes; parsing and pool round-trips overlap) |
| PERF-M18 | #387 | `detect_network_interfaces` is async and uses `tokio::process::Command`, so the `ifconfig` spawn no longer blocks a tokio worker during IDS startup |
| PERF-M19 | #388 | `PREV_CP` CPU sample state is a lock-free `[AtomicU64; 5]` + init flag instead of a `std::sync::Mutex` |
| PERF-M22 | #391 | Response compression skips payloads under 1 KiB (`compress_when(SizeAbove::new(1024))`) — they fit in one packet, so brotli/gzip on them was pure CPU cost |

## Not changed

PERF-M10 (#378) was already fixed by the PERF-H9 change — `top_signatures` / `top_sources` bind `LIMIT` today; closing it alongside this PR.

## Verification

- `cargo check` — zero warnings; pre-commit `cargo fmt --check` + `clippy -D warnings` pass
- `cargo test` — full workspace, all green (298+ tests)
- Version bumped 5.99.3 → 5.99.4 (Cargo.toml + aifw-ui/package.json)

Closes #369, closes #370, closes #371, closes #373, closes #374, closes #377, closes #381, closes #382, closes #384, closes #386, closes #387, closes #388, closes #391