### PR TITLE
perf: fix the open low performance-audit findings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.4"
+version = "5.99.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/log_tail.rs
+++ b/aifw-api/src/log_tail.rs
@@ -3,34 +3,36 @@
 //! Earlier versions did `sudo cat <full file>` then filtered in Rust on
 //! every poll. On a busy box `/var/log/messages` (the fallback for
 //! several services) is multiple MB; the resulting 10–15 s wait before
-//! the first line appeared was the worst UX in the whole product.
+//! the first line appeared was the worst UX in the whole product. The
+//! next iteration shelled out to `/bin/sh -c "tail | grep | tail"` —
+//! bounded, but three forks per poll on pages that refresh every 5–10 s
+//! (PERF-L8 #400).
 //!
-//! What this module does:
+//! What this module does now, fully in-process:
 //!  1. Probe each candidate path with `fs::metadata` so we skip files
 //!     that don't exist on this appliance.
-//!  2. `tail -n N` the first readable file (bounded read; on FreeBSD
-//!     this seeks back from EOF in O(N) bytes).
-//!  3. Optional `grep -i <needle>` BEFORE the bytes hit user space, so
-//!     filter cost scales with matches not file size.
-//!  4. Cap the response at the requested line count, newest-first.
+//!  2. Read the first readable file *backwards* from EOF in 64 KiB
+//!     chunks on the blocking pool — cost scales with the lines
+//!     actually needed, never with file size.
+//!  3. Examine at most `tail_lines` lines (the old `tail -n N` bound),
+//!     applying the optional case-insensitive substring filter as lines
+//!     are discovered, and stop as soon as `take` matches are found.
+//!  4. Return the matches newest-first.
 //!
-//! No sudo: each service's rc.d script is responsible for making its
-//! log group-readable by `aifw` (see rdns's rc.d script for the
-//! pattern — 0640 root:aifw). System logs like /var/log/messages are
-//! world-readable. Wrapping tail/grep in sudo would require the aifw
-//! sudoers file to whitelist them, and earlier versions that did so
-//! silently failed because those commands weren't in the whitelist.
-//!
-//! The full pipeline runs under `/bin/sh -c` so we can `|` between
-//! tail/grep/tail without writing a JSON-encoded ProcessBuilder graph.
-//! Inputs that flow into the shell (paths, needle) are all
-//! caller-controlled in the API layer — paths are constants in the
-//! handlers, needles are constrained to alphanumerics + `-_` here.
+//! No sudo and no shell: each service's rc.d script is responsible for
+//! making its log group-readable by `aifw` (see rdns's rc.d script for
+//! the pattern — 0640 root:aifw). System logs like /var/log/messages
+//! are world-readable. With no shell in the path, the needle no longer
+//! needs sanitizing — it's matched as a literal substring.
 
-use tokio::process::Command;
+use std::io::{Read, Seek, SeekFrom};
 
-/// Read the last `tail_lines` lines from the first existing path in
-/// `paths`, optionally filter case-insensitively for `needle`, and
+/// Chunk size for the backwards scan. Large enough that a typical logs
+/// page (a few hundred ~200-byte lines) is served in one read.
+const CHUNK: usize = 64 * 1024;
+
+/// Read up to the last `tail_lines` lines from the first existing path
+/// in `paths`, optionally filter case-insensitively for `needle`, and
 /// return up to `take` lines newest-first.
 pub async fn tail_filtered(
     paths: &[&str],
@@ -38,62 +40,173 @@ pub async fn tail_filtered(
     tail_lines: usize,
     take: usize,
 ) -> Vec<String> {
+    // Case-insensitive fixed-string match, same as the old `grep -iF`.
+    let needle_lc = needle
+        .map(str::to_lowercase)
+        .filter(|n| !n.trim().is_empty());
+
     for path in paths {
         if tokio::fs::metadata(path).await.is_err() {
             continue;
         }
-
-        let pipeline = match needle {
-            Some(n) => {
-                let safe = sanitize_needle(n);
-                if safe.is_empty() {
-                    format!("/usr/bin/tail -n {tail_lines} '{path}' | /usr/bin/tail -n {take}")
-                } else {
-                    format!(
-                        "/usr/bin/tail -n {tail_lines} '{path}' | /usr/bin/grep -iF -- '{safe}' | /usr/bin/tail -n {take}"
-                    )
-                }
-            }
-            None => {
-                format!("/usr/bin/tail -n {tail_lines} '{path}' | /usr/bin/tail -n {take}")
-            }
-        };
-
-        let out = Command::new("/bin/sh")
-            .args(["-c", &pipeline])
-            .output()
-            .await;
-        if let Ok(out) = out
-            && !out.stdout.is_empty()
-        {
-            let text = String::from_utf8_lossy(&out.stdout);
-            let lines: Vec<String> = text.lines().rev().map(String::from).collect();
-            if !lines.is_empty() {
-                return lines;
-            }
+        let path = path.to_string();
+        let needle_lc = needle_lc.clone();
+        // The backwards scan is plain seek+read std I/O — run it on the
+        // blocking pool so a slow disk never stalls a runtime worker.
+        let lines = tokio::task::spawn_blocking(move || {
+            reverse_tail(&path, needle_lc.as_deref(), tail_lines, take).unwrap_or_default()
+        })
+        .await
+        .unwrap_or_default();
+        if !lines.is_empty() {
+            return lines;
         }
     }
     Vec::new()
 }
 
-/// Strip anything that isn't an obvious word character. Keeps grep happy
-/// (no regex metacharacters even though we use `-F`) and prevents shell
-/// quote escaping. Lossy on user-provided search terms with punctuation,
-/// but the Logs UI is a free-text filter — this is the safe default.
-fn sanitize_needle(s: &str) -> String {
-    s.chars()
-        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_' || *c == '.' || *c == ' ')
-        .collect()
+/// Scan `path` backwards from EOF, newest line first. Examines at most
+/// `tail_lines` lines and returns the first `take` that contain
+/// `needle_lc` (case-insensitively; `None` matches everything).
+fn reverse_tail(
+    path: &str,
+    needle_lc: Option<&str>,
+    tail_lines: usize,
+    take: usize,
+) -> std::io::Result<Vec<String>> {
+    let mut file = std::fs::File::open(path)?;
+    let mut pos = file.seek(SeekFrom::End(0))?;
+
+    let mut out: Vec<String> = Vec::new();
+    let mut examined = 0usize;
+    // Bytes of the (not yet complete) line spanning a chunk boundary —
+    // the head of the chunk we just processed, waiting for the rest.
+    let mut carry: Vec<u8> = Vec::new();
+    // The bytes after the file's final newline form the last line.
+    let mut at_eof = true;
+
+    let push_line = |raw: &[u8], out: &mut Vec<String>, examined: &mut usize| -> bool {
+        *examined += 1;
+        let line = String::from_utf8_lossy(raw);
+        let line = line.strip_suffix('\r').unwrap_or(&line);
+        let matches = match needle_lc {
+            Some(n) => line.to_lowercase().contains(n),
+            None => true,
+        };
+        if matches {
+            out.push(line.to_string());
+        }
+        out.len() >= take || *examined >= tail_lines
+    };
+
+    while pos > 0 {
+        let read_size = CHUNK.min(pos as usize);
+        pos -= read_size as u64;
+        file.seek(SeekFrom::Start(pos))?;
+        let mut buf = vec![0u8; read_size];
+        file.read_exact(&mut buf)?;
+        buf.extend_from_slice(&carry);
+
+        // Walk the chunk backwards, emitting each complete line. The
+        // bytes before the first newline belong to a line that starts in
+        // an earlier chunk — they become the next iteration's carry.
+        let mut end = buf.len();
+        let mut done = false;
+        while let Some(nl) = buf[..end].iter().rposition(|&b| b == b'\n') {
+            let raw = &buf[nl + 1..end];
+            // Skip the empty pseudo-line after the file's final newline.
+            if !(at_eof && raw.is_empty()) && push_line(raw, &mut out, &mut examined) {
+                done = true;
+            }
+            at_eof = false;
+            end = nl;
+            if done {
+                break;
+            }
+        }
+        if done {
+            return Ok(out);
+        }
+        carry = buf[..end].to_vec();
+    }
+
+    // Whatever is left is the first line of the file.
+    if !carry.is_empty() {
+        push_line(&carry, &mut out, &mut examined);
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn sanitize_drops_dangerous_chars() {
-        assert_eq!(sanitize_needle("rdns'`;rm -rf"), "rdnsrm -rf");
-        assert_eq!(sanitize_needle("ERROR.404"), "ERROR.404");
-        assert_eq!(sanitize_needle("auth_failed"), "auth_failed");
+    fn write_temp(name: &str, contents: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join("aifw-log-tail-tests");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(name);
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[tokio::test]
+    async fn tails_newest_first() {
+        let path = write_temp("basic.log", "one\ntwo\nthree\n");
+        let lines = tail_filtered(&[path.to_str().unwrap()], None, 100, 100).await;
+        assert_eq!(lines, vec!["three", "two", "one"]);
+    }
+
+    #[tokio::test]
+    async fn respects_take_and_tail_bounds() {
+        let path = write_temp("bounds.log", "a\nb\nc\nd\ne\n");
+        let lines = tail_filtered(&[path.to_str().unwrap()], None, 100, 2).await;
+        assert_eq!(lines, vec!["e", "d"]);
+        // tail_lines bounds how far back the scan looks at all.
+        let lines = tail_filtered(&[path.to_str().unwrap()], Some("a"), 2, 10).await;
+        assert!(lines.is_empty(), "'a' is outside the last 2 lines");
+    }
+
+    #[tokio::test]
+    async fn filters_case_insensitively() {
+        let path = write_temp(
+            "filter.log",
+            "ok line\nERROR: bad\nok again\nerror: worse\n",
+        );
+        let lines = tail_filtered(&[path.to_str().unwrap()], Some("Error"), 100, 100).await;
+        assert_eq!(lines, vec!["error: worse", "ERROR: bad"]);
+    }
+
+    #[tokio::test]
+    async fn handles_missing_trailing_newline_and_crlf() {
+        let path = write_temp("edges.log", "first\r\nsecond\r\nlast-no-newline");
+        let lines = tail_filtered(&[path.to_str().unwrap()], None, 100, 100).await;
+        assert_eq!(lines, vec!["last-no-newline", "second", "first"]);
+    }
+
+    #[tokio::test]
+    async fn spans_chunk_boundaries() {
+        // Lines large enough that the backwards scan must stitch a line
+        // across the 64 KiB chunk boundary.
+        let big_a = format!("A{}", "x".repeat(CHUNK));
+        let big_b = format!("B{}", "y".repeat(CHUNK / 2));
+        let path = write_temp("chunks.log", &format!("{big_a}\n{big_b}\nend\n"));
+        let lines = tail_filtered(&[path.to_str().unwrap()], None, 100, 100).await;
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0], "end");
+        assert_eq!(lines[1], big_b);
+        assert_eq!(lines[2], big_a);
+    }
+
+    #[tokio::test]
+    async fn skips_missing_paths() {
+        let path = write_temp("fallback.log", "found\n");
+        let lines = tail_filtered(
+            &["/nonexistent/never.log", path.to_str().unwrap()],
+            None,
+            100,
+            100,
+        )
+        .await;
+        assert_eq!(lines, vec!["found"]);
     }
 }

--- a/aifw-api/src/system.rs
+++ b/aifw-api/src/system.rs
@@ -274,7 +274,12 @@ pub async fn get_info() -> Result<Json<SystemInfo>, StatusCode> {
 }
 
 pub async fn list_timezones() -> Result<Json<Vec<String>>, StatusCode> {
-    Ok(Json(enumerate_timezones()))
+    // PERF-L14: the zoneinfo walk is hundreds of synchronous fs calls —
+    // run it on the blocking pool instead of a runtime worker.
+    let zones = tokio::task::spawn_blocking(enumerate_timezones)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(zones))
 }
 
 #[cfg(target_os = "freebsd")]

--- a/aifw-api/src/ws.rs
+++ b/aifw-api/src/ws.rs
@@ -438,9 +438,12 @@ pub async fn run_dashboard_producer(state: AppState) {
         };
         // Drift correction: schedule the next tick based on the start of
         // *this* one, not the end. Keeps the cadence stable when a build
-        // takes longer than expected; falls back to "interval from now" if
-        // the build blew past the budget.
-        next_at = (started + interval).max(Instant::now());
+        // takes longer than expected. PERF-L16: when a build blows past
+        // the budget, enforce a minimum gap before the next tick instead
+        // of re-running immediately — back-to-back over-budget builds
+        // would otherwise starve the runtime.
+        const MIN_GAP: Duration = Duration::from_millis(100);
+        next_at = (started + interval).max(Instant::now() + MIN_GAP);
     }
 }
 

--- a/aifw-ids/src/lib.rs
+++ b/aifw-ids/src/lib.rs
@@ -53,6 +53,9 @@ pub enum IdsError {
     /// Underlying file or socket I/O failed
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+    /// Alert could not be serialized for an output sink
+    #[error("serialization error: {0}")]
+    Serialize(#[from] serde_json::Error),
 }
 
 /// Crate-wide result alias using [`IdsError`]

--- a/aifw-ids/src/output/eve.rs
+++ b/aifw-ids/src/output/eve.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::fs::{File, OpenOptions};
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio::sync::Mutex;
 
 use aifw_common::ids::IdsAlert;
@@ -8,15 +10,33 @@ use aifw_common::ids::IdsAlert;
 use super::AlertOutput;
 use crate::Result;
 
+/// Write buffer size. EVE lines are ~500 bytes, so this batches ~100
+/// alerts per write syscall during bursts (PERF-L1).
+const WRITE_BUF_CAPACITY: usize = 64 * 1024;
+
+/// How often the background flusher drains buffered lines to disk. Bounds
+/// how long a SIEM tailing the file can lag behind a burst.
+const FLUSH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// EVE JSON file output — Suricata-compatible one-JSON-per-line format.
 ///
 /// All file I/O is async via tokio::fs so emitting an alert never blocks
 /// the runtime worker. Previously the std::sync::Mutex was held across
 /// blocking writes; under disk pressure that stalled the whole alert
 /// pipeline.
+///
+/// PERF-L1: writes go through a 64 KiB `BufWriter`, so a high alert rate
+/// costs one syscall per buffer instead of one per line. A background task
+/// flushes dirty buffers every second, bounding how long lines can sit in
+/// memory (the pipeline only calls `flush()` on engine stop).
 pub struct EveOutput {
     path: PathBuf,
-    file: Mutex<Option<File>>,
+    file: Arc<Mutex<Option<BufWriter<File>>>>,
+    /// Set after a buffered write; cleared by whichever flush runs first.
+    dirty: Arc<AtomicBool>,
+    /// Guard so the periodic flusher is spawned exactly once, lazily on
+    /// first emit (`new()` has no runtime guarantee).
+    flusher_started: AtomicBool,
     max_size: u64,
 }
 
@@ -26,7 +46,9 @@ impl EveOutput {
     pub fn new(path: PathBuf) -> Self {
         Self {
             path,
-            file: Mutex::new(None),
+            file: Arc::new(Mutex::new(None)),
+            dirty: Arc::new(AtomicBool::new(false)),
+            flusher_started: AtomicBool::new(false),
             max_size: 100 * 1024 * 1024, // 100MB default
         }
     }
@@ -40,7 +62,7 @@ impl EveOutput {
     /// Open the file lazily on first write. Caller holds the lock.
     async fn ensure_open<'a>(
         &'a self,
-        guard: &mut tokio::sync::MutexGuard<'a, Option<File>>,
+        guard: &mut tokio::sync::MutexGuard<'a, Option<BufWriter<File>>>,
     ) -> Result<()> {
         if guard.is_none() {
             if let Some(parent) = self.path.parent() {
@@ -51,9 +73,34 @@ impl EveOutput {
                 .append(true)
                 .open(&self.path)
                 .await?;
-            **guard = Some(f);
+            **guard = Some(BufWriter::with_capacity(WRITE_BUF_CAPACITY, f));
         }
         Ok(())
+    }
+
+    /// Spawn the once-per-second background flusher on first use.
+    fn ensure_flusher(&self) {
+        if self.flusher_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let file = self.file.clone();
+        let dirty = self.dirty.clone();
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(FLUSH_INTERVAL);
+            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                tick.tick().await;
+                if !dirty.swap(false, Ordering::AcqRel) {
+                    continue;
+                }
+                let mut guard = file.lock().await;
+                if let Some(ref mut w) = *guard
+                    && let Err(e) = w.flush().await
+                {
+                    tracing::warn!(error = %e, "eve output: periodic flush failed");
+                }
+            }
+        });
     }
 
     /// Rotate the on-disk file when it exceeds `max_size`. Releases the
@@ -62,10 +109,17 @@ impl EveOutput {
         if let Ok(metadata) = tokio::fs::metadata(&self.path).await
             && metadata.len() >= self.max_size
         {
+            let mut guard = self.file.lock().await;
+            // Drain buffered lines into the file about to be rotated so
+            // they aren't lost when the handle is dropped.
+            if let Some(ref mut w) = *guard
+                && let Err(e) = w.flush().await
+            {
+                tracing::warn!(error = %e, "eve output: pre-rotation flush failed");
+            }
             let rotated = self.path.with_extension("json.1");
             let _ = tokio::fs::remove_file(&rotated).await;
             let _ = tokio::fs::rename(&self.path, &rotated).await;
-            let mut guard = self.file.lock().await;
             *guard = None;
         }
         Ok(())
@@ -98,13 +152,18 @@ impl AlertOutput for EveOutput {
             "app_proto": alert.protocol,
         });
 
-        let mut line = serde_json::to_vec(&eve).unwrap_or_default();
+        // PERF-L2: propagate instead of `unwrap_or_default()` — an empty
+        // line in the EVE file chokes downstream SIEMs, and the pipeline
+        // logs emit errors per output.
+        let mut line = serde_json::to_vec(&eve)?;
         line.push(b'\n');
 
+        self.ensure_flusher();
         let mut guard = self.file.lock().await;
         self.ensure_open(&mut guard).await?;
         if let Some(ref mut file) = *guard {
             file.write_all(&line).await?;
+            self.dirty.store(true, Ordering::Release);
         }
         Ok(())
     }
@@ -113,6 +172,7 @@ impl AlertOutput for EveOutput {
         let mut guard = self.file.lock().await;
         if let Some(ref mut file) = *guard {
             file.flush().await?;
+            self.dirty.store(false, Ordering::Release);
         }
         Ok(())
     }

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.3",
+  "version": "5.99.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.3",
+      "version": "5.99.4",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",
         "next": "^16.2.9",
         "react": "^19.2.7",
-        "react-dom": "^19.2.7",
-        "recharts": "^3.8.1"
+        "react-dom": "^19.2.7"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.1",
@@ -1324,59 +1323,11 @@
         "node": ">=12.4.0"
       }
     },
-    "node_modules/@reduxjs/toolkit": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
-      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "@standard-schema/utils": "^0.3.0",
-        "immer": "^11.0.0",
-        "redux": "^5.0.1",
-        "redux-thunk": "^3.1.0",
-        "reselect": "^5.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
-        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-redux": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
-      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT"
-    },
-    "node_modules/@standard-schema/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -1709,69 +1660,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1807,7 +1695,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1822,12 +1710,6 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
-      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.1",
@@ -2886,15 +2768,6 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2948,129 +2821,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3150,12 +2902,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/decimal.js-light": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
-      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3442,16 +3188,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es-toolkit": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
-      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
-      "license": "MIT",
-      "workspaces": [
-        "docs",
-        "benchmarks"
-      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -3970,12 +3706,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4432,16 +4162,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
-      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4482,15 +4202,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6013,81 +5724,6 @@
         "react": "^19.2.7"
       }
     },
-    "node_modules/react-is": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
-      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/react-redux": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
-      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/use-sync-external-store": "^0.0.6",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.2.25 || ^19",
-        "react": "^18.0 || ^19",
-        "redux": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/recharts": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
-      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
-      "license": "MIT",
-      "workspaces": [
-        "www"
-      ],
-      "dependencies": {
-        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
-        "clsx": "^2.1.1",
-        "decimal.js-light": "^2.5.1",
-        "es-toolkit": "^1.39.3",
-        "eventemitter3": "^5.0.1",
-        "immer": "^10.1.1",
-        "react-redux": "8.x.x || 9.x.x",
-        "reselect": "5.1.1",
-        "tiny-invariant": "^1.3.3",
-        "use-sync-external-store": "^1.2.2",
-        "victory-vendor": "^37.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
-    },
-    "node_modules/redux-thunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^5.0.0"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -6131,12 +5767,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -6730,12 +6360,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -7074,37 +6698,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/victory-vendor": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
-      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
-      "license": "MIT AND ISC",
-      "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/which": {

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.4",
+  "version": "5.99.5",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -13,9 +13,7 @@
     "lucide-react": "^1.20.0",
     "next": "^16.2.9",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7",
-    "recharts": "^3.8.1"
-  },
+    "react-dom": "^19.2.7"  },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.1",
     "@types/node": "^25.9.3",

--- a/aifw-ui/src/context/WsContext.tsx
+++ b/aifw-ui/src/context/WsContext.tsx
@@ -100,6 +100,11 @@ export function WsProvider({ children }: { children: ReactNode }) {
 
     ws.onclose = () => {
       setConnected(false);
+      // PERF-L9 (#401): reset so consumers see a genuine false→true
+      // transition when the reconnect replaces histBuf with the server's
+      // fresh history — they re-seed charts from the new buffer instead
+      // of ignoring the replacement (or double-handling the flip).
+      setHistoryLoaded(false);
       wsRef.current = null;
       reconRef.current = setTimeout(() => connectRef.current(), 3000);
     };


### PR DESCRIPTION
Clears the remaining LOW findings from the 2026-05-12 performance audit.

## Fixes

| Finding | Issue | Change |
|---|---|---|
| PERF-L1 | #393 | EVE output writes through a 64 KiB `tokio::io::BufWriter` (~100 alerts per syscall during bursts). Since the pipeline only calls `flush()` at engine stop, a lazily-spawned background task flushes dirty buffers every 1 s so a SIEM tailing the file lags at most a second. The buffer is drained before rotation so no lines are lost when the handle is dropped |
| PERF-L2 | #394 | `serde_json::to_vec(&eve)` now propagates via a new `IdsError::Serialize` variant instead of `unwrap_or_default()` writing an empty line (which downstream SIEMs can choke on); the pipeline already logs per-output emit errors |
| PERF-L6 | #398 | recharts removed from `package.json` entirely — it had zero imports left in `aifw-ui/src` (usage was removed in earlier refactors), so the 150 KB dependency was pure dead weight. No library swap needed |
| PERF-L8 | #400 | `tail_filtered` is now a native in-process backwards chunk scan (64 KiB seeks from EOF on the blocking pool) — zero forks per poll instead of three (`sh`, `tail`, `grep`, `tail`). Same semantics: examines at most `tail_lines` lines, case-insensitive fixed-string filter, up to `take` matches newest-first, first-existing-path fallback. With no shell in the path, `sanitize_needle` is gone — the needle is matched verbatim as a literal substring (slightly better UX for punctuation searches). Six new unit tests cover ordering, bounds, filtering, CRLF/no-trailing-newline edges, and chunk-boundary stitching |
| PERF-L9 | #401 | `WsContext` resets `historyLoaded` to false on socket close, so consumers see a genuine false→true transition on reconnect and re-seed charts from the replaced history buffer |
| PERF-L14 | #406 | The recursive `/usr/share/zoneinfo` walk (hundreds of sync fs calls) runs via `spawn_blocking` instead of on a runtime worker |
| PERF-L16 | #408 | The dashboard producer enforces a 100 ms minimum gap between ticks (`(started + interval).max(now + 100ms)`), so back-to-back over-budget `build_update` runs can't starve the runtime |

## Already fixed (closing alongside)

- PERF-L10 #402 — `multiwan/sla.rs::window` already selects an explicit `SLA_COLUMNS` list (fixed with the PERF-H4 SELECT-* sweep)
- PERF-L11 #403 — the workspace tokio dep already carries no default runtime features (PERF-H3 #347), and `aifw-common`/`aifw-pf` declare explicit minimal feature sets

## Verification

- `cargo check` — zero warnings; pre-commit fmt + `clippy -D warnings` pass
- `cargo test` — 683 passed, 0 failed (includes 6 new log_tail tests)
- `npm run build` — static export succeeds without recharts; `npm run lint` clean
- Version bumped 5.99.4 → 5.99.5 (Cargo.toml + aifw-ui/package.json)

Closes #393, closes #394, closes #398, closes #400, closes #401, closes #406, closes #408