### PR TITLE
perf: drop the AWS SDKs — rusty-s3 + SigV4-signed reqwest (PERF-I2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.5"
+version = "5.99.6"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"
@@ -31,10 +31,8 @@ aifw-core = { path = "aifw-core" }
 aifw-conntrack = { path = "aifw-conntrack" }
 aifw-plugins = { path = "aifw-plugins" }
 aifw-ids = { path = "aifw-ids" }
-aifw-ids-bin = { path = "aifw-ids-bin" }
 aifw-ids-ipc = { path = "aifw-ids-ipc" }
 aifw-metrics = { path = "aifw-metrics" }
-aifw-api = { path = "aifw-api" }
 axum = { version = "0.8", features = ["ws", "multipart"] }
 tower = { version = "0.5", features = ["full"] }
 tower-http = { version = "0.7", features = ["cors", "trace", "fs", "set-header", "compression-gzip", "compression-br"] }

--- a/aifw-core/Cargo.toml
+++ b/aifw-core/Cargo.toml
@@ -22,15 +22,15 @@ cron = "0.17"
 arc-swap = "1"
 ip_network = "0.4"
 ip_network_table = "0.2"
-aws-config = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
-aws-sdk-s3 = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
-aws-sdk-route53 = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-credential-types = "1"
-aws-smithy-runtime-api = "1"
 instant-acme = "0.8"
 rcgen = { workspace = true }
 reqwest = { workspace = true }
 lettre = { version = "0.11", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "builder", "hostname"] }
+rusty-s3 = "0.10"
+aws-sigv4 = { version = "1", default-features = false, features = ["sign-http", "http1"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
+url = "2"
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/aifw-core/src/acme_dns.rs
+++ b/aifw-core/src/acme_dns.rs
@@ -332,15 +332,29 @@ fn urlencoding(s: &str) -> String {
 }
 
 // =============================================================================
-// Route 53 — uses the aws-sdk we already have for S3 backups
+// Route 53 — SigV4-signed reqwest calls against the plain XML REST API.
+//
+// PERF-I2 (#410): previously used aws-sdk-route53, whose smithy runtime
+// chain gated the whole workspace build. We only ever issue two API calls
+// (ListHostedZonesByName + ChangeResourceRecordSets), so they're signed
+// with the standalone `aws-sigv4` crate and sent through the reqwest
+// client we already ship. Route 53 is a global service: the endpoint is
+// route53.amazonaws.com and requests are signed for us-east-1 regardless
+// of any configured region (the SDK did the same internally).
 // =============================================================================
+
+/// Route 53 API base. The date segment is the API version, not a region.
+const R53_BASE: &str = "https://route53.amazonaws.com/2013-04-01";
+/// XML namespace required on ChangeResourceRecordSets request bodies.
+const R53_XMLNS: &str = "https://route53.amazonaws.com/doc/2013-04-01/";
+/// Global-service signing region (fixed by AWS for Route 53).
+const R53_REGION: &str = "us-east-1";
 
 /// AWS Route 53 DNS-01 solver / DDNS record writer authenticated with an
 /// explicit access-key pair (`api_token` = access key id)
 pub struct Route53 {
     access_key: String,
     secret_key: String,
-    region: String,
     zone_name: String,
     /// Hosted zone ID — either supplied in `extra.zone_id` or resolved on
     /// first use via ListHostedZonesByName.
@@ -356,12 +370,6 @@ impl Route53 {
             .aws_secret_key
             .clone()
             .ok_or_else(|| "Route53 provider missing secret access key".to_string())?;
-        let region = p
-            .extra
-            .get("region")
-            .and_then(|v| v.as_str())
-            .unwrap_or("us-east-1")
-            .to_string();
         let zone_id = tokio::sync::OnceCell::new();
         if let Some(z) = p.extra.get("zone_id").and_then(|v| v.as_str()) {
             let _ = zone_id.set(z.to_string());
@@ -369,150 +377,204 @@ impl Route53 {
         Ok(Self {
             access_key,
             secret_key,
-            region,
             zone_name: p.zone.clone(),
             zone_id,
         })
     }
 
-    async fn client(&self) -> aws_sdk_route53::Client {
-        use aws_credential_types::{Credentials, provider::SharedCredentialsProvider};
-        let creds = Credentials::new(&self.access_key, &self.secret_key, None, None, "aifw-acme");
-        let cfg = aws_config::defaults(aws_config::BehaviorVersion::latest())
-            .region(aws_sdk_route53::config::Region::new(self.region.clone()))
-            .credentials_provider(SharedCredentialsProvider::new(creds))
-            .load()
-            .await;
-        aws_sdk_route53::Client::new(&cfg)
+    /// Sign and send one Route 53 request. `body` is the XML request body
+    /// for POSTs, empty for GETs. Returns the response body on 2xx.
+    async fn signed_request(&self, method: &str, url: &str, body: &str) -> Result<String, String> {
+        use aws_sigv4::http_request::{SignableBody, SignableRequest, SigningSettings, sign};
+        use aws_sigv4::sign::v4;
+
+        let identity = aws_credential_types::Credentials::new(
+            &self.access_key,
+            &self.secret_key,
+            None,
+            None,
+            "aifw-acme",
+        )
+        .into();
+        let params = v4::SigningParams::builder()
+            .identity(&identity)
+            .region(R53_REGION)
+            .name("route53")
+            .time(std::time::SystemTime::now())
+            .settings(SigningSettings::default())
+            .build()
+            .map_err(|e| format!("route53 signing params: {e}"))?
+            .into();
+
+        // Headers passed here are folded into the signature, so the real
+        // request below must send exactly the same set.
+        let signed_headers: Vec<(&str, &str)> = if body.is_empty() {
+            Vec::new()
+        } else {
+            vec![("content-type", "application/xml")]
+        };
+        let signable = SignableRequest::new(
+            method,
+            url,
+            signed_headers.iter().copied(),
+            SignableBody::Bytes(body.as_bytes()),
+        )
+        .map_err(|e| format!("route53 signable request: {e}"))?;
+        let (instructions, _signature) = sign(signable, &params)
+            .map_err(|e| format!("route53 sign: {e}"))?
+            .into_parts();
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .build()
+            .map_err(|e| format!("http client: {e}"))?;
+        let mut req = match method {
+            "POST" => client.post(url),
+            _ => client.get(url),
+        };
+        for (name, value) in &signed_headers {
+            req = req.header(*name, *value);
+        }
+        for (name, value) in instructions.headers() {
+            req = req.header(name, value);
+        }
+        if !body.is_empty() {
+            req = req.body(body.to_string());
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("route53 request: {e}"))?;
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            // Route 53 error bodies are small XML docs naming the failure
+            // (InvalidChangeBatch, AccessDenied, ...) — surface a snippet.
+            let snippet: String = text.chars().take(300).collect();
+            return Err(format!("route53 HTTP {status}: {snippet}"));
+        }
+        Ok(text)
     }
 
     async fn resolve_zone_id(&self) -> Result<String, String> {
         if let Some(z) = self.zone_id.get() {
             return Ok(z.clone());
         }
-        let c = self.client().await;
         let target = format!("{}.", self.zone_name.trim_end_matches('.'));
-        let resp = c
-            .list_hosted_zones_by_name()
-            .dns_name(&target)
-            .max_items(1)
-            .send()
-            .await
-            .map_err(|e| format!("route53 list zones: {e}"))?;
-        let zone = resp
+        let url = format!(
+            "{R53_BASE}/hostedzonesbyname?dnsname={}&maxitems=1",
+            urlencoding(&target)
+        );
+        let text = self.signed_request("GET", &url, "").await?;
+        let parsed: ListHostedZonesByNameResponse =
+            quick_xml::de::from_str(&text).map_err(|e| format!("route53 list zones parse: {e}"))?;
+        let zone = parsed
             .hosted_zones
+            .hosted_zone
             .into_iter()
             .next()
             .ok_or_else(|| format!("Route53: no hosted zone matching '{}'", self.zone_name))?;
-        if zone.name() != target {
+        if zone.name != target {
             return Err(format!(
                 "Route53 returned zone '{}' but configured was '{}'",
-                zone.name(),
-                target
+                zone.name, target
             ));
         }
         // Strip the "/hostedzone/" prefix Route53 returns on the zone id.
-        let raw = zone.id().trim_start_matches("/hostedzone/").to_string();
+        let raw = zone.id.trim_start_matches("/hostedzone/").to_string();
         let _ = self.zone_id.set(raw.clone());
         Ok(raw)
     }
 
-    async fn change_txt(
+    /// Submit a single-change ChangeResourceRecordSets batch.
+    async fn change_rrset(
         &self,
+        action: &str,
         fqdn: &str,
+        rtype: &str,
         value: &str,
-        action: aws_sdk_route53::types::ChangeAction,
+        ttl: u32,
     ) -> Result<(), String> {
-        use aws_sdk_route53::types::{
-            Change, ChangeBatch, ResourceRecord, ResourceRecordSet, RrType,
-        };
         let zone_id = self.resolve_zone_id().await?;
-        let c = self.client().await;
-        let rr_value = format!("\"{}\"", value); // Route53 requires quoted TXT values
-        let rrset = ResourceRecordSet::builder()
-            .name(format!("{}.", fqdn.trim_end_matches('.')))
-            .r#type(RrType::Txt)
-            .ttl(60)
-            .resource_records(
-                ResourceRecord::builder()
-                    .value(&rr_value)
-                    .build()
-                    .map_err(|e| format!("rr build: {e}"))?,
-            )
-            .build()
-            .map_err(|e| format!("rrset build: {e}"))?;
-        let change = Change::builder()
-            .action(action)
-            .resource_record_set(rrset)
-            .build()
-            .map_err(|e| format!("change build: {e}"))?;
-        let batch = ChangeBatch::builder()
-            .changes(change)
-            .build()
-            .map_err(|e| format!("batch build: {e}"))?;
-        c.change_resource_record_sets()
-            .hosted_zone_id(zone_id)
-            .change_batch(batch)
-            .send()
-            .await
-            .map_err(|e| format!("route53 ChangeRRSets: {e}"))?;
+        let url = format!("{R53_BASE}/hostedzone/{zone_id}/rrset");
+        let body = change_batch_xml(action, fqdn, rtype, value, ttl);
+        self.signed_request("POST", &url, &body).await?;
         Ok(())
     }
+}
+
+/// Build the ChangeResourceRecordSets XML request body for one change.
+fn change_batch_xml(action: &str, fqdn: &str, rtype: &str, value: &str, ttl: u32) -> String {
+    format!(
+        concat!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>"#,
+            r#"<ChangeResourceRecordSetsRequest xmlns="{ns}">"#,
+            "<ChangeBatch><Changes><Change>",
+            "<Action>{action}</Action>",
+            "<ResourceRecordSet>",
+            "<Name>{name}</Name>",
+            "<Type>{rtype}</Type>",
+            "<TTL>{ttl}</TTL>",
+            "<ResourceRecords><ResourceRecord><Value>{value}</Value></ResourceRecord></ResourceRecords>",
+            "</ResourceRecordSet>",
+            "</Change></Changes></ChangeBatch>",
+            "</ChangeResourceRecordSetsRequest>",
+        ),
+        ns = R53_XMLNS,
+        action = action,
+        name = xml_escape(&format!("{}.", fqdn.trim_end_matches('.'))),
+        rtype = rtype,
+        ttl = ttl,
+        value = xml_escape(value),
+    )
+}
+
+fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[derive(serde::Deserialize)]
+struct ListHostedZonesByNameResponse {
+    #[serde(rename = "HostedZones")]
+    hosted_zones: HostedZonesList,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct HostedZonesList {
+    #[serde(rename = "HostedZone", default)]
+    hosted_zone: Vec<HostedZoneEntry>,
+}
+
+#[derive(serde::Deserialize)]
+struct HostedZoneEntry {
+    #[serde(rename = "Id")]
+    id: String,
+    #[serde(rename = "Name")]
+    name: String,
 }
 
 #[async_trait]
 impl DnsSolver for Route53 {
     async fn add_txt(&self, fqdn: &str, value: &str) -> Result<(), String> {
-        self.change_txt(fqdn, value, aws_sdk_route53::types::ChangeAction::Upsert)
+        // Route53 requires quoted TXT values.
+        self.change_rrset("UPSERT", fqdn, "TXT", &format!("\"{value}\""), 60)
             .await
     }
     async fn remove_txt(&self, fqdn: &str, value: &str) -> Result<(), String> {
-        self.change_txt(fqdn, value, aws_sdk_route53::types::ChangeAction::Delete)
+        self.change_rrset("DELETE", fqdn, "TXT", &format!("\"{value}\""), 60)
             .await
-    }
-}
-
-impl Route53 {
-    async fn upsert_addr(
-        &self,
-        fqdn: &str,
-        rtype: aws_sdk_route53::types::RrType,
-        ip: IpAddr,
-        ttl: u32,
-    ) -> Result<(), String> {
-        use aws_sdk_route53::types::{
-            Change, ChangeAction, ChangeBatch, ResourceRecord, ResourceRecordSet,
-        };
-        let zone_id = self.resolve_zone_id().await?;
-        let c = self.client().await;
-        let rrset = ResourceRecordSet::builder()
-            .name(format!("{}.", fqdn.trim_end_matches('.')))
-            .r#type(rtype)
-            .ttl(ttl as i64)
-            .resource_records(
-                ResourceRecord::builder()
-                    .value(ip.to_string())
-                    .build()
-                    .map_err(|e| format!("rr build: {e}"))?,
-            )
-            .build()
-            .map_err(|e| format!("rrset build: {e}"))?;
-        let change = Change::builder()
-            .action(ChangeAction::Upsert)
-            .resource_record_set(rrset)
-            .build()
-            .map_err(|e| format!("change build: {e}"))?;
-        let batch = ChangeBatch::builder()
-            .changes(change)
-            .build()
-            .map_err(|e| format!("batch build: {e}"))?;
-        c.change_resource_record_sets()
-            .hosted_zone_id(zone_id)
-            .change_batch(batch)
-            .send()
-            .await
-            .map_err(|e| format!("route53 ChangeRRSets: {e}"))?;
-        Ok(())
     }
 }
 
@@ -522,14 +584,14 @@ impl DnsRecordWriter for Route53 {
         if !ip.is_ipv4() {
             return Err(format!("upsert_a got non-v4 address {ip}"));
         }
-        self.upsert_addr(fqdn, aws_sdk_route53::types::RrType::A, ip, ttl)
+        self.change_rrset("UPSERT", fqdn, "A", &ip.to_string(), ttl)
             .await
     }
     async fn upsert_aaaa(&self, fqdn: &str, ip: IpAddr, ttl: u32) -> Result<(), String> {
         if !ip.is_ipv6() {
             return Err(format!("upsert_aaaa got non-v6 address {ip}"));
         }
-        self.upsert_addr(fqdn, aws_sdk_route53::types::RrType::Aaaa, ip, ttl)
+        self.change_rrset("UPSERT", fqdn, "AAAA", &ip.to_string(), ttl)
             .await
     }
 }
@@ -559,5 +621,80 @@ impl DnsSolver for Manual {
     async fn remove_txt(&self, _fqdn: &str, _value: &str) -> Result<(), String> {
         // Nothing to do — the operator can clean up by hand.
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn change_batch_xml_shape() {
+        let xml = change_batch_xml(
+            "UPSERT",
+            "_acme-challenge.fw.example.com",
+            "TXT",
+            "\"tok-abc\"",
+            60,
+        );
+        assert!(xml.starts_with(r#"<?xml version="1.0" encoding="UTF-8"?>"#));
+        assert!(xml.contains(r#"xmlns="https://route53.amazonaws.com/doc/2013-04-01/""#));
+        assert!(xml.contains("<Action>UPSERT</Action>"));
+        // fqdn gets a trailing dot; TXT value keeps its quotes.
+        assert!(xml.contains("<Name>_acme-challenge.fw.example.com.</Name>"));
+        assert!(xml.contains("<Type>TXT</Type>"));
+        assert!(xml.contains("<TTL>60</TTL>"));
+        assert!(xml.contains("<Value>&quot;tok-abc&quot;</Value>"));
+    }
+
+    #[test]
+    fn change_batch_xml_does_not_double_dot() {
+        let xml = change_batch_xml("DELETE", "host.example.com.", "A", "203.0.113.7", 300);
+        assert!(xml.contains("<Name>host.example.com.</Name>"));
+        assert!(!xml.contains("com..</Name>"));
+    }
+
+    #[test]
+    fn xml_escape_covers_specials() {
+        assert_eq!(
+            xml_escape(r#"a&b<c>d"e'f"#),
+            "a&amp;b&lt;c&gt;d&quot;e&apos;f"
+        );
+        assert_eq!(xml_escape("plain-value"), "plain-value");
+    }
+
+    #[test]
+    fn parses_list_hosted_zones_by_name() {
+        let xml = r#"<?xml version="1.0"?>
+<ListHostedZonesByNameResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <HostedZones>
+    <HostedZone>
+      <Id>/hostedzone/Z0123456ABCDEF</Id>
+      <Name>example.com.</Name>
+      <CallerReference>ref-1</CallerReference>
+      <Config><PrivateZone>false</PrivateZone></Config>
+      <ResourceRecordSetCount>12</ResourceRecordSetCount>
+    </HostedZone>
+  </HostedZones>
+  <DNSName>example.com.</DNSName>
+  <IsTruncated>false</IsTruncated>
+  <MaxItems>1</MaxItems>
+</ListHostedZonesByNameResponse>"#;
+        let parsed: ListHostedZonesByNameResponse = quick_xml::de::from_str(xml).unwrap();
+        let zone = &parsed.hosted_zones.hosted_zone[0];
+        assert_eq!(zone.id, "/hostedzone/Z0123456ABCDEF");
+        assert_eq!(zone.name, "example.com.");
+    }
+
+    #[test]
+    fn parses_empty_zone_list() {
+        let xml = r#"<?xml version="1.0"?>
+<ListHostedZonesByNameResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <HostedZones/>
+  <IsTruncated>false</IsTruncated>
+  <MaxItems>1</MaxItems>
+</ListHostedZonesByNameResponse>"#;
+        let parsed: ListHostedZonesByNameResponse = quick_xml::de::from_str(xml).unwrap();
+        assert!(parsed.hosted_zones.hosted_zone.is_empty());
     }
 }

--- a/aifw-core/src/s3_backup.rs
+++ b/aifw-core/src/s3_backup.rs
@@ -5,22 +5,32 @@
 //! (restore) archived versions from any date — no time-based pruning
 //! applies on the S3 side; bucket lifecycle is the operator's job.
 //!
-//! Credentials: empty access_key/secret means "use the AWS default
-//! credential provider chain" — environment, `~/.aws/credentials`, or
-//! the EC2/ECS instance role. Otherwise the explicit key+secret pair
-//! is used. Stored-in-DB secrets are returned masked via the API.
+//! Credentials: empty access_key/secret means "use the AWS environment
+//! variables" (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, plus
+//! `AWS_SESSION_TOKEN` when set). Otherwise the explicit key+secret
+//! pair is used. Stored-in-DB secrets are returned masked via the API.
+//!
+//! PERF-I2 (#410): implemented with `rusty-s3` (a small sans-IO SigV4
+//! signer) + the `reqwest` client we already ship, instead of the
+//! aws-sdk-s3 stack — the SDK chain alone gated the whole workspace
+//! build for ~15 s. The SDK's wider credential chain (profile files,
+//! IMDS instance roles, SSO) was dropped with it; a firewall appliance
+//! only ever used explicit keys or env vars.
 
-use aws_config::BehaviorVersion;
-use aws_credential_types::Credentials;
-use aws_credential_types::provider::SharedCredentialsProvider;
-use aws_sdk_s3::Client;
-use aws_sdk_s3::primitives::ByteStream;
-use aws_sdk_s3::types::Object;
+use rusty_s3::actions::ListObjectsV2;
+use rusty_s3::{Bucket, Credentials, S3Action, UrlStyle};
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
+use std::time::Duration;
 
 const TEST_KEY_SUFFIX: &str = ".aifw-connectivity-test";
-const APP_TAG: &str = "aifw-backup";
+
+/// Validity window for presigned request URLs — generous enough for slow
+/// uplinks and retries, far below any replay-concern horizon.
+const SIGN_TTL: Duration = Duration::from_secs(300);
+
+/// Per-request timeout for all S3 HTTP calls.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 
 // ============================================================================
 // Config
@@ -48,8 +58,8 @@ pub struct S3Config {
     /// virtual-hosted. Required for most S3-compatible providers.
     #[serde(default)]
     pub path_style: bool,
-    /// Leave empty to use the default AWS credential chain (env, profile,
-    /// instance role). Fill in both to use explicit creds.
+    /// Leave empty to use the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
+    /// environment variables. Fill in both to use explicit creds.
     #[serde(default)]
     pub access_key_id: Option<String>,
     /// Secret is write-only from the API. GET returns `""` if set, `null`
@@ -158,16 +168,37 @@ pub async fn save(pool: &SqlitePool, cfg: &S3Config) -> Result<(), String> {
 // Client
 // ============================================================================
 
-async fn client(cfg: &S3Config) -> Result<Client, String> {
+/// Everything needed to issue signed S3 requests: the bucket/endpoint
+/// descriptor, credentials, and a reqwest client.
+struct S3Client {
+    bucket: Bucket,
+    creds: Credentials,
+    http: reqwest::Client,
+}
+
+fn client(cfg: &S3Config) -> Result<S3Client, String> {
     if cfg.bucket.trim().is_empty() {
         return Err("bucket is required".into());
     }
-    let mut loader = aws_config::defaults(BehaviorVersion::latest())
-        .region(aws_sdk_s3::config::Region::new(cfg.region.clone()));
 
-    // Explicit creds override the default chain. Otherwise AWS SDK walks
-    // env -> profile -> instance role / container role -> SSO etc.
-    if let (Some(ak), Some(sk)) = (
+    let endpoint: url::Url = match cfg.endpoint.as_deref().filter(|s| !s.trim().is_empty()) {
+        Some(ep) => ep
+            .parse()
+            .map_err(|e| format!("invalid endpoint '{ep}': {e}"))?,
+        None => format!("https://s3.{}.amazonaws.com", cfg.region)
+            .parse()
+            .map_err(|e| format!("invalid region '{}': {e}", cfg.region))?,
+    };
+    let style = if cfg.path_style {
+        UrlStyle::Path
+    } else {
+        UrlStyle::VirtualHost
+    };
+    let bucket = Bucket::new(endpoint, style, cfg.bucket.clone(), cfg.region.clone())
+        .map_err(|e| format!("bucket config: {e}"))?;
+
+    // Explicit creds win; otherwise fall back to the AWS env variables.
+    let creds = match (
         cfg.access_key_id
             .as_deref()
             .filter(|s| !s.trim().is_empty()),
@@ -175,20 +206,39 @@ async fn client(cfg: &S3Config) -> Result<Client, String> {
             .as_deref()
             .filter(|s| !s.trim().is_empty()),
     ) {
-        let creds = Credentials::new(ak, sk, None, None, APP_TAG);
-        loader = loader.credentials_provider(SharedCredentialsProvider::new(creds));
-    }
+        (Some(ak), Some(sk)) => Credentials::new(ak, sk),
+        _ => Credentials::from_env().ok_or_else(|| {
+            "credentials required: set access key + secret, or the \
+             AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY environment variables"
+                .to_string()
+        })?,
+    };
 
-    if let Some(ep) = cfg.endpoint.as_deref().filter(|s| !s.trim().is_empty()) {
-        loader = loader.endpoint_url(ep);
-    }
+    let http = reqwest::Client::builder()
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .map_err(|e| format!("http client: {e}"))?;
 
-    let sdk_cfg = loader.load().await;
-    let mut builder = aws_sdk_s3::config::Builder::from(&sdk_cfg);
-    if cfg.path_style {
-        builder = builder.force_path_style(true);
+    Ok(S3Client {
+        bucket,
+        creds,
+        http,
+    })
+}
+
+/// Render a non-2xx S3 response into a bounded, human-readable error.
+/// S3 error bodies are small XML documents that name the failing
+/// permission (`AccessDenied`, `NoSuchBucket`, …), so a snippet is the
+/// most useful thing to surface in the UI.
+async fn error_text(resp: reqwest::Response) -> String {
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    let snippet: String = body.chars().take(300).collect();
+    if snippet.is_empty() {
+        format!("HTTP {status}")
+    } else {
+        format!("HTTP {status}: {snippet}")
     }
-    Ok(Client::from_conf(builder.build()))
 }
 
 // ============================================================================
@@ -269,7 +319,7 @@ pub async fn test_connection(cfg: &S3Config) -> TestResult {
         read: false,
         delete: false,
     };
-    let c = match client(cfg).await {
+    let c = match client(cfg) {
         Ok(c) => c,
         Err(e) => {
             r.message = format!("config error: {e}");
@@ -288,40 +338,54 @@ pub async fn test_connection(cfg: &S3Config) -> TestResult {
         chrono::Utc::now().to_rfc3339(),
     );
 
+    let put_url = c.bucket.put_object(Some(&c.creds), &key).sign(SIGN_TTL);
     match c
-        .put_object()
-        .bucket(&cfg.bucket)
-        .key(&key)
-        .body(ByteStream::from(payload.as_bytes().to_vec()))
-        .content_type("text/plain")
+        .http
+        .put(put_url)
+        .header(reqwest::header::CONTENT_TYPE, "text/plain")
+        .body(payload)
         .send()
         .await
     {
-        Ok(_) => r.write = true,
+        Ok(resp) if resp.status().is_success() => r.write = true,
+        Ok(resp) => {
+            r.message = format!("write failed: {}", error_text(resp).await);
+            return r;
+        }
         Err(e) => {
-            r.message = format!("write failed: {}", summarize_sdk_error(&e));
+            r.message = format!("write failed: {e}");
             return r;
         }
     }
 
-    match c.get_object().bucket(&cfg.bucket).key(&key).send().await {
-        Ok(obj) => match obj.body.collect().await {
+    let get_url = c.bucket.get_object(Some(&c.creds), &key).sign(SIGN_TTL);
+    match c.http.get(get_url).send().await {
+        Ok(resp) if resp.status().is_success() => match resp.bytes().await {
             Ok(_) => r.read = true,
             Err(e) => {
                 r.message = format!("read drain failed: {e}");
                 return r;
             }
         },
+        Ok(resp) => {
+            r.message = format!("read failed: {}", error_text(resp).await);
+            return r;
+        }
         Err(e) => {
-            r.message = format!("read failed: {}", summarize_sdk_error(&e));
+            r.message = format!("read failed: {e}");
             return r;
         }
     }
 
-    match c.delete_object().bucket(&cfg.bucket).key(&key).send().await {
-        Ok(_) => r.delete = true,
+    let del_url = c.bucket.delete_object(Some(&c.creds), &key).sign(SIGN_TTL);
+    match c.http.delete(del_url).send().await {
+        Ok(resp) if resp.status().is_success() => r.delete = true,
+        Ok(resp) => {
+            r.message = format!("delete failed: {}", error_text(resp).await);
+            return r;
+        }
         Err(e) => {
-            r.message = format!("delete failed: {}", summarize_sdk_error(&e));
+            r.message = format!("delete failed: {e}");
             return r;
         }
     }
@@ -332,10 +396,6 @@ pub async fn test_connection(cfg: &S3Config) -> TestResult {
         cfg.bucket, key
     );
     r
-}
-
-fn summarize_sdk_error<E: std::fmt::Display, R>(err: &aws_sdk_s3::error::SdkError<E, R>) -> String {
-    format!("{err}")
 }
 
 /// One archived config version listed from the bucket
@@ -352,41 +412,48 @@ pub struct RemoteObject {
 /// List all config backups under the configured prefix (scoped to this host).
 /// Returns up to `max` objects, newest-first.
 pub async fn list(cfg: &S3Config, max: usize) -> Result<Vec<RemoteObject>, String> {
-    let c = client(cfg).await?;
+    let c = client(cfg)?;
     let prefix = format!("{}{}/", normalize_prefix(&cfg.prefix), hostname());
     let mut out = Vec::new();
     let mut token: Option<String> = None;
     loop {
-        let mut req = c.list_objects_v2().bucket(&cfg.bucket).prefix(&prefix);
-        if let Some(t) = token.as_ref() {
-            req = req.continuation_token(t);
+        let mut action = c.bucket.list_objects_v2(Some(&c.creds));
+        action.with_prefix(prefix.as_str());
+        if let Some(t) = token.as_deref() {
+            action.with_continuation_token(t);
         }
-        let resp = req.send().await.map_err(|e| summarize_sdk_error(&e))?;
-        for Object {
-            key: k,
-            size,
-            last_modified,
-            ..
-        } in resp.contents.unwrap_or_default()
-        {
-            if let Some(k) = k {
-                if k.ends_with(TEST_KEY_SUFFIX) {
-                    continue;
-                }
-                out.push(RemoteObject {
-                    key: k,
-                    size: size.unwrap_or(0),
-                    last_modified: last_modified.map(|d| d.to_string()),
-                });
+        let url = action.sign(SIGN_TTL);
+        let resp = c
+            .http
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| format!("list failed: {e}"))?;
+        if !resp.status().is_success() {
+            return Err(format!("list failed: {}", error_text(resp).await));
+        }
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| format!("list read failed: {e}"))?;
+        let parsed =
+            ListObjectsV2::parse_response(&text).map_err(|e| format!("list parse failed: {e}"))?;
+        for obj in parsed.contents {
+            if obj.key.ends_with(TEST_KEY_SUFFIX) {
+                continue;
             }
+            out.push(RemoteObject {
+                key: obj.key,
+                size: obj.size as i64,
+                last_modified: Some(obj.last_modified),
+            });
         }
         if out.len() >= max {
             break;
         }
-        if resp.is_truncated.unwrap_or(false) {
-            token = resp.next_continuation_token;
-        } else {
-            break;
+        match parsed.next_continuation_token {
+            Some(t) => token = Some(t),
+            None => break,
         }
     }
     // Sort newest-first (keys embed timestamps).
@@ -398,16 +465,18 @@ pub async fn list(cfg: &S3Config, max: usize) -> Result<Vec<RemoteObject>, Strin
 /// Fetch one archived config JSON by its S3 key. Caller is responsible for
 /// de-serializing into `FirewallConfig`.
 pub async fn fetch(cfg: &S3Config, key: &str) -> Result<String, String> {
-    let c = client(cfg).await?;
-    let obj = c
-        .get_object()
-        .bucket(&cfg.bucket)
-        .key(key)
+    let c = client(cfg)?;
+    let url = c.bucket.get_object(Some(&c.creds), key).sign(SIGN_TTL);
+    let resp = c
+        .http
+        .get(url)
         .send()
         .await
-        .map_err(|e| summarize_sdk_error(&e))?;
-    let body = obj.body.collect().await.map_err(|e| e.to_string())?;
-    String::from_utf8(body.into_bytes().to_vec()).map_err(|e| e.to_string())
+        .map_err(|e| format!("fetch failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("fetch failed: {}", error_text(resp).await));
+    }
+    resp.text().await.map_err(|e| e.to_string())
 }
 
 /// Upload one config version. Idempotent (PUT always succeeds).
@@ -417,16 +486,20 @@ pub async fn upload_version(
     created_at: &str,
     config_json: &str,
 ) -> Result<String, String> {
-    let c = client(cfg).await?;
+    let c = client(cfg)?;
     let key = object_key(&cfg.prefix, version, created_at);
-    c.put_object()
-        .bucket(&cfg.bucket)
-        .key(&key)
-        .body(ByteStream::from(config_json.as_bytes().to_vec()))
-        .content_type("application/json")
+    let url = c.bucket.put_object(Some(&c.creds), &key).sign(SIGN_TTL);
+    let resp = c
+        .http
+        .put(url)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(config_json.to_string())
         .send()
         .await
-        .map_err(|e| summarize_sdk_error(&e))?;
+        .map_err(|e| format!("upload failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("upload failed: {}", error_text(resp).await));
+    }
     Ok(key)
 }
 

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.5",
+  "version": "5.99.6",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Resolves the actionable core of PERF-I2 (#410). Investigation showed the audit's suggested fix (splitting aifw-core into sub-crates) would buy only ~3-4s: the real bottleneck was the aws-sdk dependency chain, which gated aifw-core's compile start at 35.5s of a 52s clean build — all for four S3 operations and two Route53 API calls.

## Changes

**`s3_backup.rs` → rusty-s3** (small sans-IO SigV4 signer, presigned URLs executed with the `reqwest` client we already ship):
- Same four operations: PutObject, GetObject, DeleteObject, ListObjectsV2 with continuation-token pagination
- Same custom-endpoint / path-style / MinIO-Backblaze-Wasabi support and same per-host key layout
- Error surfaces now include the S3 XML error snippet (`AccessDenied`, `NoSuchBucket`, …) plus HTTP status — comparable detail to the SDK's messages
- **Behavior change:** the SDK's credential default chain (profile files, IMDS instance roles, SSO) is dropped. Explicit keys still win; empty keys now fall back to `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (+ optional `AWS_SESSION_TOKEN`) env vars only. Documented in the module header and config field docs — appliance deployments never had instance roles.

**`acme_dns.rs` Route53 → direct XML REST calls signed with the standalone `aws-sigv4` crate:**
- `ListHostedZonesByName` (zone-id resolution, parsed with quick-xml) and `ChangeResourceRecordSets` (UPSERT/DELETE TXT for DNS-01, UPSERT A/AAAA for DDNS)
- Route53 is a global service: endpoint `route53.amazonaws.com`, signing region `us-east-1` — matches what the SDK resolved internally; the previously-configurable `extra.region` was cosmetic and is now ignored
- Exact-match DELETE semantics (quoted TXT value, TTL 60) preserved
- 5 new unit tests covering the change-batch XML builder, XML escaping, and zone-list response parsing

**Removed:** `aws-config`, `aws-sdk-s3`, `aws-sdk-route53`, `aws-smithy-runtime-api` (unused direct dep). ~50 crates leave the dependency tree. **Added:** `rusty-s3`, `aws-sigv4` (leaf signer, no smithy client), `quick-xml`, `url`.

## Measured result (clean `cargo check --timings`)

| | before | after |
|---|---|---|
| aifw-core compile start | 35.5s | **24.7s** |
| total wall | 52.1s | **40.9s** (−21%) |

`aws-lc-sys` remains (anchored by rustls/instant-acme/rcgen, off the critical path).

## Not verified against live AWS

The Route53 signing path and S3 calls are covered by unit tests and compile-time checks only — I had no AWS credentials to integration-test against. The S3 path is worth a quick check against a real bucket or MinIO via the UI's "Test connection" button before relying on it; same for a Route53 cert renewal.

## Verification

- `cargo check` zero warnings; pre-commit fmt + clippy pass
- `cargo test` — 688 passed, 0 failed
- Version bumped 5.99.5 → 5.99.6

Closes #410