### PR TITLE
fix(freebsd): label writable IMG root filesystem

### DIFF
--- a/aifw-setup/src/tests.rs
+++ b/aifw-setup/src/tests.rs
@@ -160,6 +160,17 @@ mod tests {
     }
 
     #[test]
+    fn test_writable_image_root_labels_are_consistent() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        let script = std::fs::read_to_string(root.join("freebsd/build-iso.sh"))
+            .expect("read freebsd/build-iso.sh");
+
+        assert!(script.contains("newfs -U -j -L aifw \"/dev/${MD}p3\""));
+        assert!(script.contains("/dev/ufs/aifw  /       ufs"));
+        assert!(script.contains("vfs.root.mountfrom=\"ufs:/dev/ufs/aifw\""));
+    }
+
+    #[test]
     fn test_wan_mode_display() {
         assert_eq!(WanMode::Dhcp.to_string(), "DHCP");
         assert_eq!(WanMode::Static.to_string(), "Static");

--- a/freebsd/build-iso.sh
+++ b/freebsd/build-iso.sh
@@ -323,8 +323,10 @@ umount /mnt
 # Write bootcode
 gpart bootcode -b "$STAGEDIR/boot/pmbr" -p "$STAGEDIR/boot/gptboot" -i 2 "$MD"
 
-# Format UFS root
-newfs -U -j "/dev/${MD}p3"
+# Format UFS root. The generated fstab and loader.conf both select the root
+# filesystem through /dev/ufs/aifw, which is created by the UFS label (not the
+# GPT partition label).
+newfs -U -j -L aifw "/dev/${MD}p3"
 mount "/dev/${MD}p3" /mnt
 
 # Clone staged system into USB image


### PR DESCRIPTION
## Summary

Give the writable UFS image the filesystem label its generated loader and fstab already reference.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement / refactor
- [ ] Documentation
- [x] Build / CI

## Changes

- format the writable root with UFS label `aifw`
- keep `/dev/ufs/aifw` consistent across newfs, fstab, and loader.conf
- add a portable regression test for the three-way boot contract

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --no-fail-fast`
- [x] `sh -n freebsd/build-iso.sh`
- [x] Tested on FreeBSD

External appliance validation built an exact-commit FreeBSD 15 writable IMG, imported and booted it, and confirmed that adding the UFS label resolved the pre-root `mountroot` failure. The lab-specific provisioning harness is intentionally not included in this PR.
