### PR TITLE
feat(firstboot): support unattended seed media

### DIFF
--- a/aifw-setup/src/tests.rs
+++ b/aifw-setup/src/tests.rs
@@ -160,6 +160,33 @@ mod tests {
     }
 
     #[test]
+    fn test_unattended_seed_boot_contract() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        let firstboot =
+            std::fs::read_to_string(root.join("freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot"))
+                .expect("read aifw_firstboot");
+        let build = std::fs::read_to_string(root.join("freebsd/build-iso.sh"))
+            .expect("read freebsd/build-iso.sh");
+
+        assert!(firstboot.contains("# KEYWORD: firstboot"));
+        assert!(build.contains("touch /mnt/firstboot"));
+        assert!(firstboot.contains("AIFW_SEED_LABEL=\"AIFW_SEED\""));
+        assert!(firstboot.contains("$AIFW_SETUP --config \"$AIFW_SEED_CONFIG\""));
+        assert!(firstboot.contains("$AIFW_SETUP </dev/console"));
+    }
+
+    #[test]
+    fn test_console_shell_supports_non_interactive_commands() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        let console =
+            std::fs::read_to_string(root.join("freebsd/overlay/usr/local/sbin/aifw-console"))
+                .expect("read aifw-console");
+
+        assert!(console.contains("if [ \"${1:-}\" = \"-c\" ] && [ \"$#\" -eq 2 ]"));
+        assert!(console.contains("exec /bin/sh -c \"$2\""));
+    }
+
+    #[test]
     fn test_wan_mode_display() {
         assert_eq!(WanMode::Dhcp.to_string(), "DHCP");
         assert_eq!(WanMode::Static.to_string(), "Static");

--- a/docs/unattended-setup.md
+++ b/docs/unattended-setup.md
@@ -1,0 +1,23 @@
+# Unattended first-boot setup
+
+AiFw writable images can consume optional read-only seed media during first
+boot. This provides a platform-neutral automation interface for image testing
+and repeatable appliance provisioning while preserving the interactive wizard
+when no seed is attached.
+
+Create an ISO 9660 filesystem labelled `AIFW_SEED` containing `setup.json` at
+its root. The document uses the same `SetupConfig` JSON accepted by:
+
+```sh
+aifw-setup --config /path/to/setup.json
+```
+
+Attach the filesystem before the first boot. AiFw mounts it read-only, applies
+the configuration, unmounts it, and disables the first-boot service after a
+successful setup. If the seed is missing, the console wizard starts normally.
+If unattended setup fails, first boot returns a failure and remains enabled so
+the error can be corrected rather than silently starting a partial appliance.
+
+Seed media must contain password hashes and public SSH keys, never plaintext
+passwords, API tokens, or private keys. Treat the media as configuration input,
+not as a secrets store, and remove it after provisioning.

--- a/freebsd/build-iso.sh
+++ b/freebsd/build-iso.sh
@@ -330,6 +330,9 @@ mount "/dev/${MD}p3" /mnt
 # Clone staged system into USB image
 # Update fstab for USB boot
 cp -a "$STAGEDIR/"* /mnt/
+# rc.d scripts marked KEYWORD:firstboot run only while this sentinel exists.
+# The writable IMG is assembled from a staged root, so create it explicitly.
+touch /mnt/firstboot
 cat > /mnt/etc/fstab <<USBFSTAB
 /dev/ufs/aifw  /       ufs     rw  1  1
 tmpfs          /tmp    tmpfs   rw,mode=01777  0  0

--- a/freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot
+++ b/freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot
@@ -14,6 +14,27 @@ stop_cmd=":"
 AIFW_CONF="/usr/local/etc/aifw/aifw.conf"
 AIFW_SETUP="/usr/local/sbin/aifw-setup"
 AIFW_PF_CONF="/usr/local/etc/aifw/pf.conf.aifw"
+AIFW_SEED_LABEL="AIFW_SEED"
+AIFW_SEED_MOUNT="/tmp/aifw-seed"
+AIFW_SEED_CONFIG="${AIFW_SEED_MOUNT}/setup.json"
+
+mount_seed()
+{
+    mkdir -p "$AIFW_SEED_MOUNT"
+
+    # Prefer the stable filesystem label. Optical-device fallbacks accommodate
+    # firmware and hypervisors that expose the seed before GEOM creates it.
+    for dev in "/dev/iso9660/${AIFW_SEED_LABEL}" /dev/cd1 /dev/cd0; do
+        if [ -e "$dev" ] && mount -t cd9660 -o ro "$dev" "$AIFW_SEED_MOUNT" 2>/dev/null; then
+            if [ -f "$AIFW_SEED_CONFIG" ]; then
+                return 0
+            fi
+            umount "$AIFW_SEED_MOUNT" 2>/dev/null || true
+        fi
+    done
+
+    return 1
+}
 
 aifw_firstboot_start()
 {
@@ -29,8 +50,19 @@ aifw_firstboot_start()
     echo ""
 
     if [ -x "$AIFW_SETUP" ]; then
-        # Run the setup wizard on the console
-        $AIFW_SETUP </dev/console >/dev/console 2>&1
+        if mount_seed; then
+            echo "Found unattended AiFw seed media."
+            $AIFW_SETUP --config "$AIFW_SEED_CONFIG" >/dev/console 2>&1
+            setup_status=$?
+            umount "$AIFW_SEED_MOUNT" 2>/dev/null || true
+            if [ "$setup_status" -ne 0 ]; then
+                echo "ERROR: unattended setup failed (exit $setup_status)"
+                return "$setup_status"
+            fi
+        else
+            # No seed was supplied; retain the normal interactive first boot.
+            $AIFW_SETUP </dev/console >/dev/console 2>&1
+        fi
 
         # If setup succeeded, enable and start services
         if [ -f "$AIFW_CONF" ]; then

--- a/freebsd/overlay/usr/local/sbin/aifw-console
+++ b/freebsd/overlay/usr/local/sbin/aifw-console
@@ -6,6 +6,12 @@ AIFW_CONF="/usr/local/etc/aifw/aifw.conf"
 AIFW_VERSION_FILE="/usr/local/share/aifw/version"
 AIFW_VERSION=$(cat "$AIFW_VERSION_FILE" 2>/dev/null || echo "unknown")
 
+# Honour the login-shell command contract used by sshd for non-interactive
+# administration while keeping the menu as the normal interactive shell.
+if [ "${1:-}" = "-c" ] && [ "$#" -eq 2 ]; then
+    exec /bin/sh -c "$2"
+fi
+
 show_banner()
 {
     clear


### PR DESCRIPTION
## Summary

Add a platform-neutral unattended first-boot interface for writable appliance images while preserving the interactive wizard when no seed is present.

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Improvement / refactor
- [x] Documentation
- [ ] Build / CI

## Changes

- detect read-only ISO 9660 media labelled `AIFW_SEED`
- apply root-level `setup.json` through the existing `aifw-setup --config` interface
- keep first boot enabled and return failure when unattended setup fails
- explicitly add FreeBSD's firstboot sentinel to writable IMG roots
- support the normal login-shell `-c` contract for non-interactive SSH administration
- document the seed schema, lifecycle, and secret-handling boundary
- add portable regression tests and shell syntax checks

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --no-fail-fast`
- [x] shell syntax checks for all modified scripts
- [x] Tested on FreeBSD

External appliance validation attached generated seed media to a FreeBSD 15 writable IMG, completed unattended setup with an Argon2 password hash and ephemeral public key, verified services, API and pf state, then rebooted and repeated readiness checks. The Proxmox-specific provisioning flow remains private and is not part of this PR.
