### PR TITLE
fix(setup): persist live network and pf state

### DIFF
--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -250,6 +250,9 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
                         "sysrc",
                         &[&format!("ifconfig_{}=inet {}", config.wan_interface, ip)],
                     );
+                    let args = static_interface_args(&config.wan_interface, ip);
+                    let args = args.iter().map(String::as_str).collect::<Vec<_>>();
+                    run_best_effort("ifconfig", &args);
                 }
                 if let Some(ref gw) = config.wan_gateway {
                     run_best_effort("sysrc", &[&format!("defaultrouter={}", gw)]);
@@ -289,6 +292,9 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
         // keep re-applying over the daemon's DB-driven updates (v5.57.3 fix).
 
         // Load pf rules
+        for setting in pf_rc_settings(&config.config_dir) {
+            run_best_effort("sysrc", &[&setting]);
+        }
         run_best_effort(
             "pfctl",
             &["-f", &format!("{}/pf.conf.aifw", config.config_dir)],
@@ -650,6 +656,23 @@ fn run_best_effort(cmd: &str, args: &[&str]) {
         )),
         Err(e) => console::warn(&format!("failed to run {cmd} {}: {e}", args.join(" "))),
     }
+}
+
+#[cfg(any(target_os = "freebsd", test))]
+pub(crate) fn static_interface_args(interface: &str, address: &str) -> [String; 3] {
+    [
+        interface.to_string(),
+        "inet".to_string(),
+        address.to_string(),
+    ]
+}
+
+#[cfg(any(target_os = "freebsd", test))]
+pub(crate) fn pf_rc_settings(config_dir: &str) -> [String; 2] {
+    [
+        "pf_enable=YES".to_string(),
+        format!("pf_rules={config_dir}/pf.conf.aifw"),
+    ]
 }
 
 /// Print a fallible best-effort step's failure instead of dropping it

--- a/aifw-setup/src/tests.rs
+++ b/aifw-setup/src/tests.rs
@@ -167,6 +167,22 @@ mod tests {
     }
 
     #[test]
+    fn test_static_interface_is_applied_to_the_running_system() {
+        assert_eq!(
+            apply::static_interface_args("vtnet0", "192.0.2.10/24"),
+            ["vtnet0", "inet", "192.0.2.10/24"]
+        );
+    }
+
+    #[test]
+    fn test_pf_boot_settings_use_generated_ruleset() {
+        assert_eq!(
+            apply::pf_rc_settings("/usr/local/etc/aifw"),
+            ["pf_enable=YES", "pf_rules=/usr/local/etc/aifw/pf.conf.aifw"]
+        );
+    }
+
+    #[test]
     fn test_default_policy_display() {
         let s = DefaultPolicy::Standard.to_string();
         assert!(s.contains("block inbound"));


### PR DESCRIPTION
## Summary

Make static WAN configuration effective immediately during setup and persist the generated AiFw pf ruleset for later boots.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Improvement / refactor
- [ ] Documentation
- [ ] Build / CI

## Changes

- apply a configured static WAN address to the running interface after writing rc.conf
- persist `pf_enable=YES`
- persist `pf_rules=<config_dir>/pf.conf.aifw`
- expose small pure helpers so both command contracts are covered by Linux CI tests

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --no-fail-fast`
- [x] Tested on FreeBSD

External appliance validation ran unattended setup on FreeBSD 15, verified immediate SSH reachability with a static address, rebooted the appliance, and confirmed the expected ruleset and live pf state returned. The environment-specific VM orchestration is intentionally not included.
