### PR TITLE
test(ui): add portable auth browser coverage

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -60,12 +60,20 @@ jobs:
 
       - name: npm run lint
         working-directory: aifw-ui
-        # ~70 pre-existing eslint errors (mostly setState-in-effect from Next 16 /
-        # react-hooks plugin upgrade) — running for visibility, not yet blocking.
-        # Tracked: tighten this once UI lint debt is cleaned.
-        continue-on-error: true
         run: npm run lint
 
       - name: npm run build
         working-directory: aifw-ui
         run: npm run build
+
+      - name: npm run test:unit
+        working-directory: aifw-ui
+        run: npm run test:unit
+
+      - name: Install Playwright browser
+        working-directory: aifw-ui
+        run: npx playwright install --with-deps chromium
+
+      - name: npm run test:e2e
+        working-directory: aifw-ui
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,11 @@ node_modules/
 freebsd/release/
 freebsd/ui-export/
 
+# E2E run artifacts and ephemeral credentials
+e2e/artifacts/
+e2e/.run/
+__pycache__/
+*.py[cod]
+
 # CLAUDE.md is project policy and is tracked in the repo — do not ignore it.
 Cargo.lock

--- a/.woodpecker/ci.yml
+++ b/.woodpecker/ci.yml
@@ -2,7 +2,6 @@ when:
   - event: push
     branch: main
   - event: pull_request
-  - event: manual
   - event: tag
 
 labels:

--- a/.woodpecker/ci.yml
+++ b/.woodpecker/ci.yml
@@ -1,0 +1,37 @@
+when:
+  - event: push
+    branch: main
+  - event: pull_request
+  - event: manual
+  - event: tag
+
+labels:
+  platform: linux/amd64
+
+steps:
+  - name: rust
+    image: rust:1.95-bookworm
+    environment:
+      CARGO_INCREMENTAL: "0"
+      RUSTFLAGS: "-D warnings"
+    commands:
+      - rustup component add rustfmt clippy
+      - cargo fmt --all -- --check
+      - cargo clippy --workspace --all-targets -- -D warnings
+      - cargo test --workspace --no-fail-fast
+
+  - name: ui
+    image: node:24-bookworm
+    commands:
+      - cd aifw-ui
+      - npm ci --no-audit --no-fund
+      - npm run lint || true
+      - npm run build
+
+  - name: e2e-harness-tests
+    image: python:3.13-bookworm
+    commands:
+      - apt-get update && apt-get install -y --no-install-recommends xorriso xz-utils openssh-client
+      - pip install --no-cache-dir -r e2e/requirements.txt
+      - python -m compileall -q e2e
+      - python -m pytest -q e2e/tests

--- a/.woodpecker/e2e.yml
+++ b/.woodpecker/e2e.yml
@@ -30,13 +30,13 @@ steps:
       AIFW_E2E_DNS:
         from_secret: aifw_e2e_dns
     commands:
-      - apt-get update && apt-get install -y --no-install-recommends ca-certificates curl xorriso xz-utils openssh-client
+      - apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git xorriso xz-utils openssh-client
       - pip install --no-cache-dir -r e2e/requirements.txt
       - mkdir -p e2e/.run e2e/artifacts
-      - test -n "$CI_PIPELINE_PARAM_ARTIFACT_URL" || { echo "manual parameter artifact_url is required and must point to an IMG built from this seed-capable revision"; exit 2; }
-      - curl --fail --location --retry 3 --output e2e/.run/aifw.img.xz "$CI_PIPELINE_PARAM_ARTIFACT_URL"
+      - curl --fail --location --retry 3 --output e2e/.run/freebsd-builder.qcow2.xz https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz
+      - python -m e2e.aifw_e2e build --builder-image e2e/.run/freebsd-builder.qcow2.xz --output e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-${CI_COMMIT_SHA:0:8}"
       - python -m e2e.aifw_e2e run --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-${CI_COMMIT_SHA:0:8}"
 
-# Diagnostic collection runs before the harness's finally-block destroys the
-# VM. Add the homelab's selected artifact publisher when one is standardized;
-# until then the manifest and diagnostic paths are reported in the step log.
+# The build VM is destroyed before the appliance starts, allowing the same
+# reserved management address to be reused safely. The appliance VM and all
+# uploaded media are destroyed by the harness's finally-block.

--- a/.woodpecker/e2e.yml
+++ b/.woodpecker/e2e.yml
@@ -1,8 +1,8 @@
 when:
   - event: manual
 
-# Experimental until builder-only image production and appliance-only
-# validation documented in e2e/README.md pass. Do not use as a release gate.
+# Experimental until one combined native-fix run passes. Focused builder-only
+# and appliance-only validation now pass; see e2e/README.md.
 
 # Destructive Proxmox work is restricted to the LAN agent explicitly labelled
 # for the lab. It must never be scheduled on ordinary or remote Docker agents.
@@ -37,8 +37,10 @@ steps:
       - pip install --no-cache-dir -r e2e/requirements.txt
       - mkdir -p e2e/.run e2e/artifacts
       - curl --fail --location --retry 3 --output e2e/.run/freebsd-builder.qcow2.xz https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz
-      - python -m e2e.aifw_e2e build --builder-image e2e/.run/freebsd-builder.qcow2.xz --output e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-${CI_COMMIT_SHA:0:8}"
-      - python -m e2e.aifw_e2e run --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-${CI_COMMIT_SHA:0:8}"
+      - curl --fail --location --retry 3 --output e2e/.run/CHECKSUM.SHA256 https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/CHECKSUM.SHA256
+      - sed -n 's/^SHA256 (FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz) = \([0-9a-f]*\)$/\1  e2e\/\.run\/freebsd-builder.qcow2.xz/p' e2e/.run/CHECKSUM.SHA256 | sha256sum --check --strict -
+      - python -m e2e.aifw_e2e build --builder-image e2e/.run/freebsd-builder.qcow2.xz --output e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
+      - python -m e2e.aifw_e2e run --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
 
 # The build VM is destroyed before the appliance starts, allowing the same
 # reserved management address to be reused safely. The appliance VM and all

--- a/.woodpecker/e2e.yml
+++ b/.woodpecker/e2e.yml
@@ -1,8 +1,7 @@
 when:
   - event: manual
 
-# Validated one-NIC lifecycle smoke. Keep manual until repeatability and an
-# isolated WAN/LAN topology justify promotion to a required release gate.
+# Full isolated WAN/LAN lifecycle. Manual while the lab lane is capacity-bound.
 
 # Destructive Proxmox work is restricted to the LAN agent explicitly labelled
 # for the lab. It must never be scheduled on ordinary or remote Docker agents.
@@ -19,6 +18,8 @@ steps:
       PVE_IMAGE_STORAGE: local
       PVE_VM_STORAGE: local-lvm
       PVE_BRIDGE: vmbr0
+      PVE_E2E_WAN_BRIDGE: vmbr998
+      PVE_E2E_LAN_BRIDGE: vmbr999
       PVE_VERIFY_TLS: "false"
       PVE_TOKEN_ID:
         from_secret: pve_token_id
@@ -35,14 +36,15 @@ steps:
     commands:
       - apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git xorriso xz-utils openssh-client
       - pip install --no-cache-dir -r e2e/requirements.txt
+      - python -m playwright install --with-deps chromium
       - mkdir -p e2e/.run e2e/artifacts
       - curl --fail --location --retry 3 --output e2e/.run/freebsd-builder.qcow2.xz https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz
       - curl --fail --location --retry 3 --output e2e/.run/CHECKSUM.SHA256 https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/CHECKSUM.SHA256
       - awk '$1 == "SHA256" && $2 == "(FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz)" && $3 == "=" { print $4 "  e2e/.run/freebsd-builder.qcow2.xz" }' e2e/.run/CHECKSUM.SHA256 | sha256sum --check --strict -
       - python -m e2e.aifw_e2e build --builder-image e2e/.run/freebsd-builder.qcow2.xz --output e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
-      - python -m e2e.aifw_e2e run --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
+      - python -m e2e.aifw_e2e full --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
       - python -m json.tool "e2e/artifacts/${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")/manifest.json"
 
-# The build VM is destroyed before the appliance starts, allowing the same
-# reserved management address to be reused safely. The appliance VM and all
-# uploaded media are destroyed by the harness's finally-block.
+# The build VM is destroyed before the LAN helper reuses the reserved address.
+# The appliance VM, helper containers, and uploaded media are destroyed by the
+# harness's finally-block.

--- a/.woodpecker/e2e.yml
+++ b/.woodpecker/e2e.yml
@@ -1,8 +1,8 @@
 when:
   - event: manual
 
-# Experimental until one combined native-fix run passes. Focused builder-only
-# and appliance-only validation now pass; see e2e/README.md.
+# Validated one-NIC lifecycle smoke. Keep manual until repeatability and an
+# isolated WAN/LAN topology justify promotion to a required release gate.
 
 # Destructive Proxmox work is restricted to the LAN agent explicitly labelled
 # for the lab. It must never be scheduled on ordinary or remote Docker agents.
@@ -41,6 +41,7 @@ steps:
       - awk '$1 == "SHA256" && $2 == "(FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz)" && $3 == "=" { print $4 "  e2e/.run/freebsd-builder.qcow2.xz" }' e2e/.run/CHECKSUM.SHA256 | sha256sum --check --strict -
       - python -m e2e.aifw_e2e build --builder-image e2e/.run/freebsd-builder.qcow2.xz --output e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
       - python -m e2e.aifw_e2e run --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
+      - python -m json.tool "e2e/artifacts/${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")/manifest.json"
 
 # The build VM is destroyed before the appliance starts, allowing the same
 # reserved management address to be reused safely. The appliance VM and all

--- a/.woodpecker/e2e.yml
+++ b/.woodpecker/e2e.yml
@@ -1,6 +1,9 @@
 when:
   - event: manual
 
+# Experimental until builder-only image production and appliance-only
+# validation documented in e2e/README.md pass. Do not use as a release gate.
+
 # Destructive Proxmox work is restricted to the LAN agent explicitly labelled
 # for the lab. It must never be scheduled on ordinary or remote Docker agents.
 labels:

--- a/.woodpecker/e2e.yml
+++ b/.woodpecker/e2e.yml
@@ -1,0 +1,42 @@
+when:
+  - event: manual
+
+# Destructive Proxmox work is restricted to the LAN agent explicitly labelled
+# for the lab. It must never be scheduled on ordinary or remote Docker agents.
+labels:
+  platform: linux/amd64
+  proxmox: "true"
+
+steps:
+  - name: proxmox-e2e
+    image: python:3.13-bookworm
+    environment:
+      PVE_URL: https://192.168.1.159:8006
+      PVE_NODE: trigproxmox
+      PVE_IMAGE_STORAGE: local
+      PVE_VM_STORAGE: local-lvm
+      PVE_BRIDGE: vmbr0
+      PVE_VERIFY_TLS: "false"
+      PVE_TOKEN_ID:
+        from_secret: pve_token_id
+      PVE_TOKEN_SECRET:
+        from_secret: pve_token_secret
+      AIFW_E2E_ADMIN_PASSWORD:
+        from_secret: aifw_e2e_admin_password
+      AIFW_E2E_ADDRESS:
+        from_secret: aifw_e2e_address
+      AIFW_E2E_GATEWAY:
+        from_secret: aifw_e2e_gateway
+      AIFW_E2E_DNS:
+        from_secret: aifw_e2e_dns
+    commands:
+      - apt-get update && apt-get install -y --no-install-recommends ca-certificates curl xorriso xz-utils openssh-client
+      - pip install --no-cache-dir -r e2e/requirements.txt
+      - mkdir -p e2e/.run e2e/artifacts
+      - test -n "$CI_PIPELINE_PARAM_ARTIFACT_URL" || { echo "manual parameter artifact_url is required and must point to an IMG built from this seed-capable revision"; exit 2; }
+      - curl --fail --location --retry 3 --output e2e/.run/aifw.img.xz "$CI_PIPELINE_PARAM_ARTIFACT_URL"
+      - python -m e2e.aifw_e2e run --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-${CI_COMMIT_SHA:0:8}"
+
+# Diagnostic collection runs before the harness's finally-block destroys the
+# VM. Add the homelab's selected artifact publisher when one is standardized;
+# until then the manifest and diagnostic paths are reported in the step log.

--- a/.woodpecker/e2e.yml
+++ b/.woodpecker/e2e.yml
@@ -38,7 +38,7 @@ steps:
       - mkdir -p e2e/.run e2e/artifacts
       - curl --fail --location --retry 3 --output e2e/.run/freebsd-builder.qcow2.xz https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz
       - curl --fail --location --retry 3 --output e2e/.run/CHECKSUM.SHA256 https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/CHECKSUM.SHA256
-      - sed -n 's/^SHA256 (FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz) = \([0-9a-f]*\)$/\1  e2e\/\.run\/freebsd-builder.qcow2.xz/p' e2e/.run/CHECKSUM.SHA256 | sha256sum --check --strict -
+      - awk '$1 == "SHA256" && $2 == "(FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz)" && $3 == "=" { print $4 "  e2e/.run/freebsd-builder.qcow2.xz" }' e2e/.run/CHECKSUM.SHA256 | sha256sum --check --strict -
       - python -m e2e.aifw_e2e build --builder-image e2e/.run/freebsd-builder.qcow2.xz --output e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
       - python -m e2e.aifw_e2e run --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,9 @@ cargo test   # run test suite
 # Web UI
 cd aifw-ui
 npm ci
+npm run test:unit
+npx playwright install chromium # first local browser-test run only
+npm run test:e2e
 npm run build
 ```
 
@@ -62,7 +65,7 @@ Open an issue using the [feature request template](.github/ISSUE_TEMPLATE/featur
 3. Make your changes
 4. Run `cargo check` (zero warnings required)
 5. Run `cargo test`
-6. If you changed the UI: `cd aifw-ui && npm run build`
+6. If you changed the UI: `cd aifw-ui && npm run lint && npm test && npm run build`
 7. Submit a pull request
 
 Changes under `e2e/`, `.woodpecker/e2e.yml`, `freebsd/build-*.sh`, or the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,13 @@ Open an issue using the [feature request template](.github/ISSUE_TEMPLATE/featur
 6. If you changed the UI: `cd aifw-ui && npm run build`
 7. Submit a pull request
 
+Changes under `e2e/`, `.woodpecker/e2e.yml`, `freebsd/build-*.sh`, or the
+first-boot overlay should follow the staged validation order in
+`e2e/README.md`: unit tests, focused disposable Proxmox contracts, focused
+FreeBSD boot/SSH, builder-only, appliance-only, then one combined manual
+Woodpecker run. Do not use repeated full pipelines to discover individual
+Proxmox or cloud-init API details.
+
 ### Pull Request Guidelines
 
 - Keep PRs focused on a single change

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.7"
+version = "5.99.8"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.15"
+version = "5.99.16"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.14"
+version = "5.99.15"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.11"
+version = "5.99.12"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.9"
+version = "5.99.10"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.13"
+version = "5.99.14"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.8"
+version = "5.99.9"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.12"
+version = "5.99.13"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.6"
+version = "5.99.7"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.10"
+version = "5.99.11"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/README.md
+++ b/README.md
@@ -235,7 +235,9 @@ readiness checks, diagnostics, reboot verification, and guarded teardown.
 Proxmox lifecycle contracts are directly tested, but the complete FreeBSD
 builder-to-appliance workflow is not yet a passing release gate. The FreeBSD
 builder bootstrap now passes focused Proxmox validation using a native
-`nuageinit` v2 seed; image production and appliance validation remain. The
+`nuageinit` v2 seed; direct builder-only image production and corrected
+appliance initial/reboot validation also pass. One combined Woodpecker run of
+the native fixes remains before promotion to a release gate. The
 current state, alternatives, and target WAN/LAN framework are documented in
 `testingUplift.md` and `e2e/README.md`.
 

--- a/README.md
+++ b/README.md
@@ -229,17 +229,15 @@ The hook mirrors CI's fast gates; skip a single run with `git commit --no-verify
 
 ### Appliance E2E status
 
-An experimental Woodpecker/Proxmox harness lives under `e2e/`. It implements
-tagged VM provisioning, image import, unattended appliance seed generation,
-readiness checks, diagnostics, reboot verification, and guarded teardown.
-Proxmox lifecycle contracts are directly tested, but the complete FreeBSD
-builder-to-appliance workflow is not yet a passing release gate. The FreeBSD
-builder bootstrap now passes focused Proxmox validation using a native
-`nuageinit` v2 seed; direct builder-only image production and corrected
-appliance initial/reboot validation also pass. One combined Woodpecker run of
-the native fixes remains before promotion to a release gate. The
-current state, alternatives, and target WAN/LAN framework are documented in
-`testingUplift.md` and `e2e/README.md`.
+The validated Woodpecker/Proxmox harness under `e2e/` implements exact-commit
+FreeBSD image builds, tagged VM provisioning, unattended setup, readiness and
+reboot checks, diagnostics, and guarded teardown. Woodpecker pipeline 14 passed
+the combined path on 2026-07-19: it built 5.99.14 from commit `9c146232`,
+tested that exact IMG at `192.168.0.26`, verified initial and post-reboot health
+including live `pf`, and left zero run-owned Proxmox resources. The lane remains
+manual and covers one-NIC lifecycle/control-plane smoke, not routed WAN/LAN
+data-plane behavior. See `testingUplift.md` and `e2e/README.md` for the full
+current and target states.
 
 ## Target Environment
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,18 @@ sh scripts/install-hooks.sh   # pre-commit runs fmt --check + clippy -D warnings
 
 The hook mirrors CI's fast gates; skip a single run with `git commit --no-verify`.
 
+### Appliance E2E status
+
+An experimental Woodpecker/Proxmox harness lives under `e2e/`. It implements
+tagged VM provisioning, image import, unattended appliance seed generation,
+readiness checks, diagnostics, reboot verification, and guarded teardown.
+Proxmox lifecycle contracts are directly tested, but the complete FreeBSD
+builder-to-appliance workflow is not yet a passing release gate. The FreeBSD
+builder bootstrap now passes focused Proxmox validation using a native
+`nuageinit` v2 seed; image production and appliance validation remain. The
+current state, alternatives, and target WAN/LAN framework are documented in
+`testingUplift.md` and `e2e/README.md`.
+
 ## Target Environment
 
 - **OS**: FreeBSD 15.x

--- a/README.md
+++ b/README.md
@@ -229,15 +229,15 @@ The hook mirrors CI's fast gates; skip a single run with `git commit --no-verify
 
 ### Appliance E2E status
 
-The validated Woodpecker/Proxmox harness under `e2e/` implements exact-commit
-FreeBSD image builds, tagged VM provisioning, unattended setup, readiness and
-reboot checks, diagnostics, and guarded teardown. Woodpecker pipeline 14 passed
-the combined path on 2026-07-19: it built 5.99.14 from commit `9c146232`,
-tested that exact IMG at `192.168.0.26`, verified initial and post-reboot health
-including live `pf`, and left zero run-owned Proxmox resources. The lane remains
-manual and covers one-NIC lifecycle/control-plane smoke, not routed WAN/LAN
-data-plane behavior. See `testingUplift.md` and `e2e/README.md` for the full
-current and target states.
+The Woodpecker/Proxmox harness under `e2e/` implements exact-commit FreeBSD
+image builds, guarded deployment, and a full isolated topology: Debian helper
+containers on portless WAN/LAN bridges, a two-NIC AiFw VM, live NAT and
+pass/block traffic, API rule lifecycle, Playwright login/rules checks, reboot
+revalidation, diagnostics, and ownership-proven teardown. Pipeline 14 remains
+the last passing exact-commit one-NIC baseline; the new full manual workflow is
+implemented and awaiting its fresh-image acceptance run. See
+`testingUplift.md` and `e2e/README.md` for current evidence and remaining target
+lanes.
 
 ## Target Environment
 

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -294,6 +294,15 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
         // keep re-applying over the daemon's DB-driven updates (v5.57.3 fix).
 
         // Load pf rules
+        // Persist the non-default rules path before enabling pf. FreeBSD's
+        // rc.d/pf defaults to /etc/pf.conf; AiFw writes pf.conf.aifw under
+        // config_dir. First boot explicitly loaded this file, masking the
+        // missing rc.conf setting until the next reboot.
+        run_best_effort("sysrc", &["pf_enable=YES"]);
+        run_best_effort(
+            "sysrc",
+            &[&format!("pf_rules={}/pf.conf.aifw", config.config_dir)],
+        );
         run_best_effort(
             "pfctl",
             &["-f", &format!("{}/pf.conf.aifw", config.config_dir)],

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -250,6 +250,11 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
                         "sysrc",
                         &[&format!("ifconfig_{}=inet {}", config.wan_interface, ip)],
                     );
+                    // `sysrc` persists the address for subsequent boots but
+                    // does not configure a running interface. Apply it now so
+                    // unattended first boot (including the Proxmox E2E seed)
+                    // becomes reachable without an extra reboot.
+                    run_best_effort("ifconfig", &[config.wan_interface.as_str(), "inet", ip]);
                 }
                 if let Some(ref gw) = config.wan_gateway {
                     run_best_effort("sysrc", &[&format!("defaultrouter={}", gw)]);

--- a/aifw-ui/.gitignore
+++ b/aifw-ui/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 .next/
 out/
 .env*.local
+playwright-report/
+test-results/

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.15",
+  "version": "5.99.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.15",
+      "version": "5.99.16",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.8",
+  "version": "5.99.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.8",
+      "version": "5.99.9",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.13",
+  "version": "5.99.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.13",
+      "version": "5.99.14",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.11",
+  "version": "5.99.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.11",
+      "version": "5.99.12",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.12",
+  "version": "5.99.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.12",
+      "version": "5.99.13",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.7",
+  "version": "5.99.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.7",
+      "version": "5.99.8",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "^19.2.7"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.3.1",
         "@types/node": "^25.9.3",
         "@types/react": "^19.2.17",
@@ -23,7 +24,8 @@
         "eslint-config-next": "^16.2.9",
         "postcss": "^8.5.15",
         "tailwindcss": "^4.3.1",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -38,6 +40,65 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -279,6 +340,173 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -516,6 +744,26 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1101,14 +1349,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -1174,9 +1422,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1192,9 +1437,6 @@
       "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1212,9 +1454,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1230,9 +1469,6 @@
       "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1323,10 +1559,341 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1472,9 +2039,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1492,9 +2056,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1512,9 +2073,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1532,9 +2090,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1650,15 +2205,33 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -2060,9 +2633,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2077,9 +2647,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2094,9 +2661,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2111,9 +2675,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2128,9 +2689,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2145,9 +2703,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2162,9 +2717,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2179,9 +2731,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2196,9 +2745,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2213,9 +2759,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2296,6 +2839,119 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/acorn": {
       "version": "8.17.0",
@@ -2530,6 +3186,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2603,6 +3269,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2745,6 +3423,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2817,6 +3505,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -2830,6 +3534,22 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -2902,6 +3622,15 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3010,6 +3739,21 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -3128,6 +3872,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3696,6 +4447,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3704,6 +4465,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3845,6 +4616,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -4150,6 +4936,21 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/ignore": {
@@ -4474,6 +5275,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4689,6 +5499,61 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -4941,9 +5806,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4965,9 +5827,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4989,9 +5848,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5013,9 +5869,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5146,6 +5999,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5204,9 +6066,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -5477,6 +6339,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5558,6 +6434,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5585,6 +6476,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5602,6 +6500,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5768,6 +6698,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
@@ -5821,6 +6763,40 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/run-parallel": {
@@ -5900,6 +6876,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -6124,6 +7115,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6137,6 +7135,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6339,6 +7351,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/tailwindcss": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
@@ -6360,10 +7381,27 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6408,6 +7446,40 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6419,6 +7491,36 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6614,6 +7716,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
@@ -6698,6 +7812,300 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -6805,6 +8213,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -6814,6 +8239,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.10",
+  "version": "5.99.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.10",
+      "version": "5.99.11",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.4",
+  "version": "5.99.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.4",
+      "version": "5.99.7",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.14",
+  "version": "5.99.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.14",
+      "version": "5.99.15",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.9",
+  "version": "5.99.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.9",
+      "version": "5.99.10",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.14",
+  "version": "5.99.15",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -6,15 +6,20 @@
     "dev": "next dev",
     "build": "next build --webpack",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "npm run test:unit && npm run test:e2e",
+    "test:unit": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.14.6",
     "lucide-react": "^1.20.0",
     "next": "^16.2.9",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7"  },
+    "react-dom": "^19.2.7"
+  },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.3.1",
     "@types/node": "^25.9.3",
     "@types/react": "^19.2.17",
@@ -23,6 +28,7 @@
     "eslint-config-next": "^16.2.9",
     "postcss": "^8.5.15",
     "tailwindcss": "^4.3.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.6",
+  "version": "5.99.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.7",
+  "version": "5.99.8",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.15",
+  "version": "5.99.16",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.10",
+  "version": "5.99.11",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.9",
+  "version": "5.99.10",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.12",
+  "version": "5.99.13",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.11",
+  "version": "5.99.12",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.13",
+  "version": "5.99.14",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.8",
+  "version": "5.99.9",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/playwright.config.ts
+++ b/aifw-ui/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: "http://127.0.0.1:3100",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev -- --hostname 127.0.0.1 --port 3100",
+    url: "http://127.0.0.1:3100/login/",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/aifw-ui/src/app/login/page.tsx
+++ b/aifw-ui/src/app/login/page.tsx
@@ -78,14 +78,14 @@ export default function LoginPage() {
             )}
 
             <div>
-              <label className="text-xs text-[var(--text-muted)] uppercase tracking-wider block mb-1">Username</label>
-              <input type="text" value={username} onChange={(e) => setUsername(e.target.value)}
+              <label htmlFor="username" className="text-xs text-[var(--text-muted)] uppercase tracking-wider block mb-1">Username</label>
+              <input id="username" name="username" type="text" value={username} onChange={(e) => setUsername(e.target.value)}
                 className={inputClass} required autoFocus />
             </div>
 
             <div>
-              <label className="text-xs text-[var(--text-muted)] uppercase tracking-wider block mb-1">Password</label>
-              <input type="password" value={password} onChange={(e) => setPassword(e.target.value)}
+              <label htmlFor="password" className="text-xs text-[var(--text-muted)] uppercase tracking-wider block mb-1">Password</label>
+              <input id="password" name="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)}
                 className={inputClass} required />
             </div>
 
@@ -107,8 +107,8 @@ export default function LoginPage() {
             </div>
 
             <div>
-              <label className="text-xs text-[var(--text-muted)] uppercase tracking-wider block mb-1">TOTP Code</label>
-              <input type="text" value={totpCode} onChange={(e) => setTotpCode(e.target.value)}
+              <label htmlFor="totp-code" className="text-xs text-[var(--text-muted)] uppercase tracking-wider block mb-1">TOTP Code</label>
+              <input id="totp-code" name="totp_code" type="text" value={totpCode} onChange={(e) => setTotpCode(e.target.value)}
                 className={inputClass} required autoFocus autoComplete="one-time-code"
                 placeholder="000000" maxLength={20} />
             </div>

--- a/aifw-ui/src/lib/api.test.ts
+++ b/aifw-ui/src/lib/api.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiError, api } from "./api";
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() { return values.size; },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => { values.delete(key); },
+    setItem: (key, value) => { values.set(key, String(value)); },
+  };
+}
+
+describe("API client", () => {
+  beforeEach(() => {
+    const storage = memoryStorage();
+    vi.stubGlobal("localStorage", storage);
+    vi.stubGlobal("window", { localStorage: storage });
+  });
+
+  it("serializes JSON and sends the stored bearer token", async () => {
+    localStorage.setItem("aifw_token", "test-token");
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ saved: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(api.post("/api/v1/example", { enabled: true })).resolves.toEqual({ saved: true });
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/example", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test-token",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ enabled: true }),
+      signal: undefined,
+    });
+  });
+
+  it("surfaces the API's JSON error message and status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "rule already exists" }), {
+          status: 409,
+          statusText: "Conflict",
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    const request = api.post("/api/v1/rules", { label: "duplicate" }, { noAuthRedirect: true });
+    await expect(request).rejects.toMatchObject<ApiError>({
+      name: "ApiError",
+      status: 409,
+      message: "rule already exists",
+    });
+  });
+
+  it("does not clear credentials when login itself returns unauthorized", async () => {
+    localStorage.setItem("aifw_token", "existing-token");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("bad credentials", { status: 401, statusText: "Unauthorized" }),
+      ),
+    );
+
+    await expect(
+      api.post("/api/v1/auth/login", { username: "admin", password: "wrong" }, { noAuthRedirect: true }),
+    ).rejects.toMatchObject({ status: 401, message: "bad credentials" });
+    expect(localStorage.getItem("aifw_token")).toBe("existing-token");
+  });
+
+  it("accepts an empty successful response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 204 })));
+
+    await expect(api.delete("/api/v1/rules/example")).resolves.toBeUndefined();
+  });
+});

--- a/aifw-ui/tests/e2e/auth.spec.ts
+++ b/aifw-ui/tests/e2e/auth.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const token = (payload: Record<string, unknown>) =>
+  `header.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+
+async function mockApi(page: Page) {
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+
+    if (path === "/api/v1/interfaces") {
+      await route.fulfill({ json: { data: [] } });
+      return;
+    }
+    if (path === "/api/v1/auth/ws-ticket") {
+      await route.fulfill({ json: { ticket: "browser-test-ticket", expires_in_seconds: 30 } });
+      return;
+    }
+    await route.fulfill({ json: {} });
+  });
+}
+
+test("a protected page redirects an anonymous visitor to login", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page).toHaveURL(/\/login\/$/);
+  await expect(page.getByLabel("Username")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
+});
+
+test("invalid credentials show feedback without leaving the login page", async ({ page }) => {
+  await page.route("**/api/v1/auth/login", (route) =>
+    route.fulfill({ status: 401, json: { error: "bad credentials" } }),
+  );
+  await page.goto("/login/");
+
+  await page.getByLabel("Username").fill("admin");
+  await page.getByLabel("Password").fill("wrong-password");
+  await page.getByRole("button", { name: "Sign In" }).click();
+
+  await expect(page.getByText("Invalid username or password")).toBeVisible();
+  await expect(page).toHaveURL(/\/login\/$/);
+  await expect(page.evaluate(() => localStorage.getItem("aifw_token"))).resolves.toBeNull();
+});
+
+test("TOTP login stores the session and opens the authenticated shell", async ({ page }) => {
+  await mockApi(page);
+  await page.route("**/api/v1/auth/login", (route) =>
+    route.fulfill({ json: { totp_required: true } }),
+  );
+  await page.route("**/api/v1/auth/totp/login", (route) =>
+    route.fulfill({
+      json: {
+        access_token: token({
+          sub: "user-1",
+          username: "admin",
+          role: "admin",
+          exp: Math.floor(Date.now() / 1000) + 300,
+        }),
+      },
+    }),
+  );
+  await page.goto("/login/");
+
+  await page.getByLabel("Username").fill("admin");
+  await page.getByLabel("Password").fill("correct-password");
+  await page.getByRole("button", { name: "Sign In" }).click();
+  await expect(page.getByText("Enter the 6-digit code")).toBeVisible();
+
+  await page.getByLabel("TOTP Code").fill("123456");
+  await page.getByRole("button", { name: "Verify" }).click();
+
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole("button", { name: "Monitoring" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Logout" })).toBeVisible();
+  await expect(page.evaluate(() => localStorage.getItem("aifw_token"))).resolves.toBeTruthy();
+});
+
+test("an expired session is removed before a protected page renders", async ({ page }) => {
+  await page.addInitScript((expiredToken) => {
+    localStorage.setItem("aifw_token", expiredToken);
+  }, token({ sub: "user-1", exp: Math.floor(Date.now() / 1000) - 60 }));
+
+  await page.goto("/");
+
+  await expect(page).toHaveURL(/\/login\/$/);
+  await expect(page.evaluate(() => localStorage.getItem("aifw_token"))).resolves.toBeNull();
+});

--- a/aifw-ui/vitest.config.ts
+++ b/aifw-ui/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    restoreMocks: true,
+  },
+});

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -66,6 +66,9 @@ Passing direct checks:
   its default `freebsd` user, and has the expected live default route.
 - Non-interactive build privilege works through the stock wheel account's
   passwordless `su`; the official image does not include `sudo`.
+- PVE disk import and `boot=order=virtio0` are applied as two sequential API
+  tasks. Sending both in the import request silently omitted the not-yet-created
+  disk from the boot order and left the guest attempting PXE/CD-ROM boot.
 - Harness unit tests and cleanup verification with zero residual E2E VMs.
 
 Root cause and correction:
@@ -77,6 +80,8 @@ Root cause and correction:
 - The harness now attaches its own v2/vtnet0 `cidata` ISO, uses the early
   top-level `ssh_authorized_keys` field with the stock `freebsd` user, and
   checks live `ifconfig` and route state instead of Linux cloud-init markers.
+- The harness waits for asynchronous disk import before setting the boot order;
+  a regression test fixes this request ordering contract.
 
 Remaining integration boundary:
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,9 +1,9 @@
 # AiFw Proxmox E2E harness
 
-Status: directly validated lifecycle foundation as of 2026-07-19. A clean
-official-FreeBSD builder produced the IMG, and appliance-only deployment of the
-corrected equivalent disk passed initial and post-reboot health plus teardown.
-One final combined Woodpecker run of the natively corrected source is pending.
+Status: validated one-NIC lifecycle smoke as of 2026-07-19. Woodpecker pipeline
+14 built AiFw 5.99.14 from commit `9c146232`, deployed that exact IMG, passed
+initial and post-reboot health, and completed teardown. It is a manual release
+smoke, not yet a required gate or routed firewall data-plane suite.
 
 The harness provisions the exact writable AiFw IMG in Proxmox, attaches a
 per-run unattended seed ISO, verifies the running appliance, reboots it, saves
@@ -77,6 +77,13 @@ Passing direct checks:
 - The corrected appliance-only run passed SSH, all core services, TLS login,
   authenticated API/UI health, live `pf`, reboot recovery, and zero-residual
   teardown. Its manifest records `pf_running=true` both before and after reboot.
+- Woodpecker pipeline 14 passed the combined native path in 1,840 seconds. It
+  produced a 221,009,096-byte compressed IMG from commit `9c146232`, deployed
+  it at the reserved address, and passed the same initial/reboot contract.
+- A post-run Proxmox ownership audit found zero `aifw-e2e-*` VMs and zero
+  matching uploaded or imported volumes.
+- Cleanup now polls Proxmox and records `teardown_verified=true` in the run
+  manifest only after the VM and every run-owned volume are absent.
 
 Root cause and correction:
 
@@ -90,13 +97,16 @@ Root cause and correction:
 - The harness waits for asynchronous disk import before setting the boot order;
   a regression test fixes this request ordering contract.
 
-Remaining integration boundary:
+Remaining boundaries:
 
-- The fixes discovered by the focused run must be rebuilt natively and pass one
-  combined Woodpecker run; the passing appliance reused the built IMG with
-  equivalent in-place boot metadata corrections to avoid another full compile.
-- The official image performs slow first-boot maintenance before sshd starts.
-  The current reliable lane tolerates that bounded delay.
+- The official image performs slow first-boot maintenance before sshd starts;
+  the reliable lane tolerates that bounded delay.
+- The passing lane has one NIC on the untagged management bridge. It proves
+  artifact boot, setup, control plane, real `pf` availability, persistence, and
+  cleanup—not forwarding, NAT, policy enforcement, DHCP, or WAN/LAN isolation.
+- Run evidence is currently emitted to the Woodpecker log and job-local
+  manifest. Durable external artifact retention and a stale-resource janitor
+  remain target-state work.
 
 Appliance root causes corrected in source:
 
@@ -111,8 +121,8 @@ Appliance root causes corrected in source:
   of stopping at SSH readiness.
 - Serial/VGA multicons output is enabled for future Proxmox boot diagnostics.
 
-Do not interpret the presence of `.woodpecker/e2e.yml` as evidence that the
-full lane passes or gates releases yet.
+Do not interpret this passing one-NIC smoke as the full WAN/LAN framework or a
+required publication gate.
 
 ## Development and validation order
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,46 @@
+# AiFw Proxmox E2E harness
+
+The harness provisions the exact writable AiFw IMG in Proxmox, attaches a
+per-run unattended seed ISO, verifies the running appliance, reboots it, saves
+diagnostics, and destroys every run-owned Proxmox resource in a `finally`
+block.
+
+## Safety model
+
+- Every VM and uploaded volume is named with a unique run ID.
+- Only resources whose names begin with `aifw-e2e-` are deleted.
+- Cleanup runs on success, failure, timeout, SIGINT, and SIGTERM.
+- `--keep-on-failure` is a manual debugging escape hatch and is not used by CI.
+- Credentials are accepted only through environment variables.
+- The seed contains an ephemeral public SSH key and Argon2 password hash. It
+  never contains the SSH private key or plaintext admin password.
+
+Required secrets:
+
+- `PVE_TOKEN_ID`
+- `PVE_TOKEN_SECRET`
+- `AIFW_E2E_ADMIN_PASSWORD`
+
+Required non-secret settings:
+
+- `PVE_URL`, `PVE_NODE`, `PVE_IMAGE_STORAGE`, `PVE_VM_STORAGE`, `PVE_BRIDGE`
+- `AIFW_E2E_ADDRESS`, `AIFW_E2E_GATEWAY`, `AIFW_E2E_DNS`
+
+The manual Woodpecker run also requires an `artifact_url` pipeline parameter.
+It must point to an IMG built from a revision containing the unattended seed
+support; an older release image will fall back to its interactive wizard.
+
+The current Proxmox host has only an untagged management bridge. The supported
+initial lane is therefore a one-NIC appliance lifecycle smoke test. The
+orchestrator deliberately does not claim routed WAN/LAN coverage. Add isolated
+test bridges or VLAN-aware networking before implementing data-plane suites.
+
+## Run
+
+```sh
+python -m e2e.aifw_e2e run --artifact output/aifw-<version>-amd64.img.xz
+```
+
+Artifacts are written to `e2e/artifacts/<run-id>/`.
+Ephemeral keys, seed media, and decompressed images live under `e2e/.run/`
+and are deleted by the lifecycle `finally` block.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,8 +1,9 @@
 # AiFw Proxmox E2E harness
 
-Status: experimental lifecycle foundation as of 2026-07-19. Proxmox resource
-contracts, FreeBSD builder bootstrap, and teardown are directly verified; a
-complete successful image-build-plus-appliance run is still pending.
+Status: directly validated lifecycle foundation as of 2026-07-19. A clean
+official-FreeBSD builder produced the IMG, and appliance-only deployment of the
+corrected equivalent disk passed initial and post-reboot health plus teardown.
+One final combined Woodpecker run of the natively corrected source is pending.
 
 The harness provisions the exact writable AiFw IMG in Proxmox, attaches a
 per-run unattended seed ISO, verifies the running appliance, reboots it, saves
@@ -70,6 +71,12 @@ Passing direct checks:
   tasks. Sending both in the import request silently omitted the not-yet-created
   disk from the boot order and left the guest attempting PXE/CD-ROM boot.
 - Harness unit tests and cleanup verification with zero residual E2E VMs.
+- A clean builder-only run compiled AiFw and all four companion projects,
+  produced/checksummed a 211-MB compressed IMG, returned it to the runner, and
+  destroyed the builder.
+- The corrected appliance-only run passed SSH, all core services, TLS login,
+  authenticated API/UI health, live `pf`, reboot recovery, and zero-residual
+  teardown. Its manifest records `pf_running=true` both before and after reboot.
 
 Root cause and correction:
 
@@ -85,10 +92,24 @@ Root cause and correction:
 
 Remaining integration boundary:
 
-- A builder-only run still needs to complete `freebsd/build-local.sh`, return
-  and checksum the new IMG, then an appliance-only run must validate that IMG.
+- The fixes discovered by the focused run must be rebuilt natively and pass one
+  combined Woodpecker run; the passing appliance reused the built IMG with
+  equivalent in-place boot metadata corrections to avoid another full compile.
 - The official image performs slow first-boot maintenance before sshd starts.
   The current reliable lane tolerates that bounded delay.
+
+Appliance root causes corrected in source:
+
+- The writable IMG now creates UFS label `aifw`; previously only GPT label
+  `aifw` existed while loader/fstab requested `/dev/ufs/aifw`, causing a
+  `mountroot` error 19.
+- `aifw_firstboot` is a normal idempotent rc service, not sentinel-gated, so a
+  staged writable IMG consumes unattended seed media.
+- Setup persists `pf_rules=/usr/local/etc/aifw/pf.conf.aifw`; otherwise first
+  boot enabled `pf` directly but reboot fell back to missing `/etc/pf.conf`.
+- Reboot readiness retries the complete service/API/UI/`pf` contract instead
+  of stopping at SSH readiness.
+- Serial/VGA multicons output is enabled for future Proxmox boot diagnostics.
 
 Do not interpret the presence of `.woodpecker/e2e.yml` as evidence that the
 full lane passes or gates releases yet.
@@ -111,9 +132,10 @@ volume remains.
 ### Builder alternatives
 
 The current implementation starts from the checksum-verified official image
-for maximum reproducibility. If its first-boot and dependency installation
-cost makes the lane too slow, use a versioned, periodically rebuilt Proxmox
-builder template and clone it per run. Pin the template to a FreeBSD release,
+for maximum reproducibility. The measured clean builder completed in roughly
+15 minutes, so this remains the default manual/release lane while correctness
+stabilizes. If measured duration becomes too high, use a versioned, periodically
+rebuilt Proxmox builder template and clone it per run. Pin the template to a FreeBSD release,
 record its package/toolchain manifest, inject a fresh key/network seed into
 every clone, and retain an official-image canary job so cached state cannot
 hide bootstrap regressions.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,9 +1,11 @@
 # AiFw Proxmox E2E harness
 
-Status: validated one-NIC lifecycle smoke as of 2026-07-19. Woodpecker pipeline
-14 built AiFw 5.99.14 from commit `9c146232`, deployed that exact IMG, passed
-initial and post-reboot health, and completed teardown. It is a manual release
-smoke, not yet a required gate or routed firewall data-plane suite.
+Status: the one-NIC lifecycle is validated and the full isolated WAN/LAN lane
+is implemented as of 2026-07-19. The full lane uses a real two-NIC AiFw VM,
+two Debian LXC traffic helpers, live NAT/pass/block checks, authenticated API
+rule changes, Playwright login/rules checks, reboot persistence, diagnostics,
+and ownership-verified teardown. A fresh exact-commit Woodpecker acceptance run
+is the remaining validation step.
 
 The harness provisions the exact writable AiFw IMG in Proxmox, attaches a
 per-run unattended seed ISO, verifies the running appliance, reboots it, saves
@@ -12,7 +14,7 @@ block.
 
 ## Safety model
 
-- Every VM and uploaded volume is named with a unique run ID.
+- Every VM, helper container, and uploaded volume is named with a unique run ID.
 - Only resources whose names begin with `aifw-e2e-` are deleted.
 - Cleanup runs on success, failure, timeout, SIGINT, and SIGTERM.
 - `--keep-on-failure` is a manual debugging escape hatch and is not used by CI.
@@ -29,13 +31,14 @@ Required secrets:
 Required non-secret settings:
 
 - `PVE_URL`, `PVE_NODE`, `PVE_IMAGE_STORAGE`, `PVE_VM_STORAGE`, `PVE_BRIDGE`
+- `PVE_E2E_WAN_BRIDGE`, `PVE_E2E_LAN_BRIDGE`
 - `AIFW_E2E_ADDRESS`, `AIFW_E2E_GATEWAY`, `AIFW_E2E_DNS`
 
 The manual Woodpecker workflow first creates an ephemeral FreeBSD 15 builder
 VM in Proxmox, copies the exact checked-out Git commit to it, builds a fresh
 seed-capable IMG, copies that IMG back into the job workspace, and destroys the
-builder. It then deploys that IMG as a second ephemeral VM for the appliance
-checks. The two VMs run sequentially and reuse the reserved test address.
+builder. It then deploys that IMG as a two-NIC VM plus two helper containers.
+The builder and LAN helper run sequentially and reuse the reserved address.
 
 The configured homelab lane uses:
 
@@ -43,16 +46,17 @@ The configured homelab lane uses:
 - Upload storage `local`
 - VM storage `local-lvm`
 - Bridge `vmbr0`
+- Isolated, portless bridges `vmbr998` (WAN) and `vmbr999` (LAN)
 - Reserved address `192.168.0.26/23`
 - Gateway and DNS `192.168.0.1`
 
 These operational values live in the pipeline and manual-only Woodpecker
 secrets. Credentials do not belong in this file or any repository file.
 
-The current Proxmox host has only an untagged management bridge. The supported
-initial lane is therefore a one-NIC appliance lifecycle smoke test. The
-orchestrator deliberately does not claim routed WAN/LAN coverage. Add isolated
-test bridges or VLAN-aware networking before implementing data-plane suites.
+The static isolated bridges are durable lab substrate; per-run VMs, containers,
+media, credentials, routes, and rules are disposable. The LAN helper has its
+management NIC on `vmbr0` and an isolated NIC on `vmbr999`. AiFw has only WAN
+and LAN NICs, so all appliance access is through the LAN helper.
 
 ## Current validation state
 
@@ -84,6 +88,11 @@ Passing direct checks:
   matching uploaded or imported volumes.
 - Cleanup now polls Proxmox and records `teardown_verified=true` in the run
   manifest only after the VM and every run-owned volume are absent.
+- A focused Debian helper-container check passed both NIC/address assertions,
+  SSH, source-observing HTTP service, and zero-residual teardown.
+- Direct full-topology attempts proved helper provisioning and teardown. The
+  retained 5.99.12 image did not configure its isolated LAN because it predates
+  the current first-boot fixes; it is not the acceptance artifact.
 
 Root cause and correction:
 
@@ -101,9 +110,8 @@ Remaining boundaries:
 
 - The official image performs slow first-boot maintenance before sshd starts;
   the reliable lane tolerates that bounded delay.
-- The passing lane has one NIC on the untagged management bridge. It proves
-  artifact boot, setup, control plane, real `pf` availability, persistence, and
-  cleanup—not forwarding, NAT, policy enforcement, DHCP, or WAN/LAN isolation.
+- Full-lane exact-commit acceptance in Woodpecker is pending. Until it passes,
+  pipeline 14 remains the last authoritative appliance acceptance result.
 - Run evidence is currently emitted to the Woodpecker log and job-local
   manifest. Durable external artifact retention and a stale-resource janitor
   remain target-state work.
@@ -121,8 +129,8 @@ Appliance root causes corrected in source:
   of stopping at SSH readiness.
 - Serial/VGA multicons output is enabled for future Proxmox boot diagnostics.
 
-Do not interpret this passing one-NIC smoke as the full WAN/LAN framework or a
-required publication gate.
+Do not promote this manual lane to a publication gate until repeat exact-commit
+full runs pass and durable evidence retention is added.
 
 ## Development and validation order
 
@@ -166,10 +174,11 @@ python -m e2e.aifw_e2e build \
   --output e2e/.run/aifw.img.xz
 ```
 
-Test an existing image:
+Run the quick one-NIC smoke or the full isolated suite:
 
 ```sh
 python -m e2e.aifw_e2e run --artifact output/aifw-<version>-amd64.img.xz
+python -m e2e.aifw_e2e full --artifact output/aifw-<version>-amd64.img.xz
 ```
 
 Artifacts are written to `e2e/artifacts/<run-id>/`.
@@ -178,11 +187,10 @@ and are deleted by the lifecycle `finally` block.
 
 ## Target state
 
-The one-NIC lifecycle smoke is only the first lane. The full target adds:
+The implemented first full lane still leaves these target extensions:
 
-- Isolated WAN and LAN networks plus helper client/origin VMs.
-- Real TCP, UDP, ICMP, DNS, DHCP, NAT, state, and pass/block assertions.
-- Playwright tests against the deployed UI.
+- UDP, ICMP, DNS, DHCP, and deeper state assertions.
+- Broader Playwright coverage beyond login/dashboard/rules.
 - ISO installation for UFS/ZFS and BIOS/UEFI.
 - Update, rollback, watchdog, failure-recovery, and HA suites.
 - Serial-console artifacts, JUnit, browser traces, packet captures on failure,

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -26,9 +26,11 @@ Required non-secret settings:
 - `PVE_URL`, `PVE_NODE`, `PVE_IMAGE_STORAGE`, `PVE_VM_STORAGE`, `PVE_BRIDGE`
 - `AIFW_E2E_ADDRESS`, `AIFW_E2E_GATEWAY`, `AIFW_E2E_DNS`
 
-The manual Woodpecker run also requires an `artifact_url` pipeline parameter.
-It must point to an IMG built from a revision containing the unattended seed
-support; an older release image will fall back to its interactive wizard.
+The manual Woodpecker workflow first creates an ephemeral FreeBSD 15 builder
+VM in Proxmox, copies the exact checked-out Git commit to it, builds a fresh
+seed-capable IMG, copies that IMG back into the job workspace, and destroys the
+builder. It then deploys that IMG as a second ephemeral VM for the appliance
+checks. The two VMs run sequentially and reuse the reserved test address.
 
 The current Proxmox host has only an untagged management bridge. The supported
 initial lane is therefore a one-NIC appliance lifecycle smoke test. The
@@ -36,6 +38,16 @@ orchestrator deliberately does not claim routed WAN/LAN coverage. Add isolated
 test bridges or VLAN-aware networking before implementing data-plane suites.
 
 ## Run
+
+Build an image through an ephemeral Proxmox builder:
+
+```sh
+python -m e2e.aifw_e2e build \
+  --builder-image FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz \
+  --output e2e/.run/aifw.img.xz
+```
+
+Test an existing image:
 
 ```sh
 python -m e2e.aifw_e2e run --artifact output/aifw-<version>-amd64.img.xz

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,5 +1,9 @@
 # AiFw Proxmox E2E harness
 
+Status: experimental lifecycle foundation as of 2026-07-19. Proxmox resource
+contracts, FreeBSD builder bootstrap, and teardown are directly verified; a
+complete successful image-build-plus-appliance run is still pending.
+
 The harness provisions the exact writable AiFw IMG in Proxmox, attaches a
 per-run unattended seed ISO, verifies the running appliance, reboots it, saves
 diagnostics, and destroys every run-owned Proxmox resource in a `finally`
@@ -32,10 +36,88 @@ seed-capable IMG, copies that IMG back into the job workspace, and destroys the
 builder. It then deploys that IMG as a second ephemeral VM for the appliance
 checks. The two VMs run sequentially and reuse the reserved test address.
 
+The configured homelab lane uses:
+
+- Proxmox node `trigproxmox`
+- Upload storage `local`
+- VM storage `local-lvm`
+- Bridge `vmbr0`
+- Reserved address `192.168.0.26/23`
+- Gateway and DNS `192.168.0.1`
+
+These operational values live in the pipeline and manual-only Woodpecker
+secrets. Credentials do not belong in this file or any repository file.
+
 The current Proxmox host has only an untagged management bridge. The supported
 initial lane is therefore a one-NIC appliance lifecycle smoke test. The
 orchestrator deliberately does not claim routed WAN/LAN coverage. Add isolated
 test bridges or VLAN-aware networking before implementing data-plane suites.
+
+## Current validation state
+
+Passing direct checks:
+
+- Proxmox authentication and asynchronous task polling.
+- Disposable tagged VM create/read/destroy.
+- `.raw` upload, import to `local-lvm`, disk attachment, purge, and upload
+  deletion.
+- The official FreeBSD 15.0 BASIC-CLOUDINIT image boots with a custom `cidata`
+  ISO, applies `192.168.0.26/23` to `vtnet0`, installs the ephemeral key for
+  its default `freebsd` user, and has the expected live default route.
+- Non-interactive build privilege works through the stock wheel account's
+  passwordless `su`; the official image does not include `sudo`.
+- Harness unit tests and cleanup verification with zero residual E2E VMs.
+
+Root cause and correction:
+
+- FreeBSD 15 uses native `nuageinit`, not Python cloud-init. Proxmox-generated
+  NoCloud metadata names the NIC `eth0`, while the VirtIO NIC is `vtnet0`.
+- The first custom seed used network-config v1. FreeBSD's NoCloud parser
+  expects a v2 document with `ethernets`, so it raised a Lua type error.
+- The harness now attaches its own v2/vtnet0 `cidata` ISO, uses the early
+  top-level `ssh_authorized_keys` field with the stock `freebsd` user, and
+  checks live `ifconfig` and route state instead of Linux cloud-init markers.
+
+Remaining integration boundary:
+
+- A builder-only run still needs to complete `freebsd/build-local.sh`, return
+  and checksum the new IMG, then an appliance-only run must validate that IMG.
+- The official image performs slow first-boot maintenance before sshd starts.
+  The current reliable lane tolerates that bounded delay.
+
+Do not interpret the presence of `.woodpecker/e2e.yml` as evidence that the
+full lane passes or gates releases yet.
+
+## Development and validation order
+
+Use the smallest test that can prove each change:
+
+1. `pytest e2e/tests` for local logic and request encoding.
+2. Disposable NIC-less VM for Proxmox API configuration contracts.
+3. Official FreeBSD boot plus static IP, SSH, and teardown only.
+4. Builder-only image production.
+5. Appliance-only deployment and checks.
+6. One combined Woodpecker manual run after all focused checks pass.
+
+Every direct live test must use the `aifw-e2e-` prefix, a bounded timeout, and
+the lifecycle cleanup guard. Always verify that no run-owned VM or uploaded
+volume remains.
+
+### Builder alternatives
+
+The current implementation starts from the checksum-verified official image
+for maximum reproducibility. If its first-boot and dependency installation
+cost makes the lane too slow, use a versioned, periodically rebuilt Proxmox
+builder template and clone it per run. Pin the template to a FreeBSD release,
+record its package/toolchain manifest, inject a fresh key/network seed into
+every clone, and retain an official-image canary job so cached state cannot
+hide bootstrap regressions.
+
+Other viable but less attractive options are offline qcow2 customization or a
+persistent FreeBSD build host. Offline customization adds image tooling and a
+second image supply chain; a persistent host weakens isolation and teardown.
+Neither should replace deployment testing of the exact AiFw IMG produced by
+the build.
 
 ## Run
 
@@ -56,3 +138,18 @@ python -m e2e.aifw_e2e run --artifact output/aifw-<version>-amd64.img.xz
 Artifacts are written to `e2e/artifacts/<run-id>/`.
 Ephemeral keys, seed media, and decompressed images live under `e2e/.run/`
 and are deleted by the lifecycle `finally` block.
+
+## Target state
+
+The one-NIC lifecycle smoke is only the first lane. The full target adds:
+
+- Isolated WAN and LAN networks plus helper client/origin VMs.
+- Real TCP, UDP, ICMP, DNS, DHCP, NAT, state, and pass/block assertions.
+- Playwright tests against the deployed UI.
+- ISO installation for UFS/ZFS and BIOS/UEFI.
+- Update, rollback, watchdog, failure-recovery, and HA suites.
+- Serial-console artifacts, JUnit, browser traces, packet captures on failure,
+  and a scheduled stale-resource janitor.
+- A scoped Proxmox pool/token and release publication gate.
+
+See `testingUplift.md` for the detailed current-to-target roadmap.

--- a/e2e/__init__.py
+++ b/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""AiFw appliance end-to-end harness."""

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+"""Provision, test, diagnose, and destroy an AiFw Proxmox VM."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import urllib.parse
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import requests
+import urllib3
+from argon2 import PasswordHasher
+
+RESOURCE_PREFIX = "aifw-e2e-"
+
+
+class HarnessError(RuntimeError):
+    """A bounded, user-facing harness failure."""
+
+
+def required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise HarnessError(f"required environment variable {name} is not set")
+    return value
+
+
+@dataclass(frozen=True)
+class LabConfig:
+    pve_url: str
+    pve_node: str
+    image_storage: str
+    vm_storage: str
+    bridge: str
+    verify_tls: bool
+    address_cidr: str
+    gateway: str
+    dns: str
+    token_id: str
+    token_secret: str
+    admin_password: str
+
+    @classmethod
+    def from_env(cls) -> "LabConfig":
+        return cls(
+            pve_url=required_env("PVE_URL").rstrip("/"),
+            pve_node=required_env("PVE_NODE"),
+            image_storage=os.environ.get("PVE_IMAGE_STORAGE", "local"),
+            vm_storage=os.environ.get("PVE_VM_STORAGE", "local-lvm"),
+            bridge=os.environ.get("PVE_BRIDGE", "vmbr0"),
+            verify_tls=os.environ.get("PVE_VERIFY_TLS", "true").lower()
+            in ("1", "true", "yes"),
+            address_cidr=required_env("AIFW_E2E_ADDRESS"),
+            gateway=required_env("AIFW_E2E_GATEWAY"),
+            dns=os.environ.get("AIFW_E2E_DNS", required_env("AIFW_E2E_GATEWAY")),
+            token_id=required_env("PVE_TOKEN_ID"),
+            token_secret=required_env("PVE_TOKEN_SECRET"),
+            admin_password=required_env("AIFW_E2E_ADMIN_PASSWORD"),
+        )
+
+    @property
+    def address(self) -> str:
+        return self.address_cidr.split("/", 1)[0]
+
+
+class Proxmox:
+    def __init__(self, cfg: LabConfig):
+        self.cfg = cfg
+        self.base = f"{cfg.pve_url}/api2/json"
+        self.session = requests.Session()
+        self.session.headers["Authorization"] = (
+            f"PVEAPIToken={cfg.token_id}={cfg.token_secret}"
+        )
+        self.session.verify = cfg.verify_tls
+        if not cfg.verify_tls:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    def request(self, method: str, path: str, **kwargs: Any) -> Any:
+        response = self.session.request(
+            method, f"{self.base}{path}", timeout=120, **kwargs
+        )
+        if not response.ok:
+            detail = response.text[:500]
+            raise HarnessError(
+                f"Proxmox {method} {path} failed: {response.status_code} {detail}"
+            )
+        return response.json().get("data")
+
+    def wait_task(self, upid: str, timeout: int = 900) -> None:
+        encoded = urllib.parse.quote(upid, safe="")
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            status = self.request(
+                "GET", f"/nodes/{self.cfg.pve_node}/tasks/{encoded}/status"
+            )
+            if status.get("status") == "stopped":
+                if status.get("exitstatus") != "OK":
+                    raise HarnessError(
+                        f"Proxmox task failed: {status.get('exitstatus')} ({upid})"
+                    )
+                return
+            time.sleep(2)
+        raise HarnessError(f"timed out waiting for Proxmox task {upid}")
+
+    def next_vmid(self) -> int:
+        return int(self.request("GET", "/cluster/nextid"))
+
+    def create_vm(self, vmid: int, name: str, description: str) -> None:
+        upid = self.request(
+            "POST",
+            f"/nodes/{self.cfg.pve_node}/qemu",
+            data={
+                "vmid": vmid,
+                "name": name,
+                "description": description,
+                "tags": "aifw-e2e",
+                "ostype": "other",
+                "bios": "seabios",
+                "cores": 4,
+                "memory": 4096,
+                "scsihw": "virtio-scsi-single",
+                "serial0": "socket",
+                "vga": "serial0",
+                "net0": f"virtio,bridge={self.cfg.bridge},firewall=1",
+                "onboot": 0,
+                "protection": 0,
+            },
+        )
+        if upid:
+            self.wait_task(upid)
+
+    def upload(self, path: Path, content: str) -> str:
+        checksum = sha256_file(path)
+        with path.open("rb") as handle:
+            upid = self.request(
+                "POST",
+                f"/nodes/{self.cfg.pve_node}/storage/{self.cfg.image_storage}/upload",
+                data={
+                    "content": content,
+                    "checksum-algorithm": "sha256",
+                    "checksum": checksum,
+                },
+                files={"filename": (path.name, handle, "application/octet-stream")},
+            )
+        self.wait_task(upid)
+        prefix = "iso" if content == "iso" else "import"
+        return f"{self.cfg.image_storage}:{prefix}/{path.name}"
+
+    def attach_imported_disk(
+        self, vmid: int, volume: str, seed_volume: str | None = None
+    ) -> None:
+        # Proxmox 9 imports a storage `import` volume while applying the VM
+        # disk configuration. The source upload is removed during teardown.
+        disk = f"{self.cfg.vm_storage}:0,import-from={volume},discard=on"
+        config = {
+            "virtio0": disk,
+            "boot": "order=virtio0",
+        }
+        if seed_volume is not None:
+            config["ide2"] = f"{seed_volume},media=cdrom"
+        upid = self.request(
+            "PUT",
+            f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config",
+            data=config,
+        )
+        if upid:
+            self.wait_task(upid)
+
+    def start(self, vmid: int) -> None:
+        upid = self.request(
+            "POST", f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/status/start"
+        )
+        self.wait_task(upid)
+
+    def stop(self, vmid: int) -> None:
+        status = self.request(
+            "GET", f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/status/current"
+        )
+        if status.get("status") == "stopped":
+            return
+        upid = self.request(
+            "POST", f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/status/stop"
+        )
+        self.wait_task(upid, timeout=120)
+
+    def destroy(self, vmid: int) -> None:
+        with contextlib.suppress(Exception):
+            self.stop(vmid)
+        upid = self.request(
+            "DELETE",
+            f"/nodes/{self.cfg.pve_node}/qemu/{vmid}",
+            params={"purge": 1, "destroy-unreferenced-disks": 1},
+        )
+        self.wait_task(upid, timeout=300)
+
+    def delete_volume(self, volume: str) -> None:
+        encoded = urllib.parse.quote(volume, safe="")
+        with contextlib.suppress(Exception):
+            upid = self.request(
+                "DELETE",
+                f"/nodes/{self.cfg.pve_node}/storage/{self.cfg.image_storage}/content/{encoded}",
+            )
+            if upid:
+                self.wait_task(upid, timeout=300)
+
+    def vm_config(self, vmid: int) -> dict[str, Any]:
+        return self.request(
+            "GET", f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config"
+        )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def run_checked(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, check=True, text=True, **kwargs)
+
+
+def prepare_image(artifact: Path, output_dir: Path, run_id: str) -> Path:
+    if not artifact.is_file():
+        raise HarnessError(f"artifact does not exist: {artifact}")
+    suffixes = "".join(artifact.suffixes)
+    # Proxmox's upload API accepts VM import media with `.raw`, not `.img`.
+    image = output_dir / f"{RESOURCE_PREFIX}{run_id}.raw"
+    if suffixes.endswith(".img.xz"):
+        with image.open("wb") as out:
+            subprocess.run(["xz", "-dc", str(artifact)], check=True, stdout=out)
+    elif artifact.suffix == ".img":
+        shutil.copyfile(artifact, image)
+    else:
+        raise HarnessError("artifact must be an .img or .img.xz file")
+    return image
+
+
+def make_seed(
+    cfg: LabConfig, output_dir: Path, run_id: str, public_key: str
+) -> Path:
+    password_hash = PasswordHasher().hash(cfg.admin_password)
+    setup = {
+        "hostname": f"aifw-e2e-{run_id}",
+        "wan_interface": "vtnet0",
+        "wan_mode": "static",
+        "wan_ip": cfg.address_cidr,
+        "wan_gateway": cfg.gateway,
+        "lan_interface": None,
+        "lan_ip": None,
+        "admin_username": "e2e-admin",
+        "admin_password_hash": password_hash,
+        "totp_secret": "",
+        "totp_enabled": False,
+        "recovery_codes": [],
+        "api_listen": "0.0.0.0",
+        "api_port": 8080,
+        "ui_enabled": True,
+        "dns_servers": [cfg.dns],
+        "dhcp_enabled": False,
+        "default_policy": "permissive",
+        "nat_enabled": False,
+        "ssh_auth_method": "key_only",
+        "ssh_github_user": None,
+        "ssh_authorized_keys": [public_key.strip()],
+        "ram_mb": 4096,
+        "db_path": "/var/db/aifw/aifw.db",
+        "config_dir": "/usr/local/etc/aifw",
+    }
+    seed_dir = output_dir / "seed"
+    seed_dir.mkdir(mode=0o700)
+    (seed_dir / "setup.json").write_text(json.dumps(setup, indent=2) + "\n")
+    seed = output_dir / f"{RESOURCE_PREFIX}{run_id}-seed.iso"
+    tool = shutil.which("xorrisofs") or shutil.which("genisoimage")
+    if not tool:
+        raise HarnessError("xorrisofs or genisoimage is required to create seed media")
+    run_checked(
+        [tool, "-quiet", "-V", "AIFW_SEED", "-o", str(seed), str(seed_dir)]
+    )
+    return seed
+
+
+def make_ssh_key(output_dir: Path) -> tuple[Path, str]:
+    private_key = output_dir / "id_ed25519"
+    run_checked(
+        [
+            "ssh-keygen",
+            "-q",
+            "-t",
+            "ed25519",
+            "-N",
+            "",
+            "-C",
+            "aifw-e2e",
+            "-f",
+            str(private_key),
+        ]
+    )
+    return private_key, private_key.with_suffix(".pub").read_text()
+
+
+def ssh_command(private_key: Path, host: str, command: str) -> list[str]:
+    return [
+        "ssh",
+        "-i",
+        str(private_key),
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=10",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        f"root@{host}",
+        command,
+    ]
+
+
+def wait_ssh(private_key: Path, host: str, timeout: int = 600) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            ssh_command(private_key, host, "test -f /usr/local/etc/aifw/aifw.conf"),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if result.returncode == 0:
+            return
+        time.sleep(5)
+    raise HarnessError(f"SSH/setup readiness timed out for {host}")
+
+
+def login_and_check(cfg: LabConfig) -> dict[str, Any]:
+    base = f"https://{cfg.address}:8080"
+    session = requests.Session()
+    session.verify = False
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    response = session.post(
+        f"{base}/api/v1/auth/login",
+        json={"username": "e2e-admin", "password": cfg.admin_password},
+        timeout=20,
+    )
+    response.raise_for_status()
+    token = response.json()["tokens"]["access_token"]
+    status = session.get(
+        f"{base}/api/v1/status",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=20,
+    )
+    status.raise_for_status()
+    data = status.json()
+    if not data.get("pf_running"):
+        raise HarnessError("authenticated status reports pf_running=false")
+    ui = session.get(f"{base}/", timeout=20)
+    ui.raise_for_status()
+    if "AiFw" not in ui.text:
+        raise HarnessError("served UI does not contain the AiFw marker")
+    return data
+
+
+def appliance_checks(cfg: LabConfig, private_key: Path) -> dict[str, Any]:
+    commands = [
+        "service aifw_daemon onestatus",
+        "service aifw_ids onestatus",
+        "service aifw_api onestatus",
+        "service aifw_watchdog onestatus",
+        "pfctl -si",
+        "test -s /usr/local/share/aifw/version",
+    ]
+    for command in commands:
+        run_checked(
+            ssh_command(private_key, cfg.address, command),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    return login_and_check(cfg)
+
+
+def collect_diagnostics(
+    pve: Proxmox,
+    cfg: LabConfig,
+    private_key: Path,
+    vmid: int,
+    output_dir: Path,
+) -> None:
+    with contextlib.suppress(Exception):
+        safe_config = pve.vm_config(vmid)
+        output_dir.joinpath("proxmox-vm.json").write_text(
+            json.dumps(safe_config, indent=2, sort_keys=True) + "\n"
+        )
+    command = """set +e
+echo '=== uname ==='; uname -a
+echo '=== uptime ==='; uptime
+echo '=== disks ==='; df -h
+echo '=== interfaces ==='; ifconfig -a
+echo '=== routes ==='; netstat -rn
+echo '=== services ==='
+for s in aifw_daemon aifw_ids aifw_api aifw_watchdog rdns rdhcpd trafficcop; do service "$s" onestatus; done
+echo '=== processes ==='; ps auxww
+echo '=== sockets ==='; sockstat -46l
+echo '=== pf info ==='; pfctl -si
+echo '=== pf rules ==='; pfctl -sr
+echo '=== pf nat ==='; pfctl -sn
+echo '=== recent logs ==='; tail -n 300 /var/log/aifw/*.log 2>/dev/null
+echo '=== dmesg ==='; dmesg
+"""
+    with output_dir.joinpath("appliance-diagnostics.txt").open("w") as handle:
+        subprocess.run(
+            ssh_command(private_key, cfg.address, command),
+            stdout=handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=90,
+        )
+
+
+def reboot_and_check(cfg: LabConfig, private_key: Path) -> dict[str, Any]:
+    subprocess.run(
+        ssh_command(private_key, cfg.address, "shutdown -r now"),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    time.sleep(10)
+    wait_ssh(private_key, cfg.address, timeout=600)
+    return appliance_checks(cfg, private_key)
+
+
+class Lifecycle:
+    def __init__(self, pve: Proxmox, keep_on_failure: bool):
+        self.pve = pve
+        self.keep_on_failure = keep_on_failure
+        self.vmid: int | None = None
+        self.volumes: list[str] = []
+        self.failed = False
+
+    def cleanup(self) -> None:
+        if self.keep_on_failure and self.failed:
+            print(f"preserving failed VM {self.vmid} by explicit request", flush=True)
+            return
+        if self.vmid is not None:
+            with contextlib.suppress(Exception):
+                config = self.pve.vm_config(self.vmid)
+                name = config.get("name", "")
+                if not name.startswith(RESOURCE_PREFIX):
+                    raise HarnessError(
+                        f"refusing to destroy VM {self.vmid} with unexpected name {name!r}"
+                    )
+                self.pve.destroy(self.vmid)
+        for volume in self.volumes:
+            if RESOURCE_PREFIX in volume:
+                self.pve.delete_volume(volume)
+
+
+def run(args: argparse.Namespace) -> int:
+    cfg = LabConfig.from_env()
+    run_id = args.run_id or uuid.uuid4().hex[:10]
+    if not all(c in "0123456789abcdef-" for c in run_id.lower()):
+        raise HarnessError("run ID may contain only hexadecimal characters and hyphens")
+    output_dir = Path(args.artifacts) / run_id
+    output_dir.mkdir(parents=True, mode=0o700)
+    work_root = Path(args.work_dir)
+    work_root.mkdir(parents=True, mode=0o700)
+    work_dir = work_root / f"{RESOURCE_PREFIX}{run_id}"
+    work_dir.mkdir(mode=0o700)
+    pve = Proxmox(cfg)
+    lifecycle = Lifecycle(pve, args.keep_on_failure)
+    private_key: Path | None = None
+
+    def handle_signal(signum: int, _frame: Any) -> None:
+        lifecycle.failed = True
+        raise KeyboardInterrupt(f"received signal {signum}")
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    manifest: dict[str, Any] = {
+        "run_id": run_id,
+        "artifact": Path(args.artifact).name,
+        "artifact_sha256": sha256_file(Path(args.artifact)),
+        "started_at": int(time.time()),
+        "network_scope": "single-nic-smoke",
+    }
+    try:
+        private_key, public_key = make_ssh_key(work_dir)
+        seed = make_seed(cfg, work_dir, run_id, public_key)
+        image = prepare_image(Path(args.artifact), work_dir, run_id)
+
+        image_volume = pve.upload(image, "import")
+        seed_volume = pve.upload(seed, "iso")
+        lifecycle.volumes.extend([image_volume, seed_volume])
+        vmid = pve.next_vmid()
+        lifecycle.vmid = vmid
+        name = f"{RESOURCE_PREFIX}{run_id}"
+        pve.create_vm(
+            vmid,
+            name,
+            f"AiFw E2E run {run_id}; expires {int(time.time()) + 4 * 3600}",
+        )
+        pve.attach_imported_disk(vmid, image_volume, seed_volume)
+        pve.start(vmid)
+        manifest["vmid"] = vmid
+
+        wait_ssh(private_key, cfg.address, timeout=args.boot_timeout)
+        manifest["initial_status"] = appliance_checks(cfg, private_key)
+        manifest["post_reboot_status"] = reboot_and_check(cfg, private_key)
+        manifest["result"] = "passed"
+        return 0
+    except BaseException:
+        lifecycle.failed = True
+        manifest["result"] = "failed"
+        raise
+    finally:
+        if lifecycle.vmid is not None and private_key is not None:
+            with contextlib.suppress(Exception):
+                collect_diagnostics(pve, cfg, private_key, lifecycle.vmid, output_dir)
+        manifest["finished_at"] = int(time.time())
+        output_dir.joinpath("manifest.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+        )
+        lifecycle.cleanup()
+        # Only remove the exact, prefix-validated per-run directory. This
+        # contains the private key, seed config, and decompressed source IMG.
+        if work_dir.parent == work_root and work_dir.name.startswith(RESOURCE_PREFIX):
+            shutil.rmtree(work_dir)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    sub = result.add_subparsers(dest="command", required=True)
+    run_parser = sub.add_parser("run", help="run the Proxmox appliance lifecycle")
+    run_parser.add_argument("--artifact", required=True)
+    run_parser.add_argument("--artifacts", default="e2e/artifacts")
+    run_parser.add_argument("--work-dir", default="e2e/.run")
+    run_parser.add_argument("--run-id")
+    run_parser.add_argument("--boot-timeout", type=int, default=900)
+    run_parser.add_argument("--keep-on-failure", action="store_true")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        if args.command == "run":
+            return run(args)
+    except HarnessError as error:
+        print(f"E2E ERROR: {error}", file=sys.stderr)
+        return 1
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -507,7 +507,7 @@ def copy_git_archive(
 
 def as_root(command: str) -> str:
     """Run a shell command as root on FreeBSD's passwordless wheel account."""
-    return f"su -m root -c {shlex.quote(command)}"
+    return f"su root -c {shlex.quote(command)}"
 
 
 def login_and_check(cfg: LabConfig) -> dict[str, Any]:
@@ -556,6 +556,22 @@ def appliance_checks(cfg: LabConfig, private_key: Path) -> dict[str, Any]:
     return login_and_check(cfg)
 
 
+def wait_appliance_ready(
+    cfg: LabConfig, private_key: Path, timeout: int = 600
+) -> dict[str, Any]:
+    """Wait for the complete service/API/pf contract, not merely SSH."""
+    deadline = time.monotonic() + timeout
+    last_error: BaseException | None = None
+    while time.monotonic() < deadline:
+        try:
+            return appliance_checks(cfg, private_key)
+        except (HarnessError, requests.RequestException, subprocess.SubprocessError) as error:
+            last_error = error
+            time.sleep(5)
+    detail = f": {last_error}" if last_error is not None else ""
+    raise HarnessError(f"complete appliance readiness timed out{detail}")
+
+
 def collect_diagnostics(
     pve: Proxmox,
     cfg: LabConfig,
@@ -602,7 +618,7 @@ def reboot_and_check(cfg: LabConfig, private_key: Path) -> dict[str, Any]:
     )
     time.sleep(10)
     wait_ssh(private_key, cfg.address, timeout=600)
-    return appliance_checks(cfg, private_key)
+    return wait_appliance_ready(cfg, private_key, timeout=600)
 
 
 class Lifecycle:
@@ -690,6 +706,20 @@ def build_image(args: argparse.Namespace) -> int:
         )
         copy_git_archive(
             private_key, cfg.address, "/home/freebsd/AiFw", user="freebsd"
+        )
+        commit_sha = run_checked(
+            ["git", "rev-parse", "HEAD"], capture_output=True
+        ).stdout.strip()
+        run_checked(
+            ssh_command(
+                private_key,
+                cfg.address,
+                (
+                    "printf '%s\\n' "
+                    f"{shlex.quote(commit_sha)} > /home/freebsd/AiFw/.aifw-build-commit"
+                ),
+                user="freebsd",
+            )
         )
         version = run_checked(
             [
@@ -794,7 +824,9 @@ def run(args: argparse.Namespace) -> int:
         manifest["vmid"] = vmid
 
         wait_ssh(private_key, cfg.address, timeout=args.boot_timeout)
-        manifest["initial_status"] = appliance_checks(cfg, private_key)
+        manifest["initial_status"] = wait_appliance_ready(
+            cfg, private_key, timeout=args.boot_timeout
+        )
         manifest["post_reboot_status"] = reboot_and_check(cfg, private_key)
         manifest["result"] = "passed"
         return 0

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -214,27 +214,6 @@ class Proxmox:
         if upid:
             self.wait_task(upid)
 
-    def configure_builder_cloudinit(self, vmid: int, public_key: str) -> None:
-        upid = self.request(
-            "PUT",
-            f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config",
-            data={
-                "ide2": f"{self.cfg.vm_storage}:cloudinit",
-                "citype": "nocloud",
-                "ciuser": "freebsd",
-                # Proxmox expects this field to contain a URL-encoded
-                # authorized_keys payload inside the form-encoded request.
-                "sshkeys": urllib.parse.quote(public_key.strip(), safe=""),
-                "ipconfig0": (
-                    f"ip={self.cfg.address_cidr},gw={self.cfg.gateway}"
-                ),
-                "nameserver": self.cfg.dns,
-                "searchdomain": "local",
-            },
-        )
-        if upid:
-            self.wait_task(upid)
-
     def start(self, vmid: int) -> None:
         upid = self.request(
             "POST", f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/status/start"
@@ -392,15 +371,11 @@ def make_builder_seed(
 hostname: aifw-builder-{run_id}
 disable_root: true
 ssh_pwauth: false
-users:
-  - default
-  - name: builder
-    gecos: AiFw CI Builder
-    groups: wheel
-    shell: /bin/sh
-    sudo: ALL=(ALL) NOPASSWD:ALL
-    ssh_authorized_keys:
-      - {public_key.strip()}
+# FreeBSD nuageinit processes this top-level key before networking. Entries
+# under `users` are delayed until the stock image's post-network firstboot
+# work, so using the image's default `freebsd` account avoids that delay.
+ssh_authorized_keys:
+  - {public_key.strip()}
 growpart:
   mode: auto
   devices: ['/']
@@ -408,22 +383,16 @@ resize_rootfs: true
 """
     interface = ipaddress.ip_interface(cfg.address_cidr)
     network_data = {
-        "version": 1,
-        "config": [
-            {
-                "type": "physical",
-                "name": "vtnet0",
-                "subnets": [
-                    {
-                        "type": "static",
-                        "address": str(interface.ip),
-                        "netmask": str(interface.network.netmask),
-                        "gateway": cfg.gateway,
-                        "dns_nameservers": [cfg.dns],
-                    }
-                ],
+        # FreeBSD 15's native nuageinit NoCloud parser expects cloud-init
+        # network-config v2 and iterates network.ethernets directly.
+        "version": 2,
+        "ethernets": {
+            "vtnet0": {
+                "addresses": [str(interface)],
+                "gateway4": cfg.gateway,
+                "nameservers": {"addresses": [cfg.dns]},
             }
-        ],
+        },
     }
     (seed_dir / "user-data").write_text(user_data)
     (seed_dir / "meta-data").write_text(
@@ -501,13 +470,15 @@ def wait_ssh(private_key: Path, host: str, timeout: int = 600) -> None:
     raise HarnessError(f"SSH/setup readiness timed out for {host}")
 
 
-def copy_git_archive(private_key: Path, host: str, destination: str) -> None:
+def copy_git_archive(
+    private_key: Path, host: str, destination: str, user: str = "root"
+) -> None:
     run_checked(
         ssh_command(
             private_key,
             host,
             f"mkdir -p {shlex.quote(destination)}",
-            user="builder",
+            user=user,
         )
     )
     archive = subprocess.Popen(["git", "archive", "--format=tar", "HEAD"], stdout=subprocess.PIPE)
@@ -517,7 +488,7 @@ def copy_git_archive(private_key: Path, host: str, destination: str) -> None:
             private_key,
             host,
             f"tar -xf - -C {shlex.quote(destination)}",
-            user="builder",
+            user=user,
         ),
         stdin=archive.stdout,
     )
@@ -525,6 +496,11 @@ def copy_git_archive(private_key: Path, host: str, destination: str) -> None:
     archive_status = archive.wait()
     if archive_status != 0 or unpack.returncode != 0:
         raise HarnessError("failed to copy the checked-out commit to the builder VM")
+
+
+def as_root(command: str) -> str:
+    """Run a shell command as root on FreeBSD's passwordless wheel account."""
+    return f"su -m root -c {shlex.quote(command)}"
 
 
 def login_and_check(cfg: LabConfig) -> dict[str, Any]:
@@ -672,8 +648,10 @@ def build_image(args: argparse.Namespace) -> int:
     try:
         private_key, public_key = make_ssh_key(work_dir)
         image = prepare_builder_image(Path(args.builder_image), work_dir, run_id)
+        seed = make_builder_seed(cfg, work_dir, run_id, public_key)
         image_volume = pve.upload(image, "import")
-        lifecycle.volumes.append(image_volume)
+        seed_volume = pve.upload(seed, "iso")
+        lifecycle.volumes.extend([image_volume, seed_volume])
         vmid = pve.next_vmid()
         lifecycle.vmid = vmid
         name = f"{RESOURCE_PREFIX}builder-{run_id}"
@@ -682,19 +660,30 @@ def build_image(args: argparse.Namespace) -> int:
             name,
             f"AiFw image builder {run_id}; expires {int(time.time()) + 4 * 3600}",
         )
-        pve.attach_imported_disk(vmid, image_volume)
-        pve.configure_builder_cloudinit(vmid, public_key)
+        # Proxmox-generated NoCloud metadata names the interface `eth0` and
+        # uses a schema FreeBSD 15's native nuageinit cannot apply. Attach our
+        # explicit v2/vtnet0 cidata seed instead.
+        pve.attach_imported_disk(vmid, image_volume, seed_volume)
         pve.resize_disk(vmid, "virtio0", args.builder_disk_size)
         pve.start(vmid)
 
         wait_command(
             private_key,
             cfg.address,
-            "test -f /var/lib/cloud/instance/boot-finished",
-            user="builder",
+            (
+                "test -s /var/cache/nuageinit/user_data && "
+                f"ifconfig vtnet0 inet | grep -F {shlex.quote(cfg.address)} && "
+                "netstat -rn -f inet | "
+                f"awk '$1 == \"default\" && $2 == {json.dumps(cfg.gateway)} "
+                "{found=1} END {exit !found}' && "
+                f"{as_root('id -u')} | grep -qx 0"
+            ),
+            user="freebsd",
             timeout=args.boot_timeout,
         )
-        copy_git_archive(private_key, cfg.address, "/home/freebsd/AiFw")
+        copy_git_archive(
+            private_key, cfg.address, "/home/freebsd/AiFw", user="freebsd"
+        )
         version = run_checked(
             [
                 "sh",
@@ -707,10 +696,10 @@ def build_image(args: argparse.Namespace) -> int:
         if not version:
             raise HarnessError("could not determine workspace version from Cargo.toml")
         remote_artifact = f"/usr/obj/aifw-iso/output/aifw-{version}-amd64.img.xz"
-        build_command = (
+        build_command = as_root(
             "cd /home/freebsd/AiFw && "
-            f"sudo -H sh freebsd/build-local.sh {shlex.quote(version)} && "
-            f"sudo test -s {shlex.quote(remote_artifact)}"
+            f"sh freebsd/build-local.sh {shlex.quote(version)} && "
+            f"test -s {shlex.quote(remote_artifact)}"
         )
         run_checked(
             ssh_command(
@@ -725,7 +714,7 @@ def build_image(args: argparse.Namespace) -> int:
                 ssh_command(
                     private_key,
                     cfg.address,
-                    f"sudo cat {shlex.quote(remote_artifact)}",
+                    as_root(f"cat {shlex.quote(remote_artifact)}"),
                     user="freebsd",
                 ),
                 stdout=handle,

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -191,16 +191,23 @@ class Proxmox:
         # Proxmox 9 imports a storage `import` volume while applying the VM
         # disk configuration. The source upload is removed during teardown.
         disk = f"{self.cfg.vm_storage}:0,import-from={volume},discard=on"
-        config = {
-            "virtio0": disk,
-            "boot": "order=virtio0",
-        }
+        config = {"virtio0": disk}
         if seed_volume is not None:
             config["ide2"] = f"{seed_volume},media=cdrom"
         upid = self.request(
             "PUT",
             f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config",
             data=config,
+        )
+        if upid:
+            self.wait_task(upid)
+        # The imported disk does not exist until the asynchronous task above
+        # finishes. Setting boot order in the same request makes PVE silently
+        # discard virtio0 from `boot` and fall back to PXE/CD-ROM.
+        upid = self.request(
+            "PUT",
+            f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config",
+            data={"boot": "order=virtio0"},
         )
         if upid:
             self.wait_task(upid)

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -624,7 +624,7 @@ def build_image(args: argparse.Namespace) -> int:
     if not all(c in "0123456789abcdef-" for c in run_id.lower()):
         raise HarnessError("run ID may contain only hexadecimal characters and hyphens")
     work_root = Path(args.work_dir)
-    work_root.mkdir(parents=True, mode=0o700)
+    work_root.mkdir(parents=True, mode=0o700, exist_ok=True)
     work_dir = work_root / f"{RESOURCE_PREFIX}{run_id}-builder"
     work_dir.mkdir(mode=0o700)
     output = Path(args.output)
@@ -727,7 +727,7 @@ def run(args: argparse.Namespace) -> int:
     output_dir = Path(args.artifacts) / run_id
     output_dir.mkdir(parents=True, mode=0o700)
     work_root = Path(args.work_dir)
-    work_root.mkdir(parents=True, mode=0o700)
+    work_root.mkdir(parents=True, mode=0o700, exist_ok=True)
     work_dir = work_root / f"{RESOURCE_PREFIX}{run_id}"
     work_dir.mkdir(mode=0o700)
     pve = Proxmox(cfg)

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -222,7 +222,9 @@ class Proxmox:
                 "ide2": f"{self.cfg.vm_storage}:cloudinit",
                 "citype": "nocloud",
                 "ciuser": "freebsd",
-                "sshkeys": public_key.strip(),
+                # Proxmox expects this field to contain a URL-encoded
+                # authorized_keys payload inside the form-encoded request.
+                "sshkeys": urllib.parse.quote(public_key.strip(), safe=""),
                 "ipconfig0": (
                     f"ip={self.cfg.address_cidr},gw={self.cfg.gateway}"
                 ),

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -250,18 +250,44 @@ class Proxmox:
 
     def delete_volume(self, volume: str) -> None:
         encoded = urllib.parse.quote(volume, safe="")
-        with contextlib.suppress(Exception):
-            upid = self.request(
-                "DELETE",
-                f"/nodes/{self.cfg.pve_node}/storage/{self.cfg.image_storage}/content/{encoded}",
-            )
-            if upid:
-                self.wait_task(upid, timeout=300)
+        upid = self.request(
+            "DELETE",
+            f"/nodes/{self.cfg.pve_node}/storage/{self.cfg.image_storage}/content/{encoded}",
+        )
+        if upid:
+            self.wait_task(upid, timeout=300)
 
     def vm_config(self, vmid: int) -> dict[str, Any]:
         return self.request(
             "GET", f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config"
         )
+
+    def vm_exists(self, vmid: int) -> bool:
+        resources = self.request("GET", "/cluster/resources", params={"type": "vm"})
+        return any(int(resource.get("vmid", -1)) == vmid for resource in resources)
+
+    def volume_exists(self, volume: str) -> bool:
+        resources = self.request(
+            "GET",
+            f"/nodes/{self.cfg.pve_node}/storage/{self.cfg.image_storage}/content",
+        )
+        return any(resource.get("volid") == volume for resource in resources)
+
+    def wait_resources_absent(
+        self, vmid: int | None, volumes: list[str], timeout: int = 60
+    ) -> None:
+        """Prove that every resource owned by this run has disappeared."""
+        deadline = time.monotonic() + timeout
+        remaining: list[str] = []
+        while time.monotonic() < deadline:
+            remaining = []
+            if vmid is not None and self.vm_exists(vmid):
+                remaining.append(f"VM {vmid}")
+            remaining.extend(volume for volume in volumes if self.volume_exists(volume))
+            if not remaining:
+                return
+            time.sleep(2)
+        raise HarnessError(f"run-owned Proxmox resources remain: {', '.join(remaining)}")
 
 
 def sha256_file(path: Path) -> str:
@@ -633,18 +659,21 @@ class Lifecycle:
         if self.keep_on_failure and self.failed:
             print(f"preserving failed VM {self.vmid} by explicit request", flush=True)
             return
-        if self.vmid is not None:
-            with contextlib.suppress(Exception):
-                config = self.pve.vm_config(self.vmid)
-                name = config.get("name", "")
-                if not name.startswith(RESOURCE_PREFIX):
-                    raise HarnessError(
-                        f"refusing to destroy VM {self.vmid} with unexpected name {name!r}"
-                    )
-                self.pve.destroy(self.vmid)
+        if self.vmid is not None and self.pve.vm_exists(self.vmid):
+            config = self.pve.vm_config(self.vmid)
+            name = config.get("name", "")
+            if not name.startswith(RESOURCE_PREFIX):
+                raise HarnessError(
+                    f"refusing to destroy VM {self.vmid} with unexpected name {name!r}"
+                )
+            self.pve.destroy(self.vmid)
         for volume in self.volumes:
-            if RESOURCE_PREFIX in volume:
+            if RESOURCE_PREFIX not in volume:
+                raise HarnessError(f"refusing to delete unexpected volume {volume!r}")
+            if self.pve.volume_exists(volume):
                 self.pve.delete_volume(volume)
+        self.pve.wait_resources_absent(self.vmid, self.volumes)
+        print("teardown verified: zero run-owned Proxmox resources", flush=True)
 
 
 def build_image(args: argparse.Namespace) -> int:
@@ -838,15 +867,24 @@ def run(args: argparse.Namespace) -> int:
         if lifecycle.vmid is not None and private_key is not None:
             with contextlib.suppress(Exception):
                 collect_diagnostics(pve, cfg, private_key, lifecycle.vmid, output_dir)
-        manifest["finished_at"] = int(time.time())
-        output_dir.joinpath("manifest.json").write_text(
-            json.dumps(manifest, indent=2, sort_keys=True) + "\n"
-        )
-        lifecycle.cleanup()
-        # Only remove the exact, prefix-validated per-run directory. This
-        # contains the private key, seed config, and decompressed source IMG.
-        if work_dir.parent == work_root and work_dir.name.startswith(RESOURCE_PREFIX):
-            shutil.rmtree(work_dir)
+        try:
+            lifecycle.cleanup()
+            manifest["teardown_verified"] = True
+        except BaseException:
+            manifest["result"] = "failed"
+            raise
+        finally:
+            manifest.setdefault("teardown_verified", False)
+            manifest["finished_at"] = int(time.time())
+            output_dir.joinpath("manifest.json").write_text(
+                json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+            )
+            # Only remove the exact, prefix-validated per-run directory. This
+            # contains the private key, seed config, and decompressed source IMG.
+            if work_dir.parent == work_root and work_dir.name.startswith(
+                RESOURCE_PREFIX
+            ):
+                shutil.rmtree(work_dir)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import contextlib
 import hashlib
 import ipaddress
@@ -12,6 +13,7 @@ import os
 import shlex
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import time
@@ -26,6 +28,11 @@ import urllib3
 from argon2 import PasswordHasher
 
 RESOURCE_PREFIX = "aifw-e2e-"
+FULL_WAN_CIDR = "198.18.0.1/24"
+FULL_WAN_HELPER = "198.18.0.2"
+FULL_LAN_CIDR = "198.19.0.1/24"
+FULL_LAN_HELPER = "198.19.0.2"
+HELPER_TEMPLATE = "local:vztmpl/debian-13-standard_13.6-1_amd64.tar.zst"
 
 
 class HarnessError(RuntimeError):
@@ -46,6 +53,8 @@ class LabConfig:
     image_storage: str
     vm_storage: str
     bridge: str
+    wan_bridge: str
+    lan_bridge: str
     verify_tls: bool
     address_cidr: str
     gateway: str
@@ -62,6 +71,8 @@ class LabConfig:
             image_storage=os.environ.get("PVE_IMAGE_STORAGE", "local"),
             vm_storage=os.environ.get("PVE_VM_STORAGE", "local-lvm"),
             bridge=os.environ.get("PVE_BRIDGE", "vmbr0"),
+            wan_bridge=os.environ.get("PVE_E2E_WAN_BRIDGE", "vmbr998"),
+            lan_bridge=os.environ.get("PVE_E2E_LAN_BRIDGE", "vmbr999"),
             verify_tls=os.environ.get("PVE_VERIFY_TLS", "true").lower()
             in ("1", "true", "yes"),
             address_cidr=required_env("AIFW_E2E_ADDRESS"),
@@ -108,7 +119,8 @@ class Proxmox:
                 "GET", f"/nodes/{self.cfg.pve_node}/tasks/{encoded}/status"
             )
             if status.get("status") == "stopped":
-                if status.get("exitstatus") != "OK":
+                exit_status = str(status.get("exitstatus", ""))
+                if exit_status != "OK" and not exit_status.startswith("WARNINGS"):
                     raise HarnessError(
                         f"Proxmox task failed: {status.get('exitstatus')} ({upid})"
                     )
@@ -118,6 +130,19 @@ class Proxmox:
 
     def next_vmid(self) -> int:
         return int(self.request("GET", "/cluster/nextid"))
+
+    def require_bridges(self, bridges: list[str]) -> None:
+        networks = self.request("GET", f"/nodes/{self.cfg.pve_node}/network")
+        available = {
+            network.get("iface")
+            for network in networks
+            if network.get("type") == "bridge" and network.get("active") == 1
+        }
+        missing = sorted(set(bridges) - available)
+        if missing:
+            raise HarnessError(
+                "required active Proxmox bridges are missing: " + ", ".join(missing)
+            )
 
     def create_vm(self, vmid: int, name: str, description: str) -> None:
         upid = self.request(
@@ -142,6 +167,95 @@ class Proxmox:
         )
         if upid:
             self.wait_task(upid)
+
+    def create_full_appliance_vm(self, vmid: int, name: str, description: str) -> None:
+        upid = self.request(
+            "POST",
+            f"/nodes/{self.cfg.pve_node}/qemu",
+            data={
+                "vmid": vmid,
+                "name": name,
+                "description": description,
+                "tags": "aifw-e2e",
+                "ostype": "other",
+                "bios": "seabios",
+                "cores": 4,
+                "memory": 4096,
+                "scsihw": "virtio-scsi-single",
+                "serial0": "socket",
+                "vga": "serial0",
+                "net0": f"virtio,bridge={self.cfg.wan_bridge},firewall=0",
+                "net1": f"virtio,bridge={self.cfg.lan_bridge},firewall=0",
+                "onboot": 0,
+                "protection": 0,
+            },
+        )
+        if upid:
+            self.wait_task(upid)
+
+    def create_helper_container(
+        self,
+        vmid: int,
+        name: str,
+        description: str,
+        public_key: str,
+        networks: list[str],
+    ) -> None:
+        config: dict[str, Any] = {
+            "vmid": vmid,
+            "hostname": name,
+            "description": description,
+            "tags": "aifw-e2e",
+            "ostemplate": HELPER_TEMPLATE,
+            "rootfs": f"{self.cfg.vm_storage}:2",
+            "cores": 1,
+            "memory": 512,
+            "swap": 0,
+            "unprivileged": 1,
+            "start": 0,
+            "onboot": 0,
+            "protection": 0,
+            "ssh-public-keys": public_key.strip(),
+        }
+        for index, network in enumerate(networks):
+            config[f"net{index}"] = network
+        upid = self.request(
+            "POST", f"/nodes/{self.cfg.pve_node}/lxc", data=config
+        )
+        if upid:
+            self.wait_task(upid)
+
+    def start_container(self, vmid: int) -> None:
+        upid = self.request(
+            "POST", f"/nodes/{self.cfg.pve_node}/lxc/{vmid}/status/start"
+        )
+        self.wait_task(upid)
+
+    def container_exists(self, vmid: int) -> bool:
+        resources = self.request("GET", "/cluster/resources", params={"type": "vm"})
+        return any(
+            int(resource.get("vmid", -1)) == vmid
+            and resource.get("type") == "lxc"
+            for resource in resources
+        )
+
+    def container_config(self, vmid: int) -> dict[str, Any]:
+        return self.request(
+            "GET", f"/nodes/{self.cfg.pve_node}/lxc/{vmid}/config"
+        )
+
+    def destroy_container(self, vmid: int) -> None:
+        with contextlib.suppress(Exception):
+            upid = self.request(
+                "POST", f"/nodes/{self.cfg.pve_node}/lxc/{vmid}/status/stop"
+            )
+            self.wait_task(upid, timeout=120)
+        upid = self.request(
+            "DELETE",
+            f"/nodes/{self.cfg.pve_node}/lxc/{vmid}",
+            params={"purge": 1, "destroy-unreferenced-disks": 1},
+        )
+        self.wait_task(upid, timeout=300)
 
     def create_builder_vm(self, vmid: int, name: str, description: str) -> None:
         upid = self.request(
@@ -333,17 +447,22 @@ def prepare_builder_image(artifact: Path, output_dir: Path, run_id: str) -> Path
 
 
 def make_seed(
-    cfg: LabConfig, output_dir: Path, run_id: str, public_key: str
+    cfg: LabConfig,
+    output_dir: Path,
+    run_id: str,
+    public_key: str,
+    full: bool = False,
 ) -> Path:
     password_hash = PasswordHasher().hash(cfg.admin_password)
+    wan_ip = FULL_WAN_CIDR if full else cfg.address_cidr
     setup = {
         "hostname": f"aifw-e2e-{run_id}",
         "wan_interface": "vtnet0",
         "wan_mode": "static",
-        "wan_ip": cfg.address_cidr,
-        "wan_gateway": cfg.gateway,
-        "lan_interface": None,
-        "lan_ip": None,
+        "wan_ip": wan_ip,
+        "wan_gateway": None if full else cfg.gateway,
+        "lan_interface": "vtnet1" if full else None,
+        "lan_ip": FULL_LAN_CIDR if full else None,
         "admin_username": "e2e-admin",
         "admin_password_hash": password_hash,
         "totp_secret": "",
@@ -352,10 +471,10 @@ def make_seed(
         "api_listen": "0.0.0.0",
         "api_port": 8080,
         "ui_enabled": True,
-        "dns_servers": [cfg.dns],
+        "dns_servers": [] if full else [cfg.dns],
         "dhcp_enabled": False,
-        "default_policy": "permissive",
-        "nat_enabled": False,
+        "default_policy": "standard" if full else "permissive",
+        "nat_enabled": full,
         "ssh_auth_method": "key_only",
         "ssh_github_user": None,
         "ssh_authorized_keys": [public_key.strip()],
@@ -374,6 +493,61 @@ def make_seed(
         [tool, "-quiet", "-V", "AIFW_SEED", "-o", str(seed), str(seed_dir)]
     )
     return seed
+
+
+HELPER_SERVER = """#!/usr/bin/env python3
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = (self.client_address[0] + "\\n").encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format, *_args):
+        return
+
+ThreadingHTTPServer(("0.0.0.0", int(sys.argv[1])), Handler).serve_forever()
+"""
+
+
+def start_helper_servers(
+    private_key: Path,
+    host: str,
+    ports: list[int],
+    jump: str | None = None,
+) -> None:
+    encoded = base64.b64encode(HELPER_SERVER.encode()).decode()
+    port_list = " ".join(str(port) for port in ports)
+    command = (
+        f"printf %s {shlex.quote(encoded)} | base64 -d > /tmp/aifw-e2e-server.py && "
+        "chmod 700 /tmp/aifw-e2e-server.py && "
+        f"for port in {port_list}; do "
+        "nohup python3 /tmp/aifw-e2e-server.py \"$port\" "
+        ">/tmp/aifw-e2e-server-\"$port\".log 2>&1 </dev/null & done"
+    )
+    run_checked(
+        ssh_command(private_key, host, command, user="root", jump=jump),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def configure_lan_helper_route(private_key: Path, host: str) -> None:
+    run_checked(
+        ssh_command(
+            private_key,
+            host,
+            "ip route replace 198.18.0.0/24 via 198.19.0.1 dev eth1",
+            user="root",
+        ),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
 
 
 def make_ssh_key(output_dir: Path) -> tuple[Path, str]:
@@ -450,9 +624,13 @@ resize_rootfs: true
 
 
 def ssh_command(
-    private_key: Path, host: str, command: str, user: str = "root"
+    private_key: Path,
+    host: str,
+    command: str,
+    user: str = "root",
+    jump: str | None = None,
 ) -> list[str]:
-    return [
+    args = [
         "ssh",
         "-i",
         str(private_key),
@@ -464,9 +642,82 @@ def ssh_command(
         "StrictHostKeyChecking=no",
         "-o",
         "UserKnownHostsFile=/dev/null",
-        f"{user}@{host}",
-        command,
     ]
+    if jump:
+        proxy = " ".join(
+            shlex.quote(value)
+            for value in [
+                "ssh",
+                "-i",
+                str(private_key),
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=10",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-W",
+                "%h:%p",
+                jump,
+            ]
+        )
+        args.extend(["-o", f"ProxyCommand={proxy}"])
+    args.extend([f"{user}@{host}", command])
+    return args
+
+
+@contextlib.contextmanager
+def ssh_tunnel(
+    private_key: Path,
+    bastion: str,
+    remote_host: str,
+    remote_port: int,
+):
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        local_port = int(probe.getsockname()[1])
+    process = subprocess.Popen(
+        [
+            "ssh",
+            "-i",
+            str(private_key),
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ExitOnForwardFailure=yes",
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-N",
+            "-L",
+            f"127.0.0.1:{local_port}:{remote_host}:{remote_port}",
+            bastion if "@" in bastion else f"root@{bastion}",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                raise HarnessError("SSH tunnel exited before becoming ready")
+            with socket.socket() as check:
+                check.settimeout(1)
+                if check.connect_ex(("127.0.0.1", local_port)) == 0:
+                    break
+            time.sleep(0.5)
+        else:
+            raise HarnessError("SSH tunnel readiness timed out")
+        yield local_port
+    finally:
+        process.terminate()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            process.wait(timeout=5)
+        if process.poll() is None:
+            process.kill()
 
 
 def wait_command(
@@ -475,11 +726,12 @@ def wait_command(
     command: str,
     user: str,
     timeout: int,
+    jump: str | None = None,
 ) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         result = subprocess.run(
-            ssh_command(private_key, host, command, user=user),
+            ssh_command(private_key, host, command, user=user, jump=jump),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
@@ -489,11 +741,21 @@ def wait_command(
     raise HarnessError(f"SSH readiness timed out for {user}@{host}")
 
 
-def wait_ssh(private_key: Path, host: str, timeout: int = 600) -> None:
+def wait_ssh(
+    private_key: Path,
+    host: str,
+    timeout: int = 600,
+    jump: str | None = None,
+) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         result = subprocess.run(
-            ssh_command(private_key, host, "test -f /usr/local/etc/aifw/aifw.conf"),
+            ssh_command(
+                private_key,
+                host,
+                "test -f /usr/local/etc/aifw/aifw.conf",
+                jump=jump,
+            ),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
@@ -536,8 +798,8 @@ def as_root(command: str) -> str:
     return f"su root -c {shlex.quote(command)}"
 
 
-def login_and_check(cfg: LabConfig) -> dict[str, Any]:
-    base = f"https://{cfg.address}:8080"
+def login_and_check(cfg: LabConfig, base: str | None = None) -> dict[str, Any]:
+    base = base or f"https://{cfg.address}:8080"
     session = requests.Session()
     session.verify = False
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -564,7 +826,254 @@ def login_and_check(cfg: LabConfig) -> dict[str, Any]:
     return data
 
 
-def appliance_checks(cfg: LabConfig, private_key: Path) -> dict[str, Any]:
+def api_session(cfg: LabConfig, base: str) -> requests.Session:
+    session = requests.Session()
+    session.verify = False
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    response = session.post(
+        f"{base}/api/v1/auth/login",
+        json={"username": "e2e-admin", "password": cfg.admin_password},
+        timeout=20,
+    )
+    response.raise_for_status()
+    session.headers["Authorization"] = (
+        f"Bearer {response.json()['tokens']['access_token']}"
+    )
+    return session
+
+
+def test_http_flow(
+    private_key: Path,
+    source_host: str,
+    destination: str,
+    expected: str | None,
+    jump: str | None = None,
+    user: str = "root",
+) -> str:
+    command = f"wget -q -T 8 -O - {shlex.quote(destination)}"
+    result = subprocess.run(
+        ssh_command(private_key, source_host, command, user=user, jump=jump),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    observed = result.stdout.strip()
+    if expected is None:
+        if result.returncode == 0:
+            raise HarnessError(f"flow unexpectedly succeeded: {destination}")
+        return "blocked"
+    if result.returncode != 0:
+        raise HarnessError(f"flow failed unexpectedly: {destination}")
+    if observed != expected:
+        raise HarnessError(
+            f"flow {destination} observed source {observed!r}, expected {expected!r}"
+        )
+    return observed
+
+
+def clear_pf_states(private_key: Path, appliance_host: str, jump: str) -> None:
+    run_checked(
+        ssh_command(private_key, appliance_host, "pfctl -F states", jump=jump),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def create_rule(
+    session: requests.Session,
+    base: str,
+    *,
+    action: str,
+    interface: str,
+    source: str,
+    destination: str,
+    port: int,
+    label: str,
+    priority: int,
+) -> str:
+    response = session.post(
+        f"{base}/api/v1/rules",
+        json={
+            "action": action,
+            "direction": "in",
+            "protocol": "tcp",
+            "src_addr": source,
+            "dst_addr": destination,
+            "dst_port_start": port,
+            "dst_port_end": port,
+            "interface": interface,
+            "ip_version": "inet",
+            "priority": priority,
+            "log": action == "block",
+            "quick": True,
+            "label": label,
+            "state_tracking": "keep_state" if action == "pass" else "none",
+            "status": "active",
+        },
+        timeout=20,
+    )
+    response.raise_for_status()
+    rule_id = response.json()["data"]["id"]
+    reload_response = session.post(f"{base}/api/v1/reload", timeout=60)
+    reload_response.raise_for_status()
+    if "Partial reload" in reload_response.json().get("message", ""):
+        raise HarnessError(reload_response.json()["message"])
+    return str(rule_id)
+
+
+def delete_rule(session: requests.Session, base: str, rule_id: str) -> None:
+    response = session.delete(f"{base}/api/v1/rules/{rule_id}", timeout=20)
+    response.raise_for_status()
+    reload_response = session.post(f"{base}/api/v1/reload", timeout=60)
+    reload_response.raise_for_status()
+    if "Partial reload" in reload_response.json().get("message", ""):
+        raise HarnessError(reload_response.json()["message"])
+
+
+def browser_checks(cfg: LabConfig, base: str, output_dir: Path) -> None:
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as error:
+        raise HarnessError("Playwright is required for full E2E browser checks") from error
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = browser.new_context(ignore_https_errors=True)
+        page = context.new_page()
+        page.goto(f"{base}/login", wait_until="networkidle")
+        page.get_by_label("Username").fill("e2e-admin")
+        page.get_by_label("Password").fill(cfg.admin_password)
+        page.get_by_role("button", name="Sign In").click()
+        page.wait_for_url(f"{base}/", timeout=30_000)
+        page.locator("h1").first.wait_for(state="visible")
+        page.goto(f"{base}/rules", wait_until="networkidle")
+        page.get_by_role("heading", name="Firewall Rules").wait_for(state="visible")
+        page.screenshot(path=str(output_dir / "rules-page.png"), full_page=True)
+        browser.close()
+
+
+def full_data_plane_checks(
+    cfg: LabConfig,
+    private_key: Path,
+    output_dir: Path,
+) -> tuple[dict[str, Any], str]:
+    jump = f"root@{cfg.address}"
+    appliance_host = FULL_LAN_CIDR.split("/", 1)[0]
+    evidence: dict[str, Any] = {}
+
+    evidence["lan_to_wan_nat_source"] = test_http_flow(
+        private_key,
+        cfg.address,
+        f"http://{FULL_WAN_HELPER}:9001/",
+        FULL_WAN_CIDR.split("/", 1)[0],
+    )
+    evidence["wan_to_lan_initial"] = test_http_flow(
+        private_key,
+        FULL_WAN_HELPER,
+        f"http://{FULL_LAN_HELPER}:9101/",
+        None,
+        jump=jump,
+    )
+
+    with ssh_tunnel(private_key, cfg.address, appliance_host, 8080) as port:
+        base = f"https://127.0.0.1:{port}"
+        session = api_session(cfg, base)
+        allow_id = create_rule(
+            session,
+            base,
+            action="pass",
+            interface="vtnet0",
+            source=FULL_WAN_HELPER,
+            destination=FULL_LAN_HELPER,
+            port=9102,
+            label="E2E allow WAN to LAN",
+            priority=-100,
+        )
+        clear_pf_states(private_key, appliance_host, jump)
+        evidence["wan_to_lan_after_allow"] = test_http_flow(
+            private_key,
+            FULL_WAN_HELPER,
+            f"http://{FULL_LAN_HELPER}:9102/",
+            FULL_WAN_HELPER,
+            jump=jump,
+        )
+
+        block_id = create_rule(
+            session,
+            base,
+            action="block",
+            interface="vtnet1",
+            source=FULL_LAN_HELPER,
+            destination=FULL_WAN_HELPER,
+            port=9003,
+            label="E2E block LAN to WAN",
+            priority=-200,
+        )
+        try:
+            clear_pf_states(private_key, appliance_host, jump)
+            evidence["lan_to_wan_after_block"] = test_http_flow(
+                private_key,
+                cfg.address,
+                f"http://{FULL_WAN_HELPER}:9003/",
+                None,
+            )
+        finally:
+            delete_rule(session, base, block_id)
+        clear_pf_states(private_key, appliance_host, jump)
+        evidence["lan_to_wan_after_delete"] = test_http_flow(
+            private_key,
+            cfg.address,
+            f"http://{FULL_WAN_HELPER}:9004/",
+            FULL_WAN_CIDR.split("/", 1)[0],
+        )
+        browser_checks(cfg, base, output_dir)
+        evidence["browser"] = "passed"
+    return evidence, allow_id
+
+
+def post_reboot_data_plane_checks(
+    cfg: LabConfig,
+    private_key: Path,
+    allow_rule_id: str,
+) -> dict[str, Any]:
+    jump = f"root@{cfg.address}"
+    appliance_host = FULL_LAN_CIDR.split("/", 1)[0]
+    evidence = {
+        "lan_to_wan_nat_source": test_http_flow(
+            private_key,
+            cfg.address,
+            f"http://{FULL_WAN_HELPER}:9002/",
+            FULL_WAN_CIDR.split("/", 1)[0],
+        ),
+        "persisted_wan_to_lan_allow": test_http_flow(
+            private_key,
+            FULL_WAN_HELPER,
+            f"http://{FULL_LAN_HELPER}:9102/",
+            FULL_WAN_HELPER,
+            jump=jump,
+        ),
+    }
+    with ssh_tunnel(private_key, cfg.address, appliance_host, 8080) as port:
+        base = f"https://127.0.0.1:{port}"
+        delete_rule(api_session(cfg, base), base, allow_rule_id)
+    clear_pf_states(private_key, appliance_host, jump)
+    evidence["wan_to_lan_after_allow_delete"] = test_http_flow(
+        private_key,
+        FULL_WAN_HELPER,
+        f"http://{FULL_LAN_HELPER}:9102/",
+        None,
+        jump=jump,
+    )
+    return evidence
+
+
+def appliance_checks(
+    cfg: LabConfig,
+    private_key: Path,
+    host: str | None = None,
+    jump: str | None = None,
+) -> dict[str, Any]:
+    host = host or cfg.address
     commands = [
         "service aifw_daemon onestatus",
         "service aifw_ids onestatus",
@@ -575,22 +1084,29 @@ def appliance_checks(cfg: LabConfig, private_key: Path) -> dict[str, Any]:
     ]
     for command in commands:
         run_checked(
-            ssh_command(private_key, cfg.address, command),
+            ssh_command(private_key, host, command, jump=jump),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
+    if jump:
+        with ssh_tunnel(private_key, jump, host, 8080) as port:
+            return login_and_check(cfg, f"https://127.0.0.1:{port}")
     return login_and_check(cfg)
 
 
 def wait_appliance_ready(
-    cfg: LabConfig, private_key: Path, timeout: int = 600
+    cfg: LabConfig,
+    private_key: Path,
+    timeout: int = 600,
+    host: str | None = None,
+    jump: str | None = None,
 ) -> dict[str, Any]:
     """Wait for the complete service/API/pf contract, not merely SSH."""
     deadline = time.monotonic() + timeout
     last_error: BaseException | None = None
     while time.monotonic() < deadline:
         try:
-            return appliance_checks(cfg, private_key)
+            return appliance_checks(cfg, private_key, host=host, jump=jump)
         except (HarnessError, requests.RequestException, subprocess.SubprocessError) as error:
             last_error = error
             time.sleep(5)
@@ -604,6 +1120,8 @@ def collect_diagnostics(
     private_key: Path,
     vmid: int,
     output_dir: Path,
+    host: str | None = None,
+    jump: str | None = None,
 ) -> None:
     with contextlib.suppress(Exception):
         safe_config = pve.vm_config(vmid)
@@ -628,7 +1146,7 @@ echo '=== dmesg ==='; dmesg
 """
     with output_dir.joinpath("appliance-diagnostics.txt").open("w") as handle:
         subprocess.run(
-            ssh_command(private_key, cfg.address, command),
+            ssh_command(private_key, host or cfg.address, command, jump=jump),
             stdout=handle,
             stderr=subprocess.STDOUT,
             text=True,
@@ -636,15 +1154,49 @@ echo '=== dmesg ==='; dmesg
         )
 
 
-def reboot_and_check(cfg: LabConfig, private_key: Path) -> dict[str, Any]:
+def collect_helper_diagnostics(
+    private_key: Path,
+    host: str,
+    output: Path,
+    jump: str | None = None,
+    user: str = "root",
+) -> None:
+    command = """set +e
+echo '=== uname ==='; uname -a
+echo '=== interfaces ==='; ip address
+echo '=== routes ==='; ip route
+echo '=== processes ==='; ps auxww
+echo '=== sockets ==='; netstat -lntp
+echo '=== cloud-init ==='; cloud-init status --long
+echo '=== cloud-init output ==='; tail -n 300 /var/log/cloud-init-output.log
+"""
+    with output.open("w") as handle:
+        subprocess.run(
+            ssh_command(private_key, host, command, user=user, jump=jump),
+            stdout=handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=60,
+        )
+
+
+def reboot_and_check(
+    cfg: LabConfig,
+    private_key: Path,
+    host: str | None = None,
+    jump: str | None = None,
+) -> dict[str, Any]:
+    host = host or cfg.address
     subprocess.run(
-        ssh_command(private_key, cfg.address, "shutdown -r now"),
+        ssh_command(private_key, host, "shutdown -r now", jump=jump),
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
     time.sleep(10)
-    wait_ssh(private_key, cfg.address, timeout=600)
-    return wait_appliance_ready(cfg, private_key, timeout=600)
+    wait_ssh(private_key, host, timeout=600, jump=jump)
+    return wait_appliance_ready(
+        cfg, private_key, timeout=600, host=host, jump=jump
+    )
 
 
 class Lifecycle:
@@ -652,6 +1204,8 @@ class Lifecycle:
         self.pve = pve
         self.keep_on_failure = keep_on_failure
         self.vmid: int | None = None
+        self.additional_vmids: list[int] = []
+        self.container_vmids: list[int] = []
         self.volumes: list[str] = []
         self.failed = False
 
@@ -659,20 +1213,37 @@ class Lifecycle:
         if self.keep_on_failure and self.failed:
             print(f"preserving failed VM {self.vmid} by explicit request", flush=True)
             return
-        if self.vmid is not None and self.pve.vm_exists(self.vmid):
-            config = self.pve.vm_config(self.vmid)
+        vmids = self.additional_vmids + ([self.vmid] if self.vmid is not None else [])
+        for vmid in self.container_vmids:
+            if not self.pve.container_exists(vmid):
+                continue
+            config = self.pve.container_config(vmid)
+            name = config.get("hostname", "")
+            if not name.startswith(RESOURCE_PREFIX):
+                raise HarnessError(
+                    f"refusing to destroy container {vmid} with unexpected name {name!r}"
+                )
+            self.pve.destroy_container(vmid)
+        for vmid in vmids:
+            if not self.pve.vm_exists(vmid):
+                continue
+            config = self.pve.vm_config(vmid)
             name = config.get("name", "")
             if not name.startswith(RESOURCE_PREFIX):
                 raise HarnessError(
-                    f"refusing to destroy VM {self.vmid} with unexpected name {name!r}"
+                    f"refusing to destroy VM {vmid} with unexpected name {name!r}"
                 )
-            self.pve.destroy(self.vmid)
+            self.pve.destroy(vmid)
         for volume in self.volumes:
             if RESOURCE_PREFIX not in volume:
                 raise HarnessError(f"refusing to delete unexpected volume {volume!r}")
             if self.pve.volume_exists(volume):
                 self.pve.delete_volume(volume)
-        self.pve.wait_resources_absent(self.vmid, self.volumes)
+        for vmid in vmids:
+            self.pve.wait_resources_absent(vmid, self.volumes if vmid == self.vmid else [])
+        for vmid in self.container_vmids:
+            if self.pve.container_exists(vmid):
+                raise HarnessError(f"run-owned Proxmox container remains: {vmid}")
         print("teardown verified: zero run-owned Proxmox resources", flush=True)
 
 
@@ -887,6 +1458,262 @@ def run(args: argparse.Namespace) -> int:
                 shutil.rmtree(work_dir)
 
 
+def run_full(args: argparse.Namespace) -> int:
+    cfg = LabConfig.from_env()
+    run_id = args.run_id or uuid.uuid4().hex[:10]
+    if not all(c in "0123456789abcdef-" for c in run_id.lower()):
+        raise HarnessError("run ID may contain only hexadecimal characters and hyphens")
+    output_dir = Path(args.artifacts) / run_id
+    output_dir.mkdir(parents=True, mode=0o700)
+    work_root = Path(args.work_dir)
+    work_root.mkdir(parents=True, mode=0o700, exist_ok=True)
+    work_dir = work_root / f"{RESOURCE_PREFIX}{run_id}-full"
+    work_dir.mkdir(mode=0o700)
+    pve = Proxmox(cfg)
+    lifecycle = Lifecycle(pve, args.keep_on_failure)
+    private_key: Path | None = None
+    appliance_vmid: int | None = None
+    helper_vmids: dict[str, int] = {}
+
+    def handle_signal(signum: int, _frame: Any) -> None:
+        lifecycle.failed = True
+        raise KeyboardInterrupt(f"received signal {signum}")
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    manifest: dict[str, Any] = {
+        "run_id": run_id,
+        "artifact": Path(args.artifact).name,
+        "artifact_sha256": sha256_file(Path(args.artifact)),
+        "helper_template": HELPER_TEMPLATE,
+        "started_at": int(time.time()),
+        "network_scope": "isolated-wan-lan-full",
+        "topology": {
+            "management": f"{cfg.bridge}:{cfg.address_cidr}",
+            "wan": f"{cfg.wan_bridge}:198.18.0.0/24",
+            "lan": f"{cfg.lan_bridge}:198.19.0.0/24",
+        },
+    }
+    try:
+        pve.require_bridges([cfg.bridge, cfg.wan_bridge, cfg.lan_bridge])
+        private_key, public_key = make_ssh_key(work_dir)
+        appliance_seed = make_seed(cfg, work_dir, run_id, public_key, full=True)
+        appliance_image = prepare_image(Path(args.artifact), work_dir, run_id)
+        appliance_image_volume = pve.upload(appliance_image, "import")
+        appliance_seed_volume = pve.upload(appliance_seed, "iso")
+        lifecycle.volumes.extend(
+            [
+                appliance_image_volume,
+                appliance_seed_volume,
+            ]
+        )
+
+        lan_vmid = pve.next_vmid()
+        pve.create_helper_container(
+            lan_vmid,
+            f"{RESOURCE_PREFIX}lan-{run_id}",
+            f"AiFw E2E LAN helper {run_id}; expires {int(time.time()) + 4 * 3600}",
+            public_key,
+            [
+                f"name=eth0,bridge={cfg.bridge},firewall=0,ip={cfg.address_cidr},gw={cfg.gateway},type=veth",
+                f"name=eth1,bridge={cfg.lan_bridge},firewall=0,ip={FULL_LAN_HELPER}/24,type=veth",
+            ],
+        )
+        lifecycle.container_vmids.append(lan_vmid)
+        helper_vmids["lan"] = lan_vmid
+
+        wan_vmid = pve.next_vmid()
+        pve.create_helper_container(
+            wan_vmid,
+            f"{RESOURCE_PREFIX}wan-{run_id}",
+            f"AiFw E2E WAN helper {run_id}; expires {int(time.time()) + 4 * 3600}",
+            public_key,
+            [f"name=eth0,bridge={cfg.wan_bridge},firewall=0,ip={FULL_WAN_HELPER}/24,gw={FULL_WAN_CIDR.split('/', 1)[0]},type=veth"],
+        )
+        lifecycle.container_vmids.append(wan_vmid)
+        helper_vmids["wan"] = wan_vmid
+
+        appliance_vmid = pve.next_vmid()
+        lifecycle.vmid = appliance_vmid
+        pve.create_full_appliance_vm(
+            appliance_vmid,
+            f"{RESOURCE_PREFIX}{run_id}",
+            f"AiFw full E2E run {run_id}; expires {int(time.time()) + 4 * 3600}",
+        )
+        pve.attach_imported_disk(
+            appliance_vmid, appliance_image_volume, appliance_seed_volume
+        )
+        manifest["vmids"] = {
+            "appliance": appliance_vmid,
+            "lan_helper": lan_vmid,
+            "wan_helper": wan_vmid,
+        }
+
+        pve.start_container(lan_vmid)
+        wait_command(
+            private_key,
+            cfg.address,
+            "test -x /usr/bin/python3",
+            user="root",
+            timeout=args.boot_timeout,
+        )
+        configure_lan_helper_route(private_key, cfg.address)
+        start_helper_servers(private_key, cfg.address, [9101, 9102, 9103, 9104])
+        pve.start_container(wan_vmid)
+        pve.start(appliance_vmid)
+        jump = f"root@{cfg.address}"
+        appliance_host = FULL_LAN_CIDR.split("/", 1)[0]
+        wait_ssh(
+            private_key,
+            appliance_host,
+            timeout=args.boot_timeout,
+            jump=jump,
+        )
+        wait_command(
+            private_key,
+            FULL_WAN_HELPER,
+            "test -x /usr/bin/python3",
+            user="root",
+            timeout=args.boot_timeout,
+            jump=jump,
+        )
+        start_helper_servers(
+            private_key,
+            FULL_WAN_HELPER,
+            [9001, 9002, 9003, 9004],
+            jump=jump,
+        )
+        manifest["initial_status"] = wait_appliance_ready(
+            cfg,
+            private_key,
+            timeout=args.boot_timeout,
+            host=appliance_host,
+            jump=jump,
+        )
+        data_plane, allow_rule_id = full_data_plane_checks(
+            cfg, private_key, output_dir
+        )
+        manifest["initial_data_plane"] = data_plane
+        manifest["post_reboot_status"] = reboot_and_check(
+            cfg, private_key, host=appliance_host, jump=jump
+        )
+        manifest["post_reboot_data_plane"] = post_reboot_data_plane_checks(
+            cfg, private_key, allow_rule_id
+        )
+        manifest["result"] = "passed"
+        return 0
+    except BaseException:
+        lifecycle.failed = True
+        manifest["result"] = "failed"
+        raise
+    finally:
+        if appliance_vmid is not None and private_key is not None:
+            with contextlib.suppress(Exception):
+                collect_diagnostics(
+                    pve,
+                    cfg,
+                    private_key,
+                    appliance_vmid,
+                    output_dir,
+                    host=FULL_LAN_CIDR.split("/", 1)[0],
+                    jump=f"root@{cfg.address}",
+                )
+            with contextlib.suppress(Exception):
+                collect_helper_diagnostics(
+                    private_key,
+                    cfg.address,
+                    output_dir / "lan-helper-diagnostics.txt",
+                    user="root",
+                )
+            with contextlib.suppress(Exception):
+                collect_helper_diagnostics(
+                    private_key,
+                    FULL_WAN_HELPER,
+                    output_dir / "wan-helper-diagnostics.txt",
+                    jump=f"root@{cfg.address}",
+                    user="root",
+                )
+        try:
+            lifecycle.cleanup()
+            manifest["teardown_verified"] = True
+        except BaseException:
+            manifest["result"] = "failed"
+            raise
+        finally:
+            manifest.setdefault("teardown_verified", False)
+            manifest["finished_at"] = int(time.time())
+            output_dir.joinpath("manifest.json").write_text(
+                json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+            )
+            if work_dir.parent == work_root and work_dir.name.startswith(
+                RESOURCE_PREFIX
+            ):
+                shutil.rmtree(work_dir)
+
+
+def check_helper(args: argparse.Namespace) -> int:
+    """Focused, disposable validation of the Linux helper substrate."""
+    cfg = LabConfig.from_env()
+    run_id = args.run_id or uuid.uuid4().hex[:10]
+    if not all(c in "0123456789abcdef-" for c in run_id.lower()):
+        raise HarnessError("run ID may contain only hexadecimal characters and hyphens")
+    work_root = Path(args.work_dir)
+    work_root.mkdir(parents=True, mode=0o700, exist_ok=True)
+    work_dir = work_root / f"{RESOURCE_PREFIX}{run_id}-helper-check"
+    work_dir.mkdir(mode=0o700)
+    pve = Proxmox(cfg)
+    lifecycle = Lifecycle(pve, keep_on_failure=False)
+    try:
+        pve.require_bridges([cfg.bridge, cfg.lan_bridge])
+        private_key, public_key = make_ssh_key(work_dir)
+        vmid = pve.next_vmid()
+        pve.create_helper_container(
+            vmid,
+            f"{RESOURCE_PREFIX}helper-{run_id}",
+            f"AiFw focused helper check {run_id}; expires {int(time.time()) + 3600}",
+            public_key,
+            [
+                f"name=eth0,bridge={cfg.bridge},firewall=0,ip={cfg.address_cidr},gw={cfg.gateway},type=veth",
+                f"name=eth1,bridge={cfg.lan_bridge},firewall=0,ip={FULL_LAN_HELPER}/24,type=veth",
+            ],
+        )
+        lifecycle.container_vmids.append(vmid)
+        pve.start_container(vmid)
+        wait_command(
+            private_key,
+            cfg.address,
+            (
+                f"ip -4 addr show eth0 | grep -F {shlex.quote(cfg.address_cidr)} && "
+                "ip -4 addr show eth1 | grep -F 198.19.0.2/24 && "
+                f"ip route | grep -F 'default via {cfg.gateway} dev eth0'"
+            ),
+            user="root",
+            timeout=args.boot_timeout,
+        )
+        configure_lan_helper_route(private_key, cfg.address)
+        start_helper_servers(private_key, cfg.address, [9101])
+        test_http_flow(
+            private_key,
+            cfg.address,
+            "http://127.0.0.1:9101/",
+            "127.0.0.1",
+        )
+        print("focused helper boot/network/SSH/server check passed", flush=True)
+        return 0
+    except BaseException:
+        lifecycle.failed = True
+        raise
+    finally:
+        try:
+            lifecycle.cleanup()
+        finally:
+            if work_dir.parent == work_root and work_dir.name.startswith(
+                RESOURCE_PREFIX
+            ):
+                shutil.rmtree(work_dir)
+
+
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     sub = result.add_subparsers(dest="command", required=True)
@@ -897,6 +1724,21 @@ def parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--run-id")
     run_parser.add_argument("--boot-timeout", type=int, default=900)
     run_parser.add_argument("--keep-on-failure", action="store_true")
+    full_parser = sub.add_parser(
+        "full", help="run the isolated WAN/LAN Proxmox lifecycle"
+    )
+    full_parser.add_argument("--artifact", required=True)
+    full_parser.add_argument("--artifacts", default="e2e/artifacts")
+    full_parser.add_argument("--work-dir", default="e2e/.run")
+    full_parser.add_argument("--run-id")
+    full_parser.add_argument("--boot-timeout", type=int, default=900)
+    full_parser.add_argument("--keep-on-failure", action="store_true")
+    helper_parser = sub.add_parser(
+        "check-helper", help="run a focused disposable Linux helper check"
+    )
+    helper_parser.add_argument("--work-dir", default="e2e/.run")
+    helper_parser.add_argument("--run-id")
+    helper_parser.add_argument("--boot-timeout", type=int, default=300)
     build_parser = sub.add_parser(
         "build", help="build an AiFw IMG in an ephemeral Proxmox FreeBSD VM"
     )
@@ -914,6 +1756,10 @@ def main() -> int:
     try:
         if args.command == "run":
             return run(args)
+        if args.command == "full":
+            return run_full(args)
+        if args.command == "check-helper":
+            return check_helper(args)
         if args.command == "build":
             return build_image(args)
     except HarnessError as error:

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -8,6 +8,7 @@ import contextlib
 import hashlib
 import json
 import os
+import shlex
 import shutil
 import signal
 import subprocess
@@ -141,6 +142,31 @@ class Proxmox:
         if upid:
             self.wait_task(upid)
 
+    def create_builder_vm(self, vmid: int, name: str, description: str) -> None:
+        upid = self.request(
+            "POST",
+            f"/nodes/{self.cfg.pve_node}/qemu",
+            data={
+                "vmid": vmid,
+                "name": name,
+                "description": description,
+                "tags": "aifw-e2e",
+                "ostype": "other",
+                "bios": "seabios",
+                "cpu": "host",
+                "cores": 8,
+                "memory": 12288,
+                "scsihw": "virtio-scsi-single",
+                "serial0": "socket",
+                "vga": "serial0",
+                "net0": f"virtio,bridge={self.cfg.bridge},firewall=1",
+                "onboot": 0,
+                "protection": 0,
+            },
+        )
+        if upid:
+            self.wait_task(upid)
+
     def upload(self, path: Path, content: str) -> str:
         checksum = sha256_file(path)
         with path.open("rb") as handle:
@@ -174,6 +200,15 @@ class Proxmox:
             "PUT",
             f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config",
             data=config,
+        )
+        if upid:
+            self.wait_task(upid)
+
+    def resize_disk(self, vmid: int, disk: str, size: str) -> None:
+        upid = self.request(
+            "PUT",
+            f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/resize",
+            data={"disk": disk, "size": size},
         )
         if upid:
             self.wait_task(upid)
@@ -249,6 +284,20 @@ def prepare_image(artifact: Path, output_dir: Path, run_id: str) -> Path:
     return image
 
 
+def prepare_builder_image(artifact: Path, output_dir: Path, run_id: str) -> Path:
+    if not artifact.is_file():
+        raise HarnessError(f"builder image does not exist: {artifact}")
+    image = output_dir / f"{RESOURCE_PREFIX}{run_id}-builder.qcow2"
+    if "".join(artifact.suffixes).endswith(".qcow2.xz"):
+        with image.open("wb") as out:
+            subprocess.run(["xz", "-dc", str(artifact)], check=True, stdout=out)
+    elif artifact.suffix == ".qcow2":
+        shutil.copyfile(artifact, image)
+    else:
+        raise HarnessError("builder image must be a .qcow2 or .qcow2.xz file")
+    return image
+
+
 def make_seed(
     cfg: LabConfig, output_dir: Path, run_id: str, public_key: str
 ) -> Path:
@@ -312,7 +361,65 @@ def make_ssh_key(output_dir: Path) -> tuple[Path, str]:
     return private_key, private_key.with_suffix(".pub").read_text()
 
 
-def ssh_command(private_key: Path, host: str, command: str) -> list[str]:
+def make_builder_seed(
+    cfg: LabConfig, output_dir: Path, run_id: str, public_key: str
+) -> Path:
+    seed_dir = output_dir / "builder-seed"
+    seed_dir.mkdir(mode=0o700)
+    user_data = f"""#cloud-config
+hostname: aifw-builder-{run_id}
+disable_root: true
+ssh_pwauth: false
+users:
+  - default
+  - name: builder
+    gecos: AiFw CI Builder
+    groups: wheel
+    shell: /bin/sh
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - {public_key.strip()}
+growpart:
+  mode: auto
+  devices: ['/']
+resize_rootfs: true
+"""
+    network_data = {
+        "version": 2,
+        "ethernets": {
+            "vtnet0": {
+                "match": {"name": "vtnet0"},
+                "addresses": [cfg.address_cidr],
+                "routes": [{"to": "default", "via": cfg.gateway}],
+                "nameservers": {"addresses": [cfg.dns]},
+            }
+        },
+    }
+    (seed_dir / "user-data").write_text(user_data)
+    (seed_dir / "meta-data").write_text(
+        json.dumps(
+            {
+                "instance-id": f"aifw-builder-{run_id}",
+                "local-hostname": f"aifw-builder-{run_id}",
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    (seed_dir / "network-config").write_text(
+        json.dumps(network_data, indent=2) + "\n"
+    )
+    seed = output_dir / f"{RESOURCE_PREFIX}{run_id}-builder-seed.iso"
+    tool = shutil.which("xorrisofs") or shutil.which("genisoimage")
+    if not tool:
+        raise HarnessError("xorrisofs or genisoimage is required to create seed media")
+    run_checked([tool, "-quiet", "-V", "cidata", "-o", str(seed), str(seed_dir)])
+    return seed
+
+
+def ssh_command(
+    private_key: Path, host: str, command: str, user: str = "root"
+) -> list[str]:
     return [
         "ssh",
         "-i",
@@ -325,9 +432,29 @@ def ssh_command(private_key: Path, host: str, command: str) -> list[str]:
         "StrictHostKeyChecking=no",
         "-o",
         "UserKnownHostsFile=/dev/null",
-        f"root@{host}",
+        f"{user}@{host}",
         command,
     ]
+
+
+def wait_command(
+    private_key: Path,
+    host: str,
+    command: str,
+    user: str,
+    timeout: int,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            ssh_command(private_key, host, command, user=user),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if result.returncode == 0:
+            return
+        time.sleep(5)
+    raise HarnessError(f"SSH readiness timed out for {user}@{host}")
 
 
 def wait_ssh(private_key: Path, host: str, timeout: int = 600) -> None:
@@ -342,6 +469,32 @@ def wait_ssh(private_key: Path, host: str, timeout: int = 600) -> None:
             return
         time.sleep(5)
     raise HarnessError(f"SSH/setup readiness timed out for {host}")
+
+
+def copy_git_archive(private_key: Path, host: str, destination: str) -> None:
+    run_checked(
+        ssh_command(
+            private_key,
+            host,
+            f"mkdir -p {shlex.quote(destination)}",
+            user="builder",
+        )
+    )
+    archive = subprocess.Popen(["git", "archive", "--format=tar", "HEAD"], stdout=subprocess.PIPE)
+    assert archive.stdout is not None
+    unpack = subprocess.run(
+        ssh_command(
+            private_key,
+            host,
+            f"tar -xf - -C {shlex.quote(destination)}",
+            user="builder",
+        ),
+        stdin=archive.stdout,
+    )
+    archive.stdout.close()
+    archive_status = archive.wait()
+    if archive_status != 0 or unpack.returncode != 0:
+        raise HarnessError("failed to copy the checked-out commit to the builder VM")
 
 
 def login_and_check(cfg: LabConfig) -> dict[str, Any]:
@@ -465,6 +618,107 @@ class Lifecycle:
                 self.pve.delete_volume(volume)
 
 
+def build_image(args: argparse.Namespace) -> int:
+    cfg = LabConfig.from_env()
+    run_id = args.run_id or uuid.uuid4().hex[:10]
+    if not all(c in "0123456789abcdef-" for c in run_id.lower()):
+        raise HarnessError("run ID may contain only hexadecimal characters and hyphens")
+    work_root = Path(args.work_dir)
+    work_root.mkdir(parents=True, mode=0o700)
+    work_dir = work_root / f"{RESOURCE_PREFIX}{run_id}-builder"
+    work_dir.mkdir(mode=0o700)
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    pve = Proxmox(cfg)
+    lifecycle = Lifecycle(pve, keep_on_failure=False)
+
+    def handle_signal(signum: int, _frame: Any) -> None:
+        lifecycle.failed = True
+        raise KeyboardInterrupt(f"received signal {signum}")
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    try:
+        private_key, public_key = make_ssh_key(work_dir)
+        seed = make_builder_seed(cfg, work_dir, run_id, public_key)
+        image = prepare_builder_image(Path(args.builder_image), work_dir, run_id)
+        image_volume = pve.upload(image, "import")
+        seed_volume = pve.upload(seed, "iso")
+        lifecycle.volumes.extend([image_volume, seed_volume])
+        vmid = pve.next_vmid()
+        lifecycle.vmid = vmid
+        name = f"{RESOURCE_PREFIX}builder-{run_id}"
+        pve.create_builder_vm(
+            vmid,
+            name,
+            f"AiFw image builder {run_id}; expires {int(time.time()) + 4 * 3600}",
+        )
+        pve.attach_imported_disk(vmid, image_volume, seed_volume)
+        pve.resize_disk(vmid, "virtio0", args.builder_disk_size)
+        pve.start(vmid)
+
+        wait_command(
+            private_key,
+            cfg.address,
+            "test -f /var/lib/cloud/instance/boot-finished",
+            user="builder",
+            timeout=args.boot_timeout,
+        )
+        copy_git_archive(private_key, cfg.address, "/home/builder/AiFw")
+        version = run_checked(
+            [
+                "sh",
+                "-c",
+                "sed -n 's/^version = \"\\([^\"]*\\)\"/\\1/p' Cargo.toml | head -n 1",
+            ],
+            cwd=Path.cwd(),
+            capture_output=True,
+        ).stdout.strip()
+        if not version:
+            raise HarnessError("could not determine workspace version from Cargo.toml")
+        remote_artifact = f"/usr/obj/aifw-iso/output/aifw-{version}-amd64.img.xz"
+        build_command = (
+            "cd /home/builder/AiFw && "
+            f"sudo -H sh freebsd/build-local.sh {shlex.quote(version)} && "
+            f"sudo test -s {shlex.quote(remote_artifact)}"
+        )
+        run_checked(
+            ssh_command(
+                private_key,
+                cfg.address,
+                build_command,
+                user="builder",
+            )
+        )
+        with output.open("wb") as handle:
+            result = subprocess.run(
+                ssh_command(
+                    private_key,
+                    cfg.address,
+                    f"sudo cat {shlex.quote(remote_artifact)}",
+                    user="builder",
+                ),
+                stdout=handle,
+            )
+        if result.returncode != 0 or not output.is_file() or output.stat().st_size == 0:
+            raise HarnessError("failed to copy the built IMG from the builder VM")
+        output.with_suffix(output.suffix + ".sha256").write_text(
+            f"{sha256_file(output)}  {output.name}\n"
+        )
+        print(f"built {output} ({output.stat().st_size} bytes)", flush=True)
+        return 0
+    except BaseException:
+        lifecycle.failed = True
+        raise
+    finally:
+        try:
+            lifecycle.cleanup()
+        finally:
+            if work_dir.parent == work_root and work_dir.name.startswith(RESOURCE_PREFIX):
+                shutil.rmtree(work_dir, ignore_errors=True)
+
+
 def run(args: argparse.Namespace) -> int:
     cfg = LabConfig.from_env()
     run_id = args.run_id or uuid.uuid4().hex[:10]
@@ -548,6 +802,15 @@ def parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--run-id")
     run_parser.add_argument("--boot-timeout", type=int, default=900)
     run_parser.add_argument("--keep-on-failure", action="store_true")
+    build_parser = sub.add_parser(
+        "build", help="build an AiFw IMG in an ephemeral Proxmox FreeBSD VM"
+    )
+    build_parser.add_argument("--builder-image", required=True)
+    build_parser.add_argument("--output", required=True)
+    build_parser.add_argument("--work-dir", default="e2e/.run")
+    build_parser.add_argument("--run-id")
+    build_parser.add_argument("--boot-timeout", type=int, default=900)
+    build_parser.add_argument("--builder-disk-size", default="+40G")
     return result
 
 
@@ -556,6 +819,8 @@ def main() -> int:
     try:
         if args.command == "run":
             return run(args)
+        if args.command == "build":
+            return build_image(args)
     except HarnessError as error:
         print(f"E2E ERROR: {error}", file=sys.stderr)
         return 1

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import hashlib
+import ipaddress
 import json
 import os
 import shlex
@@ -213,6 +214,25 @@ class Proxmox:
         if upid:
             self.wait_task(upid)
 
+    def configure_builder_cloudinit(self, vmid: int, public_key: str) -> None:
+        upid = self.request(
+            "PUT",
+            f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config",
+            data={
+                "ide2": f"{self.cfg.vm_storage}:cloudinit",
+                "citype": "nocloud",
+                "ciuser": "freebsd",
+                "sshkeys": public_key.strip(),
+                "ipconfig0": (
+                    f"ip={self.cfg.address_cidr},gw={self.cfg.gateway}"
+                ),
+                "nameserver": self.cfg.dns,
+                "searchdomain": "local",
+            },
+        )
+        if upid:
+            self.wait_task(upid)
+
     def start(self, vmid: int) -> None:
         upid = self.request(
             "POST", f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/status/start"
@@ -384,16 +404,24 @@ growpart:
   devices: ['/']
 resize_rootfs: true
 """
+    interface = ipaddress.ip_interface(cfg.address_cidr)
     network_data = {
-        "version": 2,
-        "ethernets": {
-            "vtnet0": {
-                "match": {"name": "vtnet0"},
-                "addresses": [cfg.address_cidr],
-                "routes": [{"to": "default", "via": cfg.gateway}],
-                "nameservers": {"addresses": [cfg.dns]},
+        "version": 1,
+        "config": [
+            {
+                "type": "physical",
+                "name": "vtnet0",
+                "subnets": [
+                    {
+                        "type": "static",
+                        "address": str(interface.ip),
+                        "netmask": str(interface.network.netmask),
+                        "gateway": cfg.gateway,
+                        "dns_nameservers": [cfg.dns],
+                    }
+                ],
             }
-        },
+        ],
     }
     (seed_dir / "user-data").write_text(user_data)
     (seed_dir / "meta-data").write_text(
@@ -641,11 +669,9 @@ def build_image(args: argparse.Namespace) -> int:
 
     try:
         private_key, public_key = make_ssh_key(work_dir)
-        seed = make_builder_seed(cfg, work_dir, run_id, public_key)
         image = prepare_builder_image(Path(args.builder_image), work_dir, run_id)
         image_volume = pve.upload(image, "import")
-        seed_volume = pve.upload(seed, "iso")
-        lifecycle.volumes.extend([image_volume, seed_volume])
+        lifecycle.volumes.append(image_volume)
         vmid = pve.next_vmid()
         lifecycle.vmid = vmid
         name = f"{RESOURCE_PREFIX}builder-{run_id}"
@@ -654,7 +680,8 @@ def build_image(args: argparse.Namespace) -> int:
             name,
             f"AiFw image builder {run_id}; expires {int(time.time()) + 4 * 3600}",
         )
-        pve.attach_imported_disk(vmid, image_volume, seed_volume)
+        pve.attach_imported_disk(vmid, image_volume)
+        pve.configure_builder_cloudinit(vmid, public_key)
         pve.resize_disk(vmid, "virtio0", args.builder_disk_size)
         pve.start(vmid)
 
@@ -665,7 +692,7 @@ def build_image(args: argparse.Namespace) -> int:
             user="builder",
             timeout=args.boot_timeout,
         )
-        copy_git_archive(private_key, cfg.address, "/home/builder/AiFw")
+        copy_git_archive(private_key, cfg.address, "/home/freebsd/AiFw")
         version = run_checked(
             [
                 "sh",
@@ -679,7 +706,7 @@ def build_image(args: argparse.Namespace) -> int:
             raise HarnessError("could not determine workspace version from Cargo.toml")
         remote_artifact = f"/usr/obj/aifw-iso/output/aifw-{version}-amd64.img.xz"
         build_command = (
-            "cd /home/builder/AiFw && "
+            "cd /home/freebsd/AiFw && "
             f"sudo -H sh freebsd/build-local.sh {shlex.quote(version)} && "
             f"sudo test -s {shlex.quote(remote_artifact)}"
         )
@@ -688,7 +715,7 @@ def build_image(args: argparse.Namespace) -> int:
                 private_key,
                 cfg.address,
                 build_command,
-                user="builder",
+                user="freebsd",
             )
         )
         with output.open("wb") as handle:
@@ -697,7 +724,7 @@ def build_image(args: argparse.Namespace) -> int:
                     private_key,
                     cfg.address,
                     f"sudo cat {shlex.quote(remote_artifact)}",
-                    user="builder",
+                    user="freebsd",
                 ),
                 stdout=handle,
             )

--- a/e2e/lab.example.env
+++ b/e2e/lab.example.env
@@ -1,0 +1,13 @@
+# Non-secret Proxmox lab settings. Credentials belong in Woodpecker secrets.
+PVE_URL=https://proxmox.example:8006
+PVE_NODE=pve
+PVE_IMAGE_STORAGE=local
+PVE_VM_STORAGE=local-lvm
+PVE_BRIDGE=vmbr0
+PVE_VERIFY_TLS=true
+
+# Static management address reserved for this run. The initial smoke lane uses
+# one NIC; add isolated WAN/LAN bridges before enabling routed data-plane tests.
+AIFW_E2E_ADDRESS=192.0.2.10/24
+AIFW_E2E_GATEWAY=192.0.2.1
+AIFW_E2E_DNS=192.0.2.1

--- a/e2e/lab.example.env
+++ b/e2e/lab.example.env
@@ -11,3 +11,8 @@ PVE_VERIFY_TLS=true
 AIFW_E2E_ADDRESS=192.0.2.10/24
 AIFW_E2E_GATEWAY=192.0.2.1
 AIFW_E2E_DNS=192.0.2.1
+
+# Current homelab deployment (documentation only; keep this example portable):
+# node=trigproxmox, bridge=vmbr0, address=192.168.0.26/23,
+# gateway/dns=192.168.0.1. Never add token IDs, token secrets, passwords, or
+# private keys to this file.

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,0 +1,3 @@
+pytest==8.4.1
+requests==2.32.4
+argon2-cffi==25.1.0

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,3 +1,4 @@
 pytest==8.4.1
 requests==2.32.4
 argon2-cffi==25.1.0
+playwright==1.61.0

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -6,6 +6,8 @@ from argon2 import PasswordHasher
 from e2e.aifw_e2e import (
     HarnessError,
     LabConfig,
+    Proxmox,
+    build_image,
     make_builder_seed,
     make_seed,
     prepare_builder_image,
@@ -112,3 +114,31 @@ def test_builder_seed_uses_reserved_address_and_public_key(
     assert "192.0.2.10/24" in network
     assert "192.0.2.1" in network
     assert seed.read_bytes() == b"fake builder seed"
+
+
+def test_build_accepts_precreated_work_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import argparse
+
+    work_root = tmp_path / ".run"
+    work_root.mkdir()
+    builder_image = tmp_path / "builder.qcow2"
+    builder_image.write_bytes(b"builder")
+    monkeypatch.setattr(LabConfig, "from_env", classmethod(lambda _cls: config()))
+    monkeypatch.setattr(Proxmox, "upload", lambda *_args, **_kwargs: (_ for _ in ()).throw(HarnessError("stop after setup")))
+
+    args = argparse.Namespace(
+        run_id="abc123",
+        work_dir=str(work_root),
+        output=str(tmp_path / "aifw.img.xz"),
+        builder_image=str(builder_image),
+        builder_disk_size="+40G",
+        boot_timeout=1,
+    )
+    monkeypatch.setattr("e2e.aifw_e2e.make_ssh_key", lambda path: (path / "key", "ssh-ed25519 test"))
+    monkeypatch.setattr("e2e.aifw_e2e.make_builder_seed", lambda _cfg, path, _run, _key: path / "seed.iso")
+    monkeypatch.setattr("e2e.aifw_e2e.prepare_builder_image", lambda _src, path, _run: path / "builder.qcow2")
+
+    with pytest.raises(HarnessError, match="stop after setup"):
+        build_image(args)

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -3,7 +3,14 @@ from pathlib import Path
 import pytest
 from argon2 import PasswordHasher
 
-from e2e.aifw_e2e import HarnessError, LabConfig, make_seed, prepare_image
+from e2e.aifw_e2e import (
+    HarnessError,
+    LabConfig,
+    make_builder_seed,
+    make_seed,
+    prepare_builder_image,
+    prepare_image,
+)
 
 
 def config(password: str = "temporary-test-password") -> LabConfig:
@@ -28,6 +35,13 @@ def test_prepare_image_rejects_non_image(tmp_path: Path) -> None:
     artifact.write_text("not an image")
     with pytest.raises(HarnessError, match="must be an .img"):
         prepare_image(artifact, tmp_path, "abc123")
+
+
+def test_prepare_builder_image_rejects_non_qcow2(tmp_path: Path) -> None:
+    artifact = tmp_path / "builder.raw.xz"
+    artifact.write_bytes(b"not a builder")
+    with pytest.raises(HarnessError, match="must be a .qcow2"):
+        prepare_builder_image(artifact, tmp_path, "abc123")
 
 
 def test_seed_uses_argon2_and_excludes_plaintext(
@@ -75,3 +89,26 @@ def test_seed_has_only_one_management_interface(
     assert setup["wan_interface"] == "vtnet0"
     assert setup["lan_interface"] is None
     assert setup["default_policy"] == "permissive"
+
+
+def test_builder_seed_uses_reserved_address_and_public_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("e2e.aifw_e2e.shutil.which", lambda _name: "/usr/bin/xorrisofs")
+
+    def fake_run(args: list[str], **_kwargs: object) -> object:
+        Path(args[args.index("-o") + 1]).write_bytes(b"fake builder seed")
+        return object()
+
+    monkeypatch.setattr("e2e.aifw_e2e.run_checked", fake_run)
+    seed = make_builder_seed(
+        config(), tmp_path, "def456", "ssh-ed25519 AAAAbuilder"
+    )
+
+    user_data = (tmp_path / "builder-seed" / "user-data").read_text()
+    network = (tmp_path / "builder-seed" / "network-config").read_text()
+    assert "ssh-ed25519 AAAAbuilder" in user_data
+    assert "temporary-test-password" not in user_data
+    assert "192.0.2.10/24" in network
+    assert "192.0.2.1" in network
+    assert seed.read_bytes() == b"fake builder seed"

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -143,3 +143,19 @@ def test_build_accepts_precreated_work_root(
 
     with pytest.raises(HarnessError, match="stop after setup"):
         build_image(args)
+
+
+def test_builder_cloudinit_url_encodes_ssh_key() -> None:
+    pve = Proxmox(config())
+    captured: dict[str, object] = {}
+
+    def fake_request(method: str, path: str, **kwargs: object) -> None:
+        captured.update(method=method, path=path, **kwargs)
+
+    pve.request = fake_request  # type: ignore[method-assign]
+    pve.configure_builder_cloudinit(101, "ssh-ed25519 AAAAtest aifw-e2e\n")
+
+    data = captured["data"]
+    assert isinstance(data, dict)
+    assert data["sshkeys"] == "ssh-ed25519%20AAAAtest%20aifw-e2e"
+    assert data["ipconfig0"] == "ip=192.0.2.10/24,gw=192.0.2.1"

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -162,3 +162,22 @@ def test_as_root_quotes_the_entire_command() -> None:
     assert as_root("id -u && echo 'safe value'") == (
         "su -m root -c 'id -u && echo '\"'\"'safe value'\"'\"''"
     )
+
+
+def test_import_finishes_before_boot_order_is_set() -> None:
+    pve = Proxmox(config())
+    requests: list[dict[str, object]] = []
+
+    def fake_request(method: str, path: str, **kwargs: object) -> str:
+        requests.append({"method": method, "path": path, **kwargs})
+        return f"task-{len(requests)}"
+
+    pve.request = fake_request  # type: ignore[method-assign]
+    pve.wait_task = lambda _task: None  # type: ignore[method-assign]
+    pve.attach_imported_disk(101, "local:import/aifw.raw", "local:iso/seed.iso")
+
+    assert requests[0]["data"] == {
+        "virtio0": "local-lvm:0,import-from=local:import/aifw.raw,discard=on",
+        "ide2": "local:iso/seed.iso,media=cdrom",
+    }
+    assert requests[1]["data"] == {"boot": "order=virtio0"}

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+import pytest
+from argon2 import PasswordHasher
+
+from e2e.aifw_e2e import HarnessError, LabConfig, make_seed, prepare_image
+
+
+def config(password: str = "temporary-test-password") -> LabConfig:
+    return LabConfig(
+        pve_url="https://pve.invalid:8006",
+        pve_node="pve",
+        image_storage="local",
+        vm_storage="local-lvm",
+        bridge="vmbr0",
+        verify_tls=True,
+        address_cidr="192.0.2.10/24",
+        gateway="192.0.2.1",
+        dns="192.0.2.1",
+        token_id="root@pam!test",
+        token_secret="not-a-real-token",
+        admin_password=password,
+    )
+
+
+def test_prepare_image_rejects_non_image(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.txt"
+    artifact.write_text("not an image")
+    with pytest.raises(HarnessError, match="must be an .img"):
+        prepare_image(artifact, tmp_path, "abc123")
+
+
+def test_seed_uses_argon2_and_excludes_plaintext(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    created: list[list[str]] = []
+
+    def fake_run(args: list[str], **_kwargs: object) -> object:
+        created.append(args)
+        Path(args[args.index("-o") + 1]).write_bytes(b"fake iso")
+        return object()
+
+    monkeypatch.setattr("e2e.aifw_e2e.shutil.which", lambda _name: "/usr/bin/xorrisofs")
+    monkeypatch.setattr("e2e.aifw_e2e.run_checked", fake_run)
+    password = "unique-plain-text-secret"
+    seed = make_seed(config(password), tmp_path, "abc123", "ssh-ed25519 AAAAtest")
+
+    setup_text = (tmp_path / "seed" / "setup.json").read_text()
+    assert password not in setup_text
+    assert "not-a-real-token" not in setup_text
+    assert seed.read_bytes() == b"fake iso"
+    assert created
+
+    import json
+
+    setup = json.loads(setup_text)
+    PasswordHasher().verify(setup["admin_password_hash"], password)
+
+
+def test_seed_has_only_one_management_interface(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("e2e.aifw_e2e.shutil.which", lambda _name: "/usr/bin/xorrisofs")
+
+    def fake_run(args: list[str], **_kwargs: object) -> object:
+        Path(args[args.index("-o") + 1]).write_bytes(b"fake iso")
+        return object()
+
+    monkeypatch.setattr("e2e.aifw_e2e.run_checked", fake_run)
+    make_seed(config(), tmp_path, "def456", "ssh-ed25519 AAAAtest")
+
+    import json
+
+    setup = json.loads((tmp_path / "seed" / "setup.json").read_text())
+    assert setup["wan_interface"] == "vtnet0"
+    assert setup["lan_interface"] is None
+    assert setup["default_policy"] == "permissive"

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -4,6 +4,8 @@ import pytest
 from argon2 import PasswordHasher
 
 from e2e.aifw_e2e import (
+    FULL_LAN_CIDR,
+    FULL_WAN_CIDR,
     HarnessError,
     LabConfig,
     Lifecycle,
@@ -25,6 +27,8 @@ def config(password: str = "temporary-test-password") -> LabConfig:
         image_storage="local",
         vm_storage="local-lvm",
         bridge="vmbr0",
+        wan_bridge="vmbr998",
+        lan_bridge="vmbr999",
         verify_tls=True,
         address_cidr="192.0.2.10/24",
         gateway="192.0.2.1",
@@ -94,6 +98,47 @@ def test_seed_has_only_one_management_interface(
     assert setup["wan_interface"] == "vtnet0"
     assert setup["lan_interface"] is None
     assert setup["default_policy"] == "permissive"
+
+
+def test_full_seed_configures_isolated_wan_lan_and_nat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("e2e.aifw_e2e.shutil.which", lambda _name: "/usr/bin/xorrisofs")
+
+    def fake_run(args: list[str], **_kwargs: object) -> object:
+        Path(args[args.index("-o") + 1]).write_bytes(b"fake iso")
+        return object()
+
+    monkeypatch.setattr("e2e.aifw_e2e.run_checked", fake_run)
+    make_seed(
+        config(), tmp_path, "feed12", "ssh-ed25519 AAAAtest", full=True
+    )
+
+    import json
+
+    setup = json.loads((tmp_path / "seed" / "setup.json").read_text())
+    assert setup["wan_ip"] == FULL_WAN_CIDR
+    assert setup["wan_gateway"] is None
+    assert setup["lan_ip"] == FULL_LAN_CIDR
+    assert setup["lan_interface"] == "vtnet1"
+    assert setup["default_policy"] == "standard"
+    assert setup["nat_enabled"] is True
+    assert setup["dns_servers"] == []
+
+
+def test_full_vm_network_order_is_wan_then_lan() -> None:
+    pve = Proxmox(config())
+    requests: list[dict[str, object]] = []
+
+    def fake_request(method: str, path: str, **kwargs: object) -> None:
+        requests.append({"method": method, "path": path, **kwargs})
+
+    pve.request = fake_request  # type: ignore[method-assign]
+    pve.create_full_appliance_vm(101, "aifw-e2e-feed12", "test")
+    data = requests[0]["data"]
+    assert isinstance(data, dict)
+    assert data["net0"] == "virtio,bridge=vmbr998,firewall=0"
+    assert data["net1"] == "virtio,bridge=vmbr999,firewall=0"
 
 
 def test_builder_seed_uses_reserved_address_and_public_key(
@@ -196,7 +241,14 @@ def test_complete_readiness_retries_transient_pf_state(
         ]
     )
 
-    def fake_checks(_cfg: LabConfig, _key: Path) -> dict[str, object]:
+    def fake_checks(
+        _cfg: LabConfig,
+        _key: Path,
+        host: str | None = None,
+        jump: str | None = None,
+    ) -> dict[str, object]:
+        assert host is None
+        assert jump is None
         result = next(attempts)
         if isinstance(result, BaseException):
             raise result
@@ -267,6 +319,39 @@ def test_cleanup_deletes_owned_resources_and_proves_absence() -> None:
     lifecycle.volumes = ["local:iso/aifw-e2e-seed.iso"]
     lifecycle.cleanup()
     assert pve.audited
+
+
+def test_cleanup_deletes_all_owned_vms() -> None:
+    class FakeProxmox:
+        present = {101, 102, 103}
+        audited: list[int] = []
+
+        def vm_exists(self, vmid: int) -> bool:
+            return vmid in self.present
+
+        def vm_config(self, vmid: int) -> dict[str, str]:
+            return {"name": f"aifw-e2e-owned-{vmid}"}
+
+        def destroy(self, vmid: int) -> None:
+            self.present.remove(vmid)
+
+        def volume_exists(self, _volume: str) -> bool:
+            return False
+
+        def wait_resources_absent(
+            self, vmid: int | None, volumes: list[str]
+        ) -> None:
+            assert vmid not in self.present
+            if vmid != 101:
+                assert volumes == []
+            self.audited.append(vmid)  # type: ignore[arg-type]
+
+    pve = FakeProxmox()
+    lifecycle = Lifecycle(pve, keep_on_failure=False)  # type: ignore[arg-type]
+    lifecycle.vmid = 101
+    lifecycle.additional_vmids = [102, 103]
+    lifecycle.cleanup()
+    assert set(pve.audited) == {101, 102, 103}
 
 
 def test_cleanup_refuses_unowned_volume() -> None:

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -7,6 +7,7 @@ from e2e.aifw_e2e import (
     HarnessError,
     LabConfig,
     Proxmox,
+    as_root,
     build_image,
     make_builder_seed,
     make_seed,
@@ -112,8 +113,10 @@ def test_builder_seed_uses_reserved_address_and_public_key(
     assert "ssh-ed25519 AAAAbuilder" in user_data
     assert "temporary-test-password" not in user_data
     assert "192.0.2.10" in network
-    assert "255.255.255.0" in network
+    assert "192.0.2.10/24" in network
     assert "192.0.2.1" in network
+    assert '"version": 2' in network
+    assert '"ethernets"' in network
     assert seed.read_bytes() == b"fake builder seed"
 
 
@@ -145,17 +148,17 @@ def test_build_accepts_precreated_work_root(
         build_image(args)
 
 
-def test_builder_cloudinit_url_encodes_ssh_key() -> None:
-    pve = Proxmox(config())
-    captured: dict[str, object] = {}
+def test_builder_uses_early_default_freebsd_user() -> None:
+    source = Path("e2e/aifw_e2e.py").read_text()
+    build_section = source[source.index("def build_image(") : source.index("def run(")]
+    assert 'user="freebsd"' in build_section
+    assert 'user="builder"' not in build_section
+    assert "/home/freebsd/AiFw" in build_section
+    assert "make_builder_seed" in build_section
+    assert "configure_builder_cloudinit" not in build_section
 
-    def fake_request(method: str, path: str, **kwargs: object) -> None:
-        captured.update(method=method, path=path, **kwargs)
 
-    pve.request = fake_request  # type: ignore[method-assign]
-    pve.configure_builder_cloudinit(101, "ssh-ed25519 AAAAtest aifw-e2e\n")
-
-    data = captured["data"]
-    assert isinstance(data, dict)
-    assert data["sshkeys"] == "ssh-ed25519%20AAAAtest%20aifw-e2e"
-    assert data["ipconfig0"] == "ip=192.0.2.10/24,gw=192.0.2.1"
+def test_as_root_quotes_the_entire_command() -> None:
+    assert as_root("id -u && echo 'safe value'") == (
+        "su -m root -c 'id -u && echo '\"'\"'safe value'\"'\"''"
+    )

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -6,6 +6,7 @@ from argon2 import PasswordHasher
 from e2e.aifw_e2e import (
     HarnessError,
     LabConfig,
+    Lifecycle,
     Proxmox,
     as_root,
     build_image,
@@ -225,3 +226,55 @@ def test_import_finishes_before_boot_order_is_set() -> None:
         "ide2": "local:iso/seed.iso,media=cdrom",
     }
     assert requests[1]["data"] == {"boot": "order=virtio0"}
+
+
+def test_cleanup_deletes_owned_resources_and_proves_absence() -> None:
+    class FakeProxmox:
+        vm_present = True
+        present_volumes = {"local:iso/aifw-e2e-seed.iso"}
+        audited = False
+
+        def vm_exists(self, vmid: int) -> bool:
+            assert vmid == 101
+            return self.vm_present
+
+        def vm_config(self, vmid: int) -> dict[str, str]:
+            assert vmid == 101
+            return {"name": "aifw-e2e-abc123"}
+
+        def destroy(self, vmid: int) -> None:
+            assert vmid == 101
+            self.vm_present = False
+
+        def volume_exists(self, volume: str) -> bool:
+            return volume in self.present_volumes
+
+        def delete_volume(self, volume: str) -> None:
+            self.present_volumes.remove(volume)
+
+        def wait_resources_absent(
+            self, vmid: int | None, volumes: list[str]
+        ) -> None:
+            assert vmid == 101
+            assert volumes == ["local:iso/aifw-e2e-seed.iso"]
+            assert not self.vm_present
+            assert not self.present_volumes
+            self.audited = True
+
+    pve = FakeProxmox()
+    lifecycle = Lifecycle(pve, keep_on_failure=False)  # type: ignore[arg-type]
+    lifecycle.vmid = 101
+    lifecycle.volumes = ["local:iso/aifw-e2e-seed.iso"]
+    lifecycle.cleanup()
+    assert pve.audited
+
+
+def test_cleanup_refuses_unowned_volume() -> None:
+    class FakeProxmox:
+        def vm_exists(self, _vmid: int) -> bool:
+            return False
+
+    lifecycle = Lifecycle(FakeProxmox(), keep_on_failure=False)  # type: ignore[arg-type]
+    lifecycle.volumes = ["local:iso/unrelated.iso"]
+    with pytest.raises(HarnessError, match="unexpected volume"):
+        lifecycle.cleanup()

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -13,6 +13,7 @@ from e2e.aifw_e2e import (
     make_seed,
     prepare_builder_image,
     prepare_image,
+    wait_appliance_ready,
 )
 
 
@@ -160,8 +161,51 @@ def test_builder_uses_early_default_freebsd_user() -> None:
 
 def test_as_root_quotes_the_entire_command() -> None:
     assert as_root("id -u && echo 'safe value'") == (
-        "su -m root -c 'id -u && echo '\"'\"'safe value'\"'\"''"
+        "su root -c 'id -u && echo '\"'\"'safe value'\"'\"''"
     )
+
+
+def test_appliance_firstboot_is_not_sentinel_gated() -> None:
+    source = Path("freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot").read_text()
+    directives = [line for line in source.splitlines() if line.startswith("# KEYWORD:")]
+    assert directives == []
+    assert 'if [ -f "$AIFW_CONF" ]; then' in source
+
+
+def test_writable_image_root_label_matches_boot_configuration() -> None:
+    source = Path("freebsd/build-iso.sh").read_text()
+    assert 'newfs -U -j -L aifw "/dev/${MD}p3"' in source
+    assert "/dev/ufs/aifw  /       ufs" in source
+    assert 'vfs.root.mountfrom="ufs:/dev/ufs/aifw"' in source
+
+
+def test_setup_persists_aifw_pf_rules_path() -> None:
+    source = Path("aifw-setup/src/apply.rs").read_text()
+    assert 'run_best_effort("sysrc", &["pf_enable=YES"])' in source
+    assert 'format!("pf_rules={}/pf.conf.aifw", config.config_dir)' in source
+
+
+def test_complete_readiness_retries_transient_pf_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = iter(
+        [
+            HarnessError("authenticated status reports pf_running=false"),
+            {"pf_running": True},
+        ]
+    )
+
+    def fake_checks(_cfg: LabConfig, _key: Path) -> dict[str, object]:
+        result = next(attempts)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    monkeypatch.setattr("e2e.aifw_e2e.appliance_checks", fake_checks)
+    monkeypatch.setattr("e2e.aifw_e2e.time.sleep", lambda _seconds: None)
+    assert wait_appliance_ready(config(), Path("key"), timeout=1) == {
+        "pf_running": True
+    }
 
 
 def test_import_finishes_before_boot_order_is_set() -> None:

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -111,7 +111,8 @@ def test_builder_seed_uses_reserved_address_and_public_key(
     network = (tmp_path / "builder-seed" / "network-config").read_text()
     assert "ssh-ed25519 AAAAbuilder" in user_data
     assert "temporary-test-password" not in user_data
-    assert "192.0.2.10/24" in network
+    assert "192.0.2.10" in network
+    assert "255.255.255.0" in network
     assert "192.0.2.1" in network
     assert seed.read_bytes() == b"fake builder seed"
 

--- a/freebsd/build-iso.sh
+++ b/freebsd/build-iso.sh
@@ -200,6 +200,12 @@ cat > "$STAGEDIR/boot/loader.conf" <<'LOADER'
 autoboot_delay="3"
 beastie_disable="YES"
 loader_logo="none"
+# Keep VGA/ttyv0 as the interactive console while mirroring boot and rc output
+# to COM1. Proxmox E2E captures serial0, making early boot failures diagnosable.
+boot_multicons="YES"
+boot_serial="YES"
+comconsole_speed="115200"
+console="comconsole,vidconsole"
 kern.geom.label.disk_ident.enable="0"
 kern.geom.label.gptid.enable="0"
 vfs.root.mountfrom="cd9660:cd0"
@@ -324,7 +330,10 @@ umount /mnt
 gpart bootcode -b "$STAGEDIR/boot/pmbr" -p "$STAGEDIR/boot/gptboot" -i 2 "$MD"
 
 # Format UFS root
-newfs -U -j "/dev/${MD}p3"
+# The generated fstab and loader.conf boot by /dev/ufs/aifw. A GPT partition
+# label alone creates /dev/gpt/aifw, not /dev/ufs/aifw; without this filesystem
+# label the writable IMG drops to mountroot with error 19.
+newfs -U -j -L aifw "/dev/${MD}p3"
 mount "/dev/${MD}p3" /mnt
 
 # Clone staged system into USB image

--- a/freebsd/build-local.sh
+++ b/freebsd/build-local.sh
@@ -100,7 +100,8 @@ cd "$PROJECT_ROOT"
 echo "=== [3/6] Building Rust binaries (release) ==="
 # Ensure cargo is in PATH (rustup installs to $HOME/.cargo/bin)
 [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
-echo "--- AiFw commit: $(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown) ---"
+AIFW_COMMIT=$(git -C "$PROJECT_ROOT" rev-parse HEAD 2>/dev/null || cat "$PROJECT_ROOT/.aifw-build-commit" 2>/dev/null || echo unknown)
+echo "--- AiFw commit: $AIFW_COMMIT ---"
 cargo build --release
 
 # --- Guard: the compiled binary version MUST match the release version ---
@@ -268,7 +269,7 @@ echo "$VERSION" > "$TARBALL_DIR/version"
 # repos (which have burned us before — rdns 1.5.1 shipping in a v5.45.0
 # tarball) visible at build time.
 {
-    echo "AiFw             $(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    echo "AiFw             $(printf '%s' "$AIFW_COMMIT" | cut -c1-12)"
     [ -d "$TRAFFICCOP_DIR/.git" ] && echo "TrafficCop       $(git -C "$TRAFFICCOP_DIR" rev-parse --short HEAD)"
     [ -d "$RDHCP_DIR/.git" ]      && echo "rDHCP            $(git -C "$RDHCP_DIR"      rev-parse --short HEAD)"
     [ -d "$RDNS_DIR/.git" ]       && echo "rDNS             $(git -C "$RDNS_DIR"       rev-parse --short HEAD)"

--- a/freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot
+++ b/freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot
@@ -2,7 +2,11 @@
 # PROVIDE: aifw_firstboot
 # REQUIRE: NETWORKING LOGIN
 # BEFORE: aifw_daemon aifw_api
-# KEYWORD: firstboot
+# This service is intentionally not KEYWORD:firstboot. Writable IMG artifacts
+# are assembled from a staged root and do not carry FreeBSD's firstboot
+# sentinel, so rc(8) would skip unattended seed processing entirely. The
+# service is idempotent: it exits when aifw.conf exists and disables itself
+# after successful setup.
 
 . /etc/rc.subr
 

--- a/freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot
+++ b/freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot
@@ -14,6 +14,28 @@ stop_cmd=":"
 AIFW_CONF="/usr/local/etc/aifw/aifw.conf"
 AIFW_SETUP="/usr/local/sbin/aifw-setup"
 AIFW_PF_CONF="/usr/local/etc/aifw/pf.conf.aifw"
+AIFW_SEED_LABEL="AIFW_SEED"
+AIFW_SEED_MOUNT="/tmp/aifw-seed"
+AIFW_SEED_CONFIG="${AIFW_SEED_MOUNT}/setup.json"
+
+mount_seed()
+{
+    mkdir -p "$AIFW_SEED_MOUNT"
+
+    # A Proxmox E2E run attaches a tiny read-only ISO labelled AIFW_SEED.
+    # Prefer GEOM labels, then fall back to optical devices because the exact
+    # cd number depends on the VM's disk layout.
+    for dev in "/dev/iso9660/${AIFW_SEED_LABEL}" /dev/cd1 /dev/cd0; do
+        if [ -e "$dev" ] && mount -t cd9660 -o ro "$dev" "$AIFW_SEED_MOUNT" 2>/dev/null; then
+            if [ -f "$AIFW_SEED_CONFIG" ]; then
+                return 0
+            fi
+            umount "$AIFW_SEED_MOUNT" 2>/dev/null || true
+        fi
+    done
+
+    return 1
+}
 
 aifw_firstboot_start()
 {
@@ -29,8 +51,19 @@ aifw_firstboot_start()
     echo ""
 
     if [ -x "$AIFW_SETUP" ]; then
-        # Run the setup wizard on the console
-        $AIFW_SETUP </dev/console >/dev/console 2>&1
+        if mount_seed; then
+            echo "Found unattended AiFw seed media."
+            $AIFW_SETUP --config "$AIFW_SEED_CONFIG" >/dev/console 2>&1
+            setup_status=$?
+            umount "$AIFW_SEED_MOUNT" 2>/dev/null || true
+            if [ "$setup_status" -ne 0 ]; then
+                echo "ERROR: unattended setup failed (exit $setup_status)"
+                return "$setup_status"
+            fi
+        else
+            # Run the setup wizard on the console.
+            $AIFW_SETUP </dev/console >/dev/console 2>&1
+        fi
 
         # If setup succeeded, enable and start services
         if [ -f "$AIFW_CONF" ]; then

--- a/freebsd/overlay/usr/local/sbin/aifw-console
+++ b/freebsd/overlay/usr/local/sbin/aifw-console
@@ -6,6 +6,13 @@ AIFW_CONF="/usr/local/etc/aifw/aifw.conf"
 AIFW_VERSION_FILE="/usr/local/share/aifw/version"
 AIFW_VERSION=$(cat "$AIFW_VERSION_FILE" 2>/dev/null || echo "unknown")
 
+# login(1) uses this program as root's appliance console shell. sshd invokes a
+# login shell with `-c <command>` for non-interactive automation; honour that
+# contract so key-only diagnostics and E2E checks do not enter the menu loop.
+if [ "${1:-}" = "-c" ] && [ "$#" -eq 2 ]; then
+    exec /bin/sh -c "$2"
+fi
+
 show_banner()
 {
     clear

--- a/testingUplift.md
+++ b/testingUplift.md
@@ -8,33 +8,112 @@ The target definition of done is:
 
 > From one command, the framework creates an isolated appliance environment from the shipped artifact, verifies both control-plane behavior and real forwarded traffic, records actionable evidence, and leaves no Proxmox resources behind—even when setup or testing fails.
 
-## Current state
+## Status snapshot — 2026-07-19
 
-AiFw currently has a strong base of Rust unit and in-process integration tests, but it does not have an appliance-level E2E framework.
+This document separates the implemented current state from the intended full
+framework. The repository now contains an initial appliance lifecycle harness,
+but a complete successful image-build-plus-appliance run has not yet been
+demonstrated.
 
-Existing coverage includes:
+### Implemented and verified
+
+- Forgejo is the private source of truth at `indexarr/AiFw`; Woodpecker repo 87
+  is active.
+- `.woodpecker/ci.yml` runs formatting, Clippy, workspace tests, the UI build,
+  and E2E harness unit tests. The latest normal push pipelines have passed.
+- `.woodpecker/e2e.yml` is manual-only and restricted to the dedicated agent
+  label `proxmox=true`.
+- The Proxmox lab is PVE 9.2 on node `trigproxmox`, using `local` for uploads,
+  `local-lvm` for VM disks, and `vmbr0` for the initial management lane.
+- `192.168.0.26/23` is the reserved sequential builder/appliance address;
+  gateway and DNS are `192.168.0.1`.
+- `e2e/aifw_e2e.py` implements Proxmox task polling, upload/import, tagged VM
+  creation, disk attachment, startup, diagnostics, reboot checks, and guarded
+  `try/finally` teardown.
+- The writable appliance IMG can be imported only after renaming its
+  decompressed form to `.raw`; this PVE 9 API contract was verified directly.
+- Disposable direct tests have verified VM create/read/destroy, import to
+  `local-lvm`, native FreeBSD `nuageinit` bootstrap at `192.168.0.26/23`,
+  ephemeral-key SSH, live routing, non-interactive elevation, and cleanup with
+  zero residual `aifw-e2e-*` VMs or import volumes.
+- First boot can consume an `AIFW_SEED` ISO and invoke
+  `aifw-setup --config`; static WAN setup applies the address immediately, and
+  the console shell supports non-interactive SSH commands.
+- Harness unit tests cover artifact validation, secret exclusion, Argon2 seed
+  generation, one-NIC policy, work-directory reuse, native builder seed
+  schema, command quoting, and builder-user consistency.
+- Woodpecker repository secrets are scoped to manual events. The Proxmox token
+  is not committed or written to generated artifacts.
+
+### Resolved builder bootstrap issue
+
+The official FreeBSD 15.0 BASIC-CLOUDINIT UFS image uses FreeBSD's native
+`nuageinit`, not Python cloud-init. Direct serial and source-level diagnosis
+found two incompatibilities:
+
+1. Proxmox-generated NoCloud network data names the NIC `eth0`, while the
+   VirtIO device is `vtnet0`.
+2. The first custom seed supplied network-config v1. FreeBSD 15's NoCloud
+   parser expects v2 `ethernets` data and failed with a Lua type error.
+
+The harness now uploads a custom `cidata` ISO with v2 network data for
+`vtnet0`, supplies the ephemeral key through the early top-level
+`ssh_authorized_keys` field, and uses the stock `freebsd` account. Its focused
+Proxmox test directly verified the requested address, live default route, SSH,
+passwordless stock wheel-to-root elevation, and zero-residual cleanup. The
+official image has no `sudo`, and `sysrc` does not read settings rendered into
+`/etc/rc.conf.d`; readiness therefore checks live `ifconfig`/`netstat` state
+and uses passwordless `su`.
+
+The Woodpecker E2E workflow remains experimental because builder-only artifact
+production and appliance-only deployment are still unverified, not because
+the builder VM is unable to boot or network.
+
+### Current coverage that predates the VM harness
 
 - Approximately 688 Rust test attributes across the workspace.
-- API integration tests using in-memory SQLite, `PfMock`, and `axum_test::TestServer`.
-- Linux CI running formatting, Clippy, and workspace Rust tests.
-- UI CI running lint and static-export builds.
-- FreeBSD CI compiling binaries and producing ISO, IMG, and update artifacts.
-- A manual deployment script targeting a persistent FreeBSD test VM.
-- `scripts/ha-verify.sh`, which verifies two already-running HA nodes over SSH.
-- `aifw-setup --config <json>`, which supports unattended appliance configuration.
+- API integration tests using in-memory SQLite, `PfMock`, and
+  `axum_test::TestServer`.
+- Linux CI formatting, Clippy, workspace Rust tests, UI lint/build, and FreeBSD
+  artifact build scripts.
+- A manual deployment script for a persistent FreeBSD test VM.
+- `scripts/ha-verify.sh` for assertions against two already-running HA nodes.
+- `aifw-setup --config <json>` for unattended appliance configuration.
 
-Important gaps remain:
+### Remaining gaps to the full target
 
-- No shipped ISO or IMG is booted before publication.
-- No Proxmox provisioning, resource allocation, ownership tagging, or teardown exists.
-- No tracked UI or browser test suite exists.
-- No real FreeBSD `pf`, service, networking, TLS, IDS, DNS, or DHCP behavior is exercised in CI.
-- No real packets are routed through an AiFw appliance under test.
-- No reboot, failure-recovery, installation, update, or rollback suite exists at VM level.
-- UI lint is currently non-blocking.
-- No stale-resource janitor protects the Proxmox environment after interrupted jobs.
+- No successful Woodpecker-built seed-capable IMG has yet completed the full
+  Proxmox boot, service, login, API, reboot, and teardown sequence.
+- No exact shipped ISO or IMG is currently gated before publication.
+- The lab has only an untagged management bridge; no isolated WAN/LAN helper
+  topology exists for routed traffic tests.
+- No tracked Playwright/browser suite exists.
+- No real FreeBSD `pf`, TLS, IDS, DNS, DHCP, NAT, or forwarded-packet behavior
+  is exercised in CI.
+- No ISO installation, update/rollback, failure injection, HA provisioning, or
+  stale-resource janitor exists at VM level.
+- UI lint remains non-blocking while existing lint debt is addressed.
 
-The current suite therefore proves substantial application logic, but not that the released appliance boots and works as an integrated firewall.
+The current suite proves substantial application logic and most Proxmox
+lifecycle contracts, but it does not yet prove that the newly built appliance
+works as an integrated firewall.
+
+## Validation workflow
+
+Infrastructure contract changes must be validated in increasing-cost order:
+
+1. Pure unit tests with mocked Proxmox calls.
+2. A tiny NIC-less create/config/read/destroy VM contract test.
+3. A focused official-FreeBSD boot, address, SSH, and teardown test.
+4. A builder-only run that produces and checksums the IMG.
+5. An appliance-only run against that retained job-local IMG.
+6. One final Woodpecker workflow exercising the combined lifecycle.
+
+Do not use a complete Woodpecker pipeline to discover individual Proxmox form
+fields, cloud-init schema details, usernames, disk buses, or readiness paths.
+Focused runs must use unique `aifw-e2e-*` names, bounded timeouts, and the same
+guarded cleanup code as CI. After every direct test, explicitly assert that no
+run-owned VM or upload remains.
 
 ## Main release risk
 
@@ -64,15 +143,74 @@ Collect diagnostics and browser traces
 Always destroy VMs, disks, seed media, and allocations
 ```
 
-The orchestrator should expose one supported lifecycle command:
+The current orchestrator exposes separate build and appliance commands:
 
 ```sh
-scripts/e2e run \
-  --artifact output/aifw-5.99.6-amd64.img.xz \
-  --suite pr
+python -m e2e.aifw_e2e build \
+  --builder-image FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz \
+  --output e2e/.run/aifw.img.xz
+
+python -m e2e.aifw_e2e run \
+  --artifact e2e/.run/aifw.img.xz
 ```
 
-It should own provisioning, readiness, testing, artifact collection, and cleanup. Individual tests should never be responsible for creating or destroying shared Proxmox infrastructure.
+The target wrapper should compose those phases and select named suites. The
+orchestrator owns provisioning, readiness, testing, artifact collection, and
+cleanup. Individual functional tests must never create or destroy shared
+Proxmox infrastructure.
+
+### Current Woodpecker lane
+
+The manual `.woodpecker/e2e.yml` workflow is designed to:
+
+1. Run only on the LAN agent labelled `proxmox=true`.
+2. Download the official FreeBSD 15.0 BASIC-CLOUDINIT UFS qcow2 image.
+3. Create an ephemeral 8-vCPU/12-GB FreeBSD builder at the reserved address.
+4. Copy the exact checked-out commit to the builder with `git archive`.
+5. Run `freebsd/build-local.sh` and copy the compressed IMG into job-local
+   storage.
+6. Destroy the builder before reusing the reserved address.
+7. Import the new IMG, attach the `AIFW_SEED` ISO, test the appliance, reboot
+   it, collect diagnostics, and destroy all run resources.
+
+This is the intended current lane, not yet a passing lane. Builder bootstrap
+is directly verified; the next evidence must come from a focused builder-only
+artifact run and a focused appliance-only run before another combined workflow
+is used as acceptance evidence.
+
+### Builder implementation options
+
+The selected correctness-first path is an ephemeral builder created from the
+checksum-verified official FreeBSD image on every run. It is stateless and
+reproducible, but the image performs slow first-boot work and every run must
+install build dependencies.
+
+If measured duration is too high, the recommended optimization is a versioned
+Proxmox builder template:
+
+- Rebuild it on a schedule from the same official image.
+- Pin its FreeBSD release, packages, Rust toolchain, Node version, and template
+  manifest.
+- Clone it for each job; never build concurrently in the template itself.
+- Inject a fresh address and SSH key into every clone, then destroy the clone.
+- Keep a scheduled official-image canary so template caching cannot mask
+  bootstrap or dependency regressions.
+
+Alternatives considered:
+
+- **Offline-customized qcow2:** removes first boot from the job, but adds
+  libguestfs/image tooling and another artifact supply chain.
+- **Persistent FreeBSD builder host:** fastest warm builds, but weaker job
+  isolation, more cache contamination, and no VM-level teardown proof.
+- **Nested KVM or Docker builder:** possible only after intentionally exposing
+  virtualization to the CI agent; it increases runner privilege and is not
+  needed when Proxmox already provides the isolation boundary.
+- **Build from a previous AiFw image:** useful for update testing, but it can
+  hide failures in the clean build/bootstrap path and cannot replace it.
+
+Regardless of builder strategy, the appliance phase must deploy the exact IMG
+returned to the Woodpecker job. A cached builder must never become a substitute
+for artifact-under-test validation.
 
 ## Proxmox lab topology
 
@@ -498,11 +636,11 @@ Target: approximately 15-30 minutes after artifact availability.
 
 Performance regression thresholds should initially warn rather than block until enough stable lab history exists to define meaningful variance.
 
-## Implementation phases
+## Implementation phases and progress
 
 ### Phase 1: appliance automation prerequisites
 
-- Add seed-media detection and unattended first boot.
+- **Implemented:** seed-media detection and unattended first boot.
 - Add explicit unattended installer arguments.
 - Add serial-console progress and failure output.
 - Add a minimal non-sensitive health endpoint.
@@ -510,13 +648,17 @@ Performance regression thresholds should initially warn rather than block until 
 
 ### Phase 2: Proxmox lifecycle foundation
 
-- Implement scoped Proxmox authentication.
+- **Implemented, scope still needs tightening:** Proxmox token authentication.
 - Implement VMID, address, subnet, and VLAN allocation.
-- Import and boot the IMG.
-- Generate and attach seed media.
-- Implement layered readiness.
-- Implement diagnostic collection.
-- Implement verified teardown and scheduled janitor.
+- **Implemented:** dynamic VMID selection and one reserved management address.
+  Dynamic subnet/VLAN allocation remains target-state work.
+- **Directly verified:** upload/import, VM creation, disk configuration, and
+  guarded teardown. Full AiFw IMG boot remains unverified.
+- **Implemented:** appliance seed generation and attachment.
+- **Implemented:** SSH, service, TLS/API, UI, and reboot readiness checks. These
+  await a successful full appliance run.
+- **Implemented:** basic diagnostics and verified per-run teardown.
+- **Not implemented:** scheduled stale-resource janitor.
 
 ### Phase 3: core appliance tests
 
@@ -559,3 +701,16 @@ The first production-useful milestone should meet all of these conditions:
 - A final ownership check proves no run-scoped Proxmox resource remains.
 
 Once this milestone is stable, ISO installation, HA, update rollback, IPv6, and destructive recovery tests can be layered onto the same lifecycle framework.
+
+## Immediate next steps from the current state
+
+1. Run the builder command directly once and retain its IMG long enough to
+   validate checksum, partition table, and expected embedded seed-support
+   files.
+2. Run the appliance command directly against that IMG and fix readiness or
+   appliance bootstrap issues one contract at a time.
+3. Run one combined Woodpecker manual workflow as final integration evidence.
+4. Measure the clean builder duration; introduce a versioned template only if
+   the performance benefit justifies its maintenance and canary requirements.
+5. Add an isolated VLAN-aware or dedicated WAN/LAN lab topology before claiming
+   firewall data-plane E2E coverage.

--- a/testingUplift.md
+++ b/testingUplift.md
@@ -11,9 +11,10 @@ The target definition of done is:
 ## Status snapshot — 2026-07-19
 
 This document separates the implemented current state from the intended full
-framework. The repository now contains a directly validated one-NIC appliance
-lifecycle harness. Woodpecker pipeline 14 passed the combined native build,
-initial health, reboot health, and teardown path on 2026-07-19.
+framework. The repository contains a validated one-NIC appliance lifecycle and
+an implemented full isolated WAN/LAN lane. Woodpecker pipeline 14 remains the
+passing exact-commit baseline; the new full workflow awaits a fresh current-
+commit acceptance run.
 
 ### Implemented and verified
 
@@ -24,12 +25,22 @@ initial health, reboot health, and teardown path on 2026-07-19.
 - `.woodpecker/e2e.yml` is manual-only and restricted to the dedicated agent
   label `proxmox=true`.
 - The Proxmox lab is PVE 9.2 on node `trigproxmox`, using `local` for uploads,
-  `local-lvm` for VM disks, and `vmbr0` for the initial management lane.
+  `local-lvm` for disks, `vmbr0` for management, and durable portless bridges
+  `vmbr998`/`vmbr999` for isolated WAN/LAN traffic.
 - `192.168.0.26/23` is the reserved sequential builder/appliance address;
   gateway and DNS are `192.168.0.1`.
 - `e2e/aifw_e2e.py` implements Proxmox task polling, upload/import, tagged VM
   creation, disk attachment, startup, diagnostics, reboot checks, and guarded
   `try/finally` teardown.
+- The full lane provisions Debian 13 LXC traffic helpers plus a two-NIC AiFw
+  VM. The LAN helper is the SSH/API jump host, so AiFw has no management-side
+  bypass NIC.
+- The implemented contract verifies observed NAT source translation, default
+  WAN-to-LAN block, API-created WAN-to-LAN pass, API-created LAN-to-WAN block,
+  delete/reload recovery, browser login/rules rendering, reboot persistence,
+  and final rule removal.
+- A focused helper-container run directly passed boot, both static NICs,
+  routing, SSH, source-observing HTTP service, and zero-residual teardown.
 - The writable appliance IMG can be imported only after renaming its
   decompressed form to `.raw`; this PVE 9 API contract was verified directly.
 - Disposable direct tests have verified VM create/read/destroy, import to
@@ -133,23 +144,23 @@ as guest-agnostic layers.
 - `scripts/ha-verify.sh` for assertions against two already-running HA nodes.
 - `aifw-setup --config <json>` for unattended appliance configuration.
 
-### Remaining gaps to the full target
+### Remaining gaps to the broader target
 
 - The passing exact-IMG lifecycle is manual, not yet a required publication
   gate, and has only one successful combined Woodpecker acceptance run.
 - ISO installation is not exercised; the tested artifact is the writable IMG.
-- The lab has only an untagged management bridge; no isolated WAN/LAN helper
-  topology exists for routed traffic tests.
-- No tracked Playwright/browser suite exists.
-- Real FreeBSD `pf` availability and TLS/API behavior are exercised, but no
-  ruleset enforcement, IDS, DNS, DHCP, NAT, or forwarded-packet behavior is.
+- The new full topology needs a passing fresh exact-commit Woodpecker run before
+  it becomes an authoritative acceptance result.
+- Browser coverage currently targets login, dashboard arrival, and rules page;
+  NAT, DNS, IDS, users, and settings flows remain future expansion.
+- UDP, ICMP, DNS, DHCP, IDS, and packet-capture assertions remain future work.
 - No ISO installation, update/rollback, failure injection, HA provisioning, or
   stale-resource janitor exists at VM level.
 - UI lint remains non-blocking while existing lint debt is addressed.
 
-The current suite proves the newly built appliance boots, configures, serves
-its control plane, keeps `pf` alive across reboot, and tears down safely. It
-does not yet prove routed firewall behavior.
+The full suite is designed to prove routed behavior as well as control-plane
+health. Pipeline 14 is still the last passing acceptance evidence until the
+new exact-commit run completes.
 
 ## Validation workflow
 
@@ -280,14 +291,16 @@ WAN origin/test server -- WAN network -- AiFw VM -- LAN network -- client VM
                                             DNS/DHCP/traffic
 ```
 
-Recommended guests:
+Implemented guests:
 
 - **AiFw appliance:** 2-4 vCPU, 4 GB RAM, two VirtIO NICs.
-- **LAN client:** small Linux cloud-init VM for DHCP, DNS, browser, API, and traffic tests.
-- **WAN origin:** small Linux VM serving HTTP, HTTPS, DNS, TCP, UDP, and `iperf3` endpoints.
+- **LAN client:** disposable Debian LXC with management and isolated LAN NICs.
+- **WAN origin:** disposable Debian LXC on the isolated WAN bridge.
 - **HA expansion:** a second AiFw VM plus a dedicated pfsync network and CARP VIP.
 
-Use fixed lab bridges or VLAN-aware bridges with a unique VLAN/subnet allocation per run. Avoid dynamically creating permanent Proxmox bridges.
+The current lab uses fixed, portless `vmbr998` and `vmbr999` bridges with
+benchmark subnets `198.18.0.0/24` and `198.19.0.0/24`. They are durable lab
+substrate; run-owned guests and routes are always disposable.
 
 Every resource should be tagged or described with:
 
@@ -711,7 +724,8 @@ Performance regression thresholds should initially warn rather than block until 
 - **Directly verified:** SSH, service, TLS/API, UI, live `pf`, and reboot
   readiness checks on the corrected retained IMG.
 - **Implemented:** basic diagnostics and verified per-run teardown.
-- **Not implemented:** scheduled stale-resource janitor.
+- **Implemented:** ownership checks for appliance VM, helper containers, and
+  uploads. **Not implemented:** scheduled stale-resource janitor.
 
 ### Phase 3: core appliance tests
 
@@ -719,13 +733,13 @@ Performance regression thresholds should initially warn rather than block until 
 - Service health.
 - Authenticated API smoke tests.
 - Live `pf` state checks.
-- LAN-to-WAN and WAN-to-LAN traffic tests.
-- NAT, DNS, DHCP, TCP, UDP, and ICMP tests.
+- **Implemented:** TCP LAN-to-WAN and WAN-to-LAN traffic transitions and NAT.
+- Add DNS, DHCP, UDP, and ICMP tests.
 
 ### Phase 4: browser and broader functional coverage
 
-- Add Playwright configuration and fixtures.
-- Cover login, dashboard, rules, NAT, DNS, IDS, users, and settings.
+- **Implemented:** Playwright login/dashboard/rules-page smoke.
+- Cover NAT, DNS, IDS, users, settings, traces, and negative auth cases.
 - Add WebSocket and SSE assertions.
 - Add backup and restore tests.
 
@@ -763,5 +777,5 @@ Once this milestone is stable, ISO installation, HA, update rollback, IPv6, and 
    add a scheduled stale-resource janitor.
 3. Introduce a versioned template only if subsequent measurements show that
    the performance benefit justifies its maintenance and canary requirements.
-4. Add an isolated VLAN-aware or dedicated WAN/LAN lab topology before claiming
-   firewall data-plane E2E coverage.
+4. Expand the implemented isolated topology with UDP, ICMP, DNS, DHCP, and
+   packet capture after the core exact-commit lane is repeatable.

--- a/testingUplift.md
+++ b/testingUplift.md
@@ -1,0 +1,561 @@
+# AiFw Full End-to-End Testing Uplift
+
+## Purpose
+
+This document reviews AiFw's current testing and deployment harness and proposes a full end-to-end (E2E) framework that provisions the shipped appliance artifact in Proxmox, tests the running VM and network data plane, gathers diagnostics, and reliably tears down all test resources.
+
+The target definition of done is:
+
+> From one command, the framework creates an isolated appliance environment from the shipped artifact, verifies both control-plane behavior and real forwarded traffic, records actionable evidence, and leaves no Proxmox resources behind—even when setup or testing fails.
+
+## Current state
+
+AiFw currently has a strong base of Rust unit and in-process integration tests, but it does not have an appliance-level E2E framework.
+
+Existing coverage includes:
+
+- Approximately 688 Rust test attributes across the workspace.
+- API integration tests using in-memory SQLite, `PfMock`, and `axum_test::TestServer`.
+- Linux CI running formatting, Clippy, and workspace Rust tests.
+- UI CI running lint and static-export builds.
+- FreeBSD CI compiling binaries and producing ISO, IMG, and update artifacts.
+- A manual deployment script targeting a persistent FreeBSD test VM.
+- `scripts/ha-verify.sh`, which verifies two already-running HA nodes over SSH.
+- `aifw-setup --config <json>`, which supports unattended appliance configuration.
+
+Important gaps remain:
+
+- No shipped ISO or IMG is booted before publication.
+- No Proxmox provisioning, resource allocation, ownership tagging, or teardown exists.
+- No tracked UI or browser test suite exists.
+- No real FreeBSD `pf`, service, networking, TLS, IDS, DNS, or DHCP behavior is exercised in CI.
+- No real packets are routed through an AiFw appliance under test.
+- No reboot, failure-recovery, installation, update, or rollback suite exists at VM level.
+- UI lint is currently non-blocking.
+- No stale-resource janitor protects the Proxmox environment after interrupted jobs.
+
+The current suite therefore proves substantial application logic, but not that the released appliance boots and works as an integrated firewall.
+
+## Main release risk
+
+The ISO workflow builds and releases artifacts without a deployed-VM validation gate between those stages. A packaging, boot, first-boot, service, permission, interface-driver, or live-`pf` regression can pass current CI and be published.
+
+The complete E2E framework should test the exact immutable artifact intended for release, rather than rebuilding or deploying source independently after the artifact has been produced.
+
+## Proposed architecture
+
+```text
+Build immutable artifact
+        |
+Create per-run credentials and network allocation
+        |
+Provision Proxmox VM(s) and helper clients
+        |
+Boot and perform unattended setup
+        |
+SSH -> services -> TLS -> authenticated API readiness
+        |
+System + API + browser + real traffic tests
+        |
+Reboot / failure / recovery tests
+        |
+Collect diagnostics and browser traces
+        |
+Always destroy VMs, disks, seed media, and allocations
+```
+
+The orchestrator should expose one supported lifecycle command:
+
+```sh
+scripts/e2e run \
+  --artifact output/aifw-5.99.6-amd64.img.xz \
+  --suite pr
+```
+
+It should own provisioning, readiness, testing, artifact collection, and cleanup. Individual tests should never be responsible for creating or destroying shared Proxmox infrastructure.
+
+## Proxmox lab topology
+
+A useful firewall E2E test requires more than an AiFw VM:
+
+```text
+                         Proxmox API
+                              ^
+                       E2E runner/control
+                              |
+WAN origin/test server -- WAN network -- AiFw VM -- LAN network -- client VM
+                                                  |
+                                            Playwright/API/
+                                            DNS/DHCP/traffic
+```
+
+Recommended guests:
+
+- **AiFw appliance:** 2-4 vCPU, 4 GB RAM, two VirtIO NICs.
+- **LAN client:** small Linux cloud-init VM for DHCP, DNS, browser, API, and traffic tests.
+- **WAN origin:** small Linux VM serving HTTP, HTTPS, DNS, TCP, UDP, and `iperf3` endpoints.
+- **HA expansion:** a second AiFw VM plus a dedicated pfsync network and CARP VIP.
+
+Use fixed lab bridges or VLAN-aware bridges with a unique VLAN/subnet allocation per run. Avoid dynamically creating permanent Proxmox bridges.
+
+Every resource should be tagged or described with:
+
+- `aifw-e2e`
+- Run UUID
+- Commit SHA
+- Expiration timestamp
+- CI job URL
+
+Use a dedicated Proxmox resource pool and storage scope for E2E workloads.
+
+## Appliance bootstrap
+
+### Seed-media first boot
+
+The existing `aifw-setup --config <json>` path is a strong foundation. The harness needs a reliable method to provide that configuration and ephemeral SSH access to a pristine appliance.
+
+Attach a small read-only ISO labeled `AIFW_SEED` containing:
+
+- `setup.json`
+- An ephemeral SSH public key
+- Run identifier
+- Optional suite-specific settings
+
+`aifw_firstboot` should detect this medium and invoke:
+
+```sh
+aifw-setup --config /mnt/aifw-seed/setup.json
+```
+
+On success, first boot should disable itself and invalidate or eject the seed. On failure, it should emit a clear serial-console error and must not report readiness.
+
+### Credential handling
+
+The setup JSON expects an already-Argon2-hashed admin password. The harness should:
+
+1. Generate a random per-run admin password.
+2. Generate its compatible Argon2 hash.
+3. Generate a per-run SSH keypair.
+4. Inject only the hash and public key into the seed.
+5. Keep the plaintext password and private key in protected job runtime state.
+6. Remove credentials from logs, request dumps, browser traces, and uploaded artifacts.
+
+No long-lived appliance credential should be stored in the repository or Proxmox configuration.
+
+### Unattended ISO installation
+
+The current disk installer is interactive. Release-level installation testing requires an explicit automation interface such as:
+
+```sh
+aifw-install \
+  --disk vtbd0 \
+  --filesystem zfs \
+  --config /mnt/aifw-seed/setup.json \
+  --yes \
+  --poweroff
+```
+
+The installer must still:
+
+- Validate the exact target disk.
+- Reject missing, ambiguous, mounted, or unsafe targets.
+- Require `--yes` for destructive unattended use.
+- Return meaningful non-zero exit statuses.
+- Write machine-readable progress and failure information to the serial console.
+
+## Artifact test lanes
+
+### IMG lane: pull requests and main
+
+The generated IMG is a writable, bootable UFS image and is the preferred frequent-test artifact.
+
+The harness should:
+
+1. Verify its checksum.
+2. Decompress it into a run-specific staging area.
+3. Import it into the E2E Proxmox storage.
+4. Attach the imported disk, seed ISO, and two network adapters.
+5. Boot it and wait for complete application readiness.
+
+This lane validates packaging, first boot, setup, services, UI, API, live firewall state, and traffic behavior with relatively low provisioning overhead.
+
+### ISO installer lane: nightly and release candidate
+
+The harness should:
+
+1. Create an empty target disk.
+2. Attach and boot the exact ISO.
+3. Attach the automation seed.
+4. Run the unattended installer.
+5. Shut down and detach the ISO and seed as appropriate.
+6. Boot from the installed disk.
+7. Run the full functional suite.
+
+Test UFS and ZFS as separate jobs. Test BIOS and UEFI at least nightly, with the release matrix covering all supported combinations.
+
+### Optional update fast lane
+
+A golden installed template may be cloned and updated with the current update tarball for rapid update testing. This is useful supplemental coverage, but it must never replace testing of the exact IMG and ISO artifacts.
+
+## Readiness contract
+
+Readiness must be layered. A successful ping or open TCP port is insufficient.
+
+Recommended progression:
+
+1. Proxmox reports VM running.
+2. Serial console reaches the expected boot phase.
+3. Expected network address is reachable.
+4. SSH succeeds with the ephemeral key.
+5. Core services report healthy through `service ... onestatus`.
+6. TLS handshake succeeds with the expected test trust policy.
+7. Login returns valid tokens.
+8. Authenticated `/api/v1/status` succeeds and reports `pf_running`.
+9. Expected version and UI assets are served.
+10. No panic, migration failure, crash loop, or watchdog restart loop is present.
+
+A small unauthenticated `/healthz` endpoint containing no sensitive state would simplify transport-level readiness. Authenticated readiness should still verify the complete application.
+
+## Test suites
+
+### Boot and packaging
+
+- Artifact checksum is correct.
+- Embedded version matches the requested build.
+- BIOS and UEFI boot as expected.
+- Every manifest-listed binary exists and is executable.
+- Expected companion services and revisions are present.
+- UI static assets exist and are served.
+- rc.d and libexec scripts have correct modes.
+- `visudo -cf` succeeds on installed sudoers content.
+- Database migrations and integrity checks succeed.
+- TLS key, database, configuration, and helper permissions are correct.
+- No stale build artifacts or missing external binaries are shipped.
+
+Companion repository revisions should be recorded in the build manifest and preferably pinned. Cloning each default branch at build time makes artifact composition non-reproducible.
+
+### Appliance health
+
+- `aifw_daemon`, `aifw_ids`, `aifw_api`, and watchdog are running.
+- Expected DNS, DHCP, time, and reverse-proxy services match configuration.
+- API TLS and certificate behavior are correct.
+- `pf` and `pflog` are enabled.
+- Correct anchors and base rules are loaded.
+- IDS IPC and packet-capture access work.
+- Disk, memory, logs, and singleton lockfiles are healthy.
+- Service start, stop, restart, and reload paths work.
+
+### API and control plane
+
+Exercise the real API on the deployed appliance:
+
+- Login, refresh, logout, invalid credentials, lockout, and RBAC.
+- Rule CRUD, reorder, reload, and live `pfctl` verification.
+- NAT, aliases, interfaces, schedules, DNS, DHCP, VPN, IDS, and settings.
+- Backup/export, mutation, restore, and equality verification.
+- WebSocket and SSE connectivity.
+- Failed apply and rollback.
+- Update installation, restart, status, and rollback.
+- Audit and snapshot creation for mutations.
+
+Assertions should compare all three layers:
+
+```text
+API/database intent == generated configuration == live kernel/service state
+```
+
+### Data plane
+
+Drive real packets between helper VMs through AiFw:
+
+- LAN-to-WAN allowed by the standard policy.
+- WAN-to-LAN blocked by default.
+- Stateful return traffic works.
+- NAT rewrites source addresses correctly.
+- Explicit pass and block rules affect real TCP and UDP.
+- ICMP behavior matches policy.
+- IPv4 and IPv6 work.
+- DNS resolution, custom blocking, and allowlisting work.
+- A LAN client acquires and renews a DHCP lease.
+- Large-transfer and multi-connection smoke tests pass.
+- Existing and new sessions behave correctly across rule changes.
+- Management access is not unintentionally reachable from WAN.
+- Packet, byte, rule, and state counters change as expected.
+
+### Browser and UI
+
+Add Playwright under `aifw-ui` and run it against the deployed appliance:
+
+- Login and logout.
+- Dashboard and live metrics rendering.
+- WebSocket-driven updates.
+- Create, edit, reorder, and delete firewall rules.
+- NAT, DNS, IDS, user/RBAC, interface, update, and settings workflows.
+- Client-side validation.
+- API error presentation.
+- Session expiry and unauthorized redirects.
+- Core responsive-layout smoke checks.
+
+Run Chromium on pull requests. Add Firefox and WebKit to nightly coverage if they are supported targets.
+
+On failure, retain Playwright HTML, screenshots, video, and traces. Configure traces for the first retry and avoid recording credentials in reusable authentication state or request attachments.
+
+### Lifecycle and resilience
+
+- Graceful reboot followed by complete authenticated readiness.
+- Database, configuration, and live `pf` state converge after reboot.
+- Kill each core service and verify watchdog recovery.
+- Restart all services without losing configuration or management access.
+- Simulate failed `pfctl` apply and confirm rollback.
+- Verify connectivity remains after a failed mutation.
+- Simulate WAN loss and restoration.
+- Exercise controlled disk-full or read-only failures where practical.
+- Test interrupted update recovery in nightly destructive suites.
+- Verify clock and certificate behavior after restart.
+
+### HA suite
+
+Provision two appliances plus LAN, WAN, management, and dedicated pfsync connectivity.
+
+Test:
+
+- Exactly one CARP master.
+- Configuration replication.
+- State synchronization.
+- Existing connection survival during failover.
+- Failover after API/daemon stop.
+- Failover after NIC disconnect.
+- Failover after VM power-off.
+- Recovery without split brain.
+- Primary return and preferred-role behavior.
+- Configuration hashes and health checks match.
+
+Reuse `scripts/ha-verify.sh` as one assertion inside this larger suite rather than treating it as the entire HA harness.
+
+## Diagnostics and artifacts
+
+Diagnostics must be captured before destroying guests, while they are still reachable.
+
+Collect:
+
+- Run manifest with commit SHA, artifact SHA-256, companion SHAs, VMIDs, MACs, addresses, timings, and Proxmox version.
+- Proxmox VM configuration and relevant task logs.
+- Full serial-console output.
+- `dmesg`, `uname`, uptime, disk usage, mount state, and `rc.conf`.
+- Interface, address, route, ARP/NDP, and socket state.
+- `service ... onestatus`, process list, and singleton lock state.
+- `pfctl -si`, rules, NAT, anchors, tables, and states.
+- `aifw-diag.sh` output.
+- API, daemon, IDS, watchdog, DNS, DHCP, time, and proxy logs.
+- Database integrity result and non-sensitive schema/version metadata.
+- Request/response summaries with authorization data removed.
+- Traffic captures for failed data-plane cases where safe.
+- Playwright HTML report, screenshots, video, and trace.
+- JUnit XML and a concise machine-readable suite summary.
+
+Artifacts must exclude:
+
+- Bearer and refresh tokens.
+- API keys.
+- Admin plaintext password.
+- SSH private key.
+- TOTP secret and recovery codes.
+- HA shared secrets.
+- TLS private keys.
+
+## Teardown contract
+
+Teardown is a core framework responsibility, not the last test step.
+
+The top-level runner should use `try/finally` plus handlers for normal exit, test failure, timeout, cancellation, SIGINT, and SIGTERM.
+
+Cleanup sequence:
+
+1. Stop scheduling new tests.
+2. Capture diagnostics while guests remain reachable.
+3. Request graceful VM shutdown with a bounded timeout.
+4. Force-stop VMs only when required.
+5. Destroy VMs and all referenced and unreferenced run-owned disks.
+6. Delete temporary seed ISOs and artifact staging files.
+7. Release VLAN, subnet, address, and VMID leases.
+8. Verify that no resources tagged with the run UUID remain.
+9. Report cleanup failures separately from test failures.
+
+Manual preservation after failure should require an explicit flag and must still assign an expiration timestamp.
+
+### Stale-resource janitor
+
+Run a scheduled janitor independently of test jobs. It should:
+
+- Enumerate only resources tagged `aifw-e2e` in the dedicated pool.
+- Compare their expiration timestamps with the current time.
+- Confirm they are not associated with an active CI run.
+- Destroy expired VMs, disks, and seed media.
+- Release expired allocation leases.
+- Emit an audit report of everything removed.
+
+The janitor must never enumerate and destroy untagged or non-E2E resources.
+
+## Security model
+
+- Use a Proxmox API token scoped to the E2E resource pool, selected storage, and test network resources.
+- Avoid unrestricted root SSH from CI where a narrow node-side import helper can be used.
+- Validate artifact and staging paths before importing or deleting them.
+- Keep destructive operations scoped by run UUID and known VMIDs.
+- Never use broad recursive deletion against a workspace, storage root, or unresolved variable.
+- Use unique ephemeral credentials per run.
+- Redact request headers and secret-bearing JSON fields before artifact upload.
+- Separate public pull-request jobs from jobs allowed to access the private Proxmox lab.
+
+## Suggested repository layout
+
+```text
+e2e/
+  README.md
+  pyproject.toml
+  lab.example.yaml
+  orchestrator/
+    cli.py
+    proxmox.py
+    allocation.py
+    seed.py
+    readiness.py
+    diagnostics.py
+    cleanup.py
+  tests/
+    test_boot.py
+    test_services.py
+    test_api.py
+    test_firewall.py
+    test_nat.py
+    test_dns_dhcp.py
+    test_reboot.py
+    test_update.py
+    test_ha.py
+  fixtures/
+    setup.json.j2
+  helpers/
+    wan-server/
+    lan-client/
+
+aifw-ui/
+  playwright.config.ts
+  e2e/
+    auth.spec.ts
+    dashboard.spec.ts
+    rules.spec.ts
+    settings.spec.ts
+
+.github/workflows/
+  e2e-pr.yml
+  e2e-nightly.yml
+  e2e-release.yml
+
+scripts/
+  e2e
+```
+
+Python with `pytest` is a practical orchestration layer because it provides mature Proxmox clients, fixtures, structured reports, timeouts, and cleanup primitives. Shell should remain limited to narrow guest helpers. Rust can be used for traffic or assertion tooling where type safety and reuse justify it.
+
+## CI tiers
+
+### Tier 0: local and every commit
+
+- Rust formatting, Clippy, and unit/integration tests.
+- UI lint made blocking after existing debt is addressed.
+- UI component tests.
+- Browser tests against mocked APIs where they provide fast feedback.
+- Shell syntax and helper allowlist tests.
+
+Target: under 10-15 minutes.
+
+### Tier 1: every eligible pull request
+
+- Build exact IMG artifact.
+- Boot it in Proxmox.
+- Run boot, readiness, service, API, core browser, and core data-plane suites.
+- Reboot once and verify recovery.
+- Always collect diagnostics and tear down.
+
+Target: approximately 15-30 minutes after artifact availability.
+
+### Tier 2: main and nightly
+
+- Full data plane, IPv6, update, rollback, failure injection, and recovery.
+- BIOS and UEFI matrix.
+- ISO installation smoke tests.
+- HA failover tests.
+- Longer throughput and stability tests with broad VM tolerances.
+
+### Tier 3: release candidate
+
+- Exact ISO-to-disk installation.
+- UFS and ZFS.
+- Supported firmware modes.
+- Complete functional and browser suite.
+- Reboot, update, rollback, and HA validation.
+- Publishing depends on successful completion.
+
+Performance regression thresholds should initially warn rather than block until enough stable lab history exists to define meaningful variance.
+
+## Implementation phases
+
+### Phase 1: appliance automation prerequisites
+
+- Add seed-media detection and unattended first boot.
+- Add explicit unattended installer arguments.
+- Add serial-console progress and failure output.
+- Add a minimal non-sensitive health endpoint.
+- Add reproducible build metadata with companion SHAs.
+
+### Phase 2: Proxmox lifecycle foundation
+
+- Implement scoped Proxmox authentication.
+- Implement VMID, address, subnet, and VLAN allocation.
+- Import and boot the IMG.
+- Generate and attach seed media.
+- Implement layered readiness.
+- Implement diagnostic collection.
+- Implement verified teardown and scheduled janitor.
+
+### Phase 3: core appliance tests
+
+- Boot and packaging assertions.
+- Service health.
+- Authenticated API smoke tests.
+- Live `pf` state checks.
+- LAN-to-WAN and WAN-to-LAN traffic tests.
+- NAT, DNS, DHCP, TCP, UDP, and ICMP tests.
+
+### Phase 4: browser and broader functional coverage
+
+- Add Playwright configuration and fixtures.
+- Cover login, dashboard, rules, NAT, DNS, IDS, users, and settings.
+- Add WebSocket and SSE assertions.
+- Add backup and restore tests.
+
+### Phase 5: resilience and release validation
+
+- Reboot and service-recovery suites.
+- Update and rollback suites.
+- ISO installation with UFS and ZFS.
+- Failure injection.
+- HA provisioning and failover.
+- Release publication gate.
+
+## Initial acceptance criteria
+
+The first production-useful milestone should meet all of these conditions:
+
+- One command provisions an exact AiFw IMG in Proxmox.
+- Setup is completely unattended and uses ephemeral credentials.
+- Readiness requires SSH, services, TLS, login, and authenticated status.
+- A Linux client routes real TCP, UDP, ICMP, and DNS traffic through AiFw.
+- At least one real pass rule and one real block rule are verified against live traffic and `pf` state.
+- A core Playwright login/dashboard/rule workflow runs against the appliance.
+- The appliance reboots and becomes fully ready again.
+- Failures upload serial, service, firewall, application, and browser diagnostics.
+- Teardown runs after success, failure, timeout, and cancellation.
+- A final ownership check proves no run-scoped Proxmox resource remains.
+
+Once this milestone is stable, ISO installation, HA, update rollback, IPv6, and destructive recovery tests can be layered onto the same lifecycle framework.

--- a/testingUplift.md
+++ b/testingUplift.md
@@ -65,6 +65,14 @@ official image has no `sudo`, and `sysrc` does not read settings rendered into
 `/etc/rc.conf.d`; readiness therefore checks live `ifconfig`/`netstat` state
 and uses passwordless `su`.
 
+A builder-only attempt then exposed an independent PVE API race: setting
+`virtio0` and `boot=order=virtio0` in the same disk-import request caused PVE
+to omit the disk from the persisted boot order because the asynchronous import
+had not created it yet. The VM attempted PXE/CD-ROM boot and remained idle.
+The harness now waits for import completion and submits boot order as a second
+task; repairing that setting on the disposable VM made the corrected network
+seed come online immediately. Unit coverage locks in the two-request order.
+
 The Woodpecker E2E workflow remains experimental because builder-only artifact
 production and appliance-only deployment are still unverified, not because
 the builder VM is unable to boot or network.

--- a/testingUplift.md
+++ b/testingUplift.md
@@ -12,8 +12,8 @@ The target definition of done is:
 
 This document separates the implemented current state from the intended full
 framework. The repository now contains a directly validated one-NIC appliance
-lifecycle harness. Builder-only image production and corrected appliance-only
-initial/reboot validation pass; one combined native-fix Woodpecker run remains.
+lifecycle harness. Woodpecker pipeline 14 passed the combined native build,
+initial health, reboot health, and teardown path on 2026-07-19.
 
 ### Implemented and verified
 
@@ -49,6 +49,11 @@ initial/reboot validation pass; one combined native-fix Woodpecker run remains.
 - Appliance-only validation passed unattended setup, core services, TLS login,
   authenticated API/UI status, live `pf`, reboot recovery, and teardown after
   applying equivalent boot metadata corrections to the retained IMG.
+- Woodpecker pipeline 14 then rebuilt the fixes natively as AiFw 5.99.14 from
+  commit `9c146232`, produced a 221,009,096-byte compressed IMG, deployed that
+  exact job-local artifact at `192.168.0.26`, and passed in 1,840 seconds.
+- A post-run Proxmox audit found zero run-owned VMs and zero matching uploaded
+  or imported volumes.
 
 ### Resolved builder bootstrap issue
 
@@ -93,11 +98,29 @@ Focused appliance deployment exposed four independent artifact/runtime bugs:
 4. Reboot checks stopped at SSH and could race the parallel rc sequence. They
    now retry the complete services, TLS login, API/UI, and `pf` contract.
 
-The retained image was patched with equivalent boot metadata to prove the
-diagnosis without repeating compilation. Its final manifest records
-`pf_running=true` before and after reboot, and teardown left zero resources.
-The Woodpecker workflow remains experimental only until a natively rebuilt
-image completes the same combined run.
+The retained image was first patched with equivalent boot metadata to prove the
+diagnosis without repeating compilation. Its final manifest recorded
+`pf_running=true` before and after reboot. Pipeline 14 subsequently proved the
+natively rebuilt source through the same combined lifecycle.
+
+### Which failures were FreeBSD-specific?
+
+Most appliance/bootstrap failures were FreeBSD-specific:
+
+- FreeBSD 15 uses native `nuageinit`; its NoCloud network parser required v2
+  data and the VirtIO interface name `vtnet0`, not Linux-style `eth0`.
+- The stock FreeBSD cloud image lacked `sudo` and required the wheel account's
+  passwordless `su`; preserving the caller environment also preserved the wrong
+  home directory.
+- `KEYWORD:firstboot`, UFS versus GPT labels, `rc.conf` `pf_rules`, and FreeBSD
+  rc startup timing caused the first-boot, mount, and reboot failures.
+
+The Proxmox disk-import/boot-order race was not FreeBSD-specific; any guest can
+hit it when an asynchronously imported disk is referenced too early. The
+Woodpecker shell interpolation and checksum-parser escaping failures were also
+generic CI portability issues. The durable design therefore keeps FreeBSD
+guest adapters explicit while treating Proxmox lifecycle and CI orchestration
+as guest-agnostic layers.
 
 ### Current coverage that predates the VM harness
 
@@ -112,21 +135,21 @@ image completes the same combined run.
 
 ### Remaining gaps to the full target
 
-- No successful Woodpecker-built seed-capable IMG has yet completed the full
-  Proxmox boot, service, login, API, reboot, and teardown sequence.
-- No exact shipped ISO or IMG is currently gated before publication.
+- The passing exact-IMG lifecycle is manual, not yet a required publication
+  gate, and has only one successful combined Woodpecker acceptance run.
+- ISO installation is not exercised; the tested artifact is the writable IMG.
 - The lab has only an untagged management bridge; no isolated WAN/LAN helper
   topology exists for routed traffic tests.
 - No tracked Playwright/browser suite exists.
-- No real FreeBSD `pf`, TLS, IDS, DNS, DHCP, NAT, or forwarded-packet behavior
-  is exercised in CI.
+- Real FreeBSD `pf` availability and TLS/API behavior are exercised, but no
+  ruleset enforcement, IDS, DNS, DHCP, NAT, or forwarded-packet behavior is.
 - No ISO installation, update/rollback, failure injection, HA provisioning, or
   stale-resource janitor exists at VM level.
 - UI lint remains non-blocking while existing lint debt is addressed.
 
-The current suite proves substantial application logic and most Proxmox
-lifecycle contracts, but it does not yet prove that the newly built appliance
-works as an integrated firewall.
+The current suite proves the newly built appliance boots, configures, serves
+its control plane, keeps `pf` alive across reboot, and tears down safely. It
+does not yet prove routed firewall behavior.
 
 ## Validation workflow
 
@@ -191,7 +214,7 @@ Proxmox infrastructure.
 
 ### Current Woodpecker lane
 
-The manual `.woodpecker/e2e.yml` workflow is designed to:
+The manual `.woodpecker/e2e.yml` workflow now:
 
 1. Run only on the LAN agent labelled `proxmox=true`.
 2. Download the official FreeBSD 15.0 BASIC-CLOUDINIT UFS qcow2 image.
@@ -203,9 +226,9 @@ The manual `.woodpecker/e2e.yml` workflow is designed to:
 7. Import the new IMG, attach the `AIFW_SEED` ISO, test the appliance, reboot
    it, collect diagnostics, and destroy all run resources.
 
-Builder-only and corrected appliance-only evidence now pass directly. The next
-and only expensive acceptance step is one combined Woodpecker run that rebuilds
-the native fixes and deploys that exact job-local IMG.
+Builder-only, corrected appliance-only, and combined Woodpecker evidence now
+pass. Pipeline 14 rebuilt the native fixes and deployed that exact job-local
+IMG successfully.
 
 ### Builder implementation options
 
@@ -734,9 +757,10 @@ Once this milestone is stable, ISO installation, HA, update rollback, IPv6, and 
 
 ## Immediate next steps from the current state
 
-1. Run one combined Woodpecker manual workflow as final native-build evidence.
-2. Promote the one-NIC lane from experimental to a required release smoke only
-   after that combined run passes consistently.
+1. Repeat the manual lane on release candidates and promote it to a required
+   release smoke after repeatability is established.
+2. Persist manifests and diagnostics outside the ephemeral Woodpecker job, and
+   add a scheduled stale-resource janitor.
 3. Introduce a versioned template only if subsequent measurements show that
    the performance benefit justifies its maintenance and canary requirements.
 4. Add an isolated VLAN-aware or dedicated WAN/LAN lab topology before claiming

--- a/testingUplift.md
+++ b/testingUplift.md
@@ -11,9 +11,9 @@ The target definition of done is:
 ## Status snapshot — 2026-07-19
 
 This document separates the implemented current state from the intended full
-framework. The repository now contains an initial appliance lifecycle harness,
-but a complete successful image-build-plus-appliance run has not yet been
-demonstrated.
+framework. The repository now contains a directly validated one-NIC appliance
+lifecycle harness. Builder-only image production and corrected appliance-only
+initial/reboot validation pass; one combined native-fix Woodpecker run remains.
 
 ### Implemented and verified
 
@@ -44,6 +44,11 @@ demonstrated.
   schema, command quoting, and builder-user consistency.
 - Woodpecker repository secrets are scoped to manual events. The Proxmox token
   is not committed or written to generated artifacts.
+- A clean official-image builder run produced and checksummed the compressed
+  IMG in roughly 15 minutes, copied it back, and left zero Proxmox resources.
+- Appliance-only validation passed unattended setup, core services, TLS login,
+  authenticated API/UI status, live `pf`, reboot recovery, and teardown after
+  applying equivalent boot metadata corrections to the retained IMG.
 
 ### Resolved builder bootstrap issue
 
@@ -73,9 +78,26 @@ The harness now waits for import completion and submits boot order as a second
 task; repairing that setting on the disposable VM made the corrected network
 seed come online immediately. Unit coverage locks in the two-request order.
 
-The Woodpecker E2E workflow remains experimental because builder-only artifact
-production and appliance-only deployment are still unverified, not because
-the builder VM is unable to boot or network.
+### Resolved appliance boot and reboot issues
+
+Focused appliance deployment exposed four independent artifact/runtime bugs:
+
+1. The IMG requested `/dev/ufs/aifw` but created only `/dev/gpt/aifw`, dropping
+   to `mountroot` with error 19. `newfs -L aifw` now creates the label the
+   loader and fstab request.
+2. `aifw_firstboot` used FreeBSD's sentinel-gated `KEYWORD:firstboot`, but a
+   staged writable IMG has no sentinel. It is now a normal idempotent rc
+   service that exits when configured and disables itself after success.
+3. Setup enabled `pf` without persisting `pf_rules`; reboot fell back to the
+   absent `/etc/pf.conf`. Setup now persists the AiFw rules path.
+4. Reboot checks stopped at SSH and could race the parallel rc sequence. They
+   now retry the complete services, TLS login, API/UI, and `pf` contract.
+
+The retained image was patched with equivalent boot metadata to prove the
+diagnosis without repeating compilation. Its final manifest records
+`pf_running=true` before and after reboot, and teardown left zero resources.
+The Woodpecker workflow remains experimental only until a natively rebuilt
+image completes the same combined run.
 
 ### Current coverage that predates the VM harness
 
@@ -181,17 +203,17 @@ The manual `.woodpecker/e2e.yml` workflow is designed to:
 7. Import the new IMG, attach the `AIFW_SEED` ISO, test the appliance, reboot
    it, collect diagnostics, and destroy all run resources.
 
-This is the intended current lane, not yet a passing lane. Builder bootstrap
-is directly verified; the next evidence must come from a focused builder-only
-artifact run and a focused appliance-only run before another combined workflow
-is used as acceptance evidence.
+Builder-only and corrected appliance-only evidence now pass directly. The next
+and only expensive acceptance step is one combined Woodpecker run that rebuilds
+the native fixes and deploys that exact job-local IMG.
 
 ### Builder implementation options
 
 The selected correctness-first path is an ephemeral builder created from the
 checksum-verified official FreeBSD image on every run. It is stateless and
-reproducible, but the image performs slow first-boot work and every run must
-install build dependencies.
+reproducible, and the measured clean run completed in roughly 15 minutes. This
+is acceptable for the manual/release lane and unblocks immediately without
+introducing mutable template state.
 
 If measured duration is too high, the recommended optimization is a versioned
 Proxmox builder template:
@@ -660,11 +682,11 @@ Performance regression thresholds should initially warn rather than block until 
 - Implement VMID, address, subnet, and VLAN allocation.
 - **Implemented:** dynamic VMID selection and one reserved management address.
   Dynamic subnet/VLAN allocation remains target-state work.
-- **Directly verified:** upload/import, VM creation, disk configuration, and
-  guarded teardown. Full AiFw IMG boot remains unverified.
+- **Directly verified:** upload/import, VM creation, disk configuration,
+  builder artifact production, corrected AiFw IMG boot, and guarded teardown.
 - **Implemented:** appliance seed generation and attachment.
-- **Implemented:** SSH, service, TLS/API, UI, and reboot readiness checks. These
-  await a successful full appliance run.
+- **Directly verified:** SSH, service, TLS/API, UI, live `pf`, and reboot
+  readiness checks on the corrected retained IMG.
 - **Implemented:** basic diagnostics and verified per-run teardown.
 - **Not implemented:** scheduled stale-resource janitor.
 
@@ -712,13 +734,10 @@ Once this milestone is stable, ISO installation, HA, update rollback, IPv6, and 
 
 ## Immediate next steps from the current state
 
-1. Run the builder command directly once and retain its IMG long enough to
-   validate checksum, partition table, and expected embedded seed-support
-   files.
-2. Run the appliance command directly against that IMG and fix readiness or
-   appliance bootstrap issues one contract at a time.
-3. Run one combined Woodpecker manual workflow as final integration evidence.
-4. Measure the clean builder duration; introduce a versioned template only if
+1. Run one combined Woodpecker manual workflow as final native-build evidence.
+2. Promote the one-NIC lane from experimental to a required release smoke only
+   after that combined run passes consistently.
+3. Introduce a versioned template only if subsequent measurements show that
    the performance benefit justifies its maintenance and canary requirements.
-5. Add an isolated VLAN-aware or dedicated WAN/LAN lab topology before claiming
+4. Add an isolated VLAN-aware or dedicated WAN/LAN lab topology before claiming
    firewall data-plane E2E coverage.


### PR DESCRIPTION
## Summary
- add Vitest API-client coverage
- add mocked Playwright auth-flow coverage
- expose portable npm test commands and CI steps

## Validation
- npm ci; npm test (8 tests); lint; build
- private Proxmox appliance flow remains internal and is not committed as generic test logic.