### PR TITLE
fix: address issues 529-542 with layered tests

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -101,9 +101,13 @@ jobs:
             for row in $(jq -c '.external_repos[]' "$MANIFEST"); do
               NAME=$(echo "$row" | jq -r '.name')
               REPO=$(echo "$row" | jq -r '.repo')
+              REV=$(echo "$row" | jq -r '.rev')
+              echo "$REV" | grep -Eq '^[0-9a-f]{40}$' || { echo "Invalid immutable revision for $NAME"; exit 1; }
               echo "=== Building $NAME ==="
-              git clone "https://github.com/${REPO}.git" "/tmp/${NAME}"
+              git clone --no-checkout "https://github.com/${REPO}.git" "/tmp/${NAME}"
               cd "/tmp/${NAME}"
+              git checkout --detach "$REV"
+              test "$(git rev-parse HEAD)" = "$REV" || exit 1
               cargo build --release
               cd /home/runner/work/AiFw/AiFw
             done

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -125,6 +125,10 @@ jobs:
                 [ -f "/tmp/${NAME}/target/release/${bin}" ] && cp "/tmp/${NAME}/target/release/${bin}" "freebsd/release/${bin}"
               done
             done
+            # Publish a machine-readable inventory alongside release artifacts.
+            # This is an inventory, not an authenticity signature; checksums
+            # remain corruption checks only until signing/attestation is wired.
+            freebsd/generate-sbom.sh freebsd/release/aifw.spdx.json
 
             echo "=== Building update tarball ==="
             VERSION="${{ steps.version.outputs.version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,11 @@ node_modules/
 freebsd/release/
 freebsd/ui-export/
 
+# E2E run artifacts and ephemeral credentials
+e2e/artifacts/
+e2e/.run/
+__pycache__/
+*.py[cod]
+
 # CLAUDE.md is project policy and is tracked in the repo — do not ignore it.
 Cargo.lock

--- a/.woodpecker/ci.yml
+++ b/.woodpecker/ci.yml
@@ -2,7 +2,6 @@ when:
   - event: push
     branch: main
   - event: pull_request
-  - event: manual
   - event: tag
 
 labels:

--- a/.woodpecker/ci.yml
+++ b/.woodpecker/ci.yml
@@ -1,0 +1,37 @@
+when:
+  - event: push
+    branch: main
+  - event: pull_request
+  - event: manual
+  - event: tag
+
+labels:
+  platform: linux/amd64
+
+steps:
+  - name: rust
+    image: rust:1.95-bookworm
+    environment:
+      CARGO_INCREMENTAL: "0"
+      RUSTFLAGS: "-D warnings"
+    commands:
+      - rustup component add rustfmt clippy
+      - cargo fmt --all -- --check
+      - cargo clippy --workspace --all-targets -- -D warnings
+      - cargo test --workspace --no-fail-fast
+
+  - name: ui
+    image: node:24-bookworm
+    commands:
+      - cd aifw-ui
+      - npm ci --no-audit --no-fund
+      - npm run lint || true
+      - npm run build
+
+  - name: e2e-harness-tests
+    image: python:3.13-bookworm
+    commands:
+      - apt-get update && apt-get install -y --no-install-recommends xorriso xz-utils openssh-client
+      - pip install --no-cache-dir -r e2e/requirements.txt
+      - python -m compileall -q e2e
+      - python -m pytest -q e2e/tests

--- a/.woodpecker/e2e.yml
+++ b/.woodpecker/e2e.yml
@@ -30,13 +30,13 @@ steps:
       AIFW_E2E_DNS:
         from_secret: aifw_e2e_dns
     commands:
-      - apt-get update && apt-get install -y --no-install-recommends ca-certificates curl xorriso xz-utils openssh-client
+      - apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git xorriso xz-utils openssh-client
       - pip install --no-cache-dir -r e2e/requirements.txt
       - mkdir -p e2e/.run e2e/artifacts
-      - test -n "$CI_PIPELINE_PARAM_ARTIFACT_URL" || { echo "manual parameter artifact_url is required and must point to an IMG built from this seed-capable revision"; exit 2; }
-      - curl --fail --location --retry 3 --output e2e/.run/aifw.img.xz "$CI_PIPELINE_PARAM_ARTIFACT_URL"
+      - curl --fail --location --retry 3 --output e2e/.run/freebsd-builder.qcow2.xz https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz
+      - python -m e2e.aifw_e2e build --builder-image e2e/.run/freebsd-builder.qcow2.xz --output e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-${CI_COMMIT_SHA:0:8}"
       - python -m e2e.aifw_e2e run --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-${CI_COMMIT_SHA:0:8}"
 
-# Diagnostic collection runs before the harness's finally-block destroys the
-# VM. Add the homelab's selected artifact publisher when one is standardized;
-# until then the manifest and diagnostic paths are reported in the step log.
+# The build VM is destroyed before the appliance starts, allowing the same
+# reserved management address to be reused safely. The appliance VM and all
+# uploaded media are destroyed by the harness's finally-block.

--- a/.woodpecker/e2e.yml
+++ b/.woodpecker/e2e.yml
@@ -1,8 +1,8 @@
 when:
   - event: manual
 
-# Experimental until builder-only image production and appliance-only
-# validation documented in e2e/README.md pass. Do not use as a release gate.
+# Experimental until one combined native-fix run passes. Focused builder-only
+# and appliance-only validation now pass; see e2e/README.md.
 
 # Destructive Proxmox work is restricted to the LAN agent explicitly labelled
 # for the lab. It must never be scheduled on ordinary or remote Docker agents.
@@ -37,8 +37,10 @@ steps:
       - pip install --no-cache-dir -r e2e/requirements.txt
       - mkdir -p e2e/.run e2e/artifacts
       - curl --fail --location --retry 3 --output e2e/.run/freebsd-builder.qcow2.xz https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz
-      - python -m e2e.aifw_e2e build --builder-image e2e/.run/freebsd-builder.qcow2.xz --output e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-${CI_COMMIT_SHA:0:8}"
-      - python -m e2e.aifw_e2e run --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-${CI_COMMIT_SHA:0:8}"
+      - curl --fail --location --retry 3 --output e2e/.run/CHECKSUM.SHA256 https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/CHECKSUM.SHA256
+      - sed -n 's/^SHA256 (FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz) = \([0-9a-f]*\)$/\1  e2e\/\.run\/freebsd-builder.qcow2.xz/p' e2e/.run/CHECKSUM.SHA256 | sha256sum --check --strict -
+      - python -m e2e.aifw_e2e build --builder-image e2e/.run/freebsd-builder.qcow2.xz --output e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
+      - python -m e2e.aifw_e2e run --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
 
 # The build VM is destroyed before the appliance starts, allowing the same
 # reserved management address to be reused safely. The appliance VM and all

--- a/.woodpecker/e2e.yml
+++ b/.woodpecker/e2e.yml
@@ -1,8 +1,7 @@
 when:
   - event: manual
 
-# Validated one-NIC lifecycle smoke. Keep manual until repeatability and an
-# isolated WAN/LAN topology justify promotion to a required release gate.
+# Full isolated WAN/LAN lifecycle. Manual while the lab lane is capacity-bound.
 
 # Destructive Proxmox work is restricted to the LAN agent explicitly labelled
 # for the lab. It must never be scheduled on ordinary or remote Docker agents.
@@ -19,6 +18,8 @@ steps:
       PVE_IMAGE_STORAGE: local
       PVE_VM_STORAGE: local-lvm
       PVE_BRIDGE: vmbr0
+      PVE_E2E_WAN_BRIDGE: vmbr998
+      PVE_E2E_LAN_BRIDGE: vmbr999
       PVE_VERIFY_TLS: "false"
       PVE_TOKEN_ID:
         from_secret: pve_token_id
@@ -35,14 +36,15 @@ steps:
     commands:
       - apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git xorriso xz-utils openssh-client
       - pip install --no-cache-dir -r e2e/requirements.txt
+      - python -m playwright install --with-deps chromium
       - mkdir -p e2e/.run e2e/artifacts
       - curl --fail --location --retry 3 --output e2e/.run/freebsd-builder.qcow2.xz https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz
       - curl --fail --location --retry 3 --output e2e/.run/CHECKSUM.SHA256 https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/CHECKSUM.SHA256
       - awk '$1 == "SHA256" && $2 == "(FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz)" && $3 == "=" { print $4 "  e2e/.run/freebsd-builder.qcow2.xz" }' e2e/.run/CHECKSUM.SHA256 | sha256sum --check --strict -
       - python -m e2e.aifw_e2e build --builder-image e2e/.run/freebsd-builder.qcow2.xz --output e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
-      - python -m e2e.aifw_e2e run --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
+      - python -m e2e.aifw_e2e full --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
       - python -m json.tool "e2e/artifacts/${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")/manifest.json"
 
-# The build VM is destroyed before the appliance starts, allowing the same
-# reserved management address to be reused safely. The appliance VM and all
-# uploaded media are destroyed by the harness's finally-block.
+# The build VM is destroyed before the LAN helper reuses the reserved address.
+# The appliance VM, helper containers, and uploaded media are destroyed by the
+# harness's finally-block.

--- a/.woodpecker/e2e.yml
+++ b/.woodpecker/e2e.yml
@@ -1,8 +1,8 @@
 when:
   - event: manual
 
-# Experimental until one combined native-fix run passes. Focused builder-only
-# and appliance-only validation now pass; see e2e/README.md.
+# Validated one-NIC lifecycle smoke. Keep manual until repeatability and an
+# isolated WAN/LAN topology justify promotion to a required release gate.
 
 # Destructive Proxmox work is restricted to the LAN agent explicitly labelled
 # for the lab. It must never be scheduled on ordinary or remote Docker agents.
@@ -41,6 +41,7 @@ steps:
       - awk '$1 == "SHA256" && $2 == "(FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz)" && $3 == "=" { print $4 "  e2e/.run/freebsd-builder.qcow2.xz" }' e2e/.run/CHECKSUM.SHA256 | sha256sum --check --strict -
       - python -m e2e.aifw_e2e build --builder-image e2e/.run/freebsd-builder.qcow2.xz --output e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
       - python -m e2e.aifw_e2e run --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
+      - python -m json.tool "e2e/artifacts/${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")/manifest.json"
 
 # The build VM is destroyed before the appliance starts, allowing the same
 # reserved management address to be reused safely. The appliance VM and all

--- a/.woodpecker/e2e.yml
+++ b/.woodpecker/e2e.yml
@@ -1,6 +1,9 @@
 when:
   - event: manual
 
+# Experimental until builder-only image production and appliance-only
+# validation documented in e2e/README.md pass. Do not use as a release gate.
+
 # Destructive Proxmox work is restricted to the LAN agent explicitly labelled
 # for the lab. It must never be scheduled on ordinary or remote Docker agents.
 labels:

--- a/.woodpecker/e2e.yml
+++ b/.woodpecker/e2e.yml
@@ -1,0 +1,42 @@
+when:
+  - event: manual
+
+# Destructive Proxmox work is restricted to the LAN agent explicitly labelled
+# for the lab. It must never be scheduled on ordinary or remote Docker agents.
+labels:
+  platform: linux/amd64
+  proxmox: "true"
+
+steps:
+  - name: proxmox-e2e
+    image: python:3.13-bookworm
+    environment:
+      PVE_URL: https://192.168.1.159:8006
+      PVE_NODE: trigproxmox
+      PVE_IMAGE_STORAGE: local
+      PVE_VM_STORAGE: local-lvm
+      PVE_BRIDGE: vmbr0
+      PVE_VERIFY_TLS: "false"
+      PVE_TOKEN_ID:
+        from_secret: pve_token_id
+      PVE_TOKEN_SECRET:
+        from_secret: pve_token_secret
+      AIFW_E2E_ADMIN_PASSWORD:
+        from_secret: aifw_e2e_admin_password
+      AIFW_E2E_ADDRESS:
+        from_secret: aifw_e2e_address
+      AIFW_E2E_GATEWAY:
+        from_secret: aifw_e2e_gateway
+      AIFW_E2E_DNS:
+        from_secret: aifw_e2e_dns
+    commands:
+      - apt-get update && apt-get install -y --no-install-recommends ca-certificates curl xorriso xz-utils openssh-client
+      - pip install --no-cache-dir -r e2e/requirements.txt
+      - mkdir -p e2e/.run e2e/artifacts
+      - test -n "$CI_PIPELINE_PARAM_ARTIFACT_URL" || { echo "manual parameter artifact_url is required and must point to an IMG built from this seed-capable revision"; exit 2; }
+      - curl --fail --location --retry 3 --output e2e/.run/aifw.img.xz "$CI_PIPELINE_PARAM_ARTIFACT_URL"
+      - python -m e2e.aifw_e2e run --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-${CI_COMMIT_SHA:0:8}"
+
+# Diagnostic collection runs before the harness's finally-block destroys the
+# VM. Add the homelab's selected artifact publisher when one is standardized;
+# until then the manifest and diagnostic paths are reported in the step log.

--- a/.woodpecker/e2e.yml
+++ b/.woodpecker/e2e.yml
@@ -38,7 +38,7 @@ steps:
       - mkdir -p e2e/.run e2e/artifacts
       - curl --fail --location --retry 3 --output e2e/.run/freebsd-builder.qcow2.xz https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz
       - curl --fail --location --retry 3 --output e2e/.run/CHECKSUM.SHA256 https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/CHECKSUM.SHA256
-      - sed -n 's/^SHA256 (FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz) = \([0-9a-f]*\)$/\1  e2e\/\.run\/freebsd-builder.qcow2.xz/p' e2e/.run/CHECKSUM.SHA256 | sha256sum --check --strict -
+      - awk '$1 == "SHA256" && $2 == "(FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz)" && $3 == "=" { print $4 "  e2e/.run/freebsd-builder.qcow2.xz" }' e2e/.run/CHECKSUM.SHA256 | sha256sum --check --strict -
       - python -m e2e.aifw_e2e build --builder-image e2e/.run/freebsd-builder.qcow2.xz --output e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
       - python -m e2e.aifw_e2e run --artifact e2e/.run/aifw.img.xz --run-id "${CI_PIPELINE_NUMBER}-$(printf '%.8s' "${CI_COMMIT_SHA}")"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,13 @@ Open an issue using the [feature request template](.github/ISSUE_TEMPLATE/featur
 6. If you changed the UI: `cd aifw-ui && npm run build`
 7. Submit a pull request
 
+Changes under `e2e/`, `.woodpecker/e2e.yml`, `freebsd/build-*.sh`, or the
+first-boot overlay should follow the staged validation order in
+`e2e/README.md`: unit tests, focused disposable Proxmox contracts, focused
+FreeBSD boot/SSH, builder-only, appliance-only, then one combined manual
+Woodpecker run. Do not use repeated full pipelines to discover individual
+Proxmox or cloud-init API details.
+
 ### Pull Request Guidelines
 
 - Keep PRs focused on a single change

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.7"
+version = "5.99.8"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.15"
+version = "5.99.16"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,8 @@ tokio-rustls = "0.26"
 rustls-pemfile = "2"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 url = "2"
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+rand_core = { version = "0.6", features = ["getrandom"] }
 
 # Workspace-wide clippy lint posture. Stylistic-only lints are allowed —
 # documented engine constructors legitimately have many parameters, the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.14"
+version = "5.99.15"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.11"
+version = "5.99.12"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.9"
+version = "5.99.10"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.13"
+version = "5.99.14"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.8"
+version = "5.99.9"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.12"
+version = "5.99.13"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.6"
+version = "5.99.7"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.10"
+version = "5.99.11"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/README.md
+++ b/README.md
@@ -235,7 +235,9 @@ readiness checks, diagnostics, reboot verification, and guarded teardown.
 Proxmox lifecycle contracts are directly tested, but the complete FreeBSD
 builder-to-appliance workflow is not yet a passing release gate. The FreeBSD
 builder bootstrap now passes focused Proxmox validation using a native
-`nuageinit` v2 seed; image production and appliance validation remain. The
+`nuageinit` v2 seed; direct builder-only image production and corrected
+appliance initial/reboot validation also pass. One combined Woodpecker run of
+the native fixes remains before promotion to a release gate. The
 current state, alternatives, and target WAN/LAN framework are documented in
 `testingUplift.md` and `e2e/README.md`.
 

--- a/README.md
+++ b/README.md
@@ -229,17 +229,15 @@ The hook mirrors CI's fast gates; skip a single run with `git commit --no-verify
 
 ### Appliance E2E status
 
-An experimental Woodpecker/Proxmox harness lives under `e2e/`. It implements
-tagged VM provisioning, image import, unattended appliance seed generation,
-readiness checks, diagnostics, reboot verification, and guarded teardown.
-Proxmox lifecycle contracts are directly tested, but the complete FreeBSD
-builder-to-appliance workflow is not yet a passing release gate. The FreeBSD
-builder bootstrap now passes focused Proxmox validation using a native
-`nuageinit` v2 seed; direct builder-only image production and corrected
-appliance initial/reboot validation also pass. One combined Woodpecker run of
-the native fixes remains before promotion to a release gate. The
-current state, alternatives, and target WAN/LAN framework are documented in
-`testingUplift.md` and `e2e/README.md`.
+The validated Woodpecker/Proxmox harness under `e2e/` implements exact-commit
+FreeBSD image builds, tagged VM provisioning, unattended setup, readiness and
+reboot checks, diagnostics, and guarded teardown. Woodpecker pipeline 14 passed
+the combined path on 2026-07-19: it built 5.99.14 from commit `9c146232`,
+tested that exact IMG at `192.168.0.26`, verified initial and post-reboot health
+including live `pf`, and left zero run-owned Proxmox resources. The lane remains
+manual and covers one-NIC lifecycle/control-plane smoke, not routed WAN/LAN
+data-plane behavior. See `testingUplift.md` and `e2e/README.md` for the full
+current and target states.
 
 ## Target Environment
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 High-performance firewall for FreeBSD built in Rust on top of pf. Optional AI/ML threat detection. All features free and open source.
 
+> **Release maturity: beta.** AiFw is under active development. Control-plane support in the API or UI does not by itself mean that a feature has a complete or production-qualified FreeBSD data plane. See the [feature maturity matrix](docs/maturity.md) before deployment.
+
 > **AI is not required.** AiFw is a full-featured firewall, router, DHCP server, DNS resolver, IDS/IPS, reverse proxy, and NTP server that works perfectly without any AI features enabled. You get stateful packet filtering, NAT, VPN, Geo-IP blocking, Suricata-compatible intrusion detection, traffic shaping, and a complete web UI — all without AI. There is no cloud dependency and no telemetry.
 
 > **AI/ML features are a work in progress.** The `aifw-ai` crate contains experimental detectors for port scans, DDoS, brute force, C2 beacons, and DNS tunneling. These are not yet production-ready and are disabled by default. The AI module is an opt-in add-on that will be developed further in future releases. The Threats page in the UI reflects the current WIP status of this module.
@@ -74,15 +76,15 @@ High-performance firewall for FreeBSD built in Rust on top of pf. Optional AI/ML
 ## Features
 
 - **Stateful packet filtering** via FreeBSD's pf with anchor isolation
-- **NAT** — SNAT, DNAT/RDR, masquerade, binat, NAT64/NAT46
+- **NAT** — SNAT, DNAT/RDR, masquerade, and binat. NAT64/NAT46 models are experimental and do not yet provide cross-family translation.
 - **Connection tracking** — real-time state table monitoring, top talkers, protocol breakdown
-- **Rate limiting & traffic shaping** — CoDel/HFSC/PriQ queues, per-IP overload tables, SYN flood protection
+- **Rate limiting & traffic shaping** — experimental queue configuration, per-IP overload tables, SYN flood protection
 - **AI/ML threat detection** *(optional, WIP)* — experimental port scan, DDoS, brute force, C2 beacon, DNS tunnel detection with auto-response (disabled by default, not yet production-ready)
-- **VPN integration** — WireGuard tunnels + peers, IPsec SAs with pf rule generation
+- **VPN integration** — WireGuard tunnels + peers. IPsec SA records currently generate firewall exceptions only; no IKE/kernel-SA backend is implemented.
 - **Geo-IP filtering** — country-based block/allow with GeoLite2 CSV, CIDR aggregation
 - **TLS inspection** — JA3/JA3S fingerprinting, SNI filtering, cert validation, version enforcement
 - **Plugin system** — native Rust + WASM sandboxed plugins with 7 hook points
-- **High availability (active-passive pair)** — Two AiFw nodes share a CARP virtual IP and pfsync state. Reboot the master and TCP sessions survive on the standby with no operator intervention. Setup via the UI in <15 minutes. See [docs/ha.md](docs/ha.md) for setup, ops, and failure modes.
+- **High availability (active-passive pair)** — CARP and pfsync configuration for two-node deployments. Validate failover and session behaviour in your environment; automated multi-node qualification is not yet available. See [docs/ha.md](docs/ha.md).
 - **Metrics engine** — RRD-style ring buffers (1s/1m/1h/1d tiers), optional PostgreSQL backend
 - **REST API** — Axum with JWT auth, API keys, full CRUD for all resources
 - **Terminal UI** — ratatui dashboard with 5 tabs

--- a/README.md
+++ b/README.md
@@ -227,6 +227,18 @@ sh scripts/install-hooks.sh   # pre-commit runs fmt --check + clippy -D warnings
 
 The hook mirrors CI's fast gates; skip a single run with `git commit --no-verify`.
 
+### Appliance E2E status
+
+An experimental Woodpecker/Proxmox harness lives under `e2e/`. It implements
+tagged VM provisioning, image import, unattended appliance seed generation,
+readiness checks, diagnostics, reboot verification, and guarded teardown.
+Proxmox lifecycle contracts are directly tested, but the complete FreeBSD
+builder-to-appliance workflow is not yet a passing release gate. The FreeBSD
+builder bootstrap now passes focused Proxmox validation using a native
+`nuageinit` v2 seed; image production and appliance validation remain. The
+current state, alternatives, and target WAN/LAN framework are documented in
+`testingUplift.md` and `e2e/README.md`.
+
 ## Target Environment
 
 - **OS**: FreeBSD 15.x

--- a/README.md
+++ b/README.md
@@ -229,15 +229,15 @@ The hook mirrors CI's fast gates; skip a single run with `git commit --no-verify
 
 ### Appliance E2E status
 
-The validated Woodpecker/Proxmox harness under `e2e/` implements exact-commit
-FreeBSD image builds, tagged VM provisioning, unattended setup, readiness and
-reboot checks, diagnostics, and guarded teardown. Woodpecker pipeline 14 passed
-the combined path on 2026-07-19: it built 5.99.14 from commit `9c146232`,
-tested that exact IMG at `192.168.0.26`, verified initial and post-reboot health
-including live `pf`, and left zero run-owned Proxmox resources. The lane remains
-manual and covers one-NIC lifecycle/control-plane smoke, not routed WAN/LAN
-data-plane behavior. See `testingUplift.md` and `e2e/README.md` for the full
-current and target states.
+The Woodpecker/Proxmox harness under `e2e/` implements exact-commit FreeBSD
+image builds, guarded deployment, and a full isolated topology: Debian helper
+containers on portless WAN/LAN bridges, a two-NIC AiFw VM, live NAT and
+pass/block traffic, API rule lifecycle, Playwright login/rules checks, reboot
+revalidation, diagnostics, and ownership-proven teardown. Pipeline 14 remains
+the last passing exact-commit one-NIC baseline; the new full manual workflow is
+implemented and awaiting its fresh-image acceptance run. See
+`testingUplift.md` and `e2e/README.md` for current evidence and remaining target
+lanes.
 
 ## Target Environment
 

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -1215,7 +1215,7 @@ fn is_option_override_safe(o: &aifw_core::config::DhcpOptionOverrideConfig) -> b
     }
     match o.value_type.as_str() {
         "ip" => v.parse::<std::net::Ipv4Addr>().is_ok(),
-        "ips" => {
+        "ips" | "reactive" => {
             let parts: Vec<&str> = v
                 .split(',')
                 .map(str::trim)

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -1514,7 +1514,8 @@ pub(crate) async fn apply_firewall_config(
             .execute(&state.pool)
             .await
         {
-            tracing::warn!(table, error = %e, "import: DELETE failed before restore");
+            tracing::error!(table, error = %e, "import: required DELETE failed before restore");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -1878,15 +1879,18 @@ pub(crate) async fn apply_firewall_config(
     if let Ok(vpn_rules) = state.vpn_engine.collect_vpn_rules().await {
         state.rule_engine.set_extra_rules(vpn_rules).await;
     }
-    if let Err(e) = state.rule_engine.apply_rules().await {
-        tracing::warn!(error = %e, "import: firewall rules apply failed");
-    }
-    if let Err(e) = state.nat_engine.apply_rules().await {
-        tracing::warn!(error = %e, "import: nat rules apply failed");
-    }
-    if let Err(e) = state.geoip_engine.apply_rules().await {
-        tracing::warn!(error = %e, "import: geoip rules apply failed");
-    }
+    state.rule_engine.apply_rules().await.map_err(|e| {
+        tracing::error!(error = %e, "import: required firewall rules apply failed");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    state.nat_engine.apply_rules().await.map_err(|e| {
+        tracing::error!(error = %e, "import: required nat rules apply failed");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    state.geoip_engine.apply_rules().await.map_err(|e| {
+        tracing::error!(error = %e, "import: required geoip rules apply failed");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     Ok(())
 }

--- a/aifw-api/src/ids.rs
+++ b/aifw-api/src/ids.rs
@@ -105,7 +105,7 @@ pub async fn update_config(
     if let Some(mode) = &req.mode {
         config.mode = match mode.as_str() {
             "ids" => IdsMode::Ids,
-            "ips" => IdsMode::Ips,
+            "ips" | "reactive" => IdsMode::Ips,
             "disabled" => IdsMode::Disabled,
             _ => return Err((bad_request(), "invalid mode".into())),
         };

--- a/aifw-api/src/routes/mod.rs
+++ b/aifw-api/src/routes/mod.rs
@@ -18,9 +18,8 @@ use uuid::Uuid;
 
 use crate::AppState;
 use aifw_common::{
-    Action, Address, Direction, Interface, IpsecMode, IpsecProtocol, IpsecSa, NatRedirect, NatRule,
-    NatStatus, NatType, PortRange, Protocol, Rule, RuleMatch, RuleStatus, StateTracking, WgPeer,
-    WgTunnel,
+    Action, Address, Direction, Interface, IpsecSa, NatRedirect, NatRule, NatStatus, NatType,
+    PortRange, Protocol, Rule, RuleMatch, RuleStatus, StateTracking, WgPeer, WgTunnel,
 };
 
 pub mod ai;

--- a/aifw-api/src/routes/nat.rs
+++ b/aifw-api/src/routes/nat.rs
@@ -39,6 +39,9 @@ pub async fn create_nat_rule(
     Json(req): Json<CreateNatRuleRequest>,
 ) -> Result<(StatusCode, Json<ApiResponse<NatRule>>), StatusCode> {
     let nat_type = NatType::parse(&req.nat_type).map_err(|_| bad_request())?;
+    if matches!(nat_type, NatType::Nat64 | NatType::Nat46) {
+        return Err(StatusCode::NOT_IMPLEMENTED);
+    }
     let protocol = Protocol::parse(&req.protocol).map_err(|_| bad_request())?;
 
     let src_addr = req
@@ -101,7 +104,11 @@ pub async fn update_nat_rule(
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
 
-    rule.nat_type = NatType::parse(&req.nat_type).map_err(|_| bad_request())?;
+    let nat_type = NatType::parse(&req.nat_type).map_err(|_| bad_request())?;
+    if matches!(nat_type, NatType::Nat64 | NatType::Nat46) {
+        return Err(StatusCode::NOT_IMPLEMENTED);
+    }
+    rule.nat_type = nat_type;
     // Validate interface and label to prevent pf rule injection
     aifw_core::validation::validate_interface_name(&req.interface).map_err(|_| bad_request())?;
     if let Some(ref label) = req.label {

--- a/aifw-api/src/routes/vpn.rs
+++ b/aifw-api/src/routes/vpn.rs
@@ -373,6 +373,7 @@ pub async fn delete_wg_peer(
 
 // --- VPN: IPsec ---
 
+#[allow(dead_code)] // retained as the documented request shape while creation is disabled
 #[derive(Debug, Deserialize)]
 pub struct CreateIpsecSaRequest {
     pub name: String,

--- a/aifw-api/src/routes/vpn.rs
+++ b/aifw-api/src/routes/vpn.rs
@@ -394,23 +394,12 @@ pub async fn list_ipsec_sas(
 }
 
 pub async fn create_ipsec_sa(
-    State(state): State<AppState>,
-    Json(req): Json<CreateIpsecSaRequest>,
+    State(_state): State<AppState>,
+    Json(_req): Json<CreateIpsecSaRequest>,
 ) -> Result<(StatusCode, Json<ApiResponse<IpsecSa>>), StatusCode> {
-    let src = Address::parse(&req.local_addr).map_err(|_| bad_request())?;
-    let dst = Address::parse(&req.remote_addr).map_err(|_| bad_request())?;
-    let protocol = IpsecProtocol::parse(&req.protocol).map_err(|_| bad_request())?;
-    let mode = match req.mode.as_str() {
-        "transport" => IpsecMode::Transport,
-        _ => IpsecMode::Tunnel,
-    };
-    let sa = IpsecSa::new(req.name, src, dst, protocol, mode);
-    let sa = state
-        .vpn_engine
-        .add_ipsec_sa(sa)
-        .await
-        .map_err(|_| bad_request())?;
-    Ok((StatusCode::CREATED, Json(ApiResponse { data: sa })))
+    // Preserve existing rows for migration, but do not create records that
+    // look active when no IKE or kernel SA/SP backend exists.
+    Err(StatusCode::NOT_IMPLEMENTED)
 }
 
 pub async fn delete_ipsec_sa(

--- a/aifw-common/Cargo.toml
+++ b/aifw-common/Cargo.toml
@@ -13,6 +13,8 @@ thiserror = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true, features = ["sync", "net", "rt", "macros"] }
 url = { workspace = true }
+x25519-dalek = { workspace = true }
+rand_core = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true }

--- a/aifw-common/src/ids.rs
+++ b/aifw-common/src/ids.rs
@@ -11,7 +11,8 @@ use uuid::Uuid;
 pub enum IdsMode {
     /// Alert only — log detections, never block
     Ids,
-    /// Inline — drop/reject packets matching drop rules
+    /// Reactive blocking — passive detection followed by source-address pf-table blocking
+    #[serde(alias = "reactive")]
     Ips,
     /// Engine disabled
     #[default]
@@ -22,7 +23,7 @@ impl std::fmt::Display for IdsMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Ids => write!(f, "ids"),
-            Self::Ips => write!(f, "ips"),
+            Self::Ips => write!(f, "reactive"),
             Self::Disabled => write!(f, "disabled"),
         }
     }

--- a/aifw-common/src/vpn.rs
+++ b/aifw-common/src/vpn.rs
@@ -628,7 +628,10 @@ pub fn generate_wg_keypair() -> (String, String) {
     // operation instead of returning unrelated random-looking values.
     let private = x25519_dalek::StaticSecret::random_from_rng(rand_core::OsRng);
     let public = x25519_dalek::PublicKey::from(&private);
-    (base64_encode(private.as_bytes()), base64_encode(public.as_bytes()))
+    (
+        base64_encode(private.as_bytes()),
+        base64_encode(public.as_bytes()),
+    )
 }
 
 /// Generate a WireGuard preshared key (32 random bytes, base64 encoded)

--- a/aifw-common/src/vpn.rs
+++ b/aifw-common/src/vpn.rs
@@ -624,18 +624,11 @@ pub fn generate_wg_keypair() -> (String, String) {
         }
     }
 
-    // Fallback: generate 32 random bytes for each key
-    let mut private_bytes = [0u8; 32];
-    let mut public_bytes = [0u8; 32];
-    let id1 = Uuid::new_v4();
-    let id2 = Uuid::new_v4();
-    private_bytes[..16].copy_from_slice(id1.as_bytes());
-    private_bytes[16..].copy_from_slice(id2.as_bytes());
-    let id3 = Uuid::new_v4();
-    let id4 = Uuid::new_v4();
-    public_bytes[..16].copy_from_slice(id3.as_bytes());
-    public_bytes[16..].copy_from_slice(id4.as_bytes());
-    (base64_encode(&private_bytes), base64_encode(&public_bytes))
+    // In-process fallback: derive the public key with WireGuard's X25519
+    // operation instead of returning unrelated random-looking values.
+    let private = x25519_dalek::StaticSecret::random_from_rng(rand_core::OsRng);
+    let public = x25519_dalek::PublicKey::from(&private);
+    (base64_encode(private.as_bytes()), base64_encode(public.as_bytes()))
 }
 
 /// Generate a WireGuard preshared key (32 random bytes, base64 encoded)
@@ -650,10 +643,7 @@ pub fn generate_wg_psk() -> String {
         }
     }
     let mut bytes = [0u8; 32];
-    let id1 = Uuid::new_v4();
-    let id2 = Uuid::new_v4();
-    bytes[..16].copy_from_slice(id1.as_bytes());
-    bytes[16..].copy_from_slice(id2.as_bytes());
+    rand_core::RngCore::fill_bytes(&mut rand_core::OsRng, &mut bytes);
     base64_encode(&bytes)
 }
 

--- a/aifw-core/src/engine.rs
+++ b/aifw-core/src/engine.rs
@@ -130,11 +130,15 @@ impl RuleEngine {
     /// so they aren't shadowed by a `block quick` default.
     pub async fn apply_rules(&self) -> Result<()> {
         let rules = self.db.list_active_rules().await?;
-        let mut pf_rules: Vec<String> = rules
-            .iter()
-            .filter(|r| r.status == RuleStatus::Active)
-            .map(|r| r.to_pf_rule(&self.anchor))
-            .collect();
+        let mut pf_rules = Vec::new();
+        for rule in rules.iter().filter(|r| r.status == RuleStatus::Active) {
+            if let Some(schedule_id) = &rule.schedule_id
+                && !schedule_active(self.db.pool(), schedule_id, chrono::Local::now()).await?
+            {
+                continue;
+            }
+            pf_rules.push(rule.to_pf_rule(&self.anchor));
+        }
 
         // Inject extra rules (VPN pass rules, etc.) before the first block rule
         let extras = self.extra_rules.read().await;
@@ -208,4 +212,40 @@ impl RuleEngine {
     pub fn anchor(&self) -> &str {
         &self.anchor
     }
+}
+
+async fn schedule_active(
+    pool: &sqlx::SqlitePool,
+    id: &str,
+    now: chrono::DateTime<chrono::Local>,
+) -> Result<bool> {
+    use chrono::{Datelike, Timelike};
+    let row: Option<(String, String, bool)> =
+        sqlx::query_as("SELECT time_ranges, days_of_week, enabled FROM schedules WHERE id = ?1")
+            .bind(id)
+            .fetch_optional(pool)
+            .await?;
+    let Some((ranges, days, true)) = row else {
+        return Ok(false);
+    };
+    let day = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+        [now.weekday().num_days_from_monday() as usize];
+    if !days.split(',').any(|d| d.trim() == day) {
+        return Ok(false);
+    }
+    let minute = now.hour() * 60 + now.minute();
+    Ok(ranges.split(',').any(|range| {
+        let Some((start, end)) = range.trim().split_once('-') else {
+            return false;
+        };
+        let parse = |s: &str| {
+            s.split_once(':')
+                .and_then(|(h, m)| Some(h.parse::<u32>().ok()? * 60 + m.parse::<u32>().ok()?))
+        };
+        match (parse(start), parse(end)) {
+            (Some(a), Some(b)) if a <= b => minute >= a && minute < b,
+            (Some(a), Some(b)) => minute >= a || minute < b,
+            _ => false,
+        }
+    }))
 }

--- a/aifw-core/src/multiwan/gateway.rs
+++ b/aifw-core/src/multiwan/gateway.rs
@@ -94,17 +94,25 @@ pub fn evaluate_transition(
     consec_ok_up: u32,
     loss_pct_down: f64,
     loss_pct_up: f64,
+    latency_ms_down: Option<u64>,
+    latency_ms_up: Option<u64>,
 ) -> GatewayState {
     if metrics.consec_fail >= consec_fail_down {
         return GatewayState::Down;
     }
     if metrics.consec_ok >= consec_ok_up {
-        if metrics.recent_loss > loss_pct_up {
+        if metrics.recent_loss > loss_pct_up
+            || latency_ms_up
+                .is_some_and(|limit| metrics.last_rtt_ms.unwrap_or_default() > limit as f64)
+        {
             return GatewayState::Warning;
         }
         return GatewayState::Up;
     }
-    if metrics.recent_loss > loss_pct_down {
+    if metrics.recent_loss > loss_pct_down
+        || latency_ms_down
+            .is_some_and(|limit| metrics.last_rtt_ms.unwrap_or_default() > limit as f64)
+    {
         return GatewayState::Warning;
     }
     current
@@ -392,6 +400,8 @@ impl GatewayEngine {
             gw.consec_ok_up,
             gw.loss_pct_down,
             gw.loss_pct_up,
+            gw.latency_ms_down,
+            gw.latency_ms_up,
         );
         let metrics_snapshot = m.clone();
         drop(metrics_map);
@@ -703,7 +713,7 @@ mod tests {
             consec_fail: 3,
             ..GatewayMetrics::default()
         };
-        let s = evaluate_transition(GatewayState::Up, &m, 3, 5, 20.0, 5.0);
+        let s = evaluate_transition(GatewayState::Up, &m, 3, 5, 20.0, 5.0, None, None);
         assert_eq!(s, GatewayState::Down);
     }
 
@@ -714,7 +724,7 @@ mod tests {
             recent_loss: 8.0,
             ..GatewayMetrics::default()
         };
-        let s = evaluate_transition(GatewayState::Down, &m, 3, 5, 20.0, 5.0);
+        let s = evaluate_transition(GatewayState::Down, &m, 3, 5, 20.0, 5.0, None, None);
         assert_eq!(s, GatewayState::Warning);
     }
 }

--- a/aifw-core/src/shaping.rs
+++ b/aifw-core/src/shaping.rs
@@ -90,6 +90,11 @@ impl ShapingEngine {
     /// Insert a queue config row. pf isn't touched until
     /// [`Self::apply_queues`]
     pub async fn add_queue(&self, config: QueueConfig) -> Result<QueueConfig> {
+        if config.queue_type == QueueType::Codel {
+            return Err(AifwError::Validation(
+                "CoDel is unavailable until the dummynet FQ-CoDel backend is implemented".into(),
+            ));
+        }
         self.insert_queue(&config).await?;
         tracing::info!(id = %config.id, name = %config.name, "queue added");
         Ok(config)

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -477,7 +477,10 @@ mod tests {
         let q = QueueConfig::new(
             Interface("em0".into()),
             QueueType::Codel,
-            Bandwidth { value: 50, unit: BandwidthUnit::Mbps },
+            Bandwidth {
+                value: 50,
+                unit: BandwidthUnit::Mbps,
+            },
             "codel".into(),
             TrafficClass::Default,
         );

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -452,7 +452,7 @@ mod tests {
 
         let q = QueueConfig::new(
             Interface("em0".to_string()),
-            QueueType::Codel,
+            QueueType::Priq,
             Bandwidth {
                 value: 100,
                 unit: BandwidthUnit::Mbps,
@@ -468,6 +468,21 @@ mod tests {
         assert_eq!(queues[0].name, "test_queue");
 
         engine.delete_queue(id).await.unwrap();
+        assert!(engine.list_queues().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_codel_queue_is_rejected_without_dummynet_backend() {
+        let engine = create_shaping_engine().await;
+        let q = QueueConfig::new(
+            Interface("em0".into()),
+            QueueType::Codel,
+            Bandwidth { value: 50, unit: BandwidthUnit::Mbps },
+            "codel".into(),
+            TrafficClass::Default,
+        );
+        let err = engine.add_queue(q).await.unwrap_err();
+        assert!(err.to_string().contains("dummynet FQ-CoDel"));
         assert!(engine.list_queues().await.unwrap().is_empty());
     }
 
@@ -510,7 +525,7 @@ mod tests {
         engine
             .add_queue(QueueConfig::new(
                 Interface("em0".to_string()),
-                QueueType::Codel,
+                QueueType::Priq,
                 Bandwidth {
                     value: 100,
                     unit: BandwidthUnit::Mbps,

--- a/aifw-ids-ipc/src/proto.rs
+++ b/aifw-ids-ipc/src/proto.rs
@@ -65,7 +65,7 @@ pub enum IpcResponse {
 /// Runtime engine statistics snapshot returned by `GetStats`
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IdsStats {
-    /// Operating mode as a lowercase string ("ids", "ips", "disabled")
+    /// Operating mode as a lowercase string ("ids", "reactive", "disabled"; legacy "ips" accepted)
     pub mode: String,
     /// Whether the capture/detection engine is currently running
     pub running: bool,

--- a/aifw-ids/src/config.rs
+++ b/aifw-ids/src/config.rs
@@ -128,7 +128,7 @@ impl RuntimeConfig {
                 "mode" => {
                     cfg.mode = match value.as_str() {
                         "ids" => IdsMode::Ids,
-                        "ips" => IdsMode::Ips,
+                        "ips" | "reactive" => IdsMode::Ips,
                         _ => IdsMode::Disabled,
                     };
                 }

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -294,6 +294,15 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
         // keep re-applying over the daemon's DB-driven updates (v5.57.3 fix).
 
         // Load pf rules
+        // Persist the non-default rules path before enabling pf. FreeBSD's
+        // rc.d/pf defaults to /etc/pf.conf; AiFw writes pf.conf.aifw under
+        // config_dir. First boot explicitly loaded this file, masking the
+        // missing rc.conf setting until the next reboot.
+        run_best_effort("sysrc", &["pf_enable=YES"]);
+        run_best_effort(
+            "sysrc",
+            &[&format!("pf_rules={}/pf.conf.aifw", config.config_dir)],
+        );
         run_best_effort(
             "pfctl",
             &["-f", &format!("{}/pf.conf.aifw", config.config_dir)],

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -250,6 +250,11 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
                         "sysrc",
                         &[&format!("ifconfig_{}=inet {}", config.wan_interface, ip)],
                     );
+                    // `sysrc` persists the address for subsequent boots but
+                    // does not configure a running interface. Apply it now so
+                    // unattended first boot (including the Proxmox E2E seed)
+                    // becomes reachable without an extra reboot.
+                    run_best_effort("ifconfig", &[config.wan_interface.as_str(), "inet", ip]);
                 }
                 if let Some(ref gw) = config.wan_gateway {
                     run_best_effort("sysrc", &[&format!("defaultrouter={}", gw)]);

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.15",
+  "version": "5.99.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.15",
+      "version": "5.99.16",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.8",
+  "version": "5.99.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.8",
+      "version": "5.99.9",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.13",
+  "version": "5.99.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.13",
+      "version": "5.99.14",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.11",
+  "version": "5.99.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.11",
+      "version": "5.99.12",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.12",
+  "version": "5.99.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.12",
+      "version": "5.99.13",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.7",
+  "version": "5.99.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.7",
+      "version": "5.99.8",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.10",
+  "version": "5.99.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.10",
+      "version": "5.99.11",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.4",
+  "version": "5.99.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.4",
+      "version": "5.99.7",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.14",
+  "version": "5.99.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.14",
+      "version": "5.99.15",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.9",
+  "version": "5.99.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.9",
+      "version": "5.99.10",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.14",
+  "version": "5.99.15",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.6",
+  "version": "5.99.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.7",
+  "version": "5.99.8",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.15",
+  "version": "5.99.16",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.10",
+  "version": "5.99.11",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.9",
+  "version": "5.99.10",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.12",
+  "version": "5.99.13",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.11",
+  "version": "5.99.12",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.13",
+  "version": "5.99.14",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.8",
+  "version": "5.99.9",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/src/app/ids/page.tsx
+++ b/aifw-ui/src/app/ids/page.tsx
@@ -62,7 +62,7 @@ const severityColors: Record<string, { bg: string; bar: string; text: string }> 
   info: { bg: "bg-blue-500/20", bar: "bg-blue-500", text: "text-blue-400" },
 };
 
-const modeOptions = ["disabled", "ids", "ips"] as const;
+const modeOptions = ["disabled", "ids", "reactive"] as const;
 
 export default function IdsDashboardPage() {
   const [data, setData] = useState<StatsResponse | null>(null);

--- a/aifw-ui/src/app/rules/components/RuleFormModal.tsx
+++ b/aifw-ui/src/app/rules/components/RuleFormModal.tsx
@@ -315,16 +315,6 @@ export function RuleFormModal({
               />
             </div>
             <div>
-              <label className={labelClass}>Gateway</label>
-              <input
-                type="text"
-                value={form.gateway}
-                onChange={(e) => setForm((f) => ({ ...f, gateway: e.target.value }))}
-                placeholder="Policy routing gateway"
-                className={inputClass}
-              />
-            </div>
-            <div>
               <label className={labelClass}>State Type</label>
               <select
                 value={form.state_tracking}

--- a/aifw-ui/src/app/vpn/components/IpsecSection.tsx
+++ b/aifw-ui/src/app/vpn/components/IpsecSection.tsx
@@ -30,7 +30,6 @@ export function IpsecSection({
   ipsecForm,
   setIpsecForm,
   ipsecSubmitting,
-  onToggleForm,
   onSubmit,
   onCancel,
   onDelete,
@@ -53,17 +52,8 @@ export function IpsecSection({
 
       {ipsecOpen && (
         <div className="border-t border-gray-700">
-          {/* Add IPsec SA button */}
-          <div className="px-4 py-3 flex justify-end border-b border-gray-700/50">
-            <button
-              onClick={onToggleForm}
-              className="flex items-center gap-2 px-3 py-1.5 text-xs font-medium rounded-md bg-blue-600 hover:bg-blue-700 text-white transition-colors"
-            >
-              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-              </svg>
-              Add IPsec SA
-            </button>
+          <div className="px-4 py-3 border-b border-gray-700/50 text-sm text-amber-300">
+            Creation is disabled: no IKE or kernel SA/SP backend is implemented. Existing records are retained for migration only.
           </div>
 
           {/* IPsec form */}

--- a/aifw-ui/src/lib/api/rules.ts
+++ b/aifw-ui/src/lib/api/rules.ts
@@ -41,7 +41,6 @@ export interface RuleForm {
   dst_port: string;
   log: boolean;
   description: string;
-  gateway: string;
   state_tracking: string;
   label: string;
   schedule_id: string;
@@ -66,7 +65,6 @@ export const defaultForm: RuleForm = {
   dst_port: "",
   log: false,
   description: "",
-  gateway: "",
   state_tracking: "keep_state",
   label: "",
   schedule_id: "",
@@ -201,7 +199,6 @@ export function buildRuleBody(form: RuleForm): UpdateRuleRequest {
     quick: true,
     label: form.label || undefined,
     description: form.description || undefined,
-    gateway: form.gateway || null,
     schedule_id: form.schedule_id || null,
     state_tracking: form.state_tracking,
     status: form.disabled ? "disabled" : "active",
@@ -234,7 +231,6 @@ export function ruleToForm(rule: Rule): RuleForm {
     dst_port: rule.rule_match.dst_port ? String(rule.rule_match.dst_port.start) : "",
     log: rule.log,
     description: rule.description || "",
-    gateway: rule.gateway || "",
     state_tracking: rule.state_options.tracking,
     label: rule.label || "",
     schedule_id: rule.schedule_id || "",
@@ -259,7 +255,6 @@ export function toggleStatusRequest(rule: Rule): UpdateRuleRequest {
     log: rule.log,
     label: rule.label || undefined,
     description: rule.description || undefined,
-    gateway: rule.gateway || null,
     schedule_id: rule.schedule_id || null,
     state_tracking: rule.state_options.tracking,
     status: newStatus,

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -42,7 +42,7 @@ breadcrumb:
 
 # AiFw vs OPNsense vs pfSense
 
-A fair, honest comparison. Where a competitor is stronger, we say so. This matrix is generated from reading the code — AiFw features are verified against the repo, OPNsense and pfSense from their official docs.
+A control-plane comparison based on repository and vendor documentation. A checkmark is not a production-readiness claim; experimental or incomplete AiFw data planes are marked explicitly and tracked in the maturity matrix.
 
 <div class="compare-wrapper" markdown="0">
 <table class="compare">
@@ -66,12 +66,12 @@ A fair, honest comparison. Where a competitor is stronger, we say so. This matri
 <tr><td>SNAT (outbound)</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>DNAT / port forwarding</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>1:1 NAT (binat)</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
-<tr><td>NAT64</td><td class="yes">✓</td><td class="partial">plugin</td><td class="yes">✓</td></tr>
-<tr><td>NAT46</td><td class="yes">✓</td><td class="no">—</td><td class="no">—</td></tr>
+<tr><td>NAT64</td><td class="no">not implemented</td><td class="partial">plugin</td><td class="yes">✓</td></tr>
+<tr><td>NAT46</td><td class="no">not implemented</td><td class="no">—</td><td class="no">—</td></tr>
 
 <tr class="section-row"><td colspan="4">VPN</td></tr>
 <tr><td>WireGuard</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
-<tr><td>IPsec</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
+<tr><td>IPsec</td><td class="no">metadata only</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>OpenVPN</td><td class="no">—</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 
 <tr class="section-row"><td colspan="4">IDS / IPS</td></tr>
@@ -95,7 +95,7 @@ A fair, honest comparison. Where a competitor is stronger, we say so. This matri
 <tr><td>DDNS</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 
 <tr class="section-row"><td colspan="4">Traffic shaping</td></tr>
-<tr><td>CoDel</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
+<tr><td>CoDel</td><td class="no">not implemented</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>HFSC</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>PRIQ</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>CBQ</td><td class="no">—</td><td class="yes">✓</td><td class="yes">✓</td></tr>
@@ -115,7 +115,7 @@ A fair, honest comparison. Where a competitor is stronger, we say so. This matri
 <tr><td>TOTP 2FA</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">RADIUS</td></tr>
 <tr><td>LDAP</td><td class="no">—</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>RADIUS</td><td class="no">—</td><td class="yes">✓</td><td class="yes">✓</td></tr>
-<tr><td>OAuth / SSO</td><td class="yes">✓</td><td class="no">—</td><td class="no">—</td></tr>
+<tr><td>OAuth / SSO</td><td class="no">callback incomplete</td><td class="no">—</td><td class="no">—</td></tr>
 <tr><td>API keys</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">community</td></tr>
 <tr><td>RBAC (granular perms)</td><td class="yes">37 perms</td><td class="yes">ACL</td><td class="partial">user/group</td></tr>
 

--- a/docs/docs/backup.md
+++ b/docs/docs/backup.md
@@ -27,6 +27,8 @@ breadcrumb:
 
 # Backup &amp; migration
 
+> **Restore safety:** restore uses snapshot/reapply across SQLite and live services; it is not a single atomic database-and-kernel transaction. Required firewall, NAT, and GeoIP apply failures are returned as errors, but complete failure-injection and verified live-state rollback coverage is still in progress. Keep an out-of-band recovery path and a separately verified backup.
+
 Three workflows live in the same place: **JSON config backup &amp; restore** for day-to-day snapshots, **OPNsense / pfSense XML import** for migrating off another firewall, and **commit-confirm** for safe remote edits that auto-revert if you lose access. Versioned history sits underneath all three so any change is one click away from a rollback.
 
 ## JSON backup &amp; restore

--- a/docs/docs/backup.md
+++ b/docs/docs/backup.md
@@ -29,6 +29,8 @@ breadcrumb:
 
 > **Restore safety:** restore uses snapshot/reapply across SQLite and live services; it is not a single atomic database-and-kernel transaction. Required firewall, NAT, and GeoIP apply failures are returned as errors, but complete failure-injection and verified live-state rollback coverage is still in progress. Keep an out-of-band recovery path and a separately verified backup.
 
+Release SHA-256 files detect corruption but do not authenticate publisher origin. Release signing, key rotation, and keyless provenance attestation remain required before artifacts can be treated as authenticated. The build now emits an SPDX inventory for the Rust workspace; companion binary inventories are tracked separately with their pinned revisions in `freebsd/manifest.json`.
+
 Three workflows live in the same place: **JSON config backup &amp; restore** for day-to-day snapshots, **OPNsense / pfSense XML import** for migrating off another firewall, and **commit-confirm** for safe remote edits that auto-revert if you lose access. Versioned history sits underneath all three so any change is one click away from a rollback.
 
 ## JSON backup &amp; restore

--- a/docs/docs/firewall.md
+++ b/docs/docs/firewall.md
@@ -114,6 +114,8 @@ A schedule is a named time window with two fields:
 
 Attach a `schedule_id` to a rule and the rule is only loaded into pf during the active window. Outside the window the rule is silently dropped from the compiled ruleset.
 
+Policy-routing gateways are configured through the Multi-WAN policy engine. The firewall-rule Gateway control is intentionally not exposed because direct rule gateway associations are not persisted or compiled into `route-to`/`reply-to` pf semantics.
+
 Schedules are evaluated in the appliance's local timezone whenever the ruleset is applied. Disabled, missing, or malformed schedule references fail closed (the associated rule is omitted). Automatic reload exactly at schedule boundaries is not yet implemented, so configure an external reload trigger if boundary precision is required.
 
 ## Traffic shaping

--- a/docs/docs/firewall.md
+++ b/docs/docs/firewall.md
@@ -114,6 +114,8 @@ A schedule is a named time window with two fields:
 
 Attach a `schedule_id` to a rule and the rule is only loaded into pf during the active window. Outside the window the rule is silently dropped from the compiled ruleset.
 
+Schedules are evaluated in the appliance's local timezone whenever the ruleset is applied. Disabled, missing, or malformed schedule references fail closed (the associated rule is omitted). Automatic reload exactly at schedule boundaries is not yet implemented, so configure an external reload trigger if boundary precision is required.
+
 ## Traffic shaping
 
 Queue policy lives alongside rules. Three queue disciplines are supported via the `aifw queue` subcommand:

--- a/docs/docs/firewall.md
+++ b/docs/docs/firewall.md
@@ -118,7 +118,7 @@ Attach a `schedule_id` to a rule and the rule is only loaded into pf during the 
 
 Queue policy lives alongside rules. Three queue disciplines are supported via the `aifw queue` subcommand:
 
-- **CoDel** &mdash; default, low-latency AQM. Best for general LAN/WAN egress.
+- **CoDel** &mdash; currently unavailable. AiFw does not yet configure FreeBSD dummynet FQ-CoDel; new CoDel queues are rejected instead of emitting invalid pf queue syntax.
 - **HFSC** &mdash; hierarchical share-based scheduler with bandwidth percentages. Use when you need strict per-class allocations (VoIP, interactive, default, bulk).
 - **PRIQ** &mdash; strict priority queueing. Highest-priority class always preempts lower ones.
 

--- a/docs/docs/ids.md
+++ b/docs/docs/ids.md
@@ -27,7 +27,7 @@ breadcrumb:
 
 # IDS / IPS
 
-AiFw ships an in-kernel intrusion detection / prevention engine that consumes three rule formats &mdash; Suricata-compatible, Sigma, and YARA &mdash; and runs in one of three modes: **Disabled**, **IDS** (alert-only), or **IPS** (inline drop). Behavioural AI detectors live alongside the rule engine and are opt-in. No Snort, no separate package install, no second daemon to babysit.
+AiFw passively captures traffic and evaluates supported subsets of Suricata, Sigma, and YARA rule formats. It runs in one of three modes: **Disabled**, **IDS** (alert-only), or **Reactive blocking**. Reactive blocking adds the detected source address to a pf table after a match; it does not stop the triggering packet and may affect unrelated flows from that source. Behavioural AI detectors are opt-in.
 
 ## Quickstart
 
@@ -37,7 +37,7 @@ Open the Web UI and go to **IDS &rarr; Settings**. Pick a mode and an interface.
 |---|---|
 | `Disabled` | Engine off, no inspection |
 | `IDS` | Inspect and log alerts; never block |
-| `IPS` | Inspect, alert, and drop matching packets inline |
+| `Reactive` | Inspect and alert, then add the source address to a pf block table; the triggering packet is not stopped |
 
 From the API:
 

--- a/docs/docs/nat.md
+++ b/docs/docs/nat.md
@@ -27,7 +27,7 @@ breadcrumb:
 
 # NAT
 
-AiFw supports six NAT types &mdash; SNAT, DNAT (port forwarding), Masquerade, 1:1 BiNAT, NAT64, and NAT46. NAT46 is unusual on consumer firewall distributions and lets you front legacy IPv4 clients onto an IPv6-only network. All NAT rules compile into the dedicated `aifw-nat` anchor and never touch the system pf config.
+AiFw supports SNAT, DNAT (port forwarding), Masquerade, and 1:1 BiNAT. NAT64 and NAT46 are retained as experimental model values for compatibility but creation is rejected: the current pf text does not perform cross-family translation. All supported NAT rules compile into the dedicated `aifw-nat` anchor.
 
 ## Quickstart
 
@@ -128,7 +128,7 @@ Bidirectional 1:1 mapping between an internal address and an external address. C
 
 ### NAT64
 
-Translate IPv6 source traffic into IPv4 destination traffic. Pair with a DNS64 resolver (the rDNS resolver has a `dns64` toggle) so IPv6-only clients can still reach IPv4 destinations.
+**Unavailable.** No cross-family FreeBSD data-plane backend is implemented. The API returns `501 Not Implemented` for new or updated NAT64 rules.
 
 ```json
 { "nat_type": "nat64", "interface": "em0",
@@ -138,7 +138,7 @@ Translate IPv6 source traffic into IPv4 destination traffic. Pair with a DNS64 r
 
 ### NAT46
 
-Translate IPv4 source traffic into IPv6 destination traffic. Front legacy IPv4 clients onto an IPv6-only backend network. NAT46 is uncommon on most firewall distros &mdash; AiFw exposes it as a first-class rule type.
+**Unavailable.** No cross-family FreeBSD data-plane backend is implemented. The API returns `501 Not Implemented` for new or updated NAT46 rules.
 
 ```json
 { "nat_type": "nat46", "interface": "em0",

--- a/docs/docs/vpn.md
+++ b/docs/docs/vpn.md
@@ -90,7 +90,7 @@ WireGuard tunnels survive a CARP failover provided peers run with `PersistentKee
 
 ## IPsec
 
-AiFw supports IPsec Security Associations with ESP, AH, or ESP+AH protocols, in either tunnel or transport mode. Each SA gets a random SPI and sensible algorithm defaults (AES-256-GCM + HMAC-SHA256). When the SA is in tunnel mode the engine also emits a `pass quick on enc0` rule so encapsulated traffic flows.
+> **Unavailable.** The current IPsec model stores metadata and can render firewall exceptions, but it does not run IKE or install kernel security associations and policies. New records are rejected until a complete backend exists. Existing records remain readable and deletable for future migration and must not be treated as live tunnels.
 
 ### Quickstart
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,7 +32,7 @@ breadcrumb:
     { "@type": "Question", "name": "Can I import my existing OPNsense config?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. AiFw ships an OPNsense XML importer that parses your config, previews a diff of what will change, and applies atomically with rollback on failure. The importer was rewritten end-to-end in 2026 (PRs #230 and #248–#252)." } },
     { "@type": "Question", "name": "Does AiFw support Multi-WAN failover and load balancing?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. AiFw ships an enterprise-grade multi-WAN system with FIB isolation per WAN, gateway groups (failover, weighted, MOS-weighted adaptive), policy routing on 5-tuple plus DSCP plus geo-IP, and blast-radius preview. See the multi-WAN guide." } },
     { "@type": "Question", "name": "What hardware do I need to run AiFw?", "acceptedAnswer": { "@type": "Answer", "text": "Minimum: 1 amd64 core, 1 GB RAM, 4 GB disk, one NIC. Recommended: 2+ cores with AES-NI, 4 GB+ RAM, 16 GB SSD, 2+ NICs. IDS workloads benefit from more RAM. arm64 is planned but not yet supported." } },
-    { "@type": "Question", "name": "Is AiFw production-ready?", "acceptedAnswer": { "@type": "Answer", "text": "Core firewall, NAT, VPN, IDS, DHCP, DNS, multi-WAN, and HA are production-ready and stable. AI threat detection is opt-in / experimental, and the plugin system is in beta — check the relevant page on this site for the current status of each." } },
+    { "@type": "Question", "name": "Is AiFw production-ready?", "acceptedAnswer": { "@type": "Answer", "text": "No. AiFw is beta software under active development. Consult the feature maturity matrix and validate the exact release in your environment before deployment." } },
     { "@type": "Question", "name": "How do I migrate from pfSense to AiFw?", "acceptedAnswer": { "@type": "Answer", "text": "Direct pfSense XML import is not supported. The recommended path is to export your pfSense config to OPNsense first (community tooling exists), then use AiFw's OPNsense importer. Or rebuild config from scratch — the AiFw web UI is fast." } },
     { "@type": "Question", "name": "Does AiFw have a paid version or paid tier?", "acceptedAnswer": { "@type": "Answer", "text": "No. Every feature is MIT-licensed and free. There is no paid tier, no gated features, and no telemetry or cloud dependency." } },
     { "@type": "Question", "name": "Where can I get help?", "acceptedAnswer": { "@type": "Answer", "text": "GitHub Discussions and Issues at https://github.com/ZerosAndOnesLLC/AiFw. The repo also includes detailed docs in CLAUDE.md and the docs/ directory." } },
@@ -80,7 +80,7 @@ arm64 (Raspberry Pi, Ampere) is planned but not yet supported. AiFw runs anywher
 
 ## Is AiFw production-ready?
 
-Core firewall, NAT, VPN, IDS, DHCP, DNS, multi-WAN, and HA are production-ready and stable. **AI threat detection is opt-in / experimental**, and the **plugin system is in beta**. Check the relevant page on this site for the current status of each subsystem.
+No. AiFw is beta software under active development. Control-plane coverage does not necessarily mean a complete or functionally tested FreeBSD data plane. Consult the [feature maturity matrix]({{ '/maturity/' | relative_url }}) and validate the exact release in your environment before deployment.
 
 ## How do I migrate from pfSense to AiFw?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -40,7 +40,7 @@ breadcrumb:
     { "@type": "Question", "name": "Does AiFw support OpenVPN?", "acceptedAnswer": { "@type": "Answer", "text": "Not currently. AiFw supports WireGuard and IPsec only. If OpenVPN is a hard requirement, stay on pfSense or OPNsense." } },
     { "@type": "Question", "name": "Can I run AiFw in a VM (Proxmox, ESXi, KVM, bhyve)?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. AiFw runs anywhere FreeBSD runs — bare metal, KVM, Proxmox, VMware ESXi, bhyve. AWS and DigitalOcean FreeBSD images are untested but should work." } },
     { "@type": "Question", "name": "Does AiFw work with WireGuard mobile clients?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. AiFw generates per-peer .conf files you can scan as a QR code from the WireGuard mobile app. Persistent keepalive can be set per peer. The handshake status is shown live in the web UI." } },
-    { "@type": "Question", "name": "How does HA failover work?", "acceptedAnswer": { "@type": "Answer", "text": "AiFw runs an active-passive pair using CARP (virtual IP) and pfsync (state-table sync). TCP sessions survive a master reboot; WireGuard tunnels reconnect within ~5 seconds if peers have PersistentKeepalive set. Failover detection takes 1.5–3 seconds depending on the configured latency profile. See the HA cluster guide for details." } },
+    { "@type": "Question", "name": "How does HA failover work?", "acceptedAnswer": { "@type": "Answer", "text": "AiFw configures an active-passive pair using CARP and pfsync. Session survival and failover timing depend on the deployment and are not yet backed by a published automated two-node qualification artifact." } },
     { "@type": "Question", "name": "Is the source code auditable / where do I read it?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. The full source is at https://github.com/ZerosAndOnesLLC/AiFw under the MIT license. The codebase is Rust workspace crates plus a Next.js web UI. CLAUDE.md in the repo root has an architectural overview." } }
   ]
 }
@@ -116,7 +116,7 @@ Yes. AiFw generates per-peer `.conf` files you can scan as a QR code from the Wi
 
 ## How does HA failover work?
 
-AiFw runs an active-passive pair using **CARP** (virtual IP) and **pfsync** (state-table sync). TCP sessions survive a master reboot. WireGuard tunnels reconnect within ~5 seconds if peers have `PersistentKeepalive` set. Failover detection takes 1.5–3 seconds depending on the configured latency profile. See the [HA cluster guide]({{ '/ha/' | relative_url }}).
+AiFw configures an active-passive pair using **CARP** and **pfsync**. Session survival and failover timing depend on the deployment and are not yet backed by a published automated two-node FreeBSD qualification artifact. Validate primary shutdown, reboot, pfsync loss, split-brain recovery, NAT state, and long-lived TCP traffic before relying on HA. See the [HA cluster guide]({{ '/ha/' | relative_url }}).
 
 ## Is the source code auditable / where do I read it?
 

--- a/docs/ha.md
+++ b/docs/ha.md
@@ -29,6 +29,8 @@ of any failure on the master.
 
 ## What survives a master reboot
 
+> **Qualification status:** the behaviours and timings below describe the intended design and require validation on the exact appliance build and network. AiFw does not yet publish an automated two-node FreeBSD failover artifact, so they are not guarantees.
+
 | Component | Survives | Notes |
 |---|---|---|
 | TCP sessions through the firewall | yes | pfsync replicates state to the backup; `state-policy floating` lets replicated states match traffic on the new master's interface |

--- a/docs/maturity.md
+++ b/docs/maturity.md
@@ -1,0 +1,24 @@
+# Feature maturity
+
+AiFw is beta software under active development. A schema, API, UI, or rendered command proves control-plane coverage only; it does not prove that FreeBSD accepts the configuration or that packets follow the intended path.
+
+| Feature | Control plane | FreeBSD data plane | Automated FreeBSD functional test | Performance / multi-node validation | Production-supported |
+|---|---|---|---|---|---|
+| Stateful pf filtering | Implemented | Implemented | Partial (build/parser; packet suite pending) | Not published | No |
+| Conventional SNAT/DNAT/BiNAT | Implemented | Implemented | Packet suite pending | Not published | No |
+| NAT64/NAT46 | Experimental models | Not implemented | No | No | No |
+| WireGuard | Implemented | Implemented | Appliance qualification pending | Not published | No |
+| IPsec | Metadata CRUD only | Not implemented (no IKE or kernel SA/SP install) | No | No | No |
+| IDS + reactive source blocking | Implemented | Passive capture plus pf-table response | Packet suite pending | Not published | No |
+| Inline IPS | Stub/experimental | Not implemented | No | No | No |
+| CoDel shaping | Experimental model | Not implemented with dummynet FQ-CoDel | No | No | No |
+| Multi-WAN | Substantial | Implemented components | Environment-specific validation required | Not published | No |
+| HA (CARP/pfsync) | Substantial | Implemented components | Two-node suite pending | Not published | No |
+| OAuth login | Provider configuration | Callback/token exchange incomplete | No | No | No |
+| Backup/import | Implemented | Best-effort snapshot/reapply | Failure-injection coverage incomplete | N/A | No |
+
+Suricata, Sigma, and YARA input means compatibility with the subsets parsed by AiFw, not full compatibility with those upstream engines. Quantitative availability or performance claims require a reproducible test artifact from the exact released build before they may be added to this table.
+
+## Claim policy
+
+Documentation may call a feature implemented only when both its control plane and intended live data plane exist. “Verified” additionally requires a repeatable FreeBSD functional test. Production support requires released-build qualification, documented recovery behaviour, and (where relevant) performance or multi-node evidence.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,14 @@
+# Test layers and release evidence
+
+Linux unit and integration tests validate models, parsers, persistence, APIs, command rendering, and mock-backend behaviour. They do not prove that FreeBSD accepts a generated configuration or that packets traverse the appliance correctly.
+
+Every data-plane change should add the lowest applicable layers:
+
+1. deterministic Rust/unit and API tests on each commit;
+2. FreeBSD functional tests using jails and `epair` links, with real `pfctl` parsing and packet traffic;
+3. an appliance smoke test that boots the exact produced ISO/IMG, completes first boot, checks service and pf health, and exercises one routed packet path;
+4. scheduled qualification for multi-node, reboot, throughput, latency, and sustained-load scenarios.
+
+A portable FreeBSD topology is `client jail -- epair -- firewall -- epair -- server jail`. Tests must retain rendered commands, `pfctl` rules/state, interface/routes, packet results, service logs, and source/artifact revisions. Infrastructure-specific hypervisor provisioning belongs in the operator's private harness; only portable assertions, fixtures, and artifact contracts belong in this repository.
+
+Release notes must distinguish tests that passed from tests that were skipped. Skipped mandatory qualification cannot support a production-ready claim.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -66,6 +66,9 @@ Passing direct checks:
   its default `freebsd` user, and has the expected live default route.
 - Non-interactive build privilege works through the stock wheel account's
   passwordless `su`; the official image does not include `sudo`.
+- PVE disk import and `boot=order=virtio0` are applied as two sequential API
+  tasks. Sending both in the import request silently omitted the not-yet-created
+  disk from the boot order and left the guest attempting PXE/CD-ROM boot.
 - Harness unit tests and cleanup verification with zero residual E2E VMs.
 
 Root cause and correction:
@@ -77,6 +80,8 @@ Root cause and correction:
 - The harness now attaches its own v2/vtnet0 `cidata` ISO, uses the early
   top-level `ssh_authorized_keys` field with the stock `freebsd` user, and
   checks live `ifconfig` and route state instead of Linux cloud-init markers.
+- The harness waits for asynchronous disk import before setting the boot order;
+  a regression test fixes this request ordering contract.
 
 Remaining integration boundary:
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,9 +1,9 @@
 # AiFw Proxmox E2E harness
 
-Status: directly validated lifecycle foundation as of 2026-07-19. A clean
-official-FreeBSD builder produced the IMG, and appliance-only deployment of the
-corrected equivalent disk passed initial and post-reboot health plus teardown.
-One final combined Woodpecker run of the natively corrected source is pending.
+Status: validated one-NIC lifecycle smoke as of 2026-07-19. Woodpecker pipeline
+14 built AiFw 5.99.14 from commit `9c146232`, deployed that exact IMG, passed
+initial and post-reboot health, and completed teardown. It is a manual release
+smoke, not yet a required gate or routed firewall data-plane suite.
 
 The harness provisions the exact writable AiFw IMG in Proxmox, attaches a
 per-run unattended seed ISO, verifies the running appliance, reboots it, saves
@@ -77,6 +77,13 @@ Passing direct checks:
 - The corrected appliance-only run passed SSH, all core services, TLS login,
   authenticated API/UI health, live `pf`, reboot recovery, and zero-residual
   teardown. Its manifest records `pf_running=true` both before and after reboot.
+- Woodpecker pipeline 14 passed the combined native path in 1,840 seconds. It
+  produced a 221,009,096-byte compressed IMG from commit `9c146232`, deployed
+  it at the reserved address, and passed the same initial/reboot contract.
+- A post-run Proxmox ownership audit found zero `aifw-e2e-*` VMs and zero
+  matching uploaded or imported volumes.
+- Cleanup now polls Proxmox and records `teardown_verified=true` in the run
+  manifest only after the VM and every run-owned volume are absent.
 
 Root cause and correction:
 
@@ -90,13 +97,16 @@ Root cause and correction:
 - The harness waits for asynchronous disk import before setting the boot order;
   a regression test fixes this request ordering contract.
 
-Remaining integration boundary:
+Remaining boundaries:
 
-- The fixes discovered by the focused run must be rebuilt natively and pass one
-  combined Woodpecker run; the passing appliance reused the built IMG with
-  equivalent in-place boot metadata corrections to avoid another full compile.
-- The official image performs slow first-boot maintenance before sshd starts.
-  The current reliable lane tolerates that bounded delay.
+- The official image performs slow first-boot maintenance before sshd starts;
+  the reliable lane tolerates that bounded delay.
+- The passing lane has one NIC on the untagged management bridge. It proves
+  artifact boot, setup, control plane, real `pf` availability, persistence, and
+  cleanup—not forwarding, NAT, policy enforcement, DHCP, or WAN/LAN isolation.
+- Run evidence is currently emitted to the Woodpecker log and job-local
+  manifest. Durable external artifact retention and a stale-resource janitor
+  remain target-state work.
 
 Appliance root causes corrected in source:
 
@@ -111,8 +121,8 @@ Appliance root causes corrected in source:
   of stopping at SSH readiness.
 - Serial/VGA multicons output is enabled for future Proxmox boot diagnostics.
 
-Do not interpret the presence of `.woodpecker/e2e.yml` as evidence that the
-full lane passes or gates releases yet.
+Do not interpret this passing one-NIC smoke as the full WAN/LAN framework or a
+required publication gate.
 
 ## Development and validation order
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,46 @@
+# AiFw Proxmox E2E harness
+
+The harness provisions the exact writable AiFw IMG in Proxmox, attaches a
+per-run unattended seed ISO, verifies the running appliance, reboots it, saves
+diagnostics, and destroys every run-owned Proxmox resource in a `finally`
+block.
+
+## Safety model
+
+- Every VM and uploaded volume is named with a unique run ID.
+- Only resources whose names begin with `aifw-e2e-` are deleted.
+- Cleanup runs on success, failure, timeout, SIGINT, and SIGTERM.
+- `--keep-on-failure` is a manual debugging escape hatch and is not used by CI.
+- Credentials are accepted only through environment variables.
+- The seed contains an ephemeral public SSH key and Argon2 password hash. It
+  never contains the SSH private key or plaintext admin password.
+
+Required secrets:
+
+- `PVE_TOKEN_ID`
+- `PVE_TOKEN_SECRET`
+- `AIFW_E2E_ADMIN_PASSWORD`
+
+Required non-secret settings:
+
+- `PVE_URL`, `PVE_NODE`, `PVE_IMAGE_STORAGE`, `PVE_VM_STORAGE`, `PVE_BRIDGE`
+- `AIFW_E2E_ADDRESS`, `AIFW_E2E_GATEWAY`, `AIFW_E2E_DNS`
+
+The manual Woodpecker run also requires an `artifact_url` pipeline parameter.
+It must point to an IMG built from a revision containing the unattended seed
+support; an older release image will fall back to its interactive wizard.
+
+The current Proxmox host has only an untagged management bridge. The supported
+initial lane is therefore a one-NIC appliance lifecycle smoke test. The
+orchestrator deliberately does not claim routed WAN/LAN coverage. Add isolated
+test bridges or VLAN-aware networking before implementing data-plane suites.
+
+## Run
+
+```sh
+python -m e2e.aifw_e2e run --artifact output/aifw-<version>-amd64.img.xz
+```
+
+Artifacts are written to `e2e/artifacts/<run-id>/`.
+Ephemeral keys, seed media, and decompressed images live under `e2e/.run/`
+and are deleted by the lifecycle `finally` block.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,8 +1,9 @@
 # AiFw Proxmox E2E harness
 
-Status: experimental lifecycle foundation as of 2026-07-19. Proxmox resource
-contracts, FreeBSD builder bootstrap, and teardown are directly verified; a
-complete successful image-build-plus-appliance run is still pending.
+Status: directly validated lifecycle foundation as of 2026-07-19. A clean
+official-FreeBSD builder produced the IMG, and appliance-only deployment of the
+corrected equivalent disk passed initial and post-reboot health plus teardown.
+One final combined Woodpecker run of the natively corrected source is pending.
 
 The harness provisions the exact writable AiFw IMG in Proxmox, attaches a
 per-run unattended seed ISO, verifies the running appliance, reboots it, saves
@@ -70,6 +71,12 @@ Passing direct checks:
   tasks. Sending both in the import request silently omitted the not-yet-created
   disk from the boot order and left the guest attempting PXE/CD-ROM boot.
 - Harness unit tests and cleanup verification with zero residual E2E VMs.
+- A clean builder-only run compiled AiFw and all four companion projects,
+  produced/checksummed a 211-MB compressed IMG, returned it to the runner, and
+  destroyed the builder.
+- The corrected appliance-only run passed SSH, all core services, TLS login,
+  authenticated API/UI health, live `pf`, reboot recovery, and zero-residual
+  teardown. Its manifest records `pf_running=true` both before and after reboot.
 
 Root cause and correction:
 
@@ -85,10 +92,24 @@ Root cause and correction:
 
 Remaining integration boundary:
 
-- A builder-only run still needs to complete `freebsd/build-local.sh`, return
-  and checksum the new IMG, then an appliance-only run must validate that IMG.
+- The fixes discovered by the focused run must be rebuilt natively and pass one
+  combined Woodpecker run; the passing appliance reused the built IMG with
+  equivalent in-place boot metadata corrections to avoid another full compile.
 - The official image performs slow first-boot maintenance before sshd starts.
   The current reliable lane tolerates that bounded delay.
+
+Appliance root causes corrected in source:
+
+- The writable IMG now creates UFS label `aifw`; previously only GPT label
+  `aifw` existed while loader/fstab requested `/dev/ufs/aifw`, causing a
+  `mountroot` error 19.
+- `aifw_firstboot` is a normal idempotent rc service, not sentinel-gated, so a
+  staged writable IMG consumes unattended seed media.
+- Setup persists `pf_rules=/usr/local/etc/aifw/pf.conf.aifw`; otherwise first
+  boot enabled `pf` directly but reboot fell back to missing `/etc/pf.conf`.
+- Reboot readiness retries the complete service/API/UI/`pf` contract instead
+  of stopping at SSH readiness.
+- Serial/VGA multicons output is enabled for future Proxmox boot diagnostics.
 
 Do not interpret the presence of `.woodpecker/e2e.yml` as evidence that the
 full lane passes or gates releases yet.
@@ -111,9 +132,10 @@ volume remains.
 ### Builder alternatives
 
 The current implementation starts from the checksum-verified official image
-for maximum reproducibility. If its first-boot and dependency installation
-cost makes the lane too slow, use a versioned, periodically rebuilt Proxmox
-builder template and clone it per run. Pin the template to a FreeBSD release,
+for maximum reproducibility. The measured clean builder completed in roughly
+15 minutes, so this remains the default manual/release lane while correctness
+stabilizes. If measured duration becomes too high, use a versioned, periodically
+rebuilt Proxmox builder template and clone it per run. Pin the template to a FreeBSD release,
 record its package/toolchain manifest, inject a fresh key/network seed into
 every clone, and retain an official-image canary job so cached state cannot
 hide bootstrap regressions.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,9 +1,11 @@
 # AiFw Proxmox E2E harness
 
-Status: validated one-NIC lifecycle smoke as of 2026-07-19. Woodpecker pipeline
-14 built AiFw 5.99.14 from commit `9c146232`, deployed that exact IMG, passed
-initial and post-reboot health, and completed teardown. It is a manual release
-smoke, not yet a required gate or routed firewall data-plane suite.
+Status: the one-NIC lifecycle is validated and the full isolated WAN/LAN lane
+is implemented as of 2026-07-19. The full lane uses a real two-NIC AiFw VM,
+two Debian LXC traffic helpers, live NAT/pass/block checks, authenticated API
+rule changes, Playwright login/rules checks, reboot persistence, diagnostics,
+and ownership-verified teardown. A fresh exact-commit Woodpecker acceptance run
+is the remaining validation step.
 
 The harness provisions the exact writable AiFw IMG in Proxmox, attaches a
 per-run unattended seed ISO, verifies the running appliance, reboots it, saves
@@ -12,7 +14,7 @@ block.
 
 ## Safety model
 
-- Every VM and uploaded volume is named with a unique run ID.
+- Every VM, helper container, and uploaded volume is named with a unique run ID.
 - Only resources whose names begin with `aifw-e2e-` are deleted.
 - Cleanup runs on success, failure, timeout, SIGINT, and SIGTERM.
 - `--keep-on-failure` is a manual debugging escape hatch and is not used by CI.
@@ -29,13 +31,14 @@ Required secrets:
 Required non-secret settings:
 
 - `PVE_URL`, `PVE_NODE`, `PVE_IMAGE_STORAGE`, `PVE_VM_STORAGE`, `PVE_BRIDGE`
+- `PVE_E2E_WAN_BRIDGE`, `PVE_E2E_LAN_BRIDGE`
 - `AIFW_E2E_ADDRESS`, `AIFW_E2E_GATEWAY`, `AIFW_E2E_DNS`
 
 The manual Woodpecker workflow first creates an ephemeral FreeBSD 15 builder
 VM in Proxmox, copies the exact checked-out Git commit to it, builds a fresh
 seed-capable IMG, copies that IMG back into the job workspace, and destroys the
-builder. It then deploys that IMG as a second ephemeral VM for the appliance
-checks. The two VMs run sequentially and reuse the reserved test address.
+builder. It then deploys that IMG as a two-NIC VM plus two helper containers.
+The builder and LAN helper run sequentially and reuse the reserved address.
 
 The configured homelab lane uses:
 
@@ -43,16 +46,17 @@ The configured homelab lane uses:
 - Upload storage `local`
 - VM storage `local-lvm`
 - Bridge `vmbr0`
+- Isolated, portless bridges `vmbr998` (WAN) and `vmbr999` (LAN)
 - Reserved address `192.168.0.26/23`
 - Gateway and DNS `192.168.0.1`
 
 These operational values live in the pipeline and manual-only Woodpecker
 secrets. Credentials do not belong in this file or any repository file.
 
-The current Proxmox host has only an untagged management bridge. The supported
-initial lane is therefore a one-NIC appliance lifecycle smoke test. The
-orchestrator deliberately does not claim routed WAN/LAN coverage. Add isolated
-test bridges or VLAN-aware networking before implementing data-plane suites.
+The static isolated bridges are durable lab substrate; per-run VMs, containers,
+media, credentials, routes, and rules are disposable. The LAN helper has its
+management NIC on `vmbr0` and an isolated NIC on `vmbr999`. AiFw has only WAN
+and LAN NICs, so all appliance access is through the LAN helper.
 
 ## Current validation state
 
@@ -84,6 +88,11 @@ Passing direct checks:
   matching uploaded or imported volumes.
 - Cleanup now polls Proxmox and records `teardown_verified=true` in the run
   manifest only after the VM and every run-owned volume are absent.
+- A focused Debian helper-container check passed both NIC/address assertions,
+  SSH, source-observing HTTP service, and zero-residual teardown.
+- Direct full-topology attempts proved helper provisioning and teardown. The
+  retained 5.99.12 image did not configure its isolated LAN because it predates
+  the current first-boot fixes; it is not the acceptance artifact.
 
 Root cause and correction:
 
@@ -101,9 +110,8 @@ Remaining boundaries:
 
 - The official image performs slow first-boot maintenance before sshd starts;
   the reliable lane tolerates that bounded delay.
-- The passing lane has one NIC on the untagged management bridge. It proves
-  artifact boot, setup, control plane, real `pf` availability, persistence, and
-  cleanup—not forwarding, NAT, policy enforcement, DHCP, or WAN/LAN isolation.
+- Full-lane exact-commit acceptance in Woodpecker is pending. Until it passes,
+  pipeline 14 remains the last authoritative appliance acceptance result.
 - Run evidence is currently emitted to the Woodpecker log and job-local
   manifest. Durable external artifact retention and a stale-resource janitor
   remain target-state work.
@@ -121,8 +129,8 @@ Appliance root causes corrected in source:
   of stopping at SSH readiness.
 - Serial/VGA multicons output is enabled for future Proxmox boot diagnostics.
 
-Do not interpret this passing one-NIC smoke as the full WAN/LAN framework or a
-required publication gate.
+Do not promote this manual lane to a publication gate until repeat exact-commit
+full runs pass and durable evidence retention is added.
 
 ## Development and validation order
 
@@ -166,10 +174,11 @@ python -m e2e.aifw_e2e build \
   --output e2e/.run/aifw.img.xz
 ```
 
-Test an existing image:
+Run the quick one-NIC smoke or the full isolated suite:
 
 ```sh
 python -m e2e.aifw_e2e run --artifact output/aifw-<version>-amd64.img.xz
+python -m e2e.aifw_e2e full --artifact output/aifw-<version>-amd64.img.xz
 ```
 
 Artifacts are written to `e2e/artifacts/<run-id>/`.
@@ -178,11 +187,10 @@ and are deleted by the lifecycle `finally` block.
 
 ## Target state
 
-The one-NIC lifecycle smoke is only the first lane. The full target adds:
+The implemented first full lane still leaves these target extensions:
 
-- Isolated WAN and LAN networks plus helper client/origin VMs.
-- Real TCP, UDP, ICMP, DNS, DHCP, NAT, state, and pass/block assertions.
-- Playwright tests against the deployed UI.
+- UDP, ICMP, DNS, DHCP, and deeper state assertions.
+- Broader Playwright coverage beyond login/dashboard/rules.
 - ISO installation for UFS/ZFS and BIOS/UEFI.
 - Update, rollback, watchdog, failure-recovery, and HA suites.
 - Serial-console artifacts, JUnit, browser traces, packet captures on failure,

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -26,9 +26,11 @@ Required non-secret settings:
 - `PVE_URL`, `PVE_NODE`, `PVE_IMAGE_STORAGE`, `PVE_VM_STORAGE`, `PVE_BRIDGE`
 - `AIFW_E2E_ADDRESS`, `AIFW_E2E_GATEWAY`, `AIFW_E2E_DNS`
 
-The manual Woodpecker run also requires an `artifact_url` pipeline parameter.
-It must point to an IMG built from a revision containing the unattended seed
-support; an older release image will fall back to its interactive wizard.
+The manual Woodpecker workflow first creates an ephemeral FreeBSD 15 builder
+VM in Proxmox, copies the exact checked-out Git commit to it, builds a fresh
+seed-capable IMG, copies that IMG back into the job workspace, and destroys the
+builder. It then deploys that IMG as a second ephemeral VM for the appliance
+checks. The two VMs run sequentially and reuse the reserved test address.
 
 The current Proxmox host has only an untagged management bridge. The supported
 initial lane is therefore a one-NIC appliance lifecycle smoke test. The
@@ -36,6 +38,16 @@ orchestrator deliberately does not claim routed WAN/LAN coverage. Add isolated
 test bridges or VLAN-aware networking before implementing data-plane suites.
 
 ## Run
+
+Build an image through an ephemeral Proxmox builder:
+
+```sh
+python -m e2e.aifw_e2e build \
+  --builder-image FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz \
+  --output e2e/.run/aifw.img.xz
+```
+
+Test an existing image:
 
 ```sh
 python -m e2e.aifw_e2e run --artifact output/aifw-<version>-amd64.img.xz

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,5 +1,9 @@
 # AiFw Proxmox E2E harness
 
+Status: experimental lifecycle foundation as of 2026-07-19. Proxmox resource
+contracts, FreeBSD builder bootstrap, and teardown are directly verified; a
+complete successful image-build-plus-appliance run is still pending.
+
 The harness provisions the exact writable AiFw IMG in Proxmox, attaches a
 per-run unattended seed ISO, verifies the running appliance, reboots it, saves
 diagnostics, and destroys every run-owned Proxmox resource in a `finally`
@@ -32,10 +36,88 @@ seed-capable IMG, copies that IMG back into the job workspace, and destroys the
 builder. It then deploys that IMG as a second ephemeral VM for the appliance
 checks. The two VMs run sequentially and reuse the reserved test address.
 
+The configured homelab lane uses:
+
+- Proxmox node `trigproxmox`
+- Upload storage `local`
+- VM storage `local-lvm`
+- Bridge `vmbr0`
+- Reserved address `192.168.0.26/23`
+- Gateway and DNS `192.168.0.1`
+
+These operational values live in the pipeline and manual-only Woodpecker
+secrets. Credentials do not belong in this file or any repository file.
+
 The current Proxmox host has only an untagged management bridge. The supported
 initial lane is therefore a one-NIC appliance lifecycle smoke test. The
 orchestrator deliberately does not claim routed WAN/LAN coverage. Add isolated
 test bridges or VLAN-aware networking before implementing data-plane suites.
+
+## Current validation state
+
+Passing direct checks:
+
+- Proxmox authentication and asynchronous task polling.
+- Disposable tagged VM create/read/destroy.
+- `.raw` upload, import to `local-lvm`, disk attachment, purge, and upload
+  deletion.
+- The official FreeBSD 15.0 BASIC-CLOUDINIT image boots with a custom `cidata`
+  ISO, applies `192.168.0.26/23` to `vtnet0`, installs the ephemeral key for
+  its default `freebsd` user, and has the expected live default route.
+- Non-interactive build privilege works through the stock wheel account's
+  passwordless `su`; the official image does not include `sudo`.
+- Harness unit tests and cleanup verification with zero residual E2E VMs.
+
+Root cause and correction:
+
+- FreeBSD 15 uses native `nuageinit`, not Python cloud-init. Proxmox-generated
+  NoCloud metadata names the NIC `eth0`, while the VirtIO NIC is `vtnet0`.
+- The first custom seed used network-config v1. FreeBSD's NoCloud parser
+  expects a v2 document with `ethernets`, so it raised a Lua type error.
+- The harness now attaches its own v2/vtnet0 `cidata` ISO, uses the early
+  top-level `ssh_authorized_keys` field with the stock `freebsd` user, and
+  checks live `ifconfig` and route state instead of Linux cloud-init markers.
+
+Remaining integration boundary:
+
+- A builder-only run still needs to complete `freebsd/build-local.sh`, return
+  and checksum the new IMG, then an appliance-only run must validate that IMG.
+- The official image performs slow first-boot maintenance before sshd starts.
+  The current reliable lane tolerates that bounded delay.
+
+Do not interpret the presence of `.woodpecker/e2e.yml` as evidence that the
+full lane passes or gates releases yet.
+
+## Development and validation order
+
+Use the smallest test that can prove each change:
+
+1. `pytest e2e/tests` for local logic and request encoding.
+2. Disposable NIC-less VM for Proxmox API configuration contracts.
+3. Official FreeBSD boot plus static IP, SSH, and teardown only.
+4. Builder-only image production.
+5. Appliance-only deployment and checks.
+6. One combined Woodpecker manual run after all focused checks pass.
+
+Every direct live test must use the `aifw-e2e-` prefix, a bounded timeout, and
+the lifecycle cleanup guard. Always verify that no run-owned VM or uploaded
+volume remains.
+
+### Builder alternatives
+
+The current implementation starts from the checksum-verified official image
+for maximum reproducibility. If its first-boot and dependency installation
+cost makes the lane too slow, use a versioned, periodically rebuilt Proxmox
+builder template and clone it per run. Pin the template to a FreeBSD release,
+record its package/toolchain manifest, inject a fresh key/network seed into
+every clone, and retain an official-image canary job so cached state cannot
+hide bootstrap regressions.
+
+Other viable but less attractive options are offline qcow2 customization or a
+persistent FreeBSD build host. Offline customization adds image tooling and a
+second image supply chain; a persistent host weakens isolation and teardown.
+Neither should replace deployment testing of the exact AiFw IMG produced by
+the build.
 
 ## Run
 
@@ -56,3 +138,18 @@ python -m e2e.aifw_e2e run --artifact output/aifw-<version>-amd64.img.xz
 Artifacts are written to `e2e/artifacts/<run-id>/`.
 Ephemeral keys, seed media, and decompressed images live under `e2e/.run/`
 and are deleted by the lifecycle `finally` block.
+
+## Target state
+
+The one-NIC lifecycle smoke is only the first lane. The full target adds:
+
+- Isolated WAN and LAN networks plus helper client/origin VMs.
+- Real TCP, UDP, ICMP, DNS, DHCP, NAT, state, and pass/block assertions.
+- Playwright tests against the deployed UI.
+- ISO installation for UFS/ZFS and BIOS/UEFI.
+- Update, rollback, watchdog, failure-recovery, and HA suites.
+- Serial-console artifacts, JUnit, browser traces, packet captures on failure,
+  and a scheduled stale-resource janitor.
+- A scoped Proxmox pool/token and release publication gate.
+
+See `testingUplift.md` for the detailed current-to-target roadmap.

--- a/e2e/__init__.py
+++ b/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""AiFw appliance end-to-end harness."""

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+"""Provision, test, diagnose, and destroy an AiFw Proxmox VM."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import urllib.parse
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import requests
+import urllib3
+from argon2 import PasswordHasher
+
+RESOURCE_PREFIX = "aifw-e2e-"
+
+
+class HarnessError(RuntimeError):
+    """A bounded, user-facing harness failure."""
+
+
+def required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise HarnessError(f"required environment variable {name} is not set")
+    return value
+
+
+@dataclass(frozen=True)
+class LabConfig:
+    pve_url: str
+    pve_node: str
+    image_storage: str
+    vm_storage: str
+    bridge: str
+    verify_tls: bool
+    address_cidr: str
+    gateway: str
+    dns: str
+    token_id: str
+    token_secret: str
+    admin_password: str
+
+    @classmethod
+    def from_env(cls) -> "LabConfig":
+        return cls(
+            pve_url=required_env("PVE_URL").rstrip("/"),
+            pve_node=required_env("PVE_NODE"),
+            image_storage=os.environ.get("PVE_IMAGE_STORAGE", "local"),
+            vm_storage=os.environ.get("PVE_VM_STORAGE", "local-lvm"),
+            bridge=os.environ.get("PVE_BRIDGE", "vmbr0"),
+            verify_tls=os.environ.get("PVE_VERIFY_TLS", "true").lower()
+            in ("1", "true", "yes"),
+            address_cidr=required_env("AIFW_E2E_ADDRESS"),
+            gateway=required_env("AIFW_E2E_GATEWAY"),
+            dns=os.environ.get("AIFW_E2E_DNS", required_env("AIFW_E2E_GATEWAY")),
+            token_id=required_env("PVE_TOKEN_ID"),
+            token_secret=required_env("PVE_TOKEN_SECRET"),
+            admin_password=required_env("AIFW_E2E_ADMIN_PASSWORD"),
+        )
+
+    @property
+    def address(self) -> str:
+        return self.address_cidr.split("/", 1)[0]
+
+
+class Proxmox:
+    def __init__(self, cfg: LabConfig):
+        self.cfg = cfg
+        self.base = f"{cfg.pve_url}/api2/json"
+        self.session = requests.Session()
+        self.session.headers["Authorization"] = (
+            f"PVEAPIToken={cfg.token_id}={cfg.token_secret}"
+        )
+        self.session.verify = cfg.verify_tls
+        if not cfg.verify_tls:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    def request(self, method: str, path: str, **kwargs: Any) -> Any:
+        response = self.session.request(
+            method, f"{self.base}{path}", timeout=120, **kwargs
+        )
+        if not response.ok:
+            detail = response.text[:500]
+            raise HarnessError(
+                f"Proxmox {method} {path} failed: {response.status_code} {detail}"
+            )
+        return response.json().get("data")
+
+    def wait_task(self, upid: str, timeout: int = 900) -> None:
+        encoded = urllib.parse.quote(upid, safe="")
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            status = self.request(
+                "GET", f"/nodes/{self.cfg.pve_node}/tasks/{encoded}/status"
+            )
+            if status.get("status") == "stopped":
+                if status.get("exitstatus") != "OK":
+                    raise HarnessError(
+                        f"Proxmox task failed: {status.get('exitstatus')} ({upid})"
+                    )
+                return
+            time.sleep(2)
+        raise HarnessError(f"timed out waiting for Proxmox task {upid}")
+
+    def next_vmid(self) -> int:
+        return int(self.request("GET", "/cluster/nextid"))
+
+    def create_vm(self, vmid: int, name: str, description: str) -> None:
+        upid = self.request(
+            "POST",
+            f"/nodes/{self.cfg.pve_node}/qemu",
+            data={
+                "vmid": vmid,
+                "name": name,
+                "description": description,
+                "tags": "aifw-e2e",
+                "ostype": "other",
+                "bios": "seabios",
+                "cores": 4,
+                "memory": 4096,
+                "scsihw": "virtio-scsi-single",
+                "serial0": "socket",
+                "vga": "serial0",
+                "net0": f"virtio,bridge={self.cfg.bridge},firewall=1",
+                "onboot": 0,
+                "protection": 0,
+            },
+        )
+        if upid:
+            self.wait_task(upid)
+
+    def upload(self, path: Path, content: str) -> str:
+        checksum = sha256_file(path)
+        with path.open("rb") as handle:
+            upid = self.request(
+                "POST",
+                f"/nodes/{self.cfg.pve_node}/storage/{self.cfg.image_storage}/upload",
+                data={
+                    "content": content,
+                    "checksum-algorithm": "sha256",
+                    "checksum": checksum,
+                },
+                files={"filename": (path.name, handle, "application/octet-stream")},
+            )
+        self.wait_task(upid)
+        prefix = "iso" if content == "iso" else "import"
+        return f"{self.cfg.image_storage}:{prefix}/{path.name}"
+
+    def attach_imported_disk(
+        self, vmid: int, volume: str, seed_volume: str | None = None
+    ) -> None:
+        # Proxmox 9 imports a storage `import` volume while applying the VM
+        # disk configuration. The source upload is removed during teardown.
+        disk = f"{self.cfg.vm_storage}:0,import-from={volume},discard=on"
+        config = {
+            "virtio0": disk,
+            "boot": "order=virtio0",
+        }
+        if seed_volume is not None:
+            config["ide2"] = f"{seed_volume},media=cdrom"
+        upid = self.request(
+            "PUT",
+            f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config",
+            data=config,
+        )
+        if upid:
+            self.wait_task(upid)
+
+    def start(self, vmid: int) -> None:
+        upid = self.request(
+            "POST", f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/status/start"
+        )
+        self.wait_task(upid)
+
+    def stop(self, vmid: int) -> None:
+        status = self.request(
+            "GET", f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/status/current"
+        )
+        if status.get("status") == "stopped":
+            return
+        upid = self.request(
+            "POST", f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/status/stop"
+        )
+        self.wait_task(upid, timeout=120)
+
+    def destroy(self, vmid: int) -> None:
+        with contextlib.suppress(Exception):
+            self.stop(vmid)
+        upid = self.request(
+            "DELETE",
+            f"/nodes/{self.cfg.pve_node}/qemu/{vmid}",
+            params={"purge": 1, "destroy-unreferenced-disks": 1},
+        )
+        self.wait_task(upid, timeout=300)
+
+    def delete_volume(self, volume: str) -> None:
+        encoded = urllib.parse.quote(volume, safe="")
+        with contextlib.suppress(Exception):
+            upid = self.request(
+                "DELETE",
+                f"/nodes/{self.cfg.pve_node}/storage/{self.cfg.image_storage}/content/{encoded}",
+            )
+            if upid:
+                self.wait_task(upid, timeout=300)
+
+    def vm_config(self, vmid: int) -> dict[str, Any]:
+        return self.request(
+            "GET", f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config"
+        )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def run_checked(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, check=True, text=True, **kwargs)
+
+
+def prepare_image(artifact: Path, output_dir: Path, run_id: str) -> Path:
+    if not artifact.is_file():
+        raise HarnessError(f"artifact does not exist: {artifact}")
+    suffixes = "".join(artifact.suffixes)
+    # Proxmox's upload API accepts VM import media with `.raw`, not `.img`.
+    image = output_dir / f"{RESOURCE_PREFIX}{run_id}.raw"
+    if suffixes.endswith(".img.xz"):
+        with image.open("wb") as out:
+            subprocess.run(["xz", "-dc", str(artifact)], check=True, stdout=out)
+    elif artifact.suffix == ".img":
+        shutil.copyfile(artifact, image)
+    else:
+        raise HarnessError("artifact must be an .img or .img.xz file")
+    return image
+
+
+def make_seed(
+    cfg: LabConfig, output_dir: Path, run_id: str, public_key: str
+) -> Path:
+    password_hash = PasswordHasher().hash(cfg.admin_password)
+    setup = {
+        "hostname": f"aifw-e2e-{run_id}",
+        "wan_interface": "vtnet0",
+        "wan_mode": "static",
+        "wan_ip": cfg.address_cidr,
+        "wan_gateway": cfg.gateway,
+        "lan_interface": None,
+        "lan_ip": None,
+        "admin_username": "e2e-admin",
+        "admin_password_hash": password_hash,
+        "totp_secret": "",
+        "totp_enabled": False,
+        "recovery_codes": [],
+        "api_listen": "0.0.0.0",
+        "api_port": 8080,
+        "ui_enabled": True,
+        "dns_servers": [cfg.dns],
+        "dhcp_enabled": False,
+        "default_policy": "permissive",
+        "nat_enabled": False,
+        "ssh_auth_method": "key_only",
+        "ssh_github_user": None,
+        "ssh_authorized_keys": [public_key.strip()],
+        "ram_mb": 4096,
+        "db_path": "/var/db/aifw/aifw.db",
+        "config_dir": "/usr/local/etc/aifw",
+    }
+    seed_dir = output_dir / "seed"
+    seed_dir.mkdir(mode=0o700)
+    (seed_dir / "setup.json").write_text(json.dumps(setup, indent=2) + "\n")
+    seed = output_dir / f"{RESOURCE_PREFIX}{run_id}-seed.iso"
+    tool = shutil.which("xorrisofs") or shutil.which("genisoimage")
+    if not tool:
+        raise HarnessError("xorrisofs or genisoimage is required to create seed media")
+    run_checked(
+        [tool, "-quiet", "-V", "AIFW_SEED", "-o", str(seed), str(seed_dir)]
+    )
+    return seed
+
+
+def make_ssh_key(output_dir: Path) -> tuple[Path, str]:
+    private_key = output_dir / "id_ed25519"
+    run_checked(
+        [
+            "ssh-keygen",
+            "-q",
+            "-t",
+            "ed25519",
+            "-N",
+            "",
+            "-C",
+            "aifw-e2e",
+            "-f",
+            str(private_key),
+        ]
+    )
+    return private_key, private_key.with_suffix(".pub").read_text()
+
+
+def ssh_command(private_key: Path, host: str, command: str) -> list[str]:
+    return [
+        "ssh",
+        "-i",
+        str(private_key),
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=10",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        f"root@{host}",
+        command,
+    ]
+
+
+def wait_ssh(private_key: Path, host: str, timeout: int = 600) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            ssh_command(private_key, host, "test -f /usr/local/etc/aifw/aifw.conf"),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if result.returncode == 0:
+            return
+        time.sleep(5)
+    raise HarnessError(f"SSH/setup readiness timed out for {host}")
+
+
+def login_and_check(cfg: LabConfig) -> dict[str, Any]:
+    base = f"https://{cfg.address}:8080"
+    session = requests.Session()
+    session.verify = False
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    response = session.post(
+        f"{base}/api/v1/auth/login",
+        json={"username": "e2e-admin", "password": cfg.admin_password},
+        timeout=20,
+    )
+    response.raise_for_status()
+    token = response.json()["tokens"]["access_token"]
+    status = session.get(
+        f"{base}/api/v1/status",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=20,
+    )
+    status.raise_for_status()
+    data = status.json()
+    if not data.get("pf_running"):
+        raise HarnessError("authenticated status reports pf_running=false")
+    ui = session.get(f"{base}/", timeout=20)
+    ui.raise_for_status()
+    if "AiFw" not in ui.text:
+        raise HarnessError("served UI does not contain the AiFw marker")
+    return data
+
+
+def appliance_checks(cfg: LabConfig, private_key: Path) -> dict[str, Any]:
+    commands = [
+        "service aifw_daemon onestatus",
+        "service aifw_ids onestatus",
+        "service aifw_api onestatus",
+        "service aifw_watchdog onestatus",
+        "pfctl -si",
+        "test -s /usr/local/share/aifw/version",
+    ]
+    for command in commands:
+        run_checked(
+            ssh_command(private_key, cfg.address, command),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    return login_and_check(cfg)
+
+
+def collect_diagnostics(
+    pve: Proxmox,
+    cfg: LabConfig,
+    private_key: Path,
+    vmid: int,
+    output_dir: Path,
+) -> None:
+    with contextlib.suppress(Exception):
+        safe_config = pve.vm_config(vmid)
+        output_dir.joinpath("proxmox-vm.json").write_text(
+            json.dumps(safe_config, indent=2, sort_keys=True) + "\n"
+        )
+    command = """set +e
+echo '=== uname ==='; uname -a
+echo '=== uptime ==='; uptime
+echo '=== disks ==='; df -h
+echo '=== interfaces ==='; ifconfig -a
+echo '=== routes ==='; netstat -rn
+echo '=== services ==='
+for s in aifw_daemon aifw_ids aifw_api aifw_watchdog rdns rdhcpd trafficcop; do service "$s" onestatus; done
+echo '=== processes ==='; ps auxww
+echo '=== sockets ==='; sockstat -46l
+echo '=== pf info ==='; pfctl -si
+echo '=== pf rules ==='; pfctl -sr
+echo '=== pf nat ==='; pfctl -sn
+echo '=== recent logs ==='; tail -n 300 /var/log/aifw/*.log 2>/dev/null
+echo '=== dmesg ==='; dmesg
+"""
+    with output_dir.joinpath("appliance-diagnostics.txt").open("w") as handle:
+        subprocess.run(
+            ssh_command(private_key, cfg.address, command),
+            stdout=handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=90,
+        )
+
+
+def reboot_and_check(cfg: LabConfig, private_key: Path) -> dict[str, Any]:
+    subprocess.run(
+        ssh_command(private_key, cfg.address, "shutdown -r now"),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    time.sleep(10)
+    wait_ssh(private_key, cfg.address, timeout=600)
+    return appliance_checks(cfg, private_key)
+
+
+class Lifecycle:
+    def __init__(self, pve: Proxmox, keep_on_failure: bool):
+        self.pve = pve
+        self.keep_on_failure = keep_on_failure
+        self.vmid: int | None = None
+        self.volumes: list[str] = []
+        self.failed = False
+
+    def cleanup(self) -> None:
+        if self.keep_on_failure and self.failed:
+            print(f"preserving failed VM {self.vmid} by explicit request", flush=True)
+            return
+        if self.vmid is not None:
+            with contextlib.suppress(Exception):
+                config = self.pve.vm_config(self.vmid)
+                name = config.get("name", "")
+                if not name.startswith(RESOURCE_PREFIX):
+                    raise HarnessError(
+                        f"refusing to destroy VM {self.vmid} with unexpected name {name!r}"
+                    )
+                self.pve.destroy(self.vmid)
+        for volume in self.volumes:
+            if RESOURCE_PREFIX in volume:
+                self.pve.delete_volume(volume)
+
+
+def run(args: argparse.Namespace) -> int:
+    cfg = LabConfig.from_env()
+    run_id = args.run_id or uuid.uuid4().hex[:10]
+    if not all(c in "0123456789abcdef-" for c in run_id.lower()):
+        raise HarnessError("run ID may contain only hexadecimal characters and hyphens")
+    output_dir = Path(args.artifacts) / run_id
+    output_dir.mkdir(parents=True, mode=0o700)
+    work_root = Path(args.work_dir)
+    work_root.mkdir(parents=True, mode=0o700)
+    work_dir = work_root / f"{RESOURCE_PREFIX}{run_id}"
+    work_dir.mkdir(mode=0o700)
+    pve = Proxmox(cfg)
+    lifecycle = Lifecycle(pve, args.keep_on_failure)
+    private_key: Path | None = None
+
+    def handle_signal(signum: int, _frame: Any) -> None:
+        lifecycle.failed = True
+        raise KeyboardInterrupt(f"received signal {signum}")
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    manifest: dict[str, Any] = {
+        "run_id": run_id,
+        "artifact": Path(args.artifact).name,
+        "artifact_sha256": sha256_file(Path(args.artifact)),
+        "started_at": int(time.time()),
+        "network_scope": "single-nic-smoke",
+    }
+    try:
+        private_key, public_key = make_ssh_key(work_dir)
+        seed = make_seed(cfg, work_dir, run_id, public_key)
+        image = prepare_image(Path(args.artifact), work_dir, run_id)
+
+        image_volume = pve.upload(image, "import")
+        seed_volume = pve.upload(seed, "iso")
+        lifecycle.volumes.extend([image_volume, seed_volume])
+        vmid = pve.next_vmid()
+        lifecycle.vmid = vmid
+        name = f"{RESOURCE_PREFIX}{run_id}"
+        pve.create_vm(
+            vmid,
+            name,
+            f"AiFw E2E run {run_id}; expires {int(time.time()) + 4 * 3600}",
+        )
+        pve.attach_imported_disk(vmid, image_volume, seed_volume)
+        pve.start(vmid)
+        manifest["vmid"] = vmid
+
+        wait_ssh(private_key, cfg.address, timeout=args.boot_timeout)
+        manifest["initial_status"] = appliance_checks(cfg, private_key)
+        manifest["post_reboot_status"] = reboot_and_check(cfg, private_key)
+        manifest["result"] = "passed"
+        return 0
+    except BaseException:
+        lifecycle.failed = True
+        manifest["result"] = "failed"
+        raise
+    finally:
+        if lifecycle.vmid is not None and private_key is not None:
+            with contextlib.suppress(Exception):
+                collect_diagnostics(pve, cfg, private_key, lifecycle.vmid, output_dir)
+        manifest["finished_at"] = int(time.time())
+        output_dir.joinpath("manifest.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+        )
+        lifecycle.cleanup()
+        # Only remove the exact, prefix-validated per-run directory. This
+        # contains the private key, seed config, and decompressed source IMG.
+        if work_dir.parent == work_root and work_dir.name.startswith(RESOURCE_PREFIX):
+            shutil.rmtree(work_dir)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    sub = result.add_subparsers(dest="command", required=True)
+    run_parser = sub.add_parser("run", help="run the Proxmox appliance lifecycle")
+    run_parser.add_argument("--artifact", required=True)
+    run_parser.add_argument("--artifacts", default="e2e/artifacts")
+    run_parser.add_argument("--work-dir", default="e2e/.run")
+    run_parser.add_argument("--run-id")
+    run_parser.add_argument("--boot-timeout", type=int, default=900)
+    run_parser.add_argument("--keep-on-failure", action="store_true")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        if args.command == "run":
+            return run(args)
+    except HarnessError as error:
+        print(f"E2E ERROR: {error}", file=sys.stderr)
+        return 1
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -507,7 +507,7 @@ def copy_git_archive(
 
 def as_root(command: str) -> str:
     """Run a shell command as root on FreeBSD's passwordless wheel account."""
-    return f"su -m root -c {shlex.quote(command)}"
+    return f"su root -c {shlex.quote(command)}"
 
 
 def login_and_check(cfg: LabConfig) -> dict[str, Any]:
@@ -556,6 +556,22 @@ def appliance_checks(cfg: LabConfig, private_key: Path) -> dict[str, Any]:
     return login_and_check(cfg)
 
 
+def wait_appliance_ready(
+    cfg: LabConfig, private_key: Path, timeout: int = 600
+) -> dict[str, Any]:
+    """Wait for the complete service/API/pf contract, not merely SSH."""
+    deadline = time.monotonic() + timeout
+    last_error: BaseException | None = None
+    while time.monotonic() < deadline:
+        try:
+            return appliance_checks(cfg, private_key)
+        except (HarnessError, requests.RequestException, subprocess.SubprocessError) as error:
+            last_error = error
+            time.sleep(5)
+    detail = f": {last_error}" if last_error is not None else ""
+    raise HarnessError(f"complete appliance readiness timed out{detail}")
+
+
 def collect_diagnostics(
     pve: Proxmox,
     cfg: LabConfig,
@@ -602,7 +618,7 @@ def reboot_and_check(cfg: LabConfig, private_key: Path) -> dict[str, Any]:
     )
     time.sleep(10)
     wait_ssh(private_key, cfg.address, timeout=600)
-    return appliance_checks(cfg, private_key)
+    return wait_appliance_ready(cfg, private_key, timeout=600)
 
 
 class Lifecycle:
@@ -690,6 +706,20 @@ def build_image(args: argparse.Namespace) -> int:
         )
         copy_git_archive(
             private_key, cfg.address, "/home/freebsd/AiFw", user="freebsd"
+        )
+        commit_sha = run_checked(
+            ["git", "rev-parse", "HEAD"], capture_output=True
+        ).stdout.strip()
+        run_checked(
+            ssh_command(
+                private_key,
+                cfg.address,
+                (
+                    "printf '%s\\n' "
+                    f"{shlex.quote(commit_sha)} > /home/freebsd/AiFw/.aifw-build-commit"
+                ),
+                user="freebsd",
+            )
         )
         version = run_checked(
             [
@@ -794,7 +824,9 @@ def run(args: argparse.Namespace) -> int:
         manifest["vmid"] = vmid
 
         wait_ssh(private_key, cfg.address, timeout=args.boot_timeout)
-        manifest["initial_status"] = appliance_checks(cfg, private_key)
+        manifest["initial_status"] = wait_appliance_ready(
+            cfg, private_key, timeout=args.boot_timeout
+        )
         manifest["post_reboot_status"] = reboot_and_check(cfg, private_key)
         manifest["result"] = "passed"
         return 0

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -214,27 +214,6 @@ class Proxmox:
         if upid:
             self.wait_task(upid)
 
-    def configure_builder_cloudinit(self, vmid: int, public_key: str) -> None:
-        upid = self.request(
-            "PUT",
-            f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config",
-            data={
-                "ide2": f"{self.cfg.vm_storage}:cloudinit",
-                "citype": "nocloud",
-                "ciuser": "freebsd",
-                # Proxmox expects this field to contain a URL-encoded
-                # authorized_keys payload inside the form-encoded request.
-                "sshkeys": urllib.parse.quote(public_key.strip(), safe=""),
-                "ipconfig0": (
-                    f"ip={self.cfg.address_cidr},gw={self.cfg.gateway}"
-                ),
-                "nameserver": self.cfg.dns,
-                "searchdomain": "local",
-            },
-        )
-        if upid:
-            self.wait_task(upid)
-
     def start(self, vmid: int) -> None:
         upid = self.request(
             "POST", f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/status/start"
@@ -392,15 +371,11 @@ def make_builder_seed(
 hostname: aifw-builder-{run_id}
 disable_root: true
 ssh_pwauth: false
-users:
-  - default
-  - name: builder
-    gecos: AiFw CI Builder
-    groups: wheel
-    shell: /bin/sh
-    sudo: ALL=(ALL) NOPASSWD:ALL
-    ssh_authorized_keys:
-      - {public_key.strip()}
+# FreeBSD nuageinit processes this top-level key before networking. Entries
+# under `users` are delayed until the stock image's post-network firstboot
+# work, so using the image's default `freebsd` account avoids that delay.
+ssh_authorized_keys:
+  - {public_key.strip()}
 growpart:
   mode: auto
   devices: ['/']
@@ -408,22 +383,16 @@ resize_rootfs: true
 """
     interface = ipaddress.ip_interface(cfg.address_cidr)
     network_data = {
-        "version": 1,
-        "config": [
-            {
-                "type": "physical",
-                "name": "vtnet0",
-                "subnets": [
-                    {
-                        "type": "static",
-                        "address": str(interface.ip),
-                        "netmask": str(interface.network.netmask),
-                        "gateway": cfg.gateway,
-                        "dns_nameservers": [cfg.dns],
-                    }
-                ],
+        # FreeBSD 15's native nuageinit NoCloud parser expects cloud-init
+        # network-config v2 and iterates network.ethernets directly.
+        "version": 2,
+        "ethernets": {
+            "vtnet0": {
+                "addresses": [str(interface)],
+                "gateway4": cfg.gateway,
+                "nameservers": {"addresses": [cfg.dns]},
             }
-        ],
+        },
     }
     (seed_dir / "user-data").write_text(user_data)
     (seed_dir / "meta-data").write_text(
@@ -501,13 +470,15 @@ def wait_ssh(private_key: Path, host: str, timeout: int = 600) -> None:
     raise HarnessError(f"SSH/setup readiness timed out for {host}")
 
 
-def copy_git_archive(private_key: Path, host: str, destination: str) -> None:
+def copy_git_archive(
+    private_key: Path, host: str, destination: str, user: str = "root"
+) -> None:
     run_checked(
         ssh_command(
             private_key,
             host,
             f"mkdir -p {shlex.quote(destination)}",
-            user="builder",
+            user=user,
         )
     )
     archive = subprocess.Popen(["git", "archive", "--format=tar", "HEAD"], stdout=subprocess.PIPE)
@@ -517,7 +488,7 @@ def copy_git_archive(private_key: Path, host: str, destination: str) -> None:
             private_key,
             host,
             f"tar -xf - -C {shlex.quote(destination)}",
-            user="builder",
+            user=user,
         ),
         stdin=archive.stdout,
     )
@@ -525,6 +496,11 @@ def copy_git_archive(private_key: Path, host: str, destination: str) -> None:
     archive_status = archive.wait()
     if archive_status != 0 or unpack.returncode != 0:
         raise HarnessError("failed to copy the checked-out commit to the builder VM")
+
+
+def as_root(command: str) -> str:
+    """Run a shell command as root on FreeBSD's passwordless wheel account."""
+    return f"su -m root -c {shlex.quote(command)}"
 
 
 def login_and_check(cfg: LabConfig) -> dict[str, Any]:
@@ -672,8 +648,10 @@ def build_image(args: argparse.Namespace) -> int:
     try:
         private_key, public_key = make_ssh_key(work_dir)
         image = prepare_builder_image(Path(args.builder_image), work_dir, run_id)
+        seed = make_builder_seed(cfg, work_dir, run_id, public_key)
         image_volume = pve.upload(image, "import")
-        lifecycle.volumes.append(image_volume)
+        seed_volume = pve.upload(seed, "iso")
+        lifecycle.volumes.extend([image_volume, seed_volume])
         vmid = pve.next_vmid()
         lifecycle.vmid = vmid
         name = f"{RESOURCE_PREFIX}builder-{run_id}"
@@ -682,19 +660,30 @@ def build_image(args: argparse.Namespace) -> int:
             name,
             f"AiFw image builder {run_id}; expires {int(time.time()) + 4 * 3600}",
         )
-        pve.attach_imported_disk(vmid, image_volume)
-        pve.configure_builder_cloudinit(vmid, public_key)
+        # Proxmox-generated NoCloud metadata names the interface `eth0` and
+        # uses a schema FreeBSD 15's native nuageinit cannot apply. Attach our
+        # explicit v2/vtnet0 cidata seed instead.
+        pve.attach_imported_disk(vmid, image_volume, seed_volume)
         pve.resize_disk(vmid, "virtio0", args.builder_disk_size)
         pve.start(vmid)
 
         wait_command(
             private_key,
             cfg.address,
-            "test -f /var/lib/cloud/instance/boot-finished",
-            user="builder",
+            (
+                "test -s /var/cache/nuageinit/user_data && "
+                f"ifconfig vtnet0 inet | grep -F {shlex.quote(cfg.address)} && "
+                "netstat -rn -f inet | "
+                f"awk '$1 == \"default\" && $2 == {json.dumps(cfg.gateway)} "
+                "{found=1} END {exit !found}' && "
+                f"{as_root('id -u')} | grep -qx 0"
+            ),
+            user="freebsd",
             timeout=args.boot_timeout,
         )
-        copy_git_archive(private_key, cfg.address, "/home/freebsd/AiFw")
+        copy_git_archive(
+            private_key, cfg.address, "/home/freebsd/AiFw", user="freebsd"
+        )
         version = run_checked(
             [
                 "sh",
@@ -707,10 +696,10 @@ def build_image(args: argparse.Namespace) -> int:
         if not version:
             raise HarnessError("could not determine workspace version from Cargo.toml")
         remote_artifact = f"/usr/obj/aifw-iso/output/aifw-{version}-amd64.img.xz"
-        build_command = (
+        build_command = as_root(
             "cd /home/freebsd/AiFw && "
-            f"sudo -H sh freebsd/build-local.sh {shlex.quote(version)} && "
-            f"sudo test -s {shlex.quote(remote_artifact)}"
+            f"sh freebsd/build-local.sh {shlex.quote(version)} && "
+            f"test -s {shlex.quote(remote_artifact)}"
         )
         run_checked(
             ssh_command(
@@ -725,7 +714,7 @@ def build_image(args: argparse.Namespace) -> int:
                 ssh_command(
                     private_key,
                     cfg.address,
-                    f"sudo cat {shlex.quote(remote_artifact)}",
+                    as_root(f"cat {shlex.quote(remote_artifact)}"),
                     user="freebsd",
                 ),
                 stdout=handle,

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -191,16 +191,23 @@ class Proxmox:
         # Proxmox 9 imports a storage `import` volume while applying the VM
         # disk configuration. The source upload is removed during teardown.
         disk = f"{self.cfg.vm_storage}:0,import-from={volume},discard=on"
-        config = {
-            "virtio0": disk,
-            "boot": "order=virtio0",
-        }
+        config = {"virtio0": disk}
         if seed_volume is not None:
             config["ide2"] = f"{seed_volume},media=cdrom"
         upid = self.request(
             "PUT",
             f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config",
             data=config,
+        )
+        if upid:
+            self.wait_task(upid)
+        # The imported disk does not exist until the asynchronous task above
+        # finishes. Setting boot order in the same request makes PVE silently
+        # discard virtio0 from `boot` and fall back to PXE/CD-ROM.
+        upid = self.request(
+            "PUT",
+            f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config",
+            data={"boot": "order=virtio0"},
         )
         if upid:
             self.wait_task(upid)

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -624,7 +624,7 @@ def build_image(args: argparse.Namespace) -> int:
     if not all(c in "0123456789abcdef-" for c in run_id.lower()):
         raise HarnessError("run ID may contain only hexadecimal characters and hyphens")
     work_root = Path(args.work_dir)
-    work_root.mkdir(parents=True, mode=0o700)
+    work_root.mkdir(parents=True, mode=0o700, exist_ok=True)
     work_dir = work_root / f"{RESOURCE_PREFIX}{run_id}-builder"
     work_dir.mkdir(mode=0o700)
     output = Path(args.output)
@@ -727,7 +727,7 @@ def run(args: argparse.Namespace) -> int:
     output_dir = Path(args.artifacts) / run_id
     output_dir.mkdir(parents=True, mode=0o700)
     work_root = Path(args.work_dir)
-    work_root.mkdir(parents=True, mode=0o700)
+    work_root.mkdir(parents=True, mode=0o700, exist_ok=True)
     work_dir = work_root / f"{RESOURCE_PREFIX}{run_id}"
     work_dir.mkdir(mode=0o700)
     pve = Proxmox(cfg)

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -222,7 +222,9 @@ class Proxmox:
                 "ide2": f"{self.cfg.vm_storage}:cloudinit",
                 "citype": "nocloud",
                 "ciuser": "freebsd",
-                "sshkeys": public_key.strip(),
+                # Proxmox expects this field to contain a URL-encoded
+                # authorized_keys payload inside the form-encoded request.
+                "sshkeys": urllib.parse.quote(public_key.strip(), safe=""),
                 "ipconfig0": (
                     f"ip={self.cfg.address_cidr},gw={self.cfg.gateway}"
                 ),

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -250,18 +250,44 @@ class Proxmox:
 
     def delete_volume(self, volume: str) -> None:
         encoded = urllib.parse.quote(volume, safe="")
-        with contextlib.suppress(Exception):
-            upid = self.request(
-                "DELETE",
-                f"/nodes/{self.cfg.pve_node}/storage/{self.cfg.image_storage}/content/{encoded}",
-            )
-            if upid:
-                self.wait_task(upid, timeout=300)
+        upid = self.request(
+            "DELETE",
+            f"/nodes/{self.cfg.pve_node}/storage/{self.cfg.image_storage}/content/{encoded}",
+        )
+        if upid:
+            self.wait_task(upid, timeout=300)
 
     def vm_config(self, vmid: int) -> dict[str, Any]:
         return self.request(
             "GET", f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config"
         )
+
+    def vm_exists(self, vmid: int) -> bool:
+        resources = self.request("GET", "/cluster/resources", params={"type": "vm"})
+        return any(int(resource.get("vmid", -1)) == vmid for resource in resources)
+
+    def volume_exists(self, volume: str) -> bool:
+        resources = self.request(
+            "GET",
+            f"/nodes/{self.cfg.pve_node}/storage/{self.cfg.image_storage}/content",
+        )
+        return any(resource.get("volid") == volume for resource in resources)
+
+    def wait_resources_absent(
+        self, vmid: int | None, volumes: list[str], timeout: int = 60
+    ) -> None:
+        """Prove that every resource owned by this run has disappeared."""
+        deadline = time.monotonic() + timeout
+        remaining: list[str] = []
+        while time.monotonic() < deadline:
+            remaining = []
+            if vmid is not None and self.vm_exists(vmid):
+                remaining.append(f"VM {vmid}")
+            remaining.extend(volume for volume in volumes if self.volume_exists(volume))
+            if not remaining:
+                return
+            time.sleep(2)
+        raise HarnessError(f"run-owned Proxmox resources remain: {', '.join(remaining)}")
 
 
 def sha256_file(path: Path) -> str:
@@ -633,18 +659,21 @@ class Lifecycle:
         if self.keep_on_failure and self.failed:
             print(f"preserving failed VM {self.vmid} by explicit request", flush=True)
             return
-        if self.vmid is not None:
-            with contextlib.suppress(Exception):
-                config = self.pve.vm_config(self.vmid)
-                name = config.get("name", "")
-                if not name.startswith(RESOURCE_PREFIX):
-                    raise HarnessError(
-                        f"refusing to destroy VM {self.vmid} with unexpected name {name!r}"
-                    )
-                self.pve.destroy(self.vmid)
+        if self.vmid is not None and self.pve.vm_exists(self.vmid):
+            config = self.pve.vm_config(self.vmid)
+            name = config.get("name", "")
+            if not name.startswith(RESOURCE_PREFIX):
+                raise HarnessError(
+                    f"refusing to destroy VM {self.vmid} with unexpected name {name!r}"
+                )
+            self.pve.destroy(self.vmid)
         for volume in self.volumes:
-            if RESOURCE_PREFIX in volume:
+            if RESOURCE_PREFIX not in volume:
+                raise HarnessError(f"refusing to delete unexpected volume {volume!r}")
+            if self.pve.volume_exists(volume):
                 self.pve.delete_volume(volume)
+        self.pve.wait_resources_absent(self.vmid, self.volumes)
+        print("teardown verified: zero run-owned Proxmox resources", flush=True)
 
 
 def build_image(args: argparse.Namespace) -> int:
@@ -838,15 +867,24 @@ def run(args: argparse.Namespace) -> int:
         if lifecycle.vmid is not None and private_key is not None:
             with contextlib.suppress(Exception):
                 collect_diagnostics(pve, cfg, private_key, lifecycle.vmid, output_dir)
-        manifest["finished_at"] = int(time.time())
-        output_dir.joinpath("manifest.json").write_text(
-            json.dumps(manifest, indent=2, sort_keys=True) + "\n"
-        )
-        lifecycle.cleanup()
-        # Only remove the exact, prefix-validated per-run directory. This
-        # contains the private key, seed config, and decompressed source IMG.
-        if work_dir.parent == work_root and work_dir.name.startswith(RESOURCE_PREFIX):
-            shutil.rmtree(work_dir)
+        try:
+            lifecycle.cleanup()
+            manifest["teardown_verified"] = True
+        except BaseException:
+            manifest["result"] = "failed"
+            raise
+        finally:
+            manifest.setdefault("teardown_verified", False)
+            manifest["finished_at"] = int(time.time())
+            output_dir.joinpath("manifest.json").write_text(
+                json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+            )
+            # Only remove the exact, prefix-validated per-run directory. This
+            # contains the private key, seed config, and decompressed source IMG.
+            if work_dir.parent == work_root and work_dir.name.startswith(
+                RESOURCE_PREFIX
+            ):
+                shutil.rmtree(work_dir)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import contextlib
 import hashlib
 import ipaddress
@@ -12,6 +13,7 @@ import os
 import shlex
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import time
@@ -26,6 +28,11 @@ import urllib3
 from argon2 import PasswordHasher
 
 RESOURCE_PREFIX = "aifw-e2e-"
+FULL_WAN_CIDR = "198.18.0.1/24"
+FULL_WAN_HELPER = "198.18.0.2"
+FULL_LAN_CIDR = "198.19.0.1/24"
+FULL_LAN_HELPER = "198.19.0.2"
+HELPER_TEMPLATE = "local:vztmpl/debian-13-standard_13.6-1_amd64.tar.zst"
 
 
 class HarnessError(RuntimeError):
@@ -46,6 +53,8 @@ class LabConfig:
     image_storage: str
     vm_storage: str
     bridge: str
+    wan_bridge: str
+    lan_bridge: str
     verify_tls: bool
     address_cidr: str
     gateway: str
@@ -62,6 +71,8 @@ class LabConfig:
             image_storage=os.environ.get("PVE_IMAGE_STORAGE", "local"),
             vm_storage=os.environ.get("PVE_VM_STORAGE", "local-lvm"),
             bridge=os.environ.get("PVE_BRIDGE", "vmbr0"),
+            wan_bridge=os.environ.get("PVE_E2E_WAN_BRIDGE", "vmbr998"),
+            lan_bridge=os.environ.get("PVE_E2E_LAN_BRIDGE", "vmbr999"),
             verify_tls=os.environ.get("PVE_VERIFY_TLS", "true").lower()
             in ("1", "true", "yes"),
             address_cidr=required_env("AIFW_E2E_ADDRESS"),
@@ -108,7 +119,8 @@ class Proxmox:
                 "GET", f"/nodes/{self.cfg.pve_node}/tasks/{encoded}/status"
             )
             if status.get("status") == "stopped":
-                if status.get("exitstatus") != "OK":
+                exit_status = str(status.get("exitstatus", ""))
+                if exit_status != "OK" and not exit_status.startswith("WARNINGS"):
                     raise HarnessError(
                         f"Proxmox task failed: {status.get('exitstatus')} ({upid})"
                     )
@@ -118,6 +130,19 @@ class Proxmox:
 
     def next_vmid(self) -> int:
         return int(self.request("GET", "/cluster/nextid"))
+
+    def require_bridges(self, bridges: list[str]) -> None:
+        networks = self.request("GET", f"/nodes/{self.cfg.pve_node}/network")
+        available = {
+            network.get("iface")
+            for network in networks
+            if network.get("type") == "bridge" and network.get("active") == 1
+        }
+        missing = sorted(set(bridges) - available)
+        if missing:
+            raise HarnessError(
+                "required active Proxmox bridges are missing: " + ", ".join(missing)
+            )
 
     def create_vm(self, vmid: int, name: str, description: str) -> None:
         upid = self.request(
@@ -142,6 +167,95 @@ class Proxmox:
         )
         if upid:
             self.wait_task(upid)
+
+    def create_full_appliance_vm(self, vmid: int, name: str, description: str) -> None:
+        upid = self.request(
+            "POST",
+            f"/nodes/{self.cfg.pve_node}/qemu",
+            data={
+                "vmid": vmid,
+                "name": name,
+                "description": description,
+                "tags": "aifw-e2e",
+                "ostype": "other",
+                "bios": "seabios",
+                "cores": 4,
+                "memory": 4096,
+                "scsihw": "virtio-scsi-single",
+                "serial0": "socket",
+                "vga": "serial0",
+                "net0": f"virtio,bridge={self.cfg.wan_bridge},firewall=0",
+                "net1": f"virtio,bridge={self.cfg.lan_bridge},firewall=0",
+                "onboot": 0,
+                "protection": 0,
+            },
+        )
+        if upid:
+            self.wait_task(upid)
+
+    def create_helper_container(
+        self,
+        vmid: int,
+        name: str,
+        description: str,
+        public_key: str,
+        networks: list[str],
+    ) -> None:
+        config: dict[str, Any] = {
+            "vmid": vmid,
+            "hostname": name,
+            "description": description,
+            "tags": "aifw-e2e",
+            "ostemplate": HELPER_TEMPLATE,
+            "rootfs": f"{self.cfg.vm_storage}:2",
+            "cores": 1,
+            "memory": 512,
+            "swap": 0,
+            "unprivileged": 1,
+            "start": 0,
+            "onboot": 0,
+            "protection": 0,
+            "ssh-public-keys": public_key.strip(),
+        }
+        for index, network in enumerate(networks):
+            config[f"net{index}"] = network
+        upid = self.request(
+            "POST", f"/nodes/{self.cfg.pve_node}/lxc", data=config
+        )
+        if upid:
+            self.wait_task(upid)
+
+    def start_container(self, vmid: int) -> None:
+        upid = self.request(
+            "POST", f"/nodes/{self.cfg.pve_node}/lxc/{vmid}/status/start"
+        )
+        self.wait_task(upid)
+
+    def container_exists(self, vmid: int) -> bool:
+        resources = self.request("GET", "/cluster/resources", params={"type": "vm"})
+        return any(
+            int(resource.get("vmid", -1)) == vmid
+            and resource.get("type") == "lxc"
+            for resource in resources
+        )
+
+    def container_config(self, vmid: int) -> dict[str, Any]:
+        return self.request(
+            "GET", f"/nodes/{self.cfg.pve_node}/lxc/{vmid}/config"
+        )
+
+    def destroy_container(self, vmid: int) -> None:
+        with contextlib.suppress(Exception):
+            upid = self.request(
+                "POST", f"/nodes/{self.cfg.pve_node}/lxc/{vmid}/status/stop"
+            )
+            self.wait_task(upid, timeout=120)
+        upid = self.request(
+            "DELETE",
+            f"/nodes/{self.cfg.pve_node}/lxc/{vmid}",
+            params={"purge": 1, "destroy-unreferenced-disks": 1},
+        )
+        self.wait_task(upid, timeout=300)
 
     def create_builder_vm(self, vmid: int, name: str, description: str) -> None:
         upid = self.request(
@@ -333,17 +447,22 @@ def prepare_builder_image(artifact: Path, output_dir: Path, run_id: str) -> Path
 
 
 def make_seed(
-    cfg: LabConfig, output_dir: Path, run_id: str, public_key: str
+    cfg: LabConfig,
+    output_dir: Path,
+    run_id: str,
+    public_key: str,
+    full: bool = False,
 ) -> Path:
     password_hash = PasswordHasher().hash(cfg.admin_password)
+    wan_ip = FULL_WAN_CIDR if full else cfg.address_cidr
     setup = {
         "hostname": f"aifw-e2e-{run_id}",
         "wan_interface": "vtnet0",
         "wan_mode": "static",
-        "wan_ip": cfg.address_cidr,
-        "wan_gateway": cfg.gateway,
-        "lan_interface": None,
-        "lan_ip": None,
+        "wan_ip": wan_ip,
+        "wan_gateway": None if full else cfg.gateway,
+        "lan_interface": "vtnet1" if full else None,
+        "lan_ip": FULL_LAN_CIDR if full else None,
         "admin_username": "e2e-admin",
         "admin_password_hash": password_hash,
         "totp_secret": "",
@@ -352,10 +471,10 @@ def make_seed(
         "api_listen": "0.0.0.0",
         "api_port": 8080,
         "ui_enabled": True,
-        "dns_servers": [cfg.dns],
+        "dns_servers": [] if full else [cfg.dns],
         "dhcp_enabled": False,
-        "default_policy": "permissive",
-        "nat_enabled": False,
+        "default_policy": "standard" if full else "permissive",
+        "nat_enabled": full,
         "ssh_auth_method": "key_only",
         "ssh_github_user": None,
         "ssh_authorized_keys": [public_key.strip()],
@@ -374,6 +493,61 @@ def make_seed(
         [tool, "-quiet", "-V", "AIFW_SEED", "-o", str(seed), str(seed_dir)]
     )
     return seed
+
+
+HELPER_SERVER = """#!/usr/bin/env python3
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = (self.client_address[0] + "\\n").encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format, *_args):
+        return
+
+ThreadingHTTPServer(("0.0.0.0", int(sys.argv[1])), Handler).serve_forever()
+"""
+
+
+def start_helper_servers(
+    private_key: Path,
+    host: str,
+    ports: list[int],
+    jump: str | None = None,
+) -> None:
+    encoded = base64.b64encode(HELPER_SERVER.encode()).decode()
+    port_list = " ".join(str(port) for port in ports)
+    command = (
+        f"printf %s {shlex.quote(encoded)} | base64 -d > /tmp/aifw-e2e-server.py && "
+        "chmod 700 /tmp/aifw-e2e-server.py && "
+        f"for port in {port_list}; do "
+        "nohup python3 /tmp/aifw-e2e-server.py \"$port\" "
+        ">/tmp/aifw-e2e-server-\"$port\".log 2>&1 </dev/null & done"
+    )
+    run_checked(
+        ssh_command(private_key, host, command, user="root", jump=jump),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def configure_lan_helper_route(private_key: Path, host: str) -> None:
+    run_checked(
+        ssh_command(
+            private_key,
+            host,
+            "ip route replace 198.18.0.0/24 via 198.19.0.1 dev eth1",
+            user="root",
+        ),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
 
 
 def make_ssh_key(output_dir: Path) -> tuple[Path, str]:
@@ -450,9 +624,13 @@ resize_rootfs: true
 
 
 def ssh_command(
-    private_key: Path, host: str, command: str, user: str = "root"
+    private_key: Path,
+    host: str,
+    command: str,
+    user: str = "root",
+    jump: str | None = None,
 ) -> list[str]:
-    return [
+    args = [
         "ssh",
         "-i",
         str(private_key),
@@ -464,9 +642,82 @@ def ssh_command(
         "StrictHostKeyChecking=no",
         "-o",
         "UserKnownHostsFile=/dev/null",
-        f"{user}@{host}",
-        command,
     ]
+    if jump:
+        proxy = " ".join(
+            shlex.quote(value)
+            for value in [
+                "ssh",
+                "-i",
+                str(private_key),
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=10",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-W",
+                "%h:%p",
+                jump,
+            ]
+        )
+        args.extend(["-o", f"ProxyCommand={proxy}"])
+    args.extend([f"{user}@{host}", command])
+    return args
+
+
+@contextlib.contextmanager
+def ssh_tunnel(
+    private_key: Path,
+    bastion: str,
+    remote_host: str,
+    remote_port: int,
+):
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        local_port = int(probe.getsockname()[1])
+    process = subprocess.Popen(
+        [
+            "ssh",
+            "-i",
+            str(private_key),
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ExitOnForwardFailure=yes",
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-N",
+            "-L",
+            f"127.0.0.1:{local_port}:{remote_host}:{remote_port}",
+            bastion if "@" in bastion else f"root@{bastion}",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                raise HarnessError("SSH tunnel exited before becoming ready")
+            with socket.socket() as check:
+                check.settimeout(1)
+                if check.connect_ex(("127.0.0.1", local_port)) == 0:
+                    break
+            time.sleep(0.5)
+        else:
+            raise HarnessError("SSH tunnel readiness timed out")
+        yield local_port
+    finally:
+        process.terminate()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            process.wait(timeout=5)
+        if process.poll() is None:
+            process.kill()
 
 
 def wait_command(
@@ -475,11 +726,12 @@ def wait_command(
     command: str,
     user: str,
     timeout: int,
+    jump: str | None = None,
 ) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         result = subprocess.run(
-            ssh_command(private_key, host, command, user=user),
+            ssh_command(private_key, host, command, user=user, jump=jump),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
@@ -489,11 +741,21 @@ def wait_command(
     raise HarnessError(f"SSH readiness timed out for {user}@{host}")
 
 
-def wait_ssh(private_key: Path, host: str, timeout: int = 600) -> None:
+def wait_ssh(
+    private_key: Path,
+    host: str,
+    timeout: int = 600,
+    jump: str | None = None,
+) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         result = subprocess.run(
-            ssh_command(private_key, host, "test -f /usr/local/etc/aifw/aifw.conf"),
+            ssh_command(
+                private_key,
+                host,
+                "test -f /usr/local/etc/aifw/aifw.conf",
+                jump=jump,
+            ),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
@@ -536,8 +798,8 @@ def as_root(command: str) -> str:
     return f"su root -c {shlex.quote(command)}"
 
 
-def login_and_check(cfg: LabConfig) -> dict[str, Any]:
-    base = f"https://{cfg.address}:8080"
+def login_and_check(cfg: LabConfig, base: str | None = None) -> dict[str, Any]:
+    base = base or f"https://{cfg.address}:8080"
     session = requests.Session()
     session.verify = False
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -564,7 +826,254 @@ def login_and_check(cfg: LabConfig) -> dict[str, Any]:
     return data
 
 
-def appliance_checks(cfg: LabConfig, private_key: Path) -> dict[str, Any]:
+def api_session(cfg: LabConfig, base: str) -> requests.Session:
+    session = requests.Session()
+    session.verify = False
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    response = session.post(
+        f"{base}/api/v1/auth/login",
+        json={"username": "e2e-admin", "password": cfg.admin_password},
+        timeout=20,
+    )
+    response.raise_for_status()
+    session.headers["Authorization"] = (
+        f"Bearer {response.json()['tokens']['access_token']}"
+    )
+    return session
+
+
+def test_http_flow(
+    private_key: Path,
+    source_host: str,
+    destination: str,
+    expected: str | None,
+    jump: str | None = None,
+    user: str = "root",
+) -> str:
+    command = f"wget -q -T 8 -O - {shlex.quote(destination)}"
+    result = subprocess.run(
+        ssh_command(private_key, source_host, command, user=user, jump=jump),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    observed = result.stdout.strip()
+    if expected is None:
+        if result.returncode == 0:
+            raise HarnessError(f"flow unexpectedly succeeded: {destination}")
+        return "blocked"
+    if result.returncode != 0:
+        raise HarnessError(f"flow failed unexpectedly: {destination}")
+    if observed != expected:
+        raise HarnessError(
+            f"flow {destination} observed source {observed!r}, expected {expected!r}"
+        )
+    return observed
+
+
+def clear_pf_states(private_key: Path, appliance_host: str, jump: str) -> None:
+    run_checked(
+        ssh_command(private_key, appliance_host, "pfctl -F states", jump=jump),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def create_rule(
+    session: requests.Session,
+    base: str,
+    *,
+    action: str,
+    interface: str,
+    source: str,
+    destination: str,
+    port: int,
+    label: str,
+    priority: int,
+) -> str:
+    response = session.post(
+        f"{base}/api/v1/rules",
+        json={
+            "action": action,
+            "direction": "in",
+            "protocol": "tcp",
+            "src_addr": source,
+            "dst_addr": destination,
+            "dst_port_start": port,
+            "dst_port_end": port,
+            "interface": interface,
+            "ip_version": "inet",
+            "priority": priority,
+            "log": action == "block",
+            "quick": True,
+            "label": label,
+            "state_tracking": "keep_state" if action == "pass" else "none",
+            "status": "active",
+        },
+        timeout=20,
+    )
+    response.raise_for_status()
+    rule_id = response.json()["data"]["id"]
+    reload_response = session.post(f"{base}/api/v1/reload", timeout=60)
+    reload_response.raise_for_status()
+    if "Partial reload" in reload_response.json().get("message", ""):
+        raise HarnessError(reload_response.json()["message"])
+    return str(rule_id)
+
+
+def delete_rule(session: requests.Session, base: str, rule_id: str) -> None:
+    response = session.delete(f"{base}/api/v1/rules/{rule_id}", timeout=20)
+    response.raise_for_status()
+    reload_response = session.post(f"{base}/api/v1/reload", timeout=60)
+    reload_response.raise_for_status()
+    if "Partial reload" in reload_response.json().get("message", ""):
+        raise HarnessError(reload_response.json()["message"])
+
+
+def browser_checks(cfg: LabConfig, base: str, output_dir: Path) -> None:
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as error:
+        raise HarnessError("Playwright is required for full E2E browser checks") from error
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = browser.new_context(ignore_https_errors=True)
+        page = context.new_page()
+        page.goto(f"{base}/login", wait_until="networkidle")
+        page.get_by_label("Username").fill("e2e-admin")
+        page.get_by_label("Password").fill(cfg.admin_password)
+        page.get_by_role("button", name="Sign In").click()
+        page.wait_for_url(f"{base}/", timeout=30_000)
+        page.locator("h1").first.wait_for(state="visible")
+        page.goto(f"{base}/rules", wait_until="networkidle")
+        page.get_by_role("heading", name="Firewall Rules").wait_for(state="visible")
+        page.screenshot(path=str(output_dir / "rules-page.png"), full_page=True)
+        browser.close()
+
+
+def full_data_plane_checks(
+    cfg: LabConfig,
+    private_key: Path,
+    output_dir: Path,
+) -> tuple[dict[str, Any], str]:
+    jump = f"root@{cfg.address}"
+    appliance_host = FULL_LAN_CIDR.split("/", 1)[0]
+    evidence: dict[str, Any] = {}
+
+    evidence["lan_to_wan_nat_source"] = test_http_flow(
+        private_key,
+        cfg.address,
+        f"http://{FULL_WAN_HELPER}:9001/",
+        FULL_WAN_CIDR.split("/", 1)[0],
+    )
+    evidence["wan_to_lan_initial"] = test_http_flow(
+        private_key,
+        FULL_WAN_HELPER,
+        f"http://{FULL_LAN_HELPER}:9101/",
+        None,
+        jump=jump,
+    )
+
+    with ssh_tunnel(private_key, cfg.address, appliance_host, 8080) as port:
+        base = f"https://127.0.0.1:{port}"
+        session = api_session(cfg, base)
+        allow_id = create_rule(
+            session,
+            base,
+            action="pass",
+            interface="vtnet0",
+            source=FULL_WAN_HELPER,
+            destination=FULL_LAN_HELPER,
+            port=9102,
+            label="E2E allow WAN to LAN",
+            priority=-100,
+        )
+        clear_pf_states(private_key, appliance_host, jump)
+        evidence["wan_to_lan_after_allow"] = test_http_flow(
+            private_key,
+            FULL_WAN_HELPER,
+            f"http://{FULL_LAN_HELPER}:9102/",
+            FULL_WAN_HELPER,
+            jump=jump,
+        )
+
+        block_id = create_rule(
+            session,
+            base,
+            action="block",
+            interface="vtnet1",
+            source=FULL_LAN_HELPER,
+            destination=FULL_WAN_HELPER,
+            port=9003,
+            label="E2E block LAN to WAN",
+            priority=-200,
+        )
+        try:
+            clear_pf_states(private_key, appliance_host, jump)
+            evidence["lan_to_wan_after_block"] = test_http_flow(
+                private_key,
+                cfg.address,
+                f"http://{FULL_WAN_HELPER}:9003/",
+                None,
+            )
+        finally:
+            delete_rule(session, base, block_id)
+        clear_pf_states(private_key, appliance_host, jump)
+        evidence["lan_to_wan_after_delete"] = test_http_flow(
+            private_key,
+            cfg.address,
+            f"http://{FULL_WAN_HELPER}:9004/",
+            FULL_WAN_CIDR.split("/", 1)[0],
+        )
+        browser_checks(cfg, base, output_dir)
+        evidence["browser"] = "passed"
+    return evidence, allow_id
+
+
+def post_reboot_data_plane_checks(
+    cfg: LabConfig,
+    private_key: Path,
+    allow_rule_id: str,
+) -> dict[str, Any]:
+    jump = f"root@{cfg.address}"
+    appliance_host = FULL_LAN_CIDR.split("/", 1)[0]
+    evidence = {
+        "lan_to_wan_nat_source": test_http_flow(
+            private_key,
+            cfg.address,
+            f"http://{FULL_WAN_HELPER}:9002/",
+            FULL_WAN_CIDR.split("/", 1)[0],
+        ),
+        "persisted_wan_to_lan_allow": test_http_flow(
+            private_key,
+            FULL_WAN_HELPER,
+            f"http://{FULL_LAN_HELPER}:9102/",
+            FULL_WAN_HELPER,
+            jump=jump,
+        ),
+    }
+    with ssh_tunnel(private_key, cfg.address, appliance_host, 8080) as port:
+        base = f"https://127.0.0.1:{port}"
+        delete_rule(api_session(cfg, base), base, allow_rule_id)
+    clear_pf_states(private_key, appliance_host, jump)
+    evidence["wan_to_lan_after_allow_delete"] = test_http_flow(
+        private_key,
+        FULL_WAN_HELPER,
+        f"http://{FULL_LAN_HELPER}:9102/",
+        None,
+        jump=jump,
+    )
+    return evidence
+
+
+def appliance_checks(
+    cfg: LabConfig,
+    private_key: Path,
+    host: str | None = None,
+    jump: str | None = None,
+) -> dict[str, Any]:
+    host = host or cfg.address
     commands = [
         "service aifw_daemon onestatus",
         "service aifw_ids onestatus",
@@ -575,22 +1084,29 @@ def appliance_checks(cfg: LabConfig, private_key: Path) -> dict[str, Any]:
     ]
     for command in commands:
         run_checked(
-            ssh_command(private_key, cfg.address, command),
+            ssh_command(private_key, host, command, jump=jump),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
+    if jump:
+        with ssh_tunnel(private_key, jump, host, 8080) as port:
+            return login_and_check(cfg, f"https://127.0.0.1:{port}")
     return login_and_check(cfg)
 
 
 def wait_appliance_ready(
-    cfg: LabConfig, private_key: Path, timeout: int = 600
+    cfg: LabConfig,
+    private_key: Path,
+    timeout: int = 600,
+    host: str | None = None,
+    jump: str | None = None,
 ) -> dict[str, Any]:
     """Wait for the complete service/API/pf contract, not merely SSH."""
     deadline = time.monotonic() + timeout
     last_error: BaseException | None = None
     while time.monotonic() < deadline:
         try:
-            return appliance_checks(cfg, private_key)
+            return appliance_checks(cfg, private_key, host=host, jump=jump)
         except (HarnessError, requests.RequestException, subprocess.SubprocessError) as error:
             last_error = error
             time.sleep(5)
@@ -604,6 +1120,8 @@ def collect_diagnostics(
     private_key: Path,
     vmid: int,
     output_dir: Path,
+    host: str | None = None,
+    jump: str | None = None,
 ) -> None:
     with contextlib.suppress(Exception):
         safe_config = pve.vm_config(vmid)
@@ -628,7 +1146,7 @@ echo '=== dmesg ==='; dmesg
 """
     with output_dir.joinpath("appliance-diagnostics.txt").open("w") as handle:
         subprocess.run(
-            ssh_command(private_key, cfg.address, command),
+            ssh_command(private_key, host or cfg.address, command, jump=jump),
             stdout=handle,
             stderr=subprocess.STDOUT,
             text=True,
@@ -636,15 +1154,49 @@ echo '=== dmesg ==='; dmesg
         )
 
 
-def reboot_and_check(cfg: LabConfig, private_key: Path) -> dict[str, Any]:
+def collect_helper_diagnostics(
+    private_key: Path,
+    host: str,
+    output: Path,
+    jump: str | None = None,
+    user: str = "root",
+) -> None:
+    command = """set +e
+echo '=== uname ==='; uname -a
+echo '=== interfaces ==='; ip address
+echo '=== routes ==='; ip route
+echo '=== processes ==='; ps auxww
+echo '=== sockets ==='; netstat -lntp
+echo '=== cloud-init ==='; cloud-init status --long
+echo '=== cloud-init output ==='; tail -n 300 /var/log/cloud-init-output.log
+"""
+    with output.open("w") as handle:
+        subprocess.run(
+            ssh_command(private_key, host, command, user=user, jump=jump),
+            stdout=handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=60,
+        )
+
+
+def reboot_and_check(
+    cfg: LabConfig,
+    private_key: Path,
+    host: str | None = None,
+    jump: str | None = None,
+) -> dict[str, Any]:
+    host = host or cfg.address
     subprocess.run(
-        ssh_command(private_key, cfg.address, "shutdown -r now"),
+        ssh_command(private_key, host, "shutdown -r now", jump=jump),
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
     time.sleep(10)
-    wait_ssh(private_key, cfg.address, timeout=600)
-    return wait_appliance_ready(cfg, private_key, timeout=600)
+    wait_ssh(private_key, host, timeout=600, jump=jump)
+    return wait_appliance_ready(
+        cfg, private_key, timeout=600, host=host, jump=jump
+    )
 
 
 class Lifecycle:
@@ -652,6 +1204,8 @@ class Lifecycle:
         self.pve = pve
         self.keep_on_failure = keep_on_failure
         self.vmid: int | None = None
+        self.additional_vmids: list[int] = []
+        self.container_vmids: list[int] = []
         self.volumes: list[str] = []
         self.failed = False
 
@@ -659,20 +1213,37 @@ class Lifecycle:
         if self.keep_on_failure and self.failed:
             print(f"preserving failed VM {self.vmid} by explicit request", flush=True)
             return
-        if self.vmid is not None and self.pve.vm_exists(self.vmid):
-            config = self.pve.vm_config(self.vmid)
+        vmids = self.additional_vmids + ([self.vmid] if self.vmid is not None else [])
+        for vmid in self.container_vmids:
+            if not self.pve.container_exists(vmid):
+                continue
+            config = self.pve.container_config(vmid)
+            name = config.get("hostname", "")
+            if not name.startswith(RESOURCE_PREFIX):
+                raise HarnessError(
+                    f"refusing to destroy container {vmid} with unexpected name {name!r}"
+                )
+            self.pve.destroy_container(vmid)
+        for vmid in vmids:
+            if not self.pve.vm_exists(vmid):
+                continue
+            config = self.pve.vm_config(vmid)
             name = config.get("name", "")
             if not name.startswith(RESOURCE_PREFIX):
                 raise HarnessError(
-                    f"refusing to destroy VM {self.vmid} with unexpected name {name!r}"
+                    f"refusing to destroy VM {vmid} with unexpected name {name!r}"
                 )
-            self.pve.destroy(self.vmid)
+            self.pve.destroy(vmid)
         for volume in self.volumes:
             if RESOURCE_PREFIX not in volume:
                 raise HarnessError(f"refusing to delete unexpected volume {volume!r}")
             if self.pve.volume_exists(volume):
                 self.pve.delete_volume(volume)
-        self.pve.wait_resources_absent(self.vmid, self.volumes)
+        for vmid in vmids:
+            self.pve.wait_resources_absent(vmid, self.volumes if vmid == self.vmid else [])
+        for vmid in self.container_vmids:
+            if self.pve.container_exists(vmid):
+                raise HarnessError(f"run-owned Proxmox container remains: {vmid}")
         print("teardown verified: zero run-owned Proxmox resources", flush=True)
 
 
@@ -887,6 +1458,262 @@ def run(args: argparse.Namespace) -> int:
                 shutil.rmtree(work_dir)
 
 
+def run_full(args: argparse.Namespace) -> int:
+    cfg = LabConfig.from_env()
+    run_id = args.run_id or uuid.uuid4().hex[:10]
+    if not all(c in "0123456789abcdef-" for c in run_id.lower()):
+        raise HarnessError("run ID may contain only hexadecimal characters and hyphens")
+    output_dir = Path(args.artifacts) / run_id
+    output_dir.mkdir(parents=True, mode=0o700)
+    work_root = Path(args.work_dir)
+    work_root.mkdir(parents=True, mode=0o700, exist_ok=True)
+    work_dir = work_root / f"{RESOURCE_PREFIX}{run_id}-full"
+    work_dir.mkdir(mode=0o700)
+    pve = Proxmox(cfg)
+    lifecycle = Lifecycle(pve, args.keep_on_failure)
+    private_key: Path | None = None
+    appliance_vmid: int | None = None
+    helper_vmids: dict[str, int] = {}
+
+    def handle_signal(signum: int, _frame: Any) -> None:
+        lifecycle.failed = True
+        raise KeyboardInterrupt(f"received signal {signum}")
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    manifest: dict[str, Any] = {
+        "run_id": run_id,
+        "artifact": Path(args.artifact).name,
+        "artifact_sha256": sha256_file(Path(args.artifact)),
+        "helper_template": HELPER_TEMPLATE,
+        "started_at": int(time.time()),
+        "network_scope": "isolated-wan-lan-full",
+        "topology": {
+            "management": f"{cfg.bridge}:{cfg.address_cidr}",
+            "wan": f"{cfg.wan_bridge}:198.18.0.0/24",
+            "lan": f"{cfg.lan_bridge}:198.19.0.0/24",
+        },
+    }
+    try:
+        pve.require_bridges([cfg.bridge, cfg.wan_bridge, cfg.lan_bridge])
+        private_key, public_key = make_ssh_key(work_dir)
+        appliance_seed = make_seed(cfg, work_dir, run_id, public_key, full=True)
+        appliance_image = prepare_image(Path(args.artifact), work_dir, run_id)
+        appliance_image_volume = pve.upload(appliance_image, "import")
+        appliance_seed_volume = pve.upload(appliance_seed, "iso")
+        lifecycle.volumes.extend(
+            [
+                appliance_image_volume,
+                appliance_seed_volume,
+            ]
+        )
+
+        lan_vmid = pve.next_vmid()
+        pve.create_helper_container(
+            lan_vmid,
+            f"{RESOURCE_PREFIX}lan-{run_id}",
+            f"AiFw E2E LAN helper {run_id}; expires {int(time.time()) + 4 * 3600}",
+            public_key,
+            [
+                f"name=eth0,bridge={cfg.bridge},firewall=0,ip={cfg.address_cidr},gw={cfg.gateway},type=veth",
+                f"name=eth1,bridge={cfg.lan_bridge},firewall=0,ip={FULL_LAN_HELPER}/24,type=veth",
+            ],
+        )
+        lifecycle.container_vmids.append(lan_vmid)
+        helper_vmids["lan"] = lan_vmid
+
+        wan_vmid = pve.next_vmid()
+        pve.create_helper_container(
+            wan_vmid,
+            f"{RESOURCE_PREFIX}wan-{run_id}",
+            f"AiFw E2E WAN helper {run_id}; expires {int(time.time()) + 4 * 3600}",
+            public_key,
+            [f"name=eth0,bridge={cfg.wan_bridge},firewall=0,ip={FULL_WAN_HELPER}/24,gw={FULL_WAN_CIDR.split('/', 1)[0]},type=veth"],
+        )
+        lifecycle.container_vmids.append(wan_vmid)
+        helper_vmids["wan"] = wan_vmid
+
+        appliance_vmid = pve.next_vmid()
+        lifecycle.vmid = appliance_vmid
+        pve.create_full_appliance_vm(
+            appliance_vmid,
+            f"{RESOURCE_PREFIX}{run_id}",
+            f"AiFw full E2E run {run_id}; expires {int(time.time()) + 4 * 3600}",
+        )
+        pve.attach_imported_disk(
+            appliance_vmid, appliance_image_volume, appliance_seed_volume
+        )
+        manifest["vmids"] = {
+            "appliance": appliance_vmid,
+            "lan_helper": lan_vmid,
+            "wan_helper": wan_vmid,
+        }
+
+        pve.start_container(lan_vmid)
+        wait_command(
+            private_key,
+            cfg.address,
+            "test -x /usr/bin/python3",
+            user="root",
+            timeout=args.boot_timeout,
+        )
+        configure_lan_helper_route(private_key, cfg.address)
+        start_helper_servers(private_key, cfg.address, [9101, 9102, 9103, 9104])
+        pve.start_container(wan_vmid)
+        pve.start(appliance_vmid)
+        jump = f"root@{cfg.address}"
+        appliance_host = FULL_LAN_CIDR.split("/", 1)[0]
+        wait_ssh(
+            private_key,
+            appliance_host,
+            timeout=args.boot_timeout,
+            jump=jump,
+        )
+        wait_command(
+            private_key,
+            FULL_WAN_HELPER,
+            "test -x /usr/bin/python3",
+            user="root",
+            timeout=args.boot_timeout,
+            jump=jump,
+        )
+        start_helper_servers(
+            private_key,
+            FULL_WAN_HELPER,
+            [9001, 9002, 9003, 9004],
+            jump=jump,
+        )
+        manifest["initial_status"] = wait_appliance_ready(
+            cfg,
+            private_key,
+            timeout=args.boot_timeout,
+            host=appliance_host,
+            jump=jump,
+        )
+        data_plane, allow_rule_id = full_data_plane_checks(
+            cfg, private_key, output_dir
+        )
+        manifest["initial_data_plane"] = data_plane
+        manifest["post_reboot_status"] = reboot_and_check(
+            cfg, private_key, host=appliance_host, jump=jump
+        )
+        manifest["post_reboot_data_plane"] = post_reboot_data_plane_checks(
+            cfg, private_key, allow_rule_id
+        )
+        manifest["result"] = "passed"
+        return 0
+    except BaseException:
+        lifecycle.failed = True
+        manifest["result"] = "failed"
+        raise
+    finally:
+        if appliance_vmid is not None and private_key is not None:
+            with contextlib.suppress(Exception):
+                collect_diagnostics(
+                    pve,
+                    cfg,
+                    private_key,
+                    appliance_vmid,
+                    output_dir,
+                    host=FULL_LAN_CIDR.split("/", 1)[0],
+                    jump=f"root@{cfg.address}",
+                )
+            with contextlib.suppress(Exception):
+                collect_helper_diagnostics(
+                    private_key,
+                    cfg.address,
+                    output_dir / "lan-helper-diagnostics.txt",
+                    user="root",
+                )
+            with contextlib.suppress(Exception):
+                collect_helper_diagnostics(
+                    private_key,
+                    FULL_WAN_HELPER,
+                    output_dir / "wan-helper-diagnostics.txt",
+                    jump=f"root@{cfg.address}",
+                    user="root",
+                )
+        try:
+            lifecycle.cleanup()
+            manifest["teardown_verified"] = True
+        except BaseException:
+            manifest["result"] = "failed"
+            raise
+        finally:
+            manifest.setdefault("teardown_verified", False)
+            manifest["finished_at"] = int(time.time())
+            output_dir.joinpath("manifest.json").write_text(
+                json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+            )
+            if work_dir.parent == work_root and work_dir.name.startswith(
+                RESOURCE_PREFIX
+            ):
+                shutil.rmtree(work_dir)
+
+
+def check_helper(args: argparse.Namespace) -> int:
+    """Focused, disposable validation of the Linux helper substrate."""
+    cfg = LabConfig.from_env()
+    run_id = args.run_id or uuid.uuid4().hex[:10]
+    if not all(c in "0123456789abcdef-" for c in run_id.lower()):
+        raise HarnessError("run ID may contain only hexadecimal characters and hyphens")
+    work_root = Path(args.work_dir)
+    work_root.mkdir(parents=True, mode=0o700, exist_ok=True)
+    work_dir = work_root / f"{RESOURCE_PREFIX}{run_id}-helper-check"
+    work_dir.mkdir(mode=0o700)
+    pve = Proxmox(cfg)
+    lifecycle = Lifecycle(pve, keep_on_failure=False)
+    try:
+        pve.require_bridges([cfg.bridge, cfg.lan_bridge])
+        private_key, public_key = make_ssh_key(work_dir)
+        vmid = pve.next_vmid()
+        pve.create_helper_container(
+            vmid,
+            f"{RESOURCE_PREFIX}helper-{run_id}",
+            f"AiFw focused helper check {run_id}; expires {int(time.time()) + 3600}",
+            public_key,
+            [
+                f"name=eth0,bridge={cfg.bridge},firewall=0,ip={cfg.address_cidr},gw={cfg.gateway},type=veth",
+                f"name=eth1,bridge={cfg.lan_bridge},firewall=0,ip={FULL_LAN_HELPER}/24,type=veth",
+            ],
+        )
+        lifecycle.container_vmids.append(vmid)
+        pve.start_container(vmid)
+        wait_command(
+            private_key,
+            cfg.address,
+            (
+                f"ip -4 addr show eth0 | grep -F {shlex.quote(cfg.address_cidr)} && "
+                "ip -4 addr show eth1 | grep -F 198.19.0.2/24 && "
+                f"ip route | grep -F 'default via {cfg.gateway} dev eth0'"
+            ),
+            user="root",
+            timeout=args.boot_timeout,
+        )
+        configure_lan_helper_route(private_key, cfg.address)
+        start_helper_servers(private_key, cfg.address, [9101])
+        test_http_flow(
+            private_key,
+            cfg.address,
+            "http://127.0.0.1:9101/",
+            "127.0.0.1",
+        )
+        print("focused helper boot/network/SSH/server check passed", flush=True)
+        return 0
+    except BaseException:
+        lifecycle.failed = True
+        raise
+    finally:
+        try:
+            lifecycle.cleanup()
+        finally:
+            if work_dir.parent == work_root and work_dir.name.startswith(
+                RESOURCE_PREFIX
+            ):
+                shutil.rmtree(work_dir)
+
+
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     sub = result.add_subparsers(dest="command", required=True)
@@ -897,6 +1724,21 @@ def parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--run-id")
     run_parser.add_argument("--boot-timeout", type=int, default=900)
     run_parser.add_argument("--keep-on-failure", action="store_true")
+    full_parser = sub.add_parser(
+        "full", help="run the isolated WAN/LAN Proxmox lifecycle"
+    )
+    full_parser.add_argument("--artifact", required=True)
+    full_parser.add_argument("--artifacts", default="e2e/artifacts")
+    full_parser.add_argument("--work-dir", default="e2e/.run")
+    full_parser.add_argument("--run-id")
+    full_parser.add_argument("--boot-timeout", type=int, default=900)
+    full_parser.add_argument("--keep-on-failure", action="store_true")
+    helper_parser = sub.add_parser(
+        "check-helper", help="run a focused disposable Linux helper check"
+    )
+    helper_parser.add_argument("--work-dir", default="e2e/.run")
+    helper_parser.add_argument("--run-id")
+    helper_parser.add_argument("--boot-timeout", type=int, default=300)
     build_parser = sub.add_parser(
         "build", help="build an AiFw IMG in an ephemeral Proxmox FreeBSD VM"
     )
@@ -914,6 +1756,10 @@ def main() -> int:
     try:
         if args.command == "run":
             return run(args)
+        if args.command == "full":
+            return run_full(args)
+        if args.command == "check-helper":
+            return check_helper(args)
         if args.command == "build":
             return build_image(args)
     except HarnessError as error:

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -8,6 +8,7 @@ import contextlib
 import hashlib
 import json
 import os
+import shlex
 import shutil
 import signal
 import subprocess
@@ -141,6 +142,31 @@ class Proxmox:
         if upid:
             self.wait_task(upid)
 
+    def create_builder_vm(self, vmid: int, name: str, description: str) -> None:
+        upid = self.request(
+            "POST",
+            f"/nodes/{self.cfg.pve_node}/qemu",
+            data={
+                "vmid": vmid,
+                "name": name,
+                "description": description,
+                "tags": "aifw-e2e",
+                "ostype": "other",
+                "bios": "seabios",
+                "cpu": "host",
+                "cores": 8,
+                "memory": 12288,
+                "scsihw": "virtio-scsi-single",
+                "serial0": "socket",
+                "vga": "serial0",
+                "net0": f"virtio,bridge={self.cfg.bridge},firewall=1",
+                "onboot": 0,
+                "protection": 0,
+            },
+        )
+        if upid:
+            self.wait_task(upid)
+
     def upload(self, path: Path, content: str) -> str:
         checksum = sha256_file(path)
         with path.open("rb") as handle:
@@ -174,6 +200,15 @@ class Proxmox:
             "PUT",
             f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config",
             data=config,
+        )
+        if upid:
+            self.wait_task(upid)
+
+    def resize_disk(self, vmid: int, disk: str, size: str) -> None:
+        upid = self.request(
+            "PUT",
+            f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/resize",
+            data={"disk": disk, "size": size},
         )
         if upid:
             self.wait_task(upid)
@@ -249,6 +284,20 @@ def prepare_image(artifact: Path, output_dir: Path, run_id: str) -> Path:
     return image
 
 
+def prepare_builder_image(artifact: Path, output_dir: Path, run_id: str) -> Path:
+    if not artifact.is_file():
+        raise HarnessError(f"builder image does not exist: {artifact}")
+    image = output_dir / f"{RESOURCE_PREFIX}{run_id}-builder.qcow2"
+    if "".join(artifact.suffixes).endswith(".qcow2.xz"):
+        with image.open("wb") as out:
+            subprocess.run(["xz", "-dc", str(artifact)], check=True, stdout=out)
+    elif artifact.suffix == ".qcow2":
+        shutil.copyfile(artifact, image)
+    else:
+        raise HarnessError("builder image must be a .qcow2 or .qcow2.xz file")
+    return image
+
+
 def make_seed(
     cfg: LabConfig, output_dir: Path, run_id: str, public_key: str
 ) -> Path:
@@ -312,7 +361,65 @@ def make_ssh_key(output_dir: Path) -> tuple[Path, str]:
     return private_key, private_key.with_suffix(".pub").read_text()
 
 
-def ssh_command(private_key: Path, host: str, command: str) -> list[str]:
+def make_builder_seed(
+    cfg: LabConfig, output_dir: Path, run_id: str, public_key: str
+) -> Path:
+    seed_dir = output_dir / "builder-seed"
+    seed_dir.mkdir(mode=0o700)
+    user_data = f"""#cloud-config
+hostname: aifw-builder-{run_id}
+disable_root: true
+ssh_pwauth: false
+users:
+  - default
+  - name: builder
+    gecos: AiFw CI Builder
+    groups: wheel
+    shell: /bin/sh
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - {public_key.strip()}
+growpart:
+  mode: auto
+  devices: ['/']
+resize_rootfs: true
+"""
+    network_data = {
+        "version": 2,
+        "ethernets": {
+            "vtnet0": {
+                "match": {"name": "vtnet0"},
+                "addresses": [cfg.address_cidr],
+                "routes": [{"to": "default", "via": cfg.gateway}],
+                "nameservers": {"addresses": [cfg.dns]},
+            }
+        },
+    }
+    (seed_dir / "user-data").write_text(user_data)
+    (seed_dir / "meta-data").write_text(
+        json.dumps(
+            {
+                "instance-id": f"aifw-builder-{run_id}",
+                "local-hostname": f"aifw-builder-{run_id}",
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    (seed_dir / "network-config").write_text(
+        json.dumps(network_data, indent=2) + "\n"
+    )
+    seed = output_dir / f"{RESOURCE_PREFIX}{run_id}-builder-seed.iso"
+    tool = shutil.which("xorrisofs") or shutil.which("genisoimage")
+    if not tool:
+        raise HarnessError("xorrisofs or genisoimage is required to create seed media")
+    run_checked([tool, "-quiet", "-V", "cidata", "-o", str(seed), str(seed_dir)])
+    return seed
+
+
+def ssh_command(
+    private_key: Path, host: str, command: str, user: str = "root"
+) -> list[str]:
     return [
         "ssh",
         "-i",
@@ -325,9 +432,29 @@ def ssh_command(private_key: Path, host: str, command: str) -> list[str]:
         "StrictHostKeyChecking=no",
         "-o",
         "UserKnownHostsFile=/dev/null",
-        f"root@{host}",
+        f"{user}@{host}",
         command,
     ]
+
+
+def wait_command(
+    private_key: Path,
+    host: str,
+    command: str,
+    user: str,
+    timeout: int,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            ssh_command(private_key, host, command, user=user),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if result.returncode == 0:
+            return
+        time.sleep(5)
+    raise HarnessError(f"SSH readiness timed out for {user}@{host}")
 
 
 def wait_ssh(private_key: Path, host: str, timeout: int = 600) -> None:
@@ -342,6 +469,32 @@ def wait_ssh(private_key: Path, host: str, timeout: int = 600) -> None:
             return
         time.sleep(5)
     raise HarnessError(f"SSH/setup readiness timed out for {host}")
+
+
+def copy_git_archive(private_key: Path, host: str, destination: str) -> None:
+    run_checked(
+        ssh_command(
+            private_key,
+            host,
+            f"mkdir -p {shlex.quote(destination)}",
+            user="builder",
+        )
+    )
+    archive = subprocess.Popen(["git", "archive", "--format=tar", "HEAD"], stdout=subprocess.PIPE)
+    assert archive.stdout is not None
+    unpack = subprocess.run(
+        ssh_command(
+            private_key,
+            host,
+            f"tar -xf - -C {shlex.quote(destination)}",
+            user="builder",
+        ),
+        stdin=archive.stdout,
+    )
+    archive.stdout.close()
+    archive_status = archive.wait()
+    if archive_status != 0 or unpack.returncode != 0:
+        raise HarnessError("failed to copy the checked-out commit to the builder VM")
 
 
 def login_and_check(cfg: LabConfig) -> dict[str, Any]:
@@ -465,6 +618,107 @@ class Lifecycle:
                 self.pve.delete_volume(volume)
 
 
+def build_image(args: argparse.Namespace) -> int:
+    cfg = LabConfig.from_env()
+    run_id = args.run_id or uuid.uuid4().hex[:10]
+    if not all(c in "0123456789abcdef-" for c in run_id.lower()):
+        raise HarnessError("run ID may contain only hexadecimal characters and hyphens")
+    work_root = Path(args.work_dir)
+    work_root.mkdir(parents=True, mode=0o700)
+    work_dir = work_root / f"{RESOURCE_PREFIX}{run_id}-builder"
+    work_dir.mkdir(mode=0o700)
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    pve = Proxmox(cfg)
+    lifecycle = Lifecycle(pve, keep_on_failure=False)
+
+    def handle_signal(signum: int, _frame: Any) -> None:
+        lifecycle.failed = True
+        raise KeyboardInterrupt(f"received signal {signum}")
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    try:
+        private_key, public_key = make_ssh_key(work_dir)
+        seed = make_builder_seed(cfg, work_dir, run_id, public_key)
+        image = prepare_builder_image(Path(args.builder_image), work_dir, run_id)
+        image_volume = pve.upload(image, "import")
+        seed_volume = pve.upload(seed, "iso")
+        lifecycle.volumes.extend([image_volume, seed_volume])
+        vmid = pve.next_vmid()
+        lifecycle.vmid = vmid
+        name = f"{RESOURCE_PREFIX}builder-{run_id}"
+        pve.create_builder_vm(
+            vmid,
+            name,
+            f"AiFw image builder {run_id}; expires {int(time.time()) + 4 * 3600}",
+        )
+        pve.attach_imported_disk(vmid, image_volume, seed_volume)
+        pve.resize_disk(vmid, "virtio0", args.builder_disk_size)
+        pve.start(vmid)
+
+        wait_command(
+            private_key,
+            cfg.address,
+            "test -f /var/lib/cloud/instance/boot-finished",
+            user="builder",
+            timeout=args.boot_timeout,
+        )
+        copy_git_archive(private_key, cfg.address, "/home/builder/AiFw")
+        version = run_checked(
+            [
+                "sh",
+                "-c",
+                "sed -n 's/^version = \"\\([^\"]*\\)\"/\\1/p' Cargo.toml | head -n 1",
+            ],
+            cwd=Path.cwd(),
+            capture_output=True,
+        ).stdout.strip()
+        if not version:
+            raise HarnessError("could not determine workspace version from Cargo.toml")
+        remote_artifact = f"/usr/obj/aifw-iso/output/aifw-{version}-amd64.img.xz"
+        build_command = (
+            "cd /home/builder/AiFw && "
+            f"sudo -H sh freebsd/build-local.sh {shlex.quote(version)} && "
+            f"sudo test -s {shlex.quote(remote_artifact)}"
+        )
+        run_checked(
+            ssh_command(
+                private_key,
+                cfg.address,
+                build_command,
+                user="builder",
+            )
+        )
+        with output.open("wb") as handle:
+            result = subprocess.run(
+                ssh_command(
+                    private_key,
+                    cfg.address,
+                    f"sudo cat {shlex.quote(remote_artifact)}",
+                    user="builder",
+                ),
+                stdout=handle,
+            )
+        if result.returncode != 0 or not output.is_file() or output.stat().st_size == 0:
+            raise HarnessError("failed to copy the built IMG from the builder VM")
+        output.with_suffix(output.suffix + ".sha256").write_text(
+            f"{sha256_file(output)}  {output.name}\n"
+        )
+        print(f"built {output} ({output.stat().st_size} bytes)", flush=True)
+        return 0
+    except BaseException:
+        lifecycle.failed = True
+        raise
+    finally:
+        try:
+            lifecycle.cleanup()
+        finally:
+            if work_dir.parent == work_root and work_dir.name.startswith(RESOURCE_PREFIX):
+                shutil.rmtree(work_dir, ignore_errors=True)
+
+
 def run(args: argparse.Namespace) -> int:
     cfg = LabConfig.from_env()
     run_id = args.run_id or uuid.uuid4().hex[:10]
@@ -548,6 +802,15 @@ def parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--run-id")
     run_parser.add_argument("--boot-timeout", type=int, default=900)
     run_parser.add_argument("--keep-on-failure", action="store_true")
+    build_parser = sub.add_parser(
+        "build", help="build an AiFw IMG in an ephemeral Proxmox FreeBSD VM"
+    )
+    build_parser.add_argument("--builder-image", required=True)
+    build_parser.add_argument("--output", required=True)
+    build_parser.add_argument("--work-dir", default="e2e/.run")
+    build_parser.add_argument("--run-id")
+    build_parser.add_argument("--boot-timeout", type=int, default=900)
+    build_parser.add_argument("--builder-disk-size", default="+40G")
     return result
 
 
@@ -556,6 +819,8 @@ def main() -> int:
     try:
         if args.command == "run":
             return run(args)
+        if args.command == "build":
+            return build_image(args)
     except HarnessError as error:
         print(f"E2E ERROR: {error}", file=sys.stderr)
         return 1

--- a/e2e/aifw_e2e.py
+++ b/e2e/aifw_e2e.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import hashlib
+import ipaddress
 import json
 import os
 import shlex
@@ -213,6 +214,25 @@ class Proxmox:
         if upid:
             self.wait_task(upid)
 
+    def configure_builder_cloudinit(self, vmid: int, public_key: str) -> None:
+        upid = self.request(
+            "PUT",
+            f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/config",
+            data={
+                "ide2": f"{self.cfg.vm_storage}:cloudinit",
+                "citype": "nocloud",
+                "ciuser": "freebsd",
+                "sshkeys": public_key.strip(),
+                "ipconfig0": (
+                    f"ip={self.cfg.address_cidr},gw={self.cfg.gateway}"
+                ),
+                "nameserver": self.cfg.dns,
+                "searchdomain": "local",
+            },
+        )
+        if upid:
+            self.wait_task(upid)
+
     def start(self, vmid: int) -> None:
         upid = self.request(
             "POST", f"/nodes/{self.cfg.pve_node}/qemu/{vmid}/status/start"
@@ -384,16 +404,24 @@ growpart:
   devices: ['/']
 resize_rootfs: true
 """
+    interface = ipaddress.ip_interface(cfg.address_cidr)
     network_data = {
-        "version": 2,
-        "ethernets": {
-            "vtnet0": {
-                "match": {"name": "vtnet0"},
-                "addresses": [cfg.address_cidr],
-                "routes": [{"to": "default", "via": cfg.gateway}],
-                "nameservers": {"addresses": [cfg.dns]},
+        "version": 1,
+        "config": [
+            {
+                "type": "physical",
+                "name": "vtnet0",
+                "subnets": [
+                    {
+                        "type": "static",
+                        "address": str(interface.ip),
+                        "netmask": str(interface.network.netmask),
+                        "gateway": cfg.gateway,
+                        "dns_nameservers": [cfg.dns],
+                    }
+                ],
             }
-        },
+        ],
     }
     (seed_dir / "user-data").write_text(user_data)
     (seed_dir / "meta-data").write_text(
@@ -641,11 +669,9 @@ def build_image(args: argparse.Namespace) -> int:
 
     try:
         private_key, public_key = make_ssh_key(work_dir)
-        seed = make_builder_seed(cfg, work_dir, run_id, public_key)
         image = prepare_builder_image(Path(args.builder_image), work_dir, run_id)
         image_volume = pve.upload(image, "import")
-        seed_volume = pve.upload(seed, "iso")
-        lifecycle.volumes.extend([image_volume, seed_volume])
+        lifecycle.volumes.append(image_volume)
         vmid = pve.next_vmid()
         lifecycle.vmid = vmid
         name = f"{RESOURCE_PREFIX}builder-{run_id}"
@@ -654,7 +680,8 @@ def build_image(args: argparse.Namespace) -> int:
             name,
             f"AiFw image builder {run_id}; expires {int(time.time()) + 4 * 3600}",
         )
-        pve.attach_imported_disk(vmid, image_volume, seed_volume)
+        pve.attach_imported_disk(vmid, image_volume)
+        pve.configure_builder_cloudinit(vmid, public_key)
         pve.resize_disk(vmid, "virtio0", args.builder_disk_size)
         pve.start(vmid)
 
@@ -665,7 +692,7 @@ def build_image(args: argparse.Namespace) -> int:
             user="builder",
             timeout=args.boot_timeout,
         )
-        copy_git_archive(private_key, cfg.address, "/home/builder/AiFw")
+        copy_git_archive(private_key, cfg.address, "/home/freebsd/AiFw")
         version = run_checked(
             [
                 "sh",
@@ -679,7 +706,7 @@ def build_image(args: argparse.Namespace) -> int:
             raise HarnessError("could not determine workspace version from Cargo.toml")
         remote_artifact = f"/usr/obj/aifw-iso/output/aifw-{version}-amd64.img.xz"
         build_command = (
-            "cd /home/builder/AiFw && "
+            "cd /home/freebsd/AiFw && "
             f"sudo -H sh freebsd/build-local.sh {shlex.quote(version)} && "
             f"sudo test -s {shlex.quote(remote_artifact)}"
         )
@@ -688,7 +715,7 @@ def build_image(args: argparse.Namespace) -> int:
                 private_key,
                 cfg.address,
                 build_command,
-                user="builder",
+                user="freebsd",
             )
         )
         with output.open("wb") as handle:
@@ -697,7 +724,7 @@ def build_image(args: argparse.Namespace) -> int:
                     private_key,
                     cfg.address,
                     f"sudo cat {shlex.quote(remote_artifact)}",
-                    user="builder",
+                    user="freebsd",
                 ),
                 stdout=handle,
             )

--- a/e2e/lab.example.env
+++ b/e2e/lab.example.env
@@ -1,0 +1,13 @@
+# Non-secret Proxmox lab settings. Credentials belong in Woodpecker secrets.
+PVE_URL=https://proxmox.example:8006
+PVE_NODE=pve
+PVE_IMAGE_STORAGE=local
+PVE_VM_STORAGE=local-lvm
+PVE_BRIDGE=vmbr0
+PVE_VERIFY_TLS=true
+
+# Static management address reserved for this run. The initial smoke lane uses
+# one NIC; add isolated WAN/LAN bridges before enabling routed data-plane tests.
+AIFW_E2E_ADDRESS=192.0.2.10/24
+AIFW_E2E_GATEWAY=192.0.2.1
+AIFW_E2E_DNS=192.0.2.1

--- a/e2e/lab.example.env
+++ b/e2e/lab.example.env
@@ -11,3 +11,8 @@ PVE_VERIFY_TLS=true
 AIFW_E2E_ADDRESS=192.0.2.10/24
 AIFW_E2E_GATEWAY=192.0.2.1
 AIFW_E2E_DNS=192.0.2.1
+
+# Current homelab deployment (documentation only; keep this example portable):
+# node=trigproxmox, bridge=vmbr0, address=192.168.0.26/23,
+# gateway/dns=192.168.0.1. Never add token IDs, token secrets, passwords, or
+# private keys to this file.

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,0 +1,3 @@
+pytest==8.4.1
+requests==2.32.4
+argon2-cffi==25.1.0

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,3 +1,4 @@
 pytest==8.4.1
 requests==2.32.4
 argon2-cffi==25.1.0
+playwright==1.61.0

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -6,6 +6,8 @@ from argon2 import PasswordHasher
 from e2e.aifw_e2e import (
     HarnessError,
     LabConfig,
+    Proxmox,
+    build_image,
     make_builder_seed,
     make_seed,
     prepare_builder_image,
@@ -112,3 +114,31 @@ def test_builder_seed_uses_reserved_address_and_public_key(
     assert "192.0.2.10/24" in network
     assert "192.0.2.1" in network
     assert seed.read_bytes() == b"fake builder seed"
+
+
+def test_build_accepts_precreated_work_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import argparse
+
+    work_root = tmp_path / ".run"
+    work_root.mkdir()
+    builder_image = tmp_path / "builder.qcow2"
+    builder_image.write_bytes(b"builder")
+    monkeypatch.setattr(LabConfig, "from_env", classmethod(lambda _cls: config()))
+    monkeypatch.setattr(Proxmox, "upload", lambda *_args, **_kwargs: (_ for _ in ()).throw(HarnessError("stop after setup")))
+
+    args = argparse.Namespace(
+        run_id="abc123",
+        work_dir=str(work_root),
+        output=str(tmp_path / "aifw.img.xz"),
+        builder_image=str(builder_image),
+        builder_disk_size="+40G",
+        boot_timeout=1,
+    )
+    monkeypatch.setattr("e2e.aifw_e2e.make_ssh_key", lambda path: (path / "key", "ssh-ed25519 test"))
+    monkeypatch.setattr("e2e.aifw_e2e.make_builder_seed", lambda _cfg, path, _run, _key: path / "seed.iso")
+    monkeypatch.setattr("e2e.aifw_e2e.prepare_builder_image", lambda _src, path, _run: path / "builder.qcow2")
+
+    with pytest.raises(HarnessError, match="stop after setup"):
+        build_image(args)

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -3,7 +3,14 @@ from pathlib import Path
 import pytest
 from argon2 import PasswordHasher
 
-from e2e.aifw_e2e import HarnessError, LabConfig, make_seed, prepare_image
+from e2e.aifw_e2e import (
+    HarnessError,
+    LabConfig,
+    make_builder_seed,
+    make_seed,
+    prepare_builder_image,
+    prepare_image,
+)
 
 
 def config(password: str = "temporary-test-password") -> LabConfig:
@@ -28,6 +35,13 @@ def test_prepare_image_rejects_non_image(tmp_path: Path) -> None:
     artifact.write_text("not an image")
     with pytest.raises(HarnessError, match="must be an .img"):
         prepare_image(artifact, tmp_path, "abc123")
+
+
+def test_prepare_builder_image_rejects_non_qcow2(tmp_path: Path) -> None:
+    artifact = tmp_path / "builder.raw.xz"
+    artifact.write_bytes(b"not a builder")
+    with pytest.raises(HarnessError, match="must be a .qcow2"):
+        prepare_builder_image(artifact, tmp_path, "abc123")
 
 
 def test_seed_uses_argon2_and_excludes_plaintext(
@@ -75,3 +89,26 @@ def test_seed_has_only_one_management_interface(
     assert setup["wan_interface"] == "vtnet0"
     assert setup["lan_interface"] is None
     assert setup["default_policy"] == "permissive"
+
+
+def test_builder_seed_uses_reserved_address_and_public_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("e2e.aifw_e2e.shutil.which", lambda _name: "/usr/bin/xorrisofs")
+
+    def fake_run(args: list[str], **_kwargs: object) -> object:
+        Path(args[args.index("-o") + 1]).write_bytes(b"fake builder seed")
+        return object()
+
+    monkeypatch.setattr("e2e.aifw_e2e.run_checked", fake_run)
+    seed = make_builder_seed(
+        config(), tmp_path, "def456", "ssh-ed25519 AAAAbuilder"
+    )
+
+    user_data = (tmp_path / "builder-seed" / "user-data").read_text()
+    network = (tmp_path / "builder-seed" / "network-config").read_text()
+    assert "ssh-ed25519 AAAAbuilder" in user_data
+    assert "temporary-test-password" not in user_data
+    assert "192.0.2.10/24" in network
+    assert "192.0.2.1" in network
+    assert seed.read_bytes() == b"fake builder seed"

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -143,3 +143,19 @@ def test_build_accepts_precreated_work_root(
 
     with pytest.raises(HarnessError, match="stop after setup"):
         build_image(args)
+
+
+def test_builder_cloudinit_url_encodes_ssh_key() -> None:
+    pve = Proxmox(config())
+    captured: dict[str, object] = {}
+
+    def fake_request(method: str, path: str, **kwargs: object) -> None:
+        captured.update(method=method, path=path, **kwargs)
+
+    pve.request = fake_request  # type: ignore[method-assign]
+    pve.configure_builder_cloudinit(101, "ssh-ed25519 AAAAtest aifw-e2e\n")
+
+    data = captured["data"]
+    assert isinstance(data, dict)
+    assert data["sshkeys"] == "ssh-ed25519%20AAAAtest%20aifw-e2e"
+    assert data["ipconfig0"] == "ip=192.0.2.10/24,gw=192.0.2.1"

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -162,3 +162,22 @@ def test_as_root_quotes_the_entire_command() -> None:
     assert as_root("id -u && echo 'safe value'") == (
         "su -m root -c 'id -u && echo '\"'\"'safe value'\"'\"''"
     )
+
+
+def test_import_finishes_before_boot_order_is_set() -> None:
+    pve = Proxmox(config())
+    requests: list[dict[str, object]] = []
+
+    def fake_request(method: str, path: str, **kwargs: object) -> str:
+        requests.append({"method": method, "path": path, **kwargs})
+        return f"task-{len(requests)}"
+
+    pve.request = fake_request  # type: ignore[method-assign]
+    pve.wait_task = lambda _task: None  # type: ignore[method-assign]
+    pve.attach_imported_disk(101, "local:import/aifw.raw", "local:iso/seed.iso")
+
+    assert requests[0]["data"] == {
+        "virtio0": "local-lvm:0,import-from=local:import/aifw.raw,discard=on",
+        "ide2": "local:iso/seed.iso,media=cdrom",
+    }
+    assert requests[1]["data"] == {"boot": "order=virtio0"}

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+import pytest
+from argon2 import PasswordHasher
+
+from e2e.aifw_e2e import HarnessError, LabConfig, make_seed, prepare_image
+
+
+def config(password: str = "temporary-test-password") -> LabConfig:
+    return LabConfig(
+        pve_url="https://pve.invalid:8006",
+        pve_node="pve",
+        image_storage="local",
+        vm_storage="local-lvm",
+        bridge="vmbr0",
+        verify_tls=True,
+        address_cidr="192.0.2.10/24",
+        gateway="192.0.2.1",
+        dns="192.0.2.1",
+        token_id="root@pam!test",
+        token_secret="not-a-real-token",
+        admin_password=password,
+    )
+
+
+def test_prepare_image_rejects_non_image(tmp_path: Path) -> None:
+    artifact = tmp_path / "artifact.txt"
+    artifact.write_text("not an image")
+    with pytest.raises(HarnessError, match="must be an .img"):
+        prepare_image(artifact, tmp_path, "abc123")
+
+
+def test_seed_uses_argon2_and_excludes_plaintext(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    created: list[list[str]] = []
+
+    def fake_run(args: list[str], **_kwargs: object) -> object:
+        created.append(args)
+        Path(args[args.index("-o") + 1]).write_bytes(b"fake iso")
+        return object()
+
+    monkeypatch.setattr("e2e.aifw_e2e.shutil.which", lambda _name: "/usr/bin/xorrisofs")
+    monkeypatch.setattr("e2e.aifw_e2e.run_checked", fake_run)
+    password = "unique-plain-text-secret"
+    seed = make_seed(config(password), tmp_path, "abc123", "ssh-ed25519 AAAAtest")
+
+    setup_text = (tmp_path / "seed" / "setup.json").read_text()
+    assert password not in setup_text
+    assert "not-a-real-token" not in setup_text
+    assert seed.read_bytes() == b"fake iso"
+    assert created
+
+    import json
+
+    setup = json.loads(setup_text)
+    PasswordHasher().verify(setup["admin_password_hash"], password)
+
+
+def test_seed_has_only_one_management_interface(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("e2e.aifw_e2e.shutil.which", lambda _name: "/usr/bin/xorrisofs")
+
+    def fake_run(args: list[str], **_kwargs: object) -> object:
+        Path(args[args.index("-o") + 1]).write_bytes(b"fake iso")
+        return object()
+
+    monkeypatch.setattr("e2e.aifw_e2e.run_checked", fake_run)
+    make_seed(config(), tmp_path, "def456", "ssh-ed25519 AAAAtest")
+
+    import json
+
+    setup = json.loads((tmp_path / "seed" / "setup.json").read_text())
+    assert setup["wan_interface"] == "vtnet0"
+    assert setup["lan_interface"] is None
+    assert setup["default_policy"] == "permissive"

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -4,6 +4,8 @@ import pytest
 from argon2 import PasswordHasher
 
 from e2e.aifw_e2e import (
+    FULL_LAN_CIDR,
+    FULL_WAN_CIDR,
     HarnessError,
     LabConfig,
     Lifecycle,
@@ -25,6 +27,8 @@ def config(password: str = "temporary-test-password") -> LabConfig:
         image_storage="local",
         vm_storage="local-lvm",
         bridge="vmbr0",
+        wan_bridge="vmbr998",
+        lan_bridge="vmbr999",
         verify_tls=True,
         address_cidr="192.0.2.10/24",
         gateway="192.0.2.1",
@@ -94,6 +98,47 @@ def test_seed_has_only_one_management_interface(
     assert setup["wan_interface"] == "vtnet0"
     assert setup["lan_interface"] is None
     assert setup["default_policy"] == "permissive"
+
+
+def test_full_seed_configures_isolated_wan_lan_and_nat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("e2e.aifw_e2e.shutil.which", lambda _name: "/usr/bin/xorrisofs")
+
+    def fake_run(args: list[str], **_kwargs: object) -> object:
+        Path(args[args.index("-o") + 1]).write_bytes(b"fake iso")
+        return object()
+
+    monkeypatch.setattr("e2e.aifw_e2e.run_checked", fake_run)
+    make_seed(
+        config(), tmp_path, "feed12", "ssh-ed25519 AAAAtest", full=True
+    )
+
+    import json
+
+    setup = json.loads((tmp_path / "seed" / "setup.json").read_text())
+    assert setup["wan_ip"] == FULL_WAN_CIDR
+    assert setup["wan_gateway"] is None
+    assert setup["lan_ip"] == FULL_LAN_CIDR
+    assert setup["lan_interface"] == "vtnet1"
+    assert setup["default_policy"] == "standard"
+    assert setup["nat_enabled"] is True
+    assert setup["dns_servers"] == []
+
+
+def test_full_vm_network_order_is_wan_then_lan() -> None:
+    pve = Proxmox(config())
+    requests: list[dict[str, object]] = []
+
+    def fake_request(method: str, path: str, **kwargs: object) -> None:
+        requests.append({"method": method, "path": path, **kwargs})
+
+    pve.request = fake_request  # type: ignore[method-assign]
+    pve.create_full_appliance_vm(101, "aifw-e2e-feed12", "test")
+    data = requests[0]["data"]
+    assert isinstance(data, dict)
+    assert data["net0"] == "virtio,bridge=vmbr998,firewall=0"
+    assert data["net1"] == "virtio,bridge=vmbr999,firewall=0"
 
 
 def test_builder_seed_uses_reserved_address_and_public_key(
@@ -196,7 +241,14 @@ def test_complete_readiness_retries_transient_pf_state(
         ]
     )
 
-    def fake_checks(_cfg: LabConfig, _key: Path) -> dict[str, object]:
+    def fake_checks(
+        _cfg: LabConfig,
+        _key: Path,
+        host: str | None = None,
+        jump: str | None = None,
+    ) -> dict[str, object]:
+        assert host is None
+        assert jump is None
         result = next(attempts)
         if isinstance(result, BaseException):
             raise result
@@ -267,6 +319,39 @@ def test_cleanup_deletes_owned_resources_and_proves_absence() -> None:
     lifecycle.volumes = ["local:iso/aifw-e2e-seed.iso"]
     lifecycle.cleanup()
     assert pve.audited
+
+
+def test_cleanup_deletes_all_owned_vms() -> None:
+    class FakeProxmox:
+        present = {101, 102, 103}
+        audited: list[int] = []
+
+        def vm_exists(self, vmid: int) -> bool:
+            return vmid in self.present
+
+        def vm_config(self, vmid: int) -> dict[str, str]:
+            return {"name": f"aifw-e2e-owned-{vmid}"}
+
+        def destroy(self, vmid: int) -> None:
+            self.present.remove(vmid)
+
+        def volume_exists(self, _volume: str) -> bool:
+            return False
+
+        def wait_resources_absent(
+            self, vmid: int | None, volumes: list[str]
+        ) -> None:
+            assert vmid not in self.present
+            if vmid != 101:
+                assert volumes == []
+            self.audited.append(vmid)  # type: ignore[arg-type]
+
+    pve = FakeProxmox()
+    lifecycle = Lifecycle(pve, keep_on_failure=False)  # type: ignore[arg-type]
+    lifecycle.vmid = 101
+    lifecycle.additional_vmids = [102, 103]
+    lifecycle.cleanup()
+    assert set(pve.audited) == {101, 102, 103}
 
 
 def test_cleanup_refuses_unowned_volume() -> None:

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -7,6 +7,7 @@ from e2e.aifw_e2e import (
     HarnessError,
     LabConfig,
     Proxmox,
+    as_root,
     build_image,
     make_builder_seed,
     make_seed,
@@ -112,8 +113,10 @@ def test_builder_seed_uses_reserved_address_and_public_key(
     assert "ssh-ed25519 AAAAbuilder" in user_data
     assert "temporary-test-password" not in user_data
     assert "192.0.2.10" in network
-    assert "255.255.255.0" in network
+    assert "192.0.2.10/24" in network
     assert "192.0.2.1" in network
+    assert '"version": 2' in network
+    assert '"ethernets"' in network
     assert seed.read_bytes() == b"fake builder seed"
 
 
@@ -145,17 +148,17 @@ def test_build_accepts_precreated_work_root(
         build_image(args)
 
 
-def test_builder_cloudinit_url_encodes_ssh_key() -> None:
-    pve = Proxmox(config())
-    captured: dict[str, object] = {}
+def test_builder_uses_early_default_freebsd_user() -> None:
+    source = Path("e2e/aifw_e2e.py").read_text()
+    build_section = source[source.index("def build_image(") : source.index("def run(")]
+    assert 'user="freebsd"' in build_section
+    assert 'user="builder"' not in build_section
+    assert "/home/freebsd/AiFw" in build_section
+    assert "make_builder_seed" in build_section
+    assert "configure_builder_cloudinit" not in build_section
 
-    def fake_request(method: str, path: str, **kwargs: object) -> None:
-        captured.update(method=method, path=path, **kwargs)
 
-    pve.request = fake_request  # type: ignore[method-assign]
-    pve.configure_builder_cloudinit(101, "ssh-ed25519 AAAAtest aifw-e2e\n")
-
-    data = captured["data"]
-    assert isinstance(data, dict)
-    assert data["sshkeys"] == "ssh-ed25519%20AAAAtest%20aifw-e2e"
-    assert data["ipconfig0"] == "ip=192.0.2.10/24,gw=192.0.2.1"
+def test_as_root_quotes_the_entire_command() -> None:
+    assert as_root("id -u && echo 'safe value'") == (
+        "su -m root -c 'id -u && echo '\"'\"'safe value'\"'\"''"
+    )

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -6,6 +6,7 @@ from argon2 import PasswordHasher
 from e2e.aifw_e2e import (
     HarnessError,
     LabConfig,
+    Lifecycle,
     Proxmox,
     as_root,
     build_image,
@@ -225,3 +226,55 @@ def test_import_finishes_before_boot_order_is_set() -> None:
         "ide2": "local:iso/seed.iso,media=cdrom",
     }
     assert requests[1]["data"] == {"boot": "order=virtio0"}
+
+
+def test_cleanup_deletes_owned_resources_and_proves_absence() -> None:
+    class FakeProxmox:
+        vm_present = True
+        present_volumes = {"local:iso/aifw-e2e-seed.iso"}
+        audited = False
+
+        def vm_exists(self, vmid: int) -> bool:
+            assert vmid == 101
+            return self.vm_present
+
+        def vm_config(self, vmid: int) -> dict[str, str]:
+            assert vmid == 101
+            return {"name": "aifw-e2e-abc123"}
+
+        def destroy(self, vmid: int) -> None:
+            assert vmid == 101
+            self.vm_present = False
+
+        def volume_exists(self, volume: str) -> bool:
+            return volume in self.present_volumes
+
+        def delete_volume(self, volume: str) -> None:
+            self.present_volumes.remove(volume)
+
+        def wait_resources_absent(
+            self, vmid: int | None, volumes: list[str]
+        ) -> None:
+            assert vmid == 101
+            assert volumes == ["local:iso/aifw-e2e-seed.iso"]
+            assert not self.vm_present
+            assert not self.present_volumes
+            self.audited = True
+
+    pve = FakeProxmox()
+    lifecycle = Lifecycle(pve, keep_on_failure=False)  # type: ignore[arg-type]
+    lifecycle.vmid = 101
+    lifecycle.volumes = ["local:iso/aifw-e2e-seed.iso"]
+    lifecycle.cleanup()
+    assert pve.audited
+
+
+def test_cleanup_refuses_unowned_volume() -> None:
+    class FakeProxmox:
+        def vm_exists(self, _vmid: int) -> bool:
+            return False
+
+    lifecycle = Lifecycle(FakeProxmox(), keep_on_failure=False)  # type: ignore[arg-type]
+    lifecycle.volumes = ["local:iso/unrelated.iso"]
+    with pytest.raises(HarnessError, match="unexpected volume"):
+        lifecycle.cleanup()

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -13,6 +13,7 @@ from e2e.aifw_e2e import (
     make_seed,
     prepare_builder_image,
     prepare_image,
+    wait_appliance_ready,
 )
 
 
@@ -160,8 +161,51 @@ def test_builder_uses_early_default_freebsd_user() -> None:
 
 def test_as_root_quotes_the_entire_command() -> None:
     assert as_root("id -u && echo 'safe value'") == (
-        "su -m root -c 'id -u && echo '\"'\"'safe value'\"'\"''"
+        "su root -c 'id -u && echo '\"'\"'safe value'\"'\"''"
     )
+
+
+def test_appliance_firstboot_is_not_sentinel_gated() -> None:
+    source = Path("freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot").read_text()
+    directives = [line for line in source.splitlines() if line.startswith("# KEYWORD:")]
+    assert directives == []
+    assert 'if [ -f "$AIFW_CONF" ]; then' in source
+
+
+def test_writable_image_root_label_matches_boot_configuration() -> None:
+    source = Path("freebsd/build-iso.sh").read_text()
+    assert 'newfs -U -j -L aifw "/dev/${MD}p3"' in source
+    assert "/dev/ufs/aifw  /       ufs" in source
+    assert 'vfs.root.mountfrom="ufs:/dev/ufs/aifw"' in source
+
+
+def test_setup_persists_aifw_pf_rules_path() -> None:
+    source = Path("aifw-setup/src/apply.rs").read_text()
+    assert 'run_best_effort("sysrc", &["pf_enable=YES"])' in source
+    assert 'format!("pf_rules={}/pf.conf.aifw", config.config_dir)' in source
+
+
+def test_complete_readiness_retries_transient_pf_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = iter(
+        [
+            HarnessError("authenticated status reports pf_running=false"),
+            {"pf_running": True},
+        ]
+    )
+
+    def fake_checks(_cfg: LabConfig, _key: Path) -> dict[str, object]:
+        result = next(attempts)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    monkeypatch.setattr("e2e.aifw_e2e.appliance_checks", fake_checks)
+    monkeypatch.setattr("e2e.aifw_e2e.time.sleep", lambda _seconds: None)
+    assert wait_appliance_ready(config(), Path("key"), timeout=1) == {
+        "pf_running": True
+    }
 
 
 def test_import_finishes_before_boot_order_is_set() -> None:

--- a/e2e/tests/test_harness.py
+++ b/e2e/tests/test_harness.py
@@ -111,7 +111,8 @@ def test_builder_seed_uses_reserved_address_and_public_key(
     network = (tmp_path / "builder-seed" / "network-config").read_text()
     assert "ssh-ed25519 AAAAbuilder" in user_data
     assert "temporary-test-password" not in user_data
-    assert "192.0.2.10/24" in network
+    assert "192.0.2.10" in network
+    assert "255.255.255.0" in network
     assert "192.0.2.1" in network
     assert seed.read_bytes() == b"fake builder seed"
 

--- a/freebsd/build-iso.sh
+++ b/freebsd/build-iso.sh
@@ -200,6 +200,12 @@ cat > "$STAGEDIR/boot/loader.conf" <<'LOADER'
 autoboot_delay="3"
 beastie_disable="YES"
 loader_logo="none"
+# Keep VGA/ttyv0 as the interactive console while mirroring boot and rc output
+# to COM1. Proxmox E2E captures serial0, making early boot failures diagnosable.
+boot_multicons="YES"
+boot_serial="YES"
+comconsole_speed="115200"
+console="comconsole,vidconsole"
 kern.geom.label.disk_ident.enable="0"
 kern.geom.label.gptid.enable="0"
 vfs.root.mountfrom="cd9660:cd0"
@@ -324,7 +330,10 @@ umount /mnt
 gpart bootcode -b "$STAGEDIR/boot/pmbr" -p "$STAGEDIR/boot/gptboot" -i 2 "$MD"
 
 # Format UFS root
-newfs -U -j "/dev/${MD}p3"
+# The generated fstab and loader.conf boot by /dev/ufs/aifw. A GPT partition
+# label alone creates /dev/gpt/aifw, not /dev/ufs/aifw; without this filesystem
+# label the writable IMG drops to mountroot with error 19.
+newfs -U -j -L aifw "/dev/${MD}p3"
 mount "/dev/${MD}p3" /mnt
 
 # Clone staged system into USB image

--- a/freebsd/build-local.sh
+++ b/freebsd/build-local.sh
@@ -100,7 +100,8 @@ cd "$PROJECT_ROOT"
 echo "=== [3/6] Building Rust binaries (release) ==="
 # Ensure cargo is in PATH (rustup installs to $HOME/.cargo/bin)
 [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
-echo "--- AiFw commit: $(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown) ---"
+AIFW_COMMIT=$(git -C "$PROJECT_ROOT" rev-parse HEAD 2>/dev/null || cat "$PROJECT_ROOT/.aifw-build-commit" 2>/dev/null || echo unknown)
+echo "--- AiFw commit: $AIFW_COMMIT ---"
 cargo build --release
 
 # --- Guard: the compiled binary version MUST match the release version ---
@@ -268,7 +269,7 @@ echo "$VERSION" > "$TARBALL_DIR/version"
 # repos (which have burned us before — rdns 1.5.1 shipping in a v5.45.0
 # tarball) visible at build time.
 {
-    echo "AiFw             $(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    echo "AiFw             $(printf '%s' "$AIFW_COMMIT" | cut -c1-12)"
     [ -d "$TRAFFICCOP_DIR/.git" ] && echo "TrafficCop       $(git -C "$TRAFFICCOP_DIR" rev-parse --short HEAD)"
     [ -d "$RDHCP_DIR/.git" ]      && echo "rDHCP            $(git -C "$RDHCP_DIR"      rev-parse --short HEAD)"
     [ -d "$RDNS_DIR/.git" ]       && echo "rDNS             $(git -C "$RDNS_DIR"       rev-parse --short HEAD)"

--- a/freebsd/generate-sbom.sh
+++ b/freebsd/generate-sbom.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Generate a deterministic, machine-readable SPDX inventory for release inputs.
+set -eu
+out=${1:?output path required}
+root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+cargo metadata --format-version 1 --no-deps --manifest-path "$root/Cargo.toml" \
+  | jq '{spdxVersion:"SPDX-2.3",dataLicense:"CC0-1.0",SPDXID:"SPDXRef-DOCUMENT",name:"aifw",documentNamespace:("https://aifw.invalid/sbom/" + (.workspace_members|join("-"))),packages:[.packages[]|{SPDXID:("SPDXRef-" + (.name|gsub("[^A-Za-z0-9.-]";"-"))),name,versionInfo: .version,downloadLocation:"NOASSERTION",licenseConcluded:"NOASSERTION",licenseDeclared:"NOASSERTION"}]}' > "$tmp"
+mv "$tmp" "$out"

--- a/freebsd/manifest.json
+++ b/freebsd/manifest.json
@@ -10,21 +10,25 @@
     {
       "name": "TrafficCop",
       "repo": "ZerosAndOnesLLC/TrafficCop",
+      "rev": "3d4d96595bea1d4f29b8729a452c95dd1be0ed25",
       "binaries": ["trafficcop"]
     },
     {
       "name": "rDHCP",
       "repo": "ZerosAndOnesLLC/rDHCP",
+      "rev": "bddd4868df6f5931b614f8412071daf31af7d0dd",
       "binaries": ["rdhcpd"]
     },
     {
       "name": "rDNS",
       "repo": "ZerosAndOnesLLC/rDNS",
+      "rev": "7bd12e293536ec3adae09e340b572b87e0fe942b",
       "binaries": ["rdns", "rdns-control"]
     },
     {
       "name": "rTIME",
       "repo": "ZerosAndOnesLLC/rTIME",
+      "rev": "444e104db55fa33f6aded7a6b0b7752509bc0a6f",
       "binaries": ["rtime"]
     }
   ],

--- a/freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot
+++ b/freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot
@@ -2,7 +2,11 @@
 # PROVIDE: aifw_firstboot
 # REQUIRE: NETWORKING LOGIN
 # BEFORE: aifw_daemon aifw_api
-# KEYWORD: firstboot
+# This service is intentionally not KEYWORD:firstboot. Writable IMG artifacts
+# are assembled from a staged root and do not carry FreeBSD's firstboot
+# sentinel, so rc(8) would skip unattended seed processing entirely. The
+# service is idempotent: it exits when aifw.conf exists and disables itself
+# after successful setup.
 
 . /etc/rc.subr
 

--- a/freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot
+++ b/freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot
@@ -14,6 +14,28 @@ stop_cmd=":"
 AIFW_CONF="/usr/local/etc/aifw/aifw.conf"
 AIFW_SETUP="/usr/local/sbin/aifw-setup"
 AIFW_PF_CONF="/usr/local/etc/aifw/pf.conf.aifw"
+AIFW_SEED_LABEL="AIFW_SEED"
+AIFW_SEED_MOUNT="/tmp/aifw-seed"
+AIFW_SEED_CONFIG="${AIFW_SEED_MOUNT}/setup.json"
+
+mount_seed()
+{
+    mkdir -p "$AIFW_SEED_MOUNT"
+
+    # A Proxmox E2E run attaches a tiny read-only ISO labelled AIFW_SEED.
+    # Prefer GEOM labels, then fall back to optical devices because the exact
+    # cd number depends on the VM's disk layout.
+    for dev in "/dev/iso9660/${AIFW_SEED_LABEL}" /dev/cd1 /dev/cd0; do
+        if [ -e "$dev" ] && mount -t cd9660 -o ro "$dev" "$AIFW_SEED_MOUNT" 2>/dev/null; then
+            if [ -f "$AIFW_SEED_CONFIG" ]; then
+                return 0
+            fi
+            umount "$AIFW_SEED_MOUNT" 2>/dev/null || true
+        fi
+    done
+
+    return 1
+}
 
 aifw_firstboot_start()
 {
@@ -29,8 +51,19 @@ aifw_firstboot_start()
     echo ""
 
     if [ -x "$AIFW_SETUP" ]; then
-        # Run the setup wizard on the console
-        $AIFW_SETUP </dev/console >/dev/console 2>&1
+        if mount_seed; then
+            echo "Found unattended AiFw seed media."
+            $AIFW_SETUP --config "$AIFW_SEED_CONFIG" >/dev/console 2>&1
+            setup_status=$?
+            umount "$AIFW_SEED_MOUNT" 2>/dev/null || true
+            if [ "$setup_status" -ne 0 ]; then
+                echo "ERROR: unattended setup failed (exit $setup_status)"
+                return "$setup_status"
+            fi
+        else
+            # Run the setup wizard on the console.
+            $AIFW_SETUP </dev/console >/dev/console 2>&1
+        fi
 
         # If setup succeeded, enable and start services
         if [ -f "$AIFW_CONF" ]; then

--- a/freebsd/overlay/usr/local/sbin/aifw-console
+++ b/freebsd/overlay/usr/local/sbin/aifw-console
@@ -6,6 +6,13 @@ AIFW_CONF="/usr/local/etc/aifw/aifw.conf"
 AIFW_VERSION_FILE="/usr/local/share/aifw/version"
 AIFW_VERSION=$(cat "$AIFW_VERSION_FILE" 2>/dev/null || echo "unknown")
 
+# login(1) uses this program as root's appliance console shell. sshd invokes a
+# login shell with `-c <command>` for non-interactive automation; honour that
+# contract so key-only diagnostics and E2E checks do not enter the menu loop.
+if [ "${1:-}" = "-c" ] && [ "$#" -eq 2 ]; then
+    exec /bin/sh -c "$2"
+fi
+
 show_banner()
 {
     clear

--- a/scripts/test-manifest-pins.sh
+++ b/scripts/test-manifest-pins.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+manifest=${1:-freebsd/manifest.json}
+jq -e '.external_repos | length > 0 and all(.[]; (.rev | test("^[0-9a-f]{40}$")))' "$manifest" >/dev/null

--- a/testingUplift.md
+++ b/testingUplift.md
@@ -8,33 +8,112 @@ The target definition of done is:
 
 > From one command, the framework creates an isolated appliance environment from the shipped artifact, verifies both control-plane behavior and real forwarded traffic, records actionable evidence, and leaves no Proxmox resources behind—even when setup or testing fails.
 
-## Current state
+## Status snapshot — 2026-07-19
 
-AiFw currently has a strong base of Rust unit and in-process integration tests, but it does not have an appliance-level E2E framework.
+This document separates the implemented current state from the intended full
+framework. The repository now contains an initial appliance lifecycle harness,
+but a complete successful image-build-plus-appliance run has not yet been
+demonstrated.
 
-Existing coverage includes:
+### Implemented and verified
+
+- Forgejo is the private source of truth at `indexarr/AiFw`; Woodpecker repo 87
+  is active.
+- `.woodpecker/ci.yml` runs formatting, Clippy, workspace tests, the UI build,
+  and E2E harness unit tests. The latest normal push pipelines have passed.
+- `.woodpecker/e2e.yml` is manual-only and restricted to the dedicated agent
+  label `proxmox=true`.
+- The Proxmox lab is PVE 9.2 on node `trigproxmox`, using `local` for uploads,
+  `local-lvm` for VM disks, and `vmbr0` for the initial management lane.
+- `192.168.0.26/23` is the reserved sequential builder/appliance address;
+  gateway and DNS are `192.168.0.1`.
+- `e2e/aifw_e2e.py` implements Proxmox task polling, upload/import, tagged VM
+  creation, disk attachment, startup, diagnostics, reboot checks, and guarded
+  `try/finally` teardown.
+- The writable appliance IMG can be imported only after renaming its
+  decompressed form to `.raw`; this PVE 9 API contract was verified directly.
+- Disposable direct tests have verified VM create/read/destroy, import to
+  `local-lvm`, native FreeBSD `nuageinit` bootstrap at `192.168.0.26/23`,
+  ephemeral-key SSH, live routing, non-interactive elevation, and cleanup with
+  zero residual `aifw-e2e-*` VMs or import volumes.
+- First boot can consume an `AIFW_SEED` ISO and invoke
+  `aifw-setup --config`; static WAN setup applies the address immediately, and
+  the console shell supports non-interactive SSH commands.
+- Harness unit tests cover artifact validation, secret exclusion, Argon2 seed
+  generation, one-NIC policy, work-directory reuse, native builder seed
+  schema, command quoting, and builder-user consistency.
+- Woodpecker repository secrets are scoped to manual events. The Proxmox token
+  is not committed or written to generated artifacts.
+
+### Resolved builder bootstrap issue
+
+The official FreeBSD 15.0 BASIC-CLOUDINIT UFS image uses FreeBSD's native
+`nuageinit`, not Python cloud-init. Direct serial and source-level diagnosis
+found two incompatibilities:
+
+1. Proxmox-generated NoCloud network data names the NIC `eth0`, while the
+   VirtIO device is `vtnet0`.
+2. The first custom seed supplied network-config v1. FreeBSD 15's NoCloud
+   parser expects v2 `ethernets` data and failed with a Lua type error.
+
+The harness now uploads a custom `cidata` ISO with v2 network data for
+`vtnet0`, supplies the ephemeral key through the early top-level
+`ssh_authorized_keys` field, and uses the stock `freebsd` account. Its focused
+Proxmox test directly verified the requested address, live default route, SSH,
+passwordless stock wheel-to-root elevation, and zero-residual cleanup. The
+official image has no `sudo`, and `sysrc` does not read settings rendered into
+`/etc/rc.conf.d`; readiness therefore checks live `ifconfig`/`netstat` state
+and uses passwordless `su`.
+
+The Woodpecker E2E workflow remains experimental because builder-only artifact
+production and appliance-only deployment are still unverified, not because
+the builder VM is unable to boot or network.
+
+### Current coverage that predates the VM harness
 
 - Approximately 688 Rust test attributes across the workspace.
-- API integration tests using in-memory SQLite, `PfMock`, and `axum_test::TestServer`.
-- Linux CI running formatting, Clippy, and workspace Rust tests.
-- UI CI running lint and static-export builds.
-- FreeBSD CI compiling binaries and producing ISO, IMG, and update artifacts.
-- A manual deployment script targeting a persistent FreeBSD test VM.
-- `scripts/ha-verify.sh`, which verifies two already-running HA nodes over SSH.
-- `aifw-setup --config <json>`, which supports unattended appliance configuration.
+- API integration tests using in-memory SQLite, `PfMock`, and
+  `axum_test::TestServer`.
+- Linux CI formatting, Clippy, workspace Rust tests, UI lint/build, and FreeBSD
+  artifact build scripts.
+- A manual deployment script for a persistent FreeBSD test VM.
+- `scripts/ha-verify.sh` for assertions against two already-running HA nodes.
+- `aifw-setup --config <json>` for unattended appliance configuration.
 
-Important gaps remain:
+### Remaining gaps to the full target
 
-- No shipped ISO or IMG is booted before publication.
-- No Proxmox provisioning, resource allocation, ownership tagging, or teardown exists.
-- No tracked UI or browser test suite exists.
-- No real FreeBSD `pf`, service, networking, TLS, IDS, DNS, or DHCP behavior is exercised in CI.
-- No real packets are routed through an AiFw appliance under test.
-- No reboot, failure-recovery, installation, update, or rollback suite exists at VM level.
-- UI lint is currently non-blocking.
-- No stale-resource janitor protects the Proxmox environment after interrupted jobs.
+- No successful Woodpecker-built seed-capable IMG has yet completed the full
+  Proxmox boot, service, login, API, reboot, and teardown sequence.
+- No exact shipped ISO or IMG is currently gated before publication.
+- The lab has only an untagged management bridge; no isolated WAN/LAN helper
+  topology exists for routed traffic tests.
+- No tracked Playwright/browser suite exists.
+- No real FreeBSD `pf`, TLS, IDS, DNS, DHCP, NAT, or forwarded-packet behavior
+  is exercised in CI.
+- No ISO installation, update/rollback, failure injection, HA provisioning, or
+  stale-resource janitor exists at VM level.
+- UI lint remains non-blocking while existing lint debt is addressed.
 
-The current suite therefore proves substantial application logic, but not that the released appliance boots and works as an integrated firewall.
+The current suite proves substantial application logic and most Proxmox
+lifecycle contracts, but it does not yet prove that the newly built appliance
+works as an integrated firewall.
+
+## Validation workflow
+
+Infrastructure contract changes must be validated in increasing-cost order:
+
+1. Pure unit tests with mocked Proxmox calls.
+2. A tiny NIC-less create/config/read/destroy VM contract test.
+3. A focused official-FreeBSD boot, address, SSH, and teardown test.
+4. A builder-only run that produces and checksums the IMG.
+5. An appliance-only run against that retained job-local IMG.
+6. One final Woodpecker workflow exercising the combined lifecycle.
+
+Do not use a complete Woodpecker pipeline to discover individual Proxmox form
+fields, cloud-init schema details, usernames, disk buses, or readiness paths.
+Focused runs must use unique `aifw-e2e-*` names, bounded timeouts, and the same
+guarded cleanup code as CI. After every direct test, explicitly assert that no
+run-owned VM or upload remains.
 
 ## Main release risk
 
@@ -64,15 +143,74 @@ Collect diagnostics and browser traces
 Always destroy VMs, disks, seed media, and allocations
 ```
 
-The orchestrator should expose one supported lifecycle command:
+The current orchestrator exposes separate build and appliance commands:
 
 ```sh
-scripts/e2e run \
-  --artifact output/aifw-5.99.6-amd64.img.xz \
-  --suite pr
+python -m e2e.aifw_e2e build \
+  --builder-image FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz \
+  --output e2e/.run/aifw.img.xz
+
+python -m e2e.aifw_e2e run \
+  --artifact e2e/.run/aifw.img.xz
 ```
 
-It should own provisioning, readiness, testing, artifact collection, and cleanup. Individual tests should never be responsible for creating or destroying shared Proxmox infrastructure.
+The target wrapper should compose those phases and select named suites. The
+orchestrator owns provisioning, readiness, testing, artifact collection, and
+cleanup. Individual functional tests must never create or destroy shared
+Proxmox infrastructure.
+
+### Current Woodpecker lane
+
+The manual `.woodpecker/e2e.yml` workflow is designed to:
+
+1. Run only on the LAN agent labelled `proxmox=true`.
+2. Download the official FreeBSD 15.0 BASIC-CLOUDINIT UFS qcow2 image.
+3. Create an ephemeral 8-vCPU/12-GB FreeBSD builder at the reserved address.
+4. Copy the exact checked-out commit to the builder with `git archive`.
+5. Run `freebsd/build-local.sh` and copy the compressed IMG into job-local
+   storage.
+6. Destroy the builder before reusing the reserved address.
+7. Import the new IMG, attach the `AIFW_SEED` ISO, test the appliance, reboot
+   it, collect diagnostics, and destroy all run resources.
+
+This is the intended current lane, not yet a passing lane. Builder bootstrap
+is directly verified; the next evidence must come from a focused builder-only
+artifact run and a focused appliance-only run before another combined workflow
+is used as acceptance evidence.
+
+### Builder implementation options
+
+The selected correctness-first path is an ephemeral builder created from the
+checksum-verified official FreeBSD image on every run. It is stateless and
+reproducible, but the image performs slow first-boot work and every run must
+install build dependencies.
+
+If measured duration is too high, the recommended optimization is a versioned
+Proxmox builder template:
+
+- Rebuild it on a schedule from the same official image.
+- Pin its FreeBSD release, packages, Rust toolchain, Node version, and template
+  manifest.
+- Clone it for each job; never build concurrently in the template itself.
+- Inject a fresh address and SSH key into every clone, then destroy the clone.
+- Keep a scheduled official-image canary so template caching cannot mask
+  bootstrap or dependency regressions.
+
+Alternatives considered:
+
+- **Offline-customized qcow2:** removes first boot from the job, but adds
+  libguestfs/image tooling and another artifact supply chain.
+- **Persistent FreeBSD builder host:** fastest warm builds, but weaker job
+  isolation, more cache contamination, and no VM-level teardown proof.
+- **Nested KVM or Docker builder:** possible only after intentionally exposing
+  virtualization to the CI agent; it increases runner privilege and is not
+  needed when Proxmox already provides the isolation boundary.
+- **Build from a previous AiFw image:** useful for update testing, but it can
+  hide failures in the clean build/bootstrap path and cannot replace it.
+
+Regardless of builder strategy, the appliance phase must deploy the exact IMG
+returned to the Woodpecker job. A cached builder must never become a substitute
+for artifact-under-test validation.
 
 ## Proxmox lab topology
 
@@ -498,11 +636,11 @@ Target: approximately 15-30 minutes after artifact availability.
 
 Performance regression thresholds should initially warn rather than block until enough stable lab history exists to define meaningful variance.
 
-## Implementation phases
+## Implementation phases and progress
 
 ### Phase 1: appliance automation prerequisites
 
-- Add seed-media detection and unattended first boot.
+- **Implemented:** seed-media detection and unattended first boot.
 - Add explicit unattended installer arguments.
 - Add serial-console progress and failure output.
 - Add a minimal non-sensitive health endpoint.
@@ -510,13 +648,17 @@ Performance regression thresholds should initially warn rather than block until 
 
 ### Phase 2: Proxmox lifecycle foundation
 
-- Implement scoped Proxmox authentication.
+- **Implemented, scope still needs tightening:** Proxmox token authentication.
 - Implement VMID, address, subnet, and VLAN allocation.
-- Import and boot the IMG.
-- Generate and attach seed media.
-- Implement layered readiness.
-- Implement diagnostic collection.
-- Implement verified teardown and scheduled janitor.
+- **Implemented:** dynamic VMID selection and one reserved management address.
+  Dynamic subnet/VLAN allocation remains target-state work.
+- **Directly verified:** upload/import, VM creation, disk configuration, and
+  guarded teardown. Full AiFw IMG boot remains unverified.
+- **Implemented:** appliance seed generation and attachment.
+- **Implemented:** SSH, service, TLS/API, UI, and reboot readiness checks. These
+  await a successful full appliance run.
+- **Implemented:** basic diagnostics and verified per-run teardown.
+- **Not implemented:** scheduled stale-resource janitor.
 
 ### Phase 3: core appliance tests
 
@@ -559,3 +701,16 @@ The first production-useful milestone should meet all of these conditions:
 - A final ownership check proves no run-scoped Proxmox resource remains.
 
 Once this milestone is stable, ISO installation, HA, update rollback, IPv6, and destructive recovery tests can be layered onto the same lifecycle framework.
+
+## Immediate next steps from the current state
+
+1. Run the builder command directly once and retain its IMG long enough to
+   validate checksum, partition table, and expected embedded seed-support
+   files.
+2. Run the appliance command directly against that IMG and fix readiness or
+   appliance bootstrap issues one contract at a time.
+3. Run one combined Woodpecker manual workflow as final integration evidence.
+4. Measure the clean builder duration; introduce a versioned template only if
+   the performance benefit justifies its maintenance and canary requirements.
+5. Add an isolated VLAN-aware or dedicated WAN/LAN lab topology before claiming
+   firewall data-plane E2E coverage.

--- a/testingUplift.md
+++ b/testingUplift.md
@@ -11,9 +11,10 @@ The target definition of done is:
 ## Status snapshot — 2026-07-19
 
 This document separates the implemented current state from the intended full
-framework. The repository now contains a directly validated one-NIC appliance
-lifecycle harness. Woodpecker pipeline 14 passed the combined native build,
-initial health, reboot health, and teardown path on 2026-07-19.
+framework. The repository contains a validated one-NIC appliance lifecycle and
+an implemented full isolated WAN/LAN lane. Woodpecker pipeline 14 remains the
+passing exact-commit baseline; the new full workflow awaits a fresh current-
+commit acceptance run.
 
 ### Implemented and verified
 
@@ -24,12 +25,22 @@ initial health, reboot health, and teardown path on 2026-07-19.
 - `.woodpecker/e2e.yml` is manual-only and restricted to the dedicated agent
   label `proxmox=true`.
 - The Proxmox lab is PVE 9.2 on node `trigproxmox`, using `local` for uploads,
-  `local-lvm` for VM disks, and `vmbr0` for the initial management lane.
+  `local-lvm` for disks, `vmbr0` for management, and durable portless bridges
+  `vmbr998`/`vmbr999` for isolated WAN/LAN traffic.
 - `192.168.0.26/23` is the reserved sequential builder/appliance address;
   gateway and DNS are `192.168.0.1`.
 - `e2e/aifw_e2e.py` implements Proxmox task polling, upload/import, tagged VM
   creation, disk attachment, startup, diagnostics, reboot checks, and guarded
   `try/finally` teardown.
+- The full lane provisions Debian 13 LXC traffic helpers plus a two-NIC AiFw
+  VM. The LAN helper is the SSH/API jump host, so AiFw has no management-side
+  bypass NIC.
+- The implemented contract verifies observed NAT source translation, default
+  WAN-to-LAN block, API-created WAN-to-LAN pass, API-created LAN-to-WAN block,
+  delete/reload recovery, browser login/rules rendering, reboot persistence,
+  and final rule removal.
+- A focused helper-container run directly passed boot, both static NICs,
+  routing, SSH, source-observing HTTP service, and zero-residual teardown.
 - The writable appliance IMG can be imported only after renaming its
   decompressed form to `.raw`; this PVE 9 API contract was verified directly.
 - Disposable direct tests have verified VM create/read/destroy, import to
@@ -133,23 +144,23 @@ as guest-agnostic layers.
 - `scripts/ha-verify.sh` for assertions against two already-running HA nodes.
 - `aifw-setup --config <json>` for unattended appliance configuration.
 
-### Remaining gaps to the full target
+### Remaining gaps to the broader target
 
 - The passing exact-IMG lifecycle is manual, not yet a required publication
   gate, and has only one successful combined Woodpecker acceptance run.
 - ISO installation is not exercised; the tested artifact is the writable IMG.
-- The lab has only an untagged management bridge; no isolated WAN/LAN helper
-  topology exists for routed traffic tests.
-- No tracked Playwright/browser suite exists.
-- Real FreeBSD `pf` availability and TLS/API behavior are exercised, but no
-  ruleset enforcement, IDS, DNS, DHCP, NAT, or forwarded-packet behavior is.
+- The new full topology needs a passing fresh exact-commit Woodpecker run before
+  it becomes an authoritative acceptance result.
+- Browser coverage currently targets login, dashboard arrival, and rules page;
+  NAT, DNS, IDS, users, and settings flows remain future expansion.
+- UDP, ICMP, DNS, DHCP, IDS, and packet-capture assertions remain future work.
 - No ISO installation, update/rollback, failure injection, HA provisioning, or
   stale-resource janitor exists at VM level.
 - UI lint remains non-blocking while existing lint debt is addressed.
 
-The current suite proves the newly built appliance boots, configures, serves
-its control plane, keeps `pf` alive across reboot, and tears down safely. It
-does not yet prove routed firewall behavior.
+The full suite is designed to prove routed behavior as well as control-plane
+health. Pipeline 14 is still the last passing acceptance evidence until the
+new exact-commit run completes.
 
 ## Validation workflow
 
@@ -280,14 +291,16 @@ WAN origin/test server -- WAN network -- AiFw VM -- LAN network -- client VM
                                             DNS/DHCP/traffic
 ```
 
-Recommended guests:
+Implemented guests:
 
 - **AiFw appliance:** 2-4 vCPU, 4 GB RAM, two VirtIO NICs.
-- **LAN client:** small Linux cloud-init VM for DHCP, DNS, browser, API, and traffic tests.
-- **WAN origin:** small Linux VM serving HTTP, HTTPS, DNS, TCP, UDP, and `iperf3` endpoints.
+- **LAN client:** disposable Debian LXC with management and isolated LAN NICs.
+- **WAN origin:** disposable Debian LXC on the isolated WAN bridge.
 - **HA expansion:** a second AiFw VM plus a dedicated pfsync network and CARP VIP.
 
-Use fixed lab bridges or VLAN-aware bridges with a unique VLAN/subnet allocation per run. Avoid dynamically creating permanent Proxmox bridges.
+The current lab uses fixed, portless `vmbr998` and `vmbr999` bridges with
+benchmark subnets `198.18.0.0/24` and `198.19.0.0/24`. They are durable lab
+substrate; run-owned guests and routes are always disposable.
 
 Every resource should be tagged or described with:
 
@@ -711,7 +724,8 @@ Performance regression thresholds should initially warn rather than block until 
 - **Directly verified:** SSH, service, TLS/API, UI, live `pf`, and reboot
   readiness checks on the corrected retained IMG.
 - **Implemented:** basic diagnostics and verified per-run teardown.
-- **Not implemented:** scheduled stale-resource janitor.
+- **Implemented:** ownership checks for appliance VM, helper containers, and
+  uploads. **Not implemented:** scheduled stale-resource janitor.
 
 ### Phase 3: core appliance tests
 
@@ -719,13 +733,13 @@ Performance regression thresholds should initially warn rather than block until 
 - Service health.
 - Authenticated API smoke tests.
 - Live `pf` state checks.
-- LAN-to-WAN and WAN-to-LAN traffic tests.
-- NAT, DNS, DHCP, TCP, UDP, and ICMP tests.
+- **Implemented:** TCP LAN-to-WAN and WAN-to-LAN traffic transitions and NAT.
+- Add DNS, DHCP, UDP, and ICMP tests.
 
 ### Phase 4: browser and broader functional coverage
 
-- Add Playwright configuration and fixtures.
-- Cover login, dashboard, rules, NAT, DNS, IDS, users, and settings.
+- **Implemented:** Playwright login/dashboard/rules-page smoke.
+- Cover NAT, DNS, IDS, users, settings, traces, and negative auth cases.
 - Add WebSocket and SSE assertions.
 - Add backup and restore tests.
 
@@ -763,5 +777,5 @@ Once this milestone is stable, ISO installation, HA, update rollback, IPv6, and 
    add a scheduled stale-resource janitor.
 3. Introduce a versioned template only if subsequent measurements show that
    the performance benefit justifies its maintenance and canary requirements.
-4. Add an isolated VLAN-aware or dedicated WAN/LAN lab topology before claiming
-   firewall data-plane E2E coverage.
+4. Expand the implemented isolated topology with UDP, ICMP, DNS, DHCP, and
+   packet capture after the core exact-commit lane is repeatable.

--- a/testingUplift.md
+++ b/testingUplift.md
@@ -1,0 +1,561 @@
+# AiFw Full End-to-End Testing Uplift
+
+## Purpose
+
+This document reviews AiFw's current testing and deployment harness and proposes a full end-to-end (E2E) framework that provisions the shipped appliance artifact in Proxmox, tests the running VM and network data plane, gathers diagnostics, and reliably tears down all test resources.
+
+The target definition of done is:
+
+> From one command, the framework creates an isolated appliance environment from the shipped artifact, verifies both control-plane behavior and real forwarded traffic, records actionable evidence, and leaves no Proxmox resources behind—even when setup or testing fails.
+
+## Current state
+
+AiFw currently has a strong base of Rust unit and in-process integration tests, but it does not have an appliance-level E2E framework.
+
+Existing coverage includes:
+
+- Approximately 688 Rust test attributes across the workspace.
+- API integration tests using in-memory SQLite, `PfMock`, and `axum_test::TestServer`.
+- Linux CI running formatting, Clippy, and workspace Rust tests.
+- UI CI running lint and static-export builds.
+- FreeBSD CI compiling binaries and producing ISO, IMG, and update artifacts.
+- A manual deployment script targeting a persistent FreeBSD test VM.
+- `scripts/ha-verify.sh`, which verifies two already-running HA nodes over SSH.
+- `aifw-setup --config <json>`, which supports unattended appliance configuration.
+
+Important gaps remain:
+
+- No shipped ISO or IMG is booted before publication.
+- No Proxmox provisioning, resource allocation, ownership tagging, or teardown exists.
+- No tracked UI or browser test suite exists.
+- No real FreeBSD `pf`, service, networking, TLS, IDS, DNS, or DHCP behavior is exercised in CI.
+- No real packets are routed through an AiFw appliance under test.
+- No reboot, failure-recovery, installation, update, or rollback suite exists at VM level.
+- UI lint is currently non-blocking.
+- No stale-resource janitor protects the Proxmox environment after interrupted jobs.
+
+The current suite therefore proves substantial application logic, but not that the released appliance boots and works as an integrated firewall.
+
+## Main release risk
+
+The ISO workflow builds and releases artifacts without a deployed-VM validation gate between those stages. A packaging, boot, first-boot, service, permission, interface-driver, or live-`pf` regression can pass current CI and be published.
+
+The complete E2E framework should test the exact immutable artifact intended for release, rather than rebuilding or deploying source independently after the artifact has been produced.
+
+## Proposed architecture
+
+```text
+Build immutable artifact
+        |
+Create per-run credentials and network allocation
+        |
+Provision Proxmox VM(s) and helper clients
+        |
+Boot and perform unattended setup
+        |
+SSH -> services -> TLS -> authenticated API readiness
+        |
+System + API + browser + real traffic tests
+        |
+Reboot / failure / recovery tests
+        |
+Collect diagnostics and browser traces
+        |
+Always destroy VMs, disks, seed media, and allocations
+```
+
+The orchestrator should expose one supported lifecycle command:
+
+```sh
+scripts/e2e run \
+  --artifact output/aifw-5.99.6-amd64.img.xz \
+  --suite pr
+```
+
+It should own provisioning, readiness, testing, artifact collection, and cleanup. Individual tests should never be responsible for creating or destroying shared Proxmox infrastructure.
+
+## Proxmox lab topology
+
+A useful firewall E2E test requires more than an AiFw VM:
+
+```text
+                         Proxmox API
+                              ^
+                       E2E runner/control
+                              |
+WAN origin/test server -- WAN network -- AiFw VM -- LAN network -- client VM
+                                                  |
+                                            Playwright/API/
+                                            DNS/DHCP/traffic
+```
+
+Recommended guests:
+
+- **AiFw appliance:** 2-4 vCPU, 4 GB RAM, two VirtIO NICs.
+- **LAN client:** small Linux cloud-init VM for DHCP, DNS, browser, API, and traffic tests.
+- **WAN origin:** small Linux VM serving HTTP, HTTPS, DNS, TCP, UDP, and `iperf3` endpoints.
+- **HA expansion:** a second AiFw VM plus a dedicated pfsync network and CARP VIP.
+
+Use fixed lab bridges or VLAN-aware bridges with a unique VLAN/subnet allocation per run. Avoid dynamically creating permanent Proxmox bridges.
+
+Every resource should be tagged or described with:
+
+- `aifw-e2e`
+- Run UUID
+- Commit SHA
+- Expiration timestamp
+- CI job URL
+
+Use a dedicated Proxmox resource pool and storage scope for E2E workloads.
+
+## Appliance bootstrap
+
+### Seed-media first boot
+
+The existing `aifw-setup --config <json>` path is a strong foundation. The harness needs a reliable method to provide that configuration and ephemeral SSH access to a pristine appliance.
+
+Attach a small read-only ISO labeled `AIFW_SEED` containing:
+
+- `setup.json`
+- An ephemeral SSH public key
+- Run identifier
+- Optional suite-specific settings
+
+`aifw_firstboot` should detect this medium and invoke:
+
+```sh
+aifw-setup --config /mnt/aifw-seed/setup.json
+```
+
+On success, first boot should disable itself and invalidate or eject the seed. On failure, it should emit a clear serial-console error and must not report readiness.
+
+### Credential handling
+
+The setup JSON expects an already-Argon2-hashed admin password. The harness should:
+
+1. Generate a random per-run admin password.
+2. Generate its compatible Argon2 hash.
+3. Generate a per-run SSH keypair.
+4. Inject only the hash and public key into the seed.
+5. Keep the plaintext password and private key in protected job runtime state.
+6. Remove credentials from logs, request dumps, browser traces, and uploaded artifacts.
+
+No long-lived appliance credential should be stored in the repository or Proxmox configuration.
+
+### Unattended ISO installation
+
+The current disk installer is interactive. Release-level installation testing requires an explicit automation interface such as:
+
+```sh
+aifw-install \
+  --disk vtbd0 \
+  --filesystem zfs \
+  --config /mnt/aifw-seed/setup.json \
+  --yes \
+  --poweroff
+```
+
+The installer must still:
+
+- Validate the exact target disk.
+- Reject missing, ambiguous, mounted, or unsafe targets.
+- Require `--yes` for destructive unattended use.
+- Return meaningful non-zero exit statuses.
+- Write machine-readable progress and failure information to the serial console.
+
+## Artifact test lanes
+
+### IMG lane: pull requests and main
+
+The generated IMG is a writable, bootable UFS image and is the preferred frequent-test artifact.
+
+The harness should:
+
+1. Verify its checksum.
+2. Decompress it into a run-specific staging area.
+3. Import it into the E2E Proxmox storage.
+4. Attach the imported disk, seed ISO, and two network adapters.
+5. Boot it and wait for complete application readiness.
+
+This lane validates packaging, first boot, setup, services, UI, API, live firewall state, and traffic behavior with relatively low provisioning overhead.
+
+### ISO installer lane: nightly and release candidate
+
+The harness should:
+
+1. Create an empty target disk.
+2. Attach and boot the exact ISO.
+3. Attach the automation seed.
+4. Run the unattended installer.
+5. Shut down and detach the ISO and seed as appropriate.
+6. Boot from the installed disk.
+7. Run the full functional suite.
+
+Test UFS and ZFS as separate jobs. Test BIOS and UEFI at least nightly, with the release matrix covering all supported combinations.
+
+### Optional update fast lane
+
+A golden installed template may be cloned and updated with the current update tarball for rapid update testing. This is useful supplemental coverage, but it must never replace testing of the exact IMG and ISO artifacts.
+
+## Readiness contract
+
+Readiness must be layered. A successful ping or open TCP port is insufficient.
+
+Recommended progression:
+
+1. Proxmox reports VM running.
+2. Serial console reaches the expected boot phase.
+3. Expected network address is reachable.
+4. SSH succeeds with the ephemeral key.
+5. Core services report healthy through `service ... onestatus`.
+6. TLS handshake succeeds with the expected test trust policy.
+7. Login returns valid tokens.
+8. Authenticated `/api/v1/status` succeeds and reports `pf_running`.
+9. Expected version and UI assets are served.
+10. No panic, migration failure, crash loop, or watchdog restart loop is present.
+
+A small unauthenticated `/healthz` endpoint containing no sensitive state would simplify transport-level readiness. Authenticated readiness should still verify the complete application.
+
+## Test suites
+
+### Boot and packaging
+
+- Artifact checksum is correct.
+- Embedded version matches the requested build.
+- BIOS and UEFI boot as expected.
+- Every manifest-listed binary exists and is executable.
+- Expected companion services and revisions are present.
+- UI static assets exist and are served.
+- rc.d and libexec scripts have correct modes.
+- `visudo -cf` succeeds on installed sudoers content.
+- Database migrations and integrity checks succeed.
+- TLS key, database, configuration, and helper permissions are correct.
+- No stale build artifacts or missing external binaries are shipped.
+
+Companion repository revisions should be recorded in the build manifest and preferably pinned. Cloning each default branch at build time makes artifact composition non-reproducible.
+
+### Appliance health
+
+- `aifw_daemon`, `aifw_ids`, `aifw_api`, and watchdog are running.
+- Expected DNS, DHCP, time, and reverse-proxy services match configuration.
+- API TLS and certificate behavior are correct.
+- `pf` and `pflog` are enabled.
+- Correct anchors and base rules are loaded.
+- IDS IPC and packet-capture access work.
+- Disk, memory, logs, and singleton lockfiles are healthy.
+- Service start, stop, restart, and reload paths work.
+
+### API and control plane
+
+Exercise the real API on the deployed appliance:
+
+- Login, refresh, logout, invalid credentials, lockout, and RBAC.
+- Rule CRUD, reorder, reload, and live `pfctl` verification.
+- NAT, aliases, interfaces, schedules, DNS, DHCP, VPN, IDS, and settings.
+- Backup/export, mutation, restore, and equality verification.
+- WebSocket and SSE connectivity.
+- Failed apply and rollback.
+- Update installation, restart, status, and rollback.
+- Audit and snapshot creation for mutations.
+
+Assertions should compare all three layers:
+
+```text
+API/database intent == generated configuration == live kernel/service state
+```
+
+### Data plane
+
+Drive real packets between helper VMs through AiFw:
+
+- LAN-to-WAN allowed by the standard policy.
+- WAN-to-LAN blocked by default.
+- Stateful return traffic works.
+- NAT rewrites source addresses correctly.
+- Explicit pass and block rules affect real TCP and UDP.
+- ICMP behavior matches policy.
+- IPv4 and IPv6 work.
+- DNS resolution, custom blocking, and allowlisting work.
+- A LAN client acquires and renews a DHCP lease.
+- Large-transfer and multi-connection smoke tests pass.
+- Existing and new sessions behave correctly across rule changes.
+- Management access is not unintentionally reachable from WAN.
+- Packet, byte, rule, and state counters change as expected.
+
+### Browser and UI
+
+Add Playwright under `aifw-ui` and run it against the deployed appliance:
+
+- Login and logout.
+- Dashboard and live metrics rendering.
+- WebSocket-driven updates.
+- Create, edit, reorder, and delete firewall rules.
+- NAT, DNS, IDS, user/RBAC, interface, update, and settings workflows.
+- Client-side validation.
+- API error presentation.
+- Session expiry and unauthorized redirects.
+- Core responsive-layout smoke checks.
+
+Run Chromium on pull requests. Add Firefox and WebKit to nightly coverage if they are supported targets.
+
+On failure, retain Playwright HTML, screenshots, video, and traces. Configure traces for the first retry and avoid recording credentials in reusable authentication state or request attachments.
+
+### Lifecycle and resilience
+
+- Graceful reboot followed by complete authenticated readiness.
+- Database, configuration, and live `pf` state converge after reboot.
+- Kill each core service and verify watchdog recovery.
+- Restart all services without losing configuration or management access.
+- Simulate failed `pfctl` apply and confirm rollback.
+- Verify connectivity remains after a failed mutation.
+- Simulate WAN loss and restoration.
+- Exercise controlled disk-full or read-only failures where practical.
+- Test interrupted update recovery in nightly destructive suites.
+- Verify clock and certificate behavior after restart.
+
+### HA suite
+
+Provision two appliances plus LAN, WAN, management, and dedicated pfsync connectivity.
+
+Test:
+
+- Exactly one CARP master.
+- Configuration replication.
+- State synchronization.
+- Existing connection survival during failover.
+- Failover after API/daemon stop.
+- Failover after NIC disconnect.
+- Failover after VM power-off.
+- Recovery without split brain.
+- Primary return and preferred-role behavior.
+- Configuration hashes and health checks match.
+
+Reuse `scripts/ha-verify.sh` as one assertion inside this larger suite rather than treating it as the entire HA harness.
+
+## Diagnostics and artifacts
+
+Diagnostics must be captured before destroying guests, while they are still reachable.
+
+Collect:
+
+- Run manifest with commit SHA, artifact SHA-256, companion SHAs, VMIDs, MACs, addresses, timings, and Proxmox version.
+- Proxmox VM configuration and relevant task logs.
+- Full serial-console output.
+- `dmesg`, `uname`, uptime, disk usage, mount state, and `rc.conf`.
+- Interface, address, route, ARP/NDP, and socket state.
+- `service ... onestatus`, process list, and singleton lock state.
+- `pfctl -si`, rules, NAT, anchors, tables, and states.
+- `aifw-diag.sh` output.
+- API, daemon, IDS, watchdog, DNS, DHCP, time, and proxy logs.
+- Database integrity result and non-sensitive schema/version metadata.
+- Request/response summaries with authorization data removed.
+- Traffic captures for failed data-plane cases where safe.
+- Playwright HTML report, screenshots, video, and trace.
+- JUnit XML and a concise machine-readable suite summary.
+
+Artifacts must exclude:
+
+- Bearer and refresh tokens.
+- API keys.
+- Admin plaintext password.
+- SSH private key.
+- TOTP secret and recovery codes.
+- HA shared secrets.
+- TLS private keys.
+
+## Teardown contract
+
+Teardown is a core framework responsibility, not the last test step.
+
+The top-level runner should use `try/finally` plus handlers for normal exit, test failure, timeout, cancellation, SIGINT, and SIGTERM.
+
+Cleanup sequence:
+
+1. Stop scheduling new tests.
+2. Capture diagnostics while guests remain reachable.
+3. Request graceful VM shutdown with a bounded timeout.
+4. Force-stop VMs only when required.
+5. Destroy VMs and all referenced and unreferenced run-owned disks.
+6. Delete temporary seed ISOs and artifact staging files.
+7. Release VLAN, subnet, address, and VMID leases.
+8. Verify that no resources tagged with the run UUID remain.
+9. Report cleanup failures separately from test failures.
+
+Manual preservation after failure should require an explicit flag and must still assign an expiration timestamp.
+
+### Stale-resource janitor
+
+Run a scheduled janitor independently of test jobs. It should:
+
+- Enumerate only resources tagged `aifw-e2e` in the dedicated pool.
+- Compare their expiration timestamps with the current time.
+- Confirm they are not associated with an active CI run.
+- Destroy expired VMs, disks, and seed media.
+- Release expired allocation leases.
+- Emit an audit report of everything removed.
+
+The janitor must never enumerate and destroy untagged or non-E2E resources.
+
+## Security model
+
+- Use a Proxmox API token scoped to the E2E resource pool, selected storage, and test network resources.
+- Avoid unrestricted root SSH from CI where a narrow node-side import helper can be used.
+- Validate artifact and staging paths before importing or deleting them.
+- Keep destructive operations scoped by run UUID and known VMIDs.
+- Never use broad recursive deletion against a workspace, storage root, or unresolved variable.
+- Use unique ephemeral credentials per run.
+- Redact request headers and secret-bearing JSON fields before artifact upload.
+- Separate public pull-request jobs from jobs allowed to access the private Proxmox lab.
+
+## Suggested repository layout
+
+```text
+e2e/
+  README.md
+  pyproject.toml
+  lab.example.yaml
+  orchestrator/
+    cli.py
+    proxmox.py
+    allocation.py
+    seed.py
+    readiness.py
+    diagnostics.py
+    cleanup.py
+  tests/
+    test_boot.py
+    test_services.py
+    test_api.py
+    test_firewall.py
+    test_nat.py
+    test_dns_dhcp.py
+    test_reboot.py
+    test_update.py
+    test_ha.py
+  fixtures/
+    setup.json.j2
+  helpers/
+    wan-server/
+    lan-client/
+
+aifw-ui/
+  playwright.config.ts
+  e2e/
+    auth.spec.ts
+    dashboard.spec.ts
+    rules.spec.ts
+    settings.spec.ts
+
+.github/workflows/
+  e2e-pr.yml
+  e2e-nightly.yml
+  e2e-release.yml
+
+scripts/
+  e2e
+```
+
+Python with `pytest` is a practical orchestration layer because it provides mature Proxmox clients, fixtures, structured reports, timeouts, and cleanup primitives. Shell should remain limited to narrow guest helpers. Rust can be used for traffic or assertion tooling where type safety and reuse justify it.
+
+## CI tiers
+
+### Tier 0: local and every commit
+
+- Rust formatting, Clippy, and unit/integration tests.
+- UI lint made blocking after existing debt is addressed.
+- UI component tests.
+- Browser tests against mocked APIs where they provide fast feedback.
+- Shell syntax and helper allowlist tests.
+
+Target: under 10-15 minutes.
+
+### Tier 1: every eligible pull request
+
+- Build exact IMG artifact.
+- Boot it in Proxmox.
+- Run boot, readiness, service, API, core browser, and core data-plane suites.
+- Reboot once and verify recovery.
+- Always collect diagnostics and tear down.
+
+Target: approximately 15-30 minutes after artifact availability.
+
+### Tier 2: main and nightly
+
+- Full data plane, IPv6, update, rollback, failure injection, and recovery.
+- BIOS and UEFI matrix.
+- ISO installation smoke tests.
+- HA failover tests.
+- Longer throughput and stability tests with broad VM tolerances.
+
+### Tier 3: release candidate
+
+- Exact ISO-to-disk installation.
+- UFS and ZFS.
+- Supported firmware modes.
+- Complete functional and browser suite.
+- Reboot, update, rollback, and HA validation.
+- Publishing depends on successful completion.
+
+Performance regression thresholds should initially warn rather than block until enough stable lab history exists to define meaningful variance.
+
+## Implementation phases
+
+### Phase 1: appliance automation prerequisites
+
+- Add seed-media detection and unattended first boot.
+- Add explicit unattended installer arguments.
+- Add serial-console progress and failure output.
+- Add a minimal non-sensitive health endpoint.
+- Add reproducible build metadata with companion SHAs.
+
+### Phase 2: Proxmox lifecycle foundation
+
+- Implement scoped Proxmox authentication.
+- Implement VMID, address, subnet, and VLAN allocation.
+- Import and boot the IMG.
+- Generate and attach seed media.
+- Implement layered readiness.
+- Implement diagnostic collection.
+- Implement verified teardown and scheduled janitor.
+
+### Phase 3: core appliance tests
+
+- Boot and packaging assertions.
+- Service health.
+- Authenticated API smoke tests.
+- Live `pf` state checks.
+- LAN-to-WAN and WAN-to-LAN traffic tests.
+- NAT, DNS, DHCP, TCP, UDP, and ICMP tests.
+
+### Phase 4: browser and broader functional coverage
+
+- Add Playwright configuration and fixtures.
+- Cover login, dashboard, rules, NAT, DNS, IDS, users, and settings.
+- Add WebSocket and SSE assertions.
+- Add backup and restore tests.
+
+### Phase 5: resilience and release validation
+
+- Reboot and service-recovery suites.
+- Update and rollback suites.
+- ISO installation with UFS and ZFS.
+- Failure injection.
+- HA provisioning and failover.
+- Release publication gate.
+
+## Initial acceptance criteria
+
+The first production-useful milestone should meet all of these conditions:
+
+- One command provisions an exact AiFw IMG in Proxmox.
+- Setup is completely unattended and uses ephemeral credentials.
+- Readiness requires SSH, services, TLS, login, and authenticated status.
+- A Linux client routes real TCP, UDP, ICMP, and DNS traffic through AiFw.
+- At least one real pass rule and one real block rule are verified against live traffic and `pf` state.
+- A core Playwright login/dashboard/rule workflow runs against the appliance.
+- The appliance reboots and becomes fully ready again.
+- Failures upload serial, service, firewall, application, and browser diagnostics.
+- Teardown runs after success, failure, timeout, and cancellation.
+- A final ownership check proves no run-scoped Proxmox resource remains.
+
+Once this milestone is stable, ISO installation, HA, update rollback, IPv6, and destructive recovery tests can be layered onto the same lifecycle framework.

--- a/testingUplift.md
+++ b/testingUplift.md
@@ -65,6 +65,14 @@ official image has no `sudo`, and `sysrc` does not read settings rendered into
 `/etc/rc.conf.d`; readiness therefore checks live `ifconfig`/`netstat` state
 and uses passwordless `su`.
 
+A builder-only attempt then exposed an independent PVE API race: setting
+`virtio0` and `boot=order=virtio0` in the same disk-import request caused PVE
+to omit the disk from the persisted boot order because the asynchronous import
+had not created it yet. The VM attempted PXE/CD-ROM boot and remained idle.
+The harness now waits for import completion and submits boot order as a second
+task; repairing that setting on the disposable VM made the corrected network
+seed come online immediately. Unit coverage locks in the two-request order.
+
 The Woodpecker E2E workflow remains experimental because builder-only artifact
 production and appliance-only deployment are still unverified, not because
 the builder VM is unable to boot or network.

--- a/testingUplift.md
+++ b/testingUplift.md
@@ -12,8 +12,8 @@ The target definition of done is:
 
 This document separates the implemented current state from the intended full
 framework. The repository now contains a directly validated one-NIC appliance
-lifecycle harness. Builder-only image production and corrected appliance-only
-initial/reboot validation pass; one combined native-fix Woodpecker run remains.
+lifecycle harness. Woodpecker pipeline 14 passed the combined native build,
+initial health, reboot health, and teardown path on 2026-07-19.
 
 ### Implemented and verified
 
@@ -49,6 +49,11 @@ initial/reboot validation pass; one combined native-fix Woodpecker run remains.
 - Appliance-only validation passed unattended setup, core services, TLS login,
   authenticated API/UI status, live `pf`, reboot recovery, and teardown after
   applying equivalent boot metadata corrections to the retained IMG.
+- Woodpecker pipeline 14 then rebuilt the fixes natively as AiFw 5.99.14 from
+  commit `9c146232`, produced a 221,009,096-byte compressed IMG, deployed that
+  exact job-local artifact at `192.168.0.26`, and passed in 1,840 seconds.
+- A post-run Proxmox audit found zero run-owned VMs and zero matching uploaded
+  or imported volumes.
 
 ### Resolved builder bootstrap issue
 
@@ -93,11 +98,29 @@ Focused appliance deployment exposed four independent artifact/runtime bugs:
 4. Reboot checks stopped at SSH and could race the parallel rc sequence. They
    now retry the complete services, TLS login, API/UI, and `pf` contract.
 
-The retained image was patched with equivalent boot metadata to prove the
-diagnosis without repeating compilation. Its final manifest records
-`pf_running=true` before and after reboot, and teardown left zero resources.
-The Woodpecker workflow remains experimental only until a natively rebuilt
-image completes the same combined run.
+The retained image was first patched with equivalent boot metadata to prove the
+diagnosis without repeating compilation. Its final manifest recorded
+`pf_running=true` before and after reboot. Pipeline 14 subsequently proved the
+natively rebuilt source through the same combined lifecycle.
+
+### Which failures were FreeBSD-specific?
+
+Most appliance/bootstrap failures were FreeBSD-specific:
+
+- FreeBSD 15 uses native `nuageinit`; its NoCloud network parser required v2
+  data and the VirtIO interface name `vtnet0`, not Linux-style `eth0`.
+- The stock FreeBSD cloud image lacked `sudo` and required the wheel account's
+  passwordless `su`; preserving the caller environment also preserved the wrong
+  home directory.
+- `KEYWORD:firstboot`, UFS versus GPT labels, `rc.conf` `pf_rules`, and FreeBSD
+  rc startup timing caused the first-boot, mount, and reboot failures.
+
+The Proxmox disk-import/boot-order race was not FreeBSD-specific; any guest can
+hit it when an asynchronously imported disk is referenced too early. The
+Woodpecker shell interpolation and checksum-parser escaping failures were also
+generic CI portability issues. The durable design therefore keeps FreeBSD
+guest adapters explicit while treating Proxmox lifecycle and CI orchestration
+as guest-agnostic layers.
 
 ### Current coverage that predates the VM harness
 
@@ -112,21 +135,21 @@ image completes the same combined run.
 
 ### Remaining gaps to the full target
 
-- No successful Woodpecker-built seed-capable IMG has yet completed the full
-  Proxmox boot, service, login, API, reboot, and teardown sequence.
-- No exact shipped ISO or IMG is currently gated before publication.
+- The passing exact-IMG lifecycle is manual, not yet a required publication
+  gate, and has only one successful combined Woodpecker acceptance run.
+- ISO installation is not exercised; the tested artifact is the writable IMG.
 - The lab has only an untagged management bridge; no isolated WAN/LAN helper
   topology exists for routed traffic tests.
 - No tracked Playwright/browser suite exists.
-- No real FreeBSD `pf`, TLS, IDS, DNS, DHCP, NAT, or forwarded-packet behavior
-  is exercised in CI.
+- Real FreeBSD `pf` availability and TLS/API behavior are exercised, but no
+  ruleset enforcement, IDS, DNS, DHCP, NAT, or forwarded-packet behavior is.
 - No ISO installation, update/rollback, failure injection, HA provisioning, or
   stale-resource janitor exists at VM level.
 - UI lint remains non-blocking while existing lint debt is addressed.
 
-The current suite proves substantial application logic and most Proxmox
-lifecycle contracts, but it does not yet prove that the newly built appliance
-works as an integrated firewall.
+The current suite proves the newly built appliance boots, configures, serves
+its control plane, keeps `pf` alive across reboot, and tears down safely. It
+does not yet prove routed firewall behavior.
 
 ## Validation workflow
 
@@ -191,7 +214,7 @@ Proxmox infrastructure.
 
 ### Current Woodpecker lane
 
-The manual `.woodpecker/e2e.yml` workflow is designed to:
+The manual `.woodpecker/e2e.yml` workflow now:
 
 1. Run only on the LAN agent labelled `proxmox=true`.
 2. Download the official FreeBSD 15.0 BASIC-CLOUDINIT UFS qcow2 image.
@@ -203,9 +226,9 @@ The manual `.woodpecker/e2e.yml` workflow is designed to:
 7. Import the new IMG, attach the `AIFW_SEED` ISO, test the appliance, reboot
    it, collect diagnostics, and destroy all run resources.
 
-Builder-only and corrected appliance-only evidence now pass directly. The next
-and only expensive acceptance step is one combined Woodpecker run that rebuilds
-the native fixes and deploys that exact job-local IMG.
+Builder-only, corrected appliance-only, and combined Woodpecker evidence now
+pass. Pipeline 14 rebuilt the native fixes and deployed that exact job-local
+IMG successfully.
 
 ### Builder implementation options
 
@@ -734,9 +757,10 @@ Once this milestone is stable, ISO installation, HA, update rollback, IPv6, and 
 
 ## Immediate next steps from the current state
 
-1. Run one combined Woodpecker manual workflow as final native-build evidence.
-2. Promote the one-NIC lane from experimental to a required release smoke only
-   after that combined run passes consistently.
+1. Repeat the manual lane on release candidates and promote it to a required
+   release smoke after repeatability is established.
+2. Persist manifests and diagnostics outside the ephemeral Woodpecker job, and
+   add a scheduled stale-resource janitor.
 3. Introduce a versioned template only if subsequent measurements show that
    the performance benefit justifies its maintenance and canary requirements.
 4. Add an isolated VLAN-aware or dedicated WAN/LAN lab topology before claiming

--- a/testingUplift.md
+++ b/testingUplift.md
@@ -11,9 +11,9 @@ The target definition of done is:
 ## Status snapshot — 2026-07-19
 
 This document separates the implemented current state from the intended full
-framework. The repository now contains an initial appliance lifecycle harness,
-but a complete successful image-build-plus-appliance run has not yet been
-demonstrated.
+framework. The repository now contains a directly validated one-NIC appliance
+lifecycle harness. Builder-only image production and corrected appliance-only
+initial/reboot validation pass; one combined native-fix Woodpecker run remains.
 
 ### Implemented and verified
 
@@ -44,6 +44,11 @@ demonstrated.
   schema, command quoting, and builder-user consistency.
 - Woodpecker repository secrets are scoped to manual events. The Proxmox token
   is not committed or written to generated artifacts.
+- A clean official-image builder run produced and checksummed the compressed
+  IMG in roughly 15 minutes, copied it back, and left zero Proxmox resources.
+- Appliance-only validation passed unattended setup, core services, TLS login,
+  authenticated API/UI status, live `pf`, reboot recovery, and teardown after
+  applying equivalent boot metadata corrections to the retained IMG.
 
 ### Resolved builder bootstrap issue
 
@@ -73,9 +78,26 @@ The harness now waits for import completion and submits boot order as a second
 task; repairing that setting on the disposable VM made the corrected network
 seed come online immediately. Unit coverage locks in the two-request order.
 
-The Woodpecker E2E workflow remains experimental because builder-only artifact
-production and appliance-only deployment are still unverified, not because
-the builder VM is unable to boot or network.
+### Resolved appliance boot and reboot issues
+
+Focused appliance deployment exposed four independent artifact/runtime bugs:
+
+1. The IMG requested `/dev/ufs/aifw` but created only `/dev/gpt/aifw`, dropping
+   to `mountroot` with error 19. `newfs -L aifw` now creates the label the
+   loader and fstab request.
+2. `aifw_firstboot` used FreeBSD's sentinel-gated `KEYWORD:firstboot`, but a
+   staged writable IMG has no sentinel. It is now a normal idempotent rc
+   service that exits when configured and disables itself after success.
+3. Setup enabled `pf` without persisting `pf_rules`; reboot fell back to the
+   absent `/etc/pf.conf`. Setup now persists the AiFw rules path.
+4. Reboot checks stopped at SSH and could race the parallel rc sequence. They
+   now retry the complete services, TLS login, API/UI, and `pf` contract.
+
+The retained image was patched with equivalent boot metadata to prove the
+diagnosis without repeating compilation. Its final manifest records
+`pf_running=true` before and after reboot, and teardown left zero resources.
+The Woodpecker workflow remains experimental only until a natively rebuilt
+image completes the same combined run.
 
 ### Current coverage that predates the VM harness
 
@@ -181,17 +203,17 @@ The manual `.woodpecker/e2e.yml` workflow is designed to:
 7. Import the new IMG, attach the `AIFW_SEED` ISO, test the appliance, reboot
    it, collect diagnostics, and destroy all run resources.
 
-This is the intended current lane, not yet a passing lane. Builder bootstrap
-is directly verified; the next evidence must come from a focused builder-only
-artifact run and a focused appliance-only run before another combined workflow
-is used as acceptance evidence.
+Builder-only and corrected appliance-only evidence now pass directly. The next
+and only expensive acceptance step is one combined Woodpecker run that rebuilds
+the native fixes and deploys that exact job-local IMG.
 
 ### Builder implementation options
 
 The selected correctness-first path is an ephemeral builder created from the
 checksum-verified official FreeBSD image on every run. It is stateless and
-reproducible, but the image performs slow first-boot work and every run must
-install build dependencies.
+reproducible, and the measured clean run completed in roughly 15 minutes. This
+is acceptable for the manual/release lane and unblocks immediately without
+introducing mutable template state.
 
 If measured duration is too high, the recommended optimization is a versioned
 Proxmox builder template:
@@ -660,11 +682,11 @@ Performance regression thresholds should initially warn rather than block until 
 - Implement VMID, address, subnet, and VLAN allocation.
 - **Implemented:** dynamic VMID selection and one reserved management address.
   Dynamic subnet/VLAN allocation remains target-state work.
-- **Directly verified:** upload/import, VM creation, disk configuration, and
-  guarded teardown. Full AiFw IMG boot remains unverified.
+- **Directly verified:** upload/import, VM creation, disk configuration,
+  builder artifact production, corrected AiFw IMG boot, and guarded teardown.
 - **Implemented:** appliance seed generation and attachment.
-- **Implemented:** SSH, service, TLS/API, UI, and reboot readiness checks. These
-  await a successful full appliance run.
+- **Directly verified:** SSH, service, TLS/API, UI, live `pf`, and reboot
+  readiness checks on the corrected retained IMG.
 - **Implemented:** basic diagnostics and verified per-run teardown.
 - **Not implemented:** scheduled stale-resource janitor.
 
@@ -712,13 +734,10 @@ Once this milestone is stable, ISO installation, HA, update rollback, IPv6, and 
 
 ## Immediate next steps from the current state
 
-1. Run the builder command directly once and retain its IMG long enough to
-   validate checksum, partition table, and expected embedded seed-support
-   files.
-2. Run the appliance command directly against that IMG and fix readiness or
-   appliance bootstrap issues one contract at a time.
-3. Run one combined Woodpecker manual workflow as final integration evidence.
-4. Measure the clean builder duration; introduce a versioned template only if
+1. Run one combined Woodpecker manual workflow as final native-build evidence.
+2. Promote the one-NIC lane from experimental to a required release smoke only
+   after that combined run passes consistently.
+3. Introduce a versioned template only if subsequent measurements show that
    the performance benefit justifies its maintenance and canary requirements.
-5. Add an isolated VLAN-aware or dedicated WAN/LAN lab topology before claiming
+4. Add an isolated VLAN-aware or dedicated WAN/LAN lab topology before claiming
    firewall data-plane E2E coverage.


### PR DESCRIPTION
## Summary
Implements issues #529 through #542 as independently ordered commits, including:
- corrected maturity and HA claims
- explicit rejection of unsupported IPsec/NAT/CoDel paths
- restore, IDS, schedule, Multi-WAN, WireGuard, and firewall fixes
- pinned companion revisions and SPDX release inventory
- appliance/data-plane testing contracts and regression coverage

## Validation
- cargo fmt and clippy with -D warnings
- workspace/API tests
- private Proxmox E2E is being run internally; lab-specific Proxmox flow is intentionally not added as generic upstream test infrastructure.

Fixes #529
Fixes #530
Fixes #531
Fixes #532
Fixes #533
Fixes #534
Fixes #535
Fixes #536
Fixes #537
Fixes #538
Fixes #539
Fixes #540
Fixes #541
Fixes #542