### PR TITLE
Fix criticals: schedule enforcement, WireGuard key derivation, strict restore (#537, #541, #535)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.6"
+version = "5.99.7"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"
@@ -68,6 +68,8 @@ tokio-rustls = "0.26"
 rustls-pemfile = "2"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 url = "2"
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+getrandom = "0.3"
 
 # Workspace-wide clippy lint posture. Stylistic-only lints are allowed —
 # documented engine constructors legitimately have many parameters, the

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -184,7 +184,7 @@ pub async fn restore_version(
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
 
-    apply_firewall_config(&state, &config, &req.interface_map).await?;
+    apply_firewall_config_or_rollback(&state, &config, &req.interface_map).await?;
 
     mgr.mark_applied(req.version)
         .await
@@ -486,7 +486,7 @@ pub(crate) async fn commit_confirm_arm_with_snapshot(
                 if let Some(inner) = store.write().await.take()
                     && let Ok(config) = serde_json::from_str::<FirewallConfig>(&inner.rollback_config) {
                         if let Err(e) = apply_firewall_config(&rollback_state, &config, &InterfaceMap::new()).await {
-                            tracing::warn!(error = %e, "commit confirm rollback: apply_firewall_config failed");
+                            tracing::error!(error = ?e, "commit confirm ROLLBACK FAILED — system may be partially configured");
                         } else {
                             tracing::info!("Config rolled back successfully");
                         }
@@ -1486,6 +1486,73 @@ fn map_iface(name: &str, map: &InterfaceMap) -> Option<String> {
 /// `iface_map` lets the caller rename interfaces (backup-name → target-name)
 /// or skip entries whose interface has no mapping on the target (value = None).
 /// Pass an empty map for literal restore (version history on the same box).
+/// Map a failed required restore step to the 500 the handlers return,
+/// logging the step so the operator can see exactly what aborted (#535).
+fn apply_fail(step: &str, e: impl std::fmt::Display) -> StatusCode {
+    tracing::error!(error = %e, "config apply: {step} failed — aborting restore");
+    StatusCode::INTERNAL_SERVER_ERROR
+}
+
+/// Restore-with-rollback wrapper around [`apply_firewall_config`] (#535).
+///
+/// Captures the current running config first, applies the target strictly,
+/// and on any required-step failure re-applies the snapshot so the system
+/// never stays half-restored. Three outcomes, never silent partial success:
+/// 1. target applied — `Ok`;
+/// 2. apply failed, prior state restored — `Err(500)`, audited;
+/// 3. apply failed AND rollback failed — `Err(500)`, audited + logged as
+///    high severity so the operator knows the system needs attention.
+///
+/// SQL transactions alone can't provide this contract because engine applies
+/// mutate pf/kernel state sqlx can't rewind (see #158 for the DB-side
+/// transaction work); snapshot/reapply is the rollback mechanism.
+pub(crate) async fn apply_firewall_config_or_rollback(
+    state: &AppState,
+    config: &FirewallConfig,
+    iface_map: &InterfaceMap,
+) -> Result<(), StatusCode> {
+    let snapshot = build_current_config(state).await?;
+    let Err(apply_err) = apply_firewall_config(state, config, iface_map).await else {
+        return Ok(());
+    };
+    tracing::error!("config apply failed; rolling back to pre-apply snapshot");
+    let audit = state.rule_engine.audit();
+    match apply_firewall_config(state, &snapshot, &InterfaceMap::new()).await {
+        Ok(()) => {
+            if let Err(e) = audit
+                .log(
+                    aifw_core::AuditAction::ConfigChanged,
+                    None,
+                    "config restore failed; rolled back to pre-restore state",
+                    "restore",
+                )
+                .await
+            {
+                tracing::warn!(error = %e, "config apply: rollback audit write failed");
+            }
+        }
+        Err(rollback_err) => {
+            tracing::error!(
+                ?rollback_err,
+                "config apply ROLLBACK FAILED — system may be partially configured; \
+                 restore from a known-good backup"
+            );
+            if let Err(e) = audit
+                .log(
+                    aifw_core::AuditAction::ConfigChanged,
+                    None,
+                    "config restore failed AND rollback failed — system may be partially configured",
+                    "restore",
+                )
+                .await
+            {
+                tracing::warn!(error = %e, "config apply: rollback audit write failed");
+            }
+        }
+    }
+    Err(apply_err)
+}
+
 pub(crate) async fn apply_firewall_config(
     state: &AppState,
     config: &FirewallConfig,
@@ -1496,10 +1563,11 @@ pub(crate) async fn apply_firewall_config(
     };
 
     // Restore preludes — clear existing rows before re-populating from the
-    // imported config. A silent failure here (locked DB, FK violation, schema
-    // drift) used to leave stale rows that produced a half-imported firewall
-    // with no diagnostic. We now log each error and continue, so the operator
-    // can see what didn't clear in `journalctl`/`tail -f`.
+    // imported config. A failed DELETE (locked DB, FK violation, schema
+    // drift) used to warn and continue, leaving stale rows in a half-imported
+    // firewall; since #535 it aborts the restore instead. Parse/mapping skips
+    // (`continue`) below are intentional drops the import preview already
+    // surfaced; operational failures are errors.
     for table in [
         "wg_peers",
         "wg_tunnels",
@@ -1510,12 +1578,10 @@ pub(crate) async fn apply_firewall_config(
         "aliases",
         "static_routes",
     ] {
-        if let Err(e) = sqlx::query(sqlx::AssertSqlSafe(format!("DELETE FROM {table}")))
+        sqlx::query(sqlx::AssertSqlSafe(format!("DELETE FROM {table}")))
             .execute(&state.pool)
             .await
-        {
-            tracing::warn!(table, error = %e, "import: DELETE failed before restore");
-        }
+            .map_err(|e| apply_fail(&format!("clearing {table}"), e))?;
     }
 
     for rc in &config.rules {
@@ -1530,9 +1596,13 @@ pub(crate) async fn apply_firewall_config(
         rc.interface = iface_after;
         if let Some(rule) = rule_from_config(&rc) {
             let rule_id = rule.id;
-            if let Err(e) = state.rule_engine.add_rule(rule).await {
-                tracing::warn!(rule_id = %rule_id, error = %e, "import: rule restore failed");
-            }
+            state
+                .rule_engine
+                .add_rule(rule)
+                .await
+                .map_err(|e| apply_fail(&format!("rule {rule_id} restore"), e))?;
+        } else {
+            tracing::warn!(rule_id = %rc.id, "import: skipping unparseable rule entry");
         }
     }
 
@@ -1544,9 +1614,13 @@ pub(crate) async fn apply_firewall_config(
         nc.interface = mapped_iface;
         if let Some(nat) = nat_from_config(&nc) {
             let nat_id = nat.id;
-            if let Err(e) = state.nat_engine.add_rule(nat).await {
-                tracing::warn!(nat_id = %nat_id, error = %e, "import: nat rule restore failed");
-            }
+            state
+                .nat_engine
+                .add_rule(nat)
+                .await
+                .map_err(|e| apply_fail(&format!("nat rule {nat_id} restore"), e))?;
+        } else {
+            tracing::warn!(nat_id = %nc.id, "import: skipping unparseable nat entry");
         }
     }
 
@@ -1570,9 +1644,11 @@ pub(crate) async fn apply_firewall_config(
             updated_at: chrono::Utc::now(),
         };
         let alias_name = alias.name.clone();
-        if let Err(e) = state.alias_engine.add(alias).await {
-            tracing::warn!(alias = %alias_name, error = %e, "import: alias restore failed");
-        }
+        state
+            .alias_engine
+            .add(alias)
+            .await
+            .map_err(|e| apply_fail(&format!("alias {alias_name} restore"), e))?;
     }
 
     // Static routes — restored via direct INSERT + apply_route_to_system,
@@ -1600,9 +1676,11 @@ pub(crate) async fn apply_firewall_config(
         .bind(rc.fib as i64)
         .execute(&state.pool)
         .await;
-        if let Err(e) = insert_res {
-            tracing::warn!(dest = %rc.destination, error = %e, "import: static route restore failed");
-        }
+        insert_res
+            .map_err(|e| apply_fail(&format!("static route {} restore", rc.destination), e))?;
+        // Kernel route application stays best-effort: it shells out to
+        // `route`, which is absent/unprivileged on dev hosts, and the row is
+        // reapplied at boot.
         if rc.enabled {
             crate::routes::apply_route_to_system(
                 &rc.destination,
@@ -1624,9 +1702,11 @@ pub(crate) async fn apply_firewall_config(
         rule.label = gc.label.clone();
         rule.status = gc.status;
         let country = rule.country.0.clone();
-        if let Err(e) = state.geoip_engine.add_rule(rule).await {
-            tracing::warn!(country = %country, error = %e, "import: geo-ip rule restore failed");
-        }
+        state
+            .geoip_engine
+            .add_rule(rule)
+            .await
+            .map_err(|e| apply_fail(&format!("geo-ip rule {country} restore"), e))?;
     }
 
     for wg in &config.vpn.wireguard {
@@ -1654,9 +1734,12 @@ pub(crate) async fn apply_firewall_config(
             created_at: now,
             updated_at: now,
         };
-        if state.vpn_engine.add_wg_tunnel(tunnel).await.is_err() {
-            continue;
-        }
+        let tunnel_name = tunnel.name.clone();
+        state
+            .vpn_engine
+            .add_wg_tunnel(tunnel)
+            .await
+            .map_err(|e| apply_fail(&format!("wg tunnel {tunnel_name} restore"), e))?;
         for p in &wg.peers {
             let peer_id = uuid::Uuid::parse_str(&p.id).unwrap_or_else(|_| uuid::Uuid::new_v4());
             let allowed_ips: Vec<Address> = p
@@ -1678,9 +1761,11 @@ pub(crate) async fn apply_firewall_config(
                 updated_at: now,
             };
             let peer_name = peer.name.clone();
-            if let Err(e) = state.vpn_engine.add_wg_peer(peer).await {
-                tracing::warn!(peer = %peer_name, error = %e, "import: wg peer restore failed");
-            }
+            state
+                .vpn_engine
+                .add_wg_peer(peer)
+                .await
+                .map_err(|e| apply_fail(&format!("wg peer {peer_name} restore"), e))?;
         }
     }
 
@@ -1697,9 +1782,11 @@ pub(crate) async fn apply_firewall_config(
         sa.enc_algo = sac.enc_algo.clone();
         sa.auth_algo = sac.auth_algo.clone();
         let sa_name = sa.name.clone();
-        if let Err(e) = state.vpn_engine.add_ipsec_sa(sa).await {
-            tracing::warn!(sa = %sa_name, error = %e, "import: ipsec SA restore failed");
-        }
+        state
+            .vpn_engine
+            .add_ipsec_sa(sa)
+            .await
+            .map_err(|e| apply_fail(&format!("ipsec SA {sa_name} restore"), e))?;
     }
 
     if !config.system.dns_servers.is_empty() {
@@ -1710,51 +1797,50 @@ pub(crate) async fn apply_firewall_config(
             .map(|s| format!("nameserver {s}"))
             .collect::<Vec<_>>()
             .join("\n");
+        // Best-effort: /etc/resolv.conf is a root-owned system file the aifw
+        // user may not be able to write; the DB remains the source of truth.
         if let Err(e) = tokio::fs::write("/etc/resolv.conf", &content).await {
             tracing::warn!(error = %e, "import: /etc/resolv.conf write failed");
         }
     }
 
     let auth = &config.auth;
-    if let Err(e) = sqlx::query(
-        "INSERT OR REPLACE INTO auth_config (key, value) VALUES ('access_token_expiry_mins', ?1)",
-    )
-    .bind(auth.access_token_expiry_mins.to_string())
-    .execute(&state.pool)
-    .await
-    {
-        tracing::warn!(key = "access_token_expiry_mins", error = %e, "import: auth config restore failed");
-    }
-    if let Err(e) = sqlx::query(
-        "INSERT OR REPLACE INTO auth_config (key, value) VALUES ('refresh_token_expiry_days', ?1)",
-    )
-    .bind(auth.refresh_token_expiry_days.to_string())
-    .execute(&state.pool)
-    .await
-    {
-        tracing::warn!(key = "refresh_token_expiry_days", error = %e, "import: auth config restore failed");
-    }
-    if let Err(e) =
-        sqlx::query("INSERT OR REPLACE INTO auth_config (key, value) VALUES ('require_totp', ?1)")
-            .bind(if auth.require_totp { "true" } else { "false" })
+    for (key, value) in [
+        (
+            "access_token_expiry_mins",
+            auth.access_token_expiry_mins.to_string(),
+        ),
+        (
+            "refresh_token_expiry_days",
+            auth.refresh_token_expiry_days.to_string(),
+        ),
+        (
+            "require_totp",
+            if auth.require_totp { "true" } else { "false" }.to_string(),
+        ),
+    ] {
+        sqlx::query("INSERT OR REPLACE INTO auth_config (key, value) VALUES (?1, ?2)")
+            .bind(key)
+            .bind(value)
             .execute(&state.pool)
             .await
-    {
-        tracing::warn!(key = "require_totp", error = %e, "import: auth config restore failed");
+            .map_err(|e| apply_fail(&format!("auth config {key} restore"), e))?;
     }
 
     // Traffic shaping: queues + per-IP rate limits
     let shaping = aifw_core::shaping::ShapingEngine::new(state.pool.clone(), state.pf.clone());
-    if let Err(e) = shaping.migrate().await {
-        tracing::warn!(error = %e, "import: shaping migrate failed");
-    }
-    for table in ["queues", "rate_limits"] {
-        if let Err(e) = sqlx::query(sqlx::AssertSqlSafe(format!("DELETE FROM {table}")))
+    shaping
+        .migrate()
+        .await
+        .map_err(|e| apply_fail("shaping migrate", e))?;
+    // NB: the pre-#535 code deleted from "queues"/"rate_limits" — tables that
+    // don't exist — and swallowed the error, so shaping rows were never
+    // actually cleared before re-insert. These are the real table names.
+    for table in ["queue_configs", "rate_limit_rules"] {
+        sqlx::query(sqlx::AssertSqlSafe(format!("DELETE FROM {table}")))
             .execute(&state.pool)
             .await
-        {
-            tracing::warn!(table, error = %e, "import: DELETE failed before restore");
-        }
+            .map_err(|e| apply_fail(&format!("clearing {table}"), e))?;
     }
     for qc in &config.queues {
         let Some(mapped) = map_iface(&qc.interface, iface_map) else {
@@ -1762,10 +1848,11 @@ pub(crate) async fn apply_firewall_config(
         };
         let mut qc = qc.clone();
         qc.interface = mapped;
-        if let Some(q) = queue_from_config(&qc)
-            && let Err(e) = shaping.add_queue(q).await
-        {
-            tracing::warn!(queue = %qc.name, error = %e, "import: shaping queue restore failed");
+        if let Some(q) = queue_from_config(&qc) {
+            shaping
+                .add_queue(q)
+                .await
+                .map_err(|e| apply_fail(&format!("shaping queue {} restore", qc.name), e))?;
         }
     }
     for rc in &config.rate_limits {
@@ -1778,57 +1865,60 @@ pub(crate) async fn apply_firewall_config(
         };
         let mut rc = rc.clone();
         rc.interface = iface_after;
-        if let Some(r) = rate_limit_from_config(&rc)
-            && let Err(e) = shaping.add_rate_limit(r).await
-        {
-            tracing::warn!(error = %e, "import: rate limit restore failed");
+        if let Some(r) = rate_limit_from_config(&rc) {
+            shaping
+                .add_rate_limit(r)
+                .await
+                .map_err(|e| apply_fail("rate limit restore", e))?;
         }
     }
-    if let Err(e) = shaping.apply_queues().await {
-        tracing::warn!(error = %e, "import: shaping queues apply failed");
-    }
-    if let Err(e) = shaping.apply_rate_limits().await {
-        tracing::warn!(error = %e, "import: rate limits apply failed");
-    }
+    shaping
+        .apply_queues()
+        .await
+        .map_err(|e| apply_fail("shaping queues apply", e))?;
+    shaping
+        .apply_rate_limits()
+        .await
+        .map_err(|e| apply_fail("rate limits apply", e))?;
 
     // TLS: SNI rules + JA3 blocklist
     let tls_engine = aifw_core::tls::TlsEngine::new(state.pool.clone(), state.pf.clone());
-    if let Err(e) = tls_engine.migrate().await {
-        tracing::warn!(error = %e, "import: tls migrate failed");
-    }
+    tls_engine
+        .migrate()
+        .await
+        .map_err(|e| apply_fail("tls migrate", e))?;
     for table in ["sni_rules", "ja3_blocklist"] {
-        if let Err(e) = sqlx::query(sqlx::AssertSqlSafe(format!("DELETE FROM {table}")))
+        sqlx::query(sqlx::AssertSqlSafe(format!("DELETE FROM {table}")))
             .execute(&state.pool)
             .await
-        {
-            tracing::warn!(table, error = %e, "import: DELETE failed before restore");
-        }
+            .map_err(|e| apply_fail(&format!("clearing {table}"), e))?;
     }
     for sc in &config.tls.sni_rules {
-        if let Some(sni) = sni_rule_from_config(sc)
-            && let Err(e) = tls_engine.add_sni_rule(sni).await
-        {
-            tracing::warn!(pattern = %sc.pattern, error = %e, "import: sni rule restore failed");
+        if let Some(sni) = sni_rule_from_config(sc) {
+            tls_engine
+                .add_sni_rule(sni)
+                .await
+                .map_err(|e| apply_fail(&format!("sni rule {} restore", sc.pattern), e))?;
         }
     }
     for hash in &config.tls.blocked_ja3 {
-        if let Err(e) = tls_engine.add_ja3_block(hash, "restored from backup").await {
-            tracing::warn!(hash = %hash, error = %e, "import: ja3 block restore failed");
-        }
+        tls_engine
+            .add_ja3_block(hash, "restored from backup")
+            .await
+            .map_err(|e| apply_fail(&format!("ja3 block {hash} restore"), e))?;
     }
 
     // HA: CARP VIPs + pfsync + cluster nodes
     let ha_engine = aifw_core::ha::ClusterEngine::new(state.pool.clone(), state.pf.clone());
-    if let Err(e) = ha_engine.migrate().await {
-        tracing::warn!(error = %e, "import: ha migrate failed");
-    }
+    ha_engine
+        .migrate()
+        .await
+        .map_err(|e| apply_fail("ha migrate", e))?;
     for table in ["carp_vips", "pfsync_config", "cluster_nodes"] {
-        if let Err(e) = sqlx::query(sqlx::AssertSqlSafe(format!("DELETE FROM {table}")))
+        sqlx::query(sqlx::AssertSqlSafe(format!("DELETE FROM {table}")))
             .execute(&state.pool)
             .await
-        {
-            tracing::warn!(table, error = %e, "import: DELETE failed before restore");
-        }
+            .map_err(|e| apply_fail(&format!("clearing {table}"), e))?;
     }
     for vc in &config.ha.carp_vips {
         let Some(mapped) = map_iface(&vc.interface, iface_map) else {
@@ -1836,10 +1926,11 @@ pub(crate) async fn apply_firewall_config(
         };
         let mut vc = vc.clone();
         vc.interface = mapped;
-        if let Some(vip) = carp_vip_from_config(&vc)
-            && let Err(e) = ha_engine.add_carp_vip(vip).await
-        {
-            tracing::warn!(vip = %vc.virtual_ip, error = %e, "import: carp vip restore failed");
+        if let Some(vip) = carp_vip_from_config(&vc) {
+            ha_engine
+                .add_carp_vip(vip)
+                .await
+                .map_err(|e| apply_fail(&format!("carp vip {} restore", vc.virtual_ip), e))?;
         }
     }
     if let Some(pc) = &config.ha.pfsync
@@ -1847,21 +1938,26 @@ pub(crate) async fn apply_firewall_config(
     {
         let mut pc = pc.clone();
         pc.sync_interface = mapped_sync;
-        if let Some(pfsync) = pfsync_from_config(&pc)
-            && let Err(e) = ha_engine.set_pfsync(pfsync).await
-        {
-            tracing::warn!(error = %e, "import: pfsync restore failed");
+        if let Some(pfsync) = pfsync_from_config(&pc) {
+            ha_engine
+                .set_pfsync(pfsync)
+                .await
+                .map_err(|e| apply_fail("pfsync restore", e))?;
         }
     }
     for nc in &config.ha.nodes {
-        if let Some(node) = cluster_node_from_config(nc)
-            && let Err(e) = ha_engine.add_node(node).await
-        {
-            tracing::warn!(error = %e, "import: cluster node restore failed");
+        if let Some(node) = cluster_node_from_config(nc) {
+            ha_engine
+                .add_node(node)
+                .await
+                .map_err(|e| apply_fail("cluster node restore", e))?;
         }
     }
 
-    // pf state-table tuning
+    // pf state-table tuning. Best-effort: this shells out to system tooling
+    // absent on dev hosts, the same setting is reapplied at every boot
+    // (`pf_tuning::apply_on_boot`, also warn-only), and a missed tuning value
+    // degrades capacity rather than firewall policy.
     for t in &config.tuning {
         if t.enabled
             && t.key == "pf.max_states"
@@ -1873,27 +1969,42 @@ pub(crate) async fn apply_firewall_config(
     }
 
     // DHCP: subnets, reservations, global/DDNS/HA config
-    apply_dhcp_section(state, &config.dhcp).await;
+    apply_dhcp_section(state, &config.dhcp).await?;
 
-    if let Ok(vpn_rules) = state.vpn_engine.collect_vpn_rules().await {
-        state.rule_engine.set_extra_rules(vpn_rules).await;
-    }
-    if let Err(e) = state.rule_engine.apply_rules().await {
-        tracing::warn!(error = %e, "import: firewall rules apply failed");
-    }
-    if let Err(e) = state.nat_engine.apply_rules().await {
-        tracing::warn!(error = %e, "import: nat rules apply failed");
-    }
-    if let Err(e) = state.geoip_engine.apply_rules().await {
-        tracing::warn!(error = %e, "import: geoip rules apply failed");
-    }
+    // Final data-plane applies — a failure here means the kernel does NOT
+    // match the restored DB, so it must not report success (#535).
+    let vpn_rules = state
+        .vpn_engine
+        .collect_vpn_rules()
+        .await
+        .map_err(|e| apply_fail("collecting vpn rules", e))?;
+    state.rule_engine.set_extra_rules(vpn_rules).await;
+    state
+        .rule_engine
+        .apply_rules()
+        .await
+        .map_err(|e| apply_fail("firewall rules apply", e))?;
+    state
+        .nat_engine
+        .apply_rules()
+        .await
+        .map_err(|e| apply_fail("nat rules apply", e))?;
+    state
+        .geoip_engine
+        .apply_rules()
+        .await
+        .map_err(|e| apply_fail("geoip rules apply", e))?;
 
     Ok(())
 }
 
-async fn apply_dhcp_section(state: &AppState, dhcp: &aifw_core::config::DhcpSection) {
+async fn apply_dhcp_section(
+    state: &AppState,
+    dhcp: &aifw_core::config::DhcpSection,
+) -> Result<(), StatusCode> {
     // Wipe + re-insert for a clean restore. `auto_apply` at the end regenerates
-    // the rDHCP TOML config and restarts the service.
+    // the rDHCP TOML config and restarts the service. DB mutations are
+    // required steps (#535); only the service regeneration is best-effort.
     for table in [
         "dhcp_subnets",
         "dhcp_reservations",
@@ -1901,12 +2012,10 @@ async fn apply_dhcp_section(state: &AppState, dhcp: &aifw_core::config::DhcpSect
         "dhcp_ddns_config",
         "dhcp_ha_config",
     ] {
-        if let Err(e) = sqlx::query(sqlx::AssertSqlSafe(format!("DELETE FROM {table}")))
+        sqlx::query(sqlx::AssertSqlSafe(format!("DELETE FROM {table}")))
             .execute(&state.pool)
             .await
-        {
-            tracing::warn!(table, error = %e, "dhcp restore: DELETE failed before restore");
-        }
+            .map_err(|e| apply_fail(&format!("clearing {table}"), e))?;
     }
 
     // --- global ----------------------------------------------
@@ -1956,15 +2065,12 @@ async fn apply_dhcp_section(state: &AppState, dhcp: &aifw_core::config::DhcpSect
         ),
         ("relay_rate_limit_pps", g.relay_rate_limit_pps.to_string()),
     ] {
-        if let Err(e) =
-            sqlx::query("INSERT OR REPLACE INTO dhcp_config (key, value) VALUES (?1, ?2)")
-                .bind(k)
-                .bind(v)
-                .execute(&state.pool)
-                .await
-        {
-            tracing::warn!(key = k, error = %e, "dhcp restore: config insert failed");
-        }
+        sqlx::query("INSERT OR REPLACE INTO dhcp_config (key, value) VALUES (?1, ?2)")
+            .bind(k)
+            .bind(v)
+            .execute(&state.pool)
+            .await
+            .map_err(|e| apply_fail(&format!("dhcp config {k} restore"), e))?;
     }
 
     // --- subnets ---------------------------------------------
@@ -2011,7 +2117,7 @@ async fn apply_dhcp_section(state: &AppState, dhcp: &aifw_core::config::DhcpSect
         }
         let options_json =
             serde_json::to_string(&safe_options).unwrap_or_else(|_| "[]".to_string());
-        if let Err(e) = sqlx::query(
+        sqlx::query(
             "INSERT INTO dhcp_subnets \
              (id, network, pool_start, pool_end, gateway, dns_servers, domain_name, \
               lease_time, max_lease_time, renewal_time, rebinding_time, preferred_time, \
@@ -2041,23 +2147,19 @@ async fn apply_dhcp_section(state: &AppState, dhcp: &aifw_core::config::DhcpSect
         .bind(&s.created_at)
         .execute(&state.pool)
         .await
-        {
-            tracing::warn!(network = %s.network, error = %e, "dhcp restore: subnet insert failed");
-        }
+        .map_err(|e| apply_fail(&format!("dhcp subnet {} restore", s.network), e))?;
     }
 
     // --- reservations ----------------------------------------
     for r in &dhcp.reservations {
-        if let Err(e) = sqlx::query(
+        sqlx::query(
             "INSERT INTO dhcp_reservations (id, subnet_id, mac_address, ip_address, hostname, client_id, description, created_at) \
              VALUES (?1,?2,?3,?4,?5,?6,?7,?8)"
         )
         .bind(&r.id).bind(&r.subnet_id).bind(&r.mac_address).bind(&r.ip_address)
         .bind(&r.hostname).bind(&r.client_id).bind(&r.description).bind(&r.created_at)
         .execute(&state.pool).await
-        {
-            tracing::warn!(ip = %r.ip_address, error = %e, "dhcp restore: reservation insert failed");
-        }
+        .map_err(|e| apply_fail(&format!("dhcp reservation {} restore", r.ip_address), e))?;
     }
 
     // --- DDNS ------------------------------------------------
@@ -2080,15 +2182,12 @@ async fn apply_dhcp_section(state: &AppState, dhcp: &aifw_core::config::DhcpSect
         ("tsig_secret", d.tsig_secret.clone()),
         ("ttl", d.ttl.to_string()),
     ] {
-        if let Err(e) =
-            sqlx::query("INSERT OR REPLACE INTO dhcp_ddns_config (key, value) VALUES (?1, ?2)")
-                .bind(k)
-                .bind(v)
-                .execute(&state.pool)
-                .await
-        {
-            tracing::warn!(key = k, error = %e, "dhcp restore: ddns config insert failed");
-        }
+        sqlx::query("INSERT OR REPLACE INTO dhcp_ddns_config (key, value) VALUES (?1, ?2)")
+            .bind(k)
+            .bind(v)
+            .execute(&state.pool)
+            .await
+            .map_err(|e| apply_fail(&format!("dhcp ddns config {k} restore"), e))?;
     }
 
     // --- DHCP HA ---------------------------------------------
@@ -2120,19 +2219,19 @@ async fn apply_dhcp_section(state: &AppState, dhcp: &aifw_core::config::DhcpSect
         ("tls_key", h.tls_key.clone().unwrap_or_default()),
         ("tls_ca", h.tls_ca.clone().unwrap_or_default()),
     ] {
-        if let Err(e) =
-            sqlx::query("INSERT OR REPLACE INTO dhcp_ha_config (key, value) VALUES (?1, ?2)")
-                .bind(k)
-                .bind(v)
-                .execute(&state.pool)
-                .await
-        {
-            tracing::warn!(key = k, error = %e, "dhcp restore: ha config insert failed");
-        }
+        sqlx::query("INSERT OR REPLACE INTO dhcp_ha_config (key, value) VALUES (?1, ?2)")
+            .bind(k)
+            .bind(v)
+            .execute(&state.pool)
+            .await
+            .map_err(|e| apply_fail(&format!("dhcp ha config {k} restore"), e))?;
     }
 
-    // Regenerate rDHCP TOML + restart service so the restored config takes effect.
+    // Regenerate rDHCP TOML + restart service so the restored config takes
+    // effect. Best-effort: the companion service may be absent (dev hosts);
+    // the DB rows above are authoritative and reapplied at boot.
     crate::dhcp::auto_apply(state).await;
+    Ok(())
 }
 
 fn rule_from_config(rc: &aifw_core::config::RuleConfig) -> Option<aifw_common::Rule> {

--- a/aifw-api/src/opnsense/importer.rs
+++ b/aifw-api/src/opnsense/importer.rs
@@ -618,7 +618,12 @@ pub async fn import_opnsense(
         if let Some(v) = pre_import_version {
             // Snapshot path fully covers rules/NAT/aliases/routes; this is
             // the cleanest restore.
-            let _ = restore_pre_import(&state, v).await;
+            if let Err(e) = restore_pre_import(&state, v).await {
+                tracing::error!(
+                    error = %e,
+                    "OPNsense import ROLLBACK FAILED — system may be partially configured"
+                );
+            }
         } else {
             // Fallback: surgical cleanup of what we know we inserted.
             tracker.cleanup(&state).await;

--- a/aifw-api/src/routes/config_io.rs
+++ b/aifw-api/src/routes/config_io.rs
@@ -55,7 +55,7 @@ pub async fn import_config(
     let ipsec_n = config.vpn.ipsec.len();
     let dns_n = config.system.dns_servers.len();
 
-    crate::backup::apply_firewall_config(&state, &config, &iface_map).await?;
+    crate::backup::apply_firewall_config_or_rollback(&state, &config, &iface_map).await?;
 
     let _ = sqlx::query("DELETE FROM static_routes")
         .execute(&state.pool)

--- a/aifw-api/src/routes/schedules.rs
+++ b/aifw-api/src/routes/schedules.rs
@@ -40,6 +40,19 @@ pub struct CreateScheduleRequest {
     pub enabled: Option<bool>,
 }
 
+/// Reload the pf anchor after a schedule mutation so the change is enforced
+/// immediately (#537) — apply_rules re-evaluates schedule windows.
+async fn reapply_rules(state: &AppState) -> Result<(), StatusCode> {
+    match state.vpn_engine.collect_vpn_rules().await {
+        Ok(extras) => state.rule_engine.set_extra_rules(extras).await,
+        Err(e) => tracing::warn!(error = %e, "schedule change: collecting vpn rules failed"),
+    }
+    state.rule_engine.apply_rules().await.map_err(|e| {
+        tracing::error!(error = %e, "schedule change: rules reapply failed");
+        internal()
+    })
+}
+
 pub async fn list_schedules(
     State(state): State<AppState>,
 ) -> Result<Json<ApiResponse<Vec<Schedule>>>, StatusCode> {
@@ -154,6 +167,7 @@ pub async fn update_schedule(
     if result.rows_affected() == 0 {
         return Err(StatusCode::NOT_FOUND);
     }
+    reapply_rules(&state).await?;
     let now = chrono::Utc::now().to_rfc3339();
     Ok(Json(ApiResponse {
         data: Schedule {
@@ -180,11 +194,16 @@ pub async fn delete_schedule(
     if result.rows_affected() == 0 {
         return Err(StatusCode::NOT_FOUND);
     }
-    // Unlink from rules
-    let _ = sqlx::query("UPDATE rules SET schedule_id = NULL WHERE schedule_id = ?1")
+    // Unlink from rules. On failure the dangling reference fails open in the
+    // engine (rule stays active) — warn so the operator can see why.
+    if let Err(e) = sqlx::query("UPDATE rules SET schedule_id = NULL WHERE schedule_id = ?1")
         .bind(&id)
         .execute(&state.pool)
-        .await;
+        .await
+    {
+        tracing::warn!(schedule_id = %id, error = %e, "schedule delete: rules unlink failed");
+    }
+    reapply_rules(&state).await?;
     Ok(Json(MessageResponse {
         message: format!("Schedule {id} deleted"),
     }))

--- a/aifw-api/src/routes/vpn.rs
+++ b/aifw-api/src/routes/vpn.rs
@@ -45,8 +45,11 @@ pub async fn create_wg_tunnel(
         .collect();
     let next_idx = (0u32..).find(|i| !used_indices.contains(i)).unwrap_or(0);
     let iface_name = format!("wg{next_idx}");
-    let mut tunnel = WgTunnel::new(req.name, Interface(iface_name), req.listen_port, address);
+    let mut tunnel = WgTunnel::new(req.name, Interface(iface_name), req.listen_port, address)
+        .map_err(|_| internal())?;
     if let Some(ref pk) = req.private_key {
+        // Re-derive the public key so the stored pair is always related (#541)
+        tunnel.public_key = aifw_common::vpn::derive_wg_pubkey(pk).map_err(|_| bad_request())?;
         tunnel.private_key = pk.clone();
     }
     tunnel.dns = req.dns;
@@ -240,7 +243,7 @@ pub async fn create_wg_peer(
 
     let auto_gen = req.auto_generate_key.unwrap_or(false);
     let mut peer = if auto_gen {
-        WgPeer::new_with_generated_key(tid, req.name.unwrap_or_default())
+        WgPeer::new_with_generated_key(tid, req.name.unwrap_or_default()).map_err(|_| internal())?
     } else {
         let pk = req.public_key.unwrap_or_default();
         if pk.is_empty() {

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -2145,4 +2145,54 @@ mod tests {
             .await;
         resp.assert_status(StatusCode::BAD_REQUEST);
     }
+
+    // ============================================================
+    // Backup/restore strict-apply contract (#535)
+    // ============================================================
+
+    fn plain_auth_settings() -> AuthSettings {
+        AuthSettings {
+            jwt_secret: "test-secret-key".to_string(),
+            access_token_expiry_mins: 60,
+            refresh_token_expiry_days: 7,
+            require_totp: false,
+            require_totp_for_oauth: false,
+            auto_create_oauth_users: true,
+            max_login_attempts: 5,
+            lockout_duration_secs: 300,
+            allow_registration: true,
+            password_min_length: 8,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_restore_roundtrip_succeeds() {
+        let _ = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::ERROR)
+            .try_init();
+        let state = crate::create_app_state_in_memory(plain_auth_settings())
+            .await
+            .unwrap();
+        let config = crate::backup::build_current_config(&state).await.unwrap();
+        crate::backup::apply_firewall_config(&state, &config, &Default::default())
+            .await
+            .expect("restoring the current config must succeed");
+    }
+
+    #[tokio::test]
+    async fn test_restore_fails_instead_of_partial_apply() {
+        // A required step failing (here: clearing a table that no longer
+        // exists) must abort the restore with an error, never return Ok after
+        // a partial apply (#535).
+        let state = crate::create_app_state_in_memory(plain_auth_settings())
+            .await
+            .unwrap();
+        let config = crate::backup::build_current_config(&state).await.unwrap();
+        sqlx::query("DROP TABLE nat_rules")
+            .execute(&state.pool)
+            .await
+            .unwrap();
+        let res = crate::backup::apply_firewall_config(&state, &config, &Default::default()).await;
+        assert!(res.is_err(), "partial apply must not report success");
+    }
 }

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -687,7 +687,7 @@ pub async fn vpn_wg_add(
         Interface(interface.to_string()),
         port,
         Address::parse(address)?,
-    );
+    )?;
     let tunnel = engine.add_wg_tunnel(tunnel).await?;
     println!("Added WireGuard tunnel {}", tunnel.id);
     println!("  Interface:  {}", tunnel.interface);

--- a/aifw-common/Cargo.toml
+++ b/aifw-common/Cargo.toml
@@ -13,6 +13,8 @@ thiserror = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true, features = ["sync", "net", "rt", "macros"] }
 url = { workspace = true }
+x25519-dalek = { workspace = true }
+getrandom = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true }

--- a/aifw-common/src/error.rs
+++ b/aifw-common/src/error.rs
@@ -35,6 +35,10 @@ pub enum AifwError {
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 
+    /// A cryptographic operation failed (key generation, derivation)
+    #[error("crypto error: {0}")]
+    Crypto(String),
+
     /// Catch-all for errors that fit no other variant
     #[error("{0}")]
     Other(String),

--- a/aifw-common/src/lib.rs
+++ b/aifw-common/src/lib.rs
@@ -37,6 +37,7 @@ pub mod permission;
 pub mod ratelimit;
 /// Core firewall rule model and pf rule rendering
 pub mod rule;
+pub mod schedule;
 pub mod schemas;
 #[cfg(unix)]
 pub mod single_instance;

--- a/aifw-common/src/schedule.rs
+++ b/aifw-common/src/schedule.rs
@@ -1,0 +1,127 @@
+//! Schedule window evaluation (#537). Pure time logic the rule engine uses
+//! to decide whether a rule referencing a schedule is inside its active
+//! window. Persistence lives in `aifw-core::db`; HTTP CRUD and storage-format
+//! validation live in `aifw-api` (`routes::schedules`).
+//!
+//! Evaluation runs against the appliance's **local time** (callers pass
+//! `Local::now().naive_local()`), so windows follow the configured system
+//! timezone including DST shifts.
+
+use chrono::{Datelike, NaiveDateTime, Timelike, Weekday};
+use std::collections::HashMap;
+
+/// A parsed schedule: a day-of-week set plus minute-of-day ranges.
+///
+/// Storage format (from the `schedules` table):
+/// - `time_ranges`: `"08:00-17:00"` or comma-separated `"08:00-12:00,13:00-17:00"`
+/// - `days_of_week`: `"mon,tue,wed,thu,fri"`
+///
+/// Range semantics:
+/// - `start < end` — active on a listed day within `[start, end)`
+/// - `start > end` — overnight window: `[start, midnight)` on a listed day,
+///   continuing through `[midnight, end)` of the following day (the day check
+///   applies to the day the window *started*)
+/// - `start == end` — full-day window on listed days
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScheduleSpec {
+    /// A disabled schedule never constrains a rule (rule behaves unscheduled)
+    pub enabled: bool,
+    /// Active days, indexed by `Weekday::num_days_from_monday()`
+    days: [bool; 7],
+    /// Minute-of-day ranges
+    ranges: Vec<(u16, u16)>,
+}
+
+impl ScheduleSpec {
+    /// Parse the stored representation. Returns `None` if either field is
+    /// malformed (callers treat unparseable schedules as non-constraining
+    /// and log, mirroring the dangling-reference case).
+    pub fn parse(time_ranges: &str, days_of_week: &str, enabled: bool) -> Option<Self> {
+        let mut days = [false; 7];
+        for d in days_of_week.split(',') {
+            let idx = match d.trim() {
+                "mon" => 0,
+                "tue" => 1,
+                "wed" => 2,
+                "thu" => 3,
+                "fri" => 4,
+                "sat" => 5,
+                "sun" => 6,
+                "" => continue,
+                _ => return None,
+            };
+            days[idx] = true;
+        }
+        let mut ranges = Vec::new();
+        for range in time_ranges.split(',') {
+            let range = range.trim();
+            if range.is_empty() {
+                continue;
+            }
+            let (start, end) = range.split_once('-')?;
+            ranges.push((parse_minute(start)?, parse_minute(end)?));
+        }
+        Some(Self {
+            enabled,
+            days,
+            ranges,
+        })
+    }
+
+    fn day_on(&self, day: Weekday) -> bool {
+        self.days[day.num_days_from_monday() as usize]
+    }
+
+    /// Whether the schedule's window covers the given local time
+    pub fn is_active_at(&self, now: NaiveDateTime) -> bool {
+        let day = now.weekday();
+        let minute = (now.hour() * 60 + now.minute()) as u16;
+        for &(start, end) in &self.ranges {
+            let active = if start < end {
+                self.day_on(day) && minute >= start && minute < end
+            } else if start > end {
+                // Overnight wrap: the pre-midnight half belongs to the listed
+                // day; the post-midnight half to the day after it.
+                (self.day_on(day) && minute >= start) || (self.day_on(day.pred()) && minute < end)
+            } else {
+                self.day_on(day)
+            };
+            if active {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+fn parse_minute(hm: &str) -> Option<u16> {
+    let (h, m) = hm.trim().split_once(':')?;
+    let h: u16 = h.parse().ok()?;
+    let m: u16 = m.parse().ok()?;
+    if h > 23 || m > 59 {
+        return None;
+    }
+    Some(h * 60 + m)
+}
+
+/// Whether a rule with the given optional schedule reference is currently
+/// inside its active window.
+///
+/// Missing or unparseable schedule references **fail open** (rule stays
+/// loaded, identical to an unscheduled rule): rules can be `block` as well as
+/// `pass`, so silently unloading on a dangling reference could open the
+/// firewall rather than close it. Callers log dangling references.
+pub fn rule_schedule_active(
+    schedule_id: Option<&str>,
+    schedules: &HashMap<String, ScheduleSpec>,
+    now: NaiveDateTime,
+) -> bool {
+    match schedule_id {
+        None => true,
+        Some(id) => match schedules.get(id) {
+            None => true,
+            Some(s) if !s.enabled => true,
+            Some(s) => s.is_active_at(now),
+        },
+    }
+}

--- a/aifw-common/src/tests.rs
+++ b/aifw-common/src/tests.rs
@@ -5,6 +5,7 @@ mod tests {
     use crate::nat::*;
     use crate::ratelimit::*;
     use crate::rule::*;
+    use crate::schedule::{ScheduleSpec, rule_schedule_active};
     use crate::tls::*;
     use crate::types::*;
     use crate::vpn::*;
@@ -551,7 +552,8 @@ mod tests {
             Interface("wg0".to_string()),
             51820,
             Address::Network(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 24),
-        );
+        )
+        .unwrap();
         assert_eq!(tunnel.name, "wg0-tunnel");
         assert_eq!(tunnel.listen_port, 51820);
         assert!(!tunnel.private_key.is_empty());
@@ -567,7 +569,8 @@ mod tests {
             Interface("wg0".to_string()),
             51820,
             Address::Network(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 24),
-        );
+        )
+        .unwrap();
         let rules = tunnel.to_pf_rules();
         assert_eq!(rules.len(), 2);
         assert!(rules[0].contains("proto udp"));
@@ -633,15 +636,148 @@ mod tests {
         assert!(IpsecProtocol::parse("bogus").is_err());
     }
 
+    // --- Schedule window tests (#537) ---
+    // All evaluations use an injected NaiveDateTime — no wall clock.
+    // 2026-07-15 is a Wednesday.
+
+    fn at(day: u32, h: u32, m: u32) -> chrono::NaiveDateTime {
+        chrono::NaiveDate::from_ymd_opt(2026, 7, day)
+            .unwrap()
+            .and_hms_opt(h, m, 0)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_schedule_business_hours() {
+        let s = ScheduleSpec::parse("08:00-17:00", "mon,tue,wed,thu,fri", true).unwrap();
+        assert!(s.is_active_at(at(15, 9, 0))); // Wed 09:00
+        assert!(s.is_active_at(at(15, 8, 0))); // start inclusive
+        assert!(!s.is_active_at(at(15, 7, 59)));
+        assert!(!s.is_active_at(at(15, 17, 0))); // end exclusive
+        assert!(!s.is_active_at(at(18, 9, 0))); // Saturday
+        assert!(!s.is_active_at(at(19, 9, 0))); // Sunday
+    }
+
+    #[test]
+    fn test_schedule_multiple_ranges() {
+        let s = ScheduleSpec::parse("08:00-12:00,13:00-17:00", "wed", true).unwrap();
+        assert!(s.is_active_at(at(15, 11, 59)));
+        assert!(!s.is_active_at(at(15, 12, 30))); // lunch gap
+        assert!(s.is_active_at(at(15, 13, 0)));
+        assert!(!s.is_active_at(at(16, 11, 0))); // Thursday
+    }
+
+    #[test]
+    fn test_schedule_overnight_wrap() {
+        // Window belongs to the day it starts: Wed 22:00 → Thu 06:00
+        let s = ScheduleSpec::parse("22:00-06:00", "wed", true).unwrap();
+        assert!(s.is_active_at(at(15, 23, 30))); // Wed night
+        assert!(s.is_active_at(at(16, 5, 59))); // Thu early morning
+        assert!(!s.is_active_at(at(16, 6, 0))); // Thu past end
+        assert!(!s.is_active_at(at(15, 5, 0))); // Wed morning is Tue's window
+        assert!(!s.is_active_at(at(16, 23, 0))); // Thu night not listed
+    }
+
+    #[test]
+    fn test_schedule_full_day_range() {
+        // start == end means a 24h window on listed days
+        let s = ScheduleSpec::parse("00:00-00:00", "sat,sun", true).unwrap();
+        assert!(s.is_active_at(at(18, 0, 0)));
+        assert!(s.is_active_at(at(19, 23, 59)));
+        assert!(!s.is_active_at(at(15, 12, 0))); // Wednesday
+    }
+
+    #[test]
+    fn test_schedule_parse_rejects_malformed() {
+        assert!(ScheduleSpec::parse("25:00-26:00", "mon", true).is_none());
+        assert!(ScheduleSpec::parse("08:00-17:60", "mon", true).is_none());
+        assert!(ScheduleSpec::parse("08:00", "mon", true).is_none());
+        assert!(ScheduleSpec::parse("08:00-17:00", "monday", true).is_none());
+    }
+
+    #[test]
+    fn test_rule_schedule_active_fail_open() {
+        use std::collections::HashMap;
+        let mut schedules = HashMap::new();
+        schedules.insert(
+            "off-now".to_string(),
+            ScheduleSpec::parse("08:00-09:00", "mon", true).unwrap(),
+        );
+        schedules.insert(
+            "disabled".to_string(),
+            ScheduleSpec::parse("08:00-09:00", "mon", false).unwrap(),
+        );
+        let now = at(15, 12, 0); // Wed noon — outside every window above
+
+        // No schedule → active
+        assert!(rule_schedule_active(None, &schedules, now));
+        // Dangling reference → fail open, stays active
+        assert!(rule_schedule_active(Some("deleted"), &schedules, now));
+        // Disabled schedule doesn't constrain
+        assert!(rule_schedule_active(Some("disabled"), &schedules, now));
+        // Enabled schedule outside its window → inactive
+        assert!(!rule_schedule_active(Some("off-now"), &schedules, now));
+    }
+
     #[test]
     fn test_wg_key_generation() {
-        let (priv1, pub1) = generate_wg_keypair();
-        let (priv2, pub2) = generate_wg_keypair();
-        // Keys should be non-empty and different each time
-        assert!(!priv1.is_empty());
-        assert!(!pub1.is_empty());
+        let (priv1, pub1) = generate_wg_keypair().unwrap();
+        let (priv2, pub2) = generate_wg_keypair().unwrap();
+        // Standard base64 of 32 bytes: 44 chars including one '=' pad
+        assert_eq!(priv1.len(), 44);
+        assert_eq!(pub1.len(), 44);
         assert_ne!(priv1, priv2);
         assert_ne!(pub1, pub2);
+        assert_ne!(priv1, pub1);
+        // The public key must derive from the private key (#541)
+        assert_eq!(derive_wg_pubkey(&priv1).unwrap(), pub1);
+        assert_eq!(derive_wg_pubkey(&priv2).unwrap(), pub2);
+    }
+
+    #[test]
+    fn test_wg_keypair_matches_wireguard_tools() {
+        // Cross-check in-process derivation against `wg pubkey` when
+        // wireguard-tools is installed (FreeBSD CI / appliance); silently
+        // skipped elsewhere.
+        let Ok(probe) = std::process::Command::new("wg").arg("--version").output() else {
+            return;
+        };
+        if !probe.status.success() {
+            return;
+        }
+        let (privkey, pubkey) = generate_wg_keypair().unwrap();
+        use std::io::Write;
+        let mut child = std::process::Command::new("wg")
+            .arg("pubkey")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        child
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(privkey.as_bytes())
+            .unwrap();
+        let out = child.wait_with_output().unwrap();
+        assert!(out.status.success());
+        assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), pubkey);
+    }
+
+    #[test]
+    fn test_wg_psk_generation() {
+        let a = generate_wg_psk().unwrap();
+        let b = generate_wg_psk().unwrap();
+        assert_eq!(a.len(), 44);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_derive_wg_pubkey_rejects_malformed_input() {
+        assert!(derive_wg_pubkey("not base64 !!!").is_err());
+        assert!(derive_wg_pubkey("").is_err());
+        // Valid base64 but wrong length (16 bytes)
+        assert!(derive_wg_pubkey("AAAAAAAAAAAAAAAAAAAAAA==").is_err());
     }
 
     // --- Geo-IP tests ---

--- a/aifw-common/src/vpn.rs
+++ b/aifw-common/src/vpn.rs
@@ -44,12 +44,18 @@ pub struct WgTunnel {
 }
 
 impl WgTunnel {
-    /// Create a tunnel with a freshly generated keypair (via `generate_wg_keypair`,
-    /// which shells out to `wg` when available), status `Down`, and no DNS/MTU overrides
-    pub fn new(name: String, interface: Interface, listen_port: u16, address: Address) -> Self {
-        let (private_key, public_key) = generate_wg_keypair();
+    /// Create a tunnel with a freshly generated in-process X25519 keypair,
+    /// status `Down`, and no DNS/MTU overrides. Fails if the OS CSPRNG is
+    /// unavailable — never constructs a tunnel with an invalid keypair.
+    pub fn new(
+        name: String,
+        interface: Interface,
+        listen_port: u16,
+        address: Address,
+    ) -> crate::Result<Self> {
+        let (private_key, public_key) = generate_wg_keypair()?;
         let now = Utc::now();
-        Self {
+        Ok(Self {
             id: Uuid::new_v4(),
             name,
             interface,
@@ -64,7 +70,7 @@ impl WgTunnel {
             status: VpnStatus::Down,
             created_at: now,
             updated_at: now,
-        }
+        })
     }
 
     /// Generate ifconfig commands to create the WireGuard interface
@@ -181,12 +187,13 @@ impl WgPeer {
         }
     }
 
-    /// Create a peer with an auto-generated keypair (private key stored for config export).
-    pub fn new_with_generated_key(tunnel_id: Uuid, name: String) -> Self {
-        let (private_key, public_key) = generate_wg_keypair();
+    /// Create a peer with an auto-generated keypair (private key stored for
+    /// config export). Fails if the OS CSPRNG is unavailable.
+    pub fn new_with_generated_key(tunnel_id: Uuid, name: String) -> crate::Result<Self> {
+        let (private_key, public_key) = generate_wg_keypair()?;
         let mut peer = Self::new(tunnel_id, name, public_key);
         peer.client_private_key = Some(private_key);
-        peer
+        Ok(peer)
     }
 
     /// Generate a WireGuard client .conf file for this peer.
@@ -586,75 +593,51 @@ impl std::fmt::Display for VpnType {
 }
 
 // ============================================================
-// Key generation helpers (mock for non-FreeBSD)
+// Key generation (in-process X25519, no `wg` subprocess)
 // ============================================================
 
-/// Generate a WireGuard keypair (32 random bytes each, base64 encoded).
-/// On FreeBSD with wireguard-tools, uses `wg genkey` + `wg pubkey` for real Curve25519 keys.
-/// Elsewhere, generates random 32-byte keys (valid format but not cryptographically derived).
-pub fn generate_wg_keypair() -> (String, String) {
-    // Try wg genkey first (FreeBSD with wireguard-tools installed)
-    if let Ok(output) = std::process::Command::new("wg").arg("genkey").output()
-        && output.status.success()
-    {
-        let privkey = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if privkey.len() >= 40 {
-            // Derive public key from private key
-            if let Ok(pub_output) = std::process::Command::new("wg")
-                .arg("pubkey")
-                .stdin(std::process::Stdio::piped())
-                .stdout(std::process::Stdio::piped())
-                .spawn()
-                .and_then(|mut child| {
-                    use std::io::Write;
-                    if let Some(ref mut stdin) = child.stdin {
-                        let _ = stdin.write_all(privkey.as_bytes());
-                    }
-                    child.wait_with_output()
-                })
-                && pub_output.status.success()
-            {
-                let pubkey = String::from_utf8_lossy(&pub_output.stdout)
-                    .trim()
-                    .to_string();
-                if pubkey.len() >= 40 {
-                    return (privkey, pubkey);
-                }
-            }
-        }
-    }
-
-    // Fallback: generate 32 random bytes for each key
-    let mut private_bytes = [0u8; 32];
-    let mut public_bytes = [0u8; 32];
-    let id1 = Uuid::new_v4();
-    let id2 = Uuid::new_v4();
-    private_bytes[..16].copy_from_slice(id1.as_bytes());
-    private_bytes[16..].copy_from_slice(id2.as_bytes());
-    let id3 = Uuid::new_v4();
-    let id4 = Uuid::new_v4();
-    public_bytes[..16].copy_from_slice(id3.as_bytes());
-    public_bytes[16..].copy_from_slice(id4.as_bytes());
-    (base64_encode(&private_bytes), base64_encode(&public_bytes))
+/// Generate a WireGuard keypair: 32 CSPRNG bytes clamped per the Curve25519
+/// convention (matching `wg genkey`), public key derived in-process via
+/// X25519. Fails closed if the OS CSPRNG is unavailable — never returns a
+/// pair whose halves aren't cryptographically related (#541).
+pub fn generate_wg_keypair() -> crate::Result<(String, String)> {
+    let mut secret_bytes = [0u8; 32];
+    getrandom::fill(&mut secret_bytes)
+        .map_err(|e| crate::AifwError::Crypto(format!("OS CSPRNG unavailable: {e}")))?;
+    // Clamp so the stored private key is byte-identical to `wg genkey` output
+    // for the same entropy; X25519 impls clamp on use, so this is idempotent.
+    secret_bytes[0] &= 248;
+    secret_bytes[31] &= 127;
+    secret_bytes[31] |= 64;
+    let secret = x25519_dalek::StaticSecret::from(secret_bytes);
+    let public = x25519_dalek::PublicKey::from(&secret);
+    Ok((
+        base64_encode(&secret.to_bytes()),
+        base64_encode(public.as_bytes()),
+    ))
 }
 
-/// Generate a WireGuard preshared key (32 random bytes, base64 encoded)
-pub fn generate_wg_psk() -> String {
-    // Try wg genpsk first
-    if let Ok(output) = std::process::Command::new("wg").arg("genpsk").output()
-        && output.status.success()
-    {
-        let psk = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if psk.len() >= 40 {
-            return psk;
-        }
-    }
+/// Derive the WireGuard public key for a base64-encoded private key.
+/// Errors on malformed input (not valid base64 / not 32 bytes).
+pub fn derive_wg_pubkey(private_key_b64: &str) -> crate::Result<String> {
+    let bytes = base64_decode(private_key_b64)
+        .ok_or_else(|| crate::AifwError::Crypto("private key is not valid base64".to_string()))?;
+    let arr: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| crate::AifwError::Crypto("private key must decode to 32 bytes".to_string()))?;
+    let secret = x25519_dalek::StaticSecret::from(arr);
+    Ok(base64_encode(
+        x25519_dalek::PublicKey::from(&secret).as_bytes(),
+    ))
+}
+
+/// Generate a WireGuard preshared key (32 OS-CSPRNG bytes, base64 encoded).
+/// Fails closed if the OS CSPRNG is unavailable.
+pub fn generate_wg_psk() -> crate::Result<String> {
     let mut bytes = [0u8; 32];
-    let id1 = Uuid::new_v4();
-    let id2 = Uuid::new_v4();
-    bytes[..16].copy_from_slice(id1.as_bytes());
-    bytes[16..].copy_from_slice(id2.as_bytes());
-    base64_encode(&bytes)
+    getrandom::fill(&mut bytes)
+        .map_err(|e| crate::AifwError::Crypto(format!("OS CSPRNG unavailable: {e}")))?;
+    Ok(base64_encode(&bytes))
 }
 
 fn base64_encode(data: &[u8]) -> String {
@@ -688,6 +671,49 @@ fn base64_encode(data: &[u8]) -> String {
         }
     }
     result
+}
+
+/// Decode standard base64 (with padding). Returns `None` on any malformed
+/// input. Counterpart to `base64_encode`; kept dependency-free like it.
+fn base64_decode(s: &str) -> Option<Vec<u8>> {
+    fn val(c: u8) -> Option<u32> {
+        match c {
+            b'A'..=b'Z' => Some((c - b'A') as u32),
+            b'a'..=b'z' => Some((c - b'a' + 26) as u32),
+            b'0'..=b'9' => Some((c - b'0' + 52) as u32),
+            b'+' => Some(62),
+            b'/' => Some(63),
+            _ => None,
+        }
+    }
+    let s = s.trim().as_bytes();
+    if s.is_empty() || !s.len().is_multiple_of(4) {
+        return None;
+    }
+    let mut out = Vec::with_capacity(s.len() / 4 * 3);
+    for chunk in s.chunks(4) {
+        let pad = chunk.iter().filter(|&&c| c == b'=').count();
+        if pad > 2 || chunk[..4 - pad].iter().any(|&c| val(c).is_none()) {
+            return None;
+        }
+        // '=' only valid as trailing padding
+        if chunk[..4 - pad].contains(&b'=') {
+            return None;
+        }
+        let mut triple: u32 = 0;
+        for (i, &c) in chunk.iter().enumerate() {
+            let v = if c == b'=' { 0 } else { val(c)? };
+            triple |= v << (18 - 6 * i);
+        }
+        out.push((triple >> 16) as u8);
+        if pad < 2 {
+            out.push((triple >> 8) as u8);
+        }
+        if pad < 1 {
+            out.push(triple as u8);
+        }
+    }
+    Some(out)
 }
 
 /// Generate a random SPI value for IPsec

--- a/aifw-core/src/db.rs
+++ b/aifw-core/src/db.rs
@@ -147,6 +147,25 @@ impl Database {
             .execute(&self.pool)
             .await?;
 
+        // Schedules referenced by rules.schedule_id. Same DDL as the
+        // aifw-api auth migration — duplicated here so the daemon and core
+        // tests can evaluate schedules on a DB the API never migrated (#537).
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS schedules (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT,
+                time_ranges TEXT NOT NULL,
+                days_of_week TEXT NOT NULL DEFAULT 'mon,tue,wed,thu,fri,sat,sun',
+                enabled INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT NOT NULL
+            );
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+
         // Audit log table
         let audit_log = crate::audit::AuditLog::new(self.pool.clone());
         audit_log.migrate().await?;
@@ -267,6 +286,32 @@ impl Database {
         .await?;
 
         rows.into_iter().map(|r| r.into_rule()).collect()
+    }
+
+    /// Load all schedules parsed into evaluation specs, keyed by id (#537).
+    /// Unparseable rows are skipped with a warning — rules referencing them
+    /// then fail open exactly like a dangling reference.
+    pub async fn list_schedule_specs(
+        &self,
+    ) -> Result<std::collections::HashMap<String, aifw_common::schedule::ScheduleSpec>> {
+        let rows = sqlx::query_as::<_, (String, String, String, bool)>(
+            "SELECT id, time_ranges, days_of_week, enabled FROM schedules",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        let mut map = std::collections::HashMap::with_capacity(rows.len());
+        for (id, ranges, days, enabled) in rows {
+            match aifw_common::schedule::ScheduleSpec::parse(&ranges, &days, enabled) {
+                Some(spec) => {
+                    map.insert(id, spec);
+                }
+                None => tracing::warn!(
+                    schedule_id = %id,
+                    "unparseable schedule row; referencing rules stay active"
+                ),
+            }
+        }
+        Ok(map)
     }
 
     /// Update a filter rule in place (refreshing `updated_at`). Fails with

--- a/aifw-core/src/engine.rs
+++ b/aifw-core/src/engine.rs
@@ -126,13 +126,30 @@ impl RuleEngine {
     }
 
     /// Generate pf rules from active rules and load them into the pf anchor.
+    /// Rules referencing a schedule are only compiled while inside their
+    /// active window, evaluated against appliance local time (#537).
     /// Extra rules (from VPN, etc.) are inserted just before any block rule
     /// so they aren't shadowed by a `block quick` default.
     pub async fn apply_rules(&self) -> Result<()> {
         let rules = self.db.list_active_rules().await?;
+        let schedules = self.db.list_schedule_specs().await?;
+        let now = chrono::Local::now().naive_local();
         let mut pf_rules: Vec<String> = rules
             .iter()
             .filter(|r| r.status == RuleStatus::Active)
+            .filter(|r| {
+                if let Some(id) = r.schedule_id.as_deref()
+                    && !schedules.contains_key(id)
+                {
+                    tracing::warn!(rule_id = %r.id, schedule_id = %id,
+                        "rule references a missing schedule; treating as unscheduled");
+                }
+                aifw_common::schedule::rule_schedule_active(
+                    r.schedule_id.as_deref(),
+                    &schedules,
+                    now,
+                )
+            })
             .map(|r| r.to_pf_rule(&self.anchor))
             .collect();
 

--- a/aifw-core/src/error.rs
+++ b/aifw-core/src/error.rs
@@ -78,6 +78,7 @@ impl From<aifw_common::AifwError> for CoreError {
             aifw_common::AifwError::Validation(s) => CoreError::Validation(s),
             aifw_common::AifwError::NotFound(s) => CoreError::NotFound(s),
             aifw_common::AifwError::Io(e) => CoreError::Io(e),
+            aifw_common::AifwError::Crypto(s) => CoreError::Other(format!("crypto error: {s}")),
             aifw_common::AifwError::Other(s) => CoreError::Other(s),
         }
     }

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -166,6 +166,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_engine_schedule_gating() {
+        // apply_rules must exclude rules whose schedule window is closed and
+        // keep rules whose schedule is open, disabled, or dangling (#537).
+        let db = Database::new_in_memory().await.unwrap();
+        let mock = Arc::new(aifw_pf::PfMock::new());
+        let pf: Arc<dyn PfBackend> = mock.clone();
+        let engine = RuleEngine::new(db.pool().clone(), pf);
+
+        let insert_schedule = |id: &str, name: &str, ranges: &str, days: &str, enabled: bool| {
+            let q = sqlx::query(
+                "INSERT INTO schedules (id, name, time_ranges, days_of_week, enabled, created_at) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            )
+            .bind(id.to_string())
+            .bind(name.to_string())
+            .bind(ranges.to_string())
+            .bind(days.to_string())
+            .bind(enabled)
+            .bind("2026-01-01T00:00:00Z");
+            let pool = db.pool().clone();
+            async move { q.execute(&pool).await.unwrap() }
+        };
+        // No listed days → never inside the window, regardless of clock
+        insert_schedule("never", "never", "00:00-00:00", "", true).await;
+        // All days, full-day range → always inside the window
+        insert_schedule(
+            "always",
+            "always",
+            "00:00-00:00",
+            "mon,tue,wed,thu,fri,sat,sun",
+            true,
+        )
+        .await;
+        // Disabled → doesn't constrain
+        insert_schedule("off", "off", "00:00-00:00", "", false).await;
+
+        let mut gated = make_test_rule();
+        gated.schedule_id = Some("never".to_string());
+        gated.label = Some("gated".to_string());
+        let mut open = make_test_rule();
+        open.schedule_id = Some("always".to_string());
+        open.label = Some("open".to_string());
+        let mut disabled_sched = make_test_rule();
+        disabled_sched.schedule_id = Some("off".to_string());
+        disabled_sched.label = Some("disabled-sched".to_string());
+        let mut dangling = make_test_rule();
+        dangling.schedule_id = Some("deleted-schedule".to_string());
+        dangling.label = Some("dangling".to_string());
+        for r in [gated, open, disabled_sched, dangling] {
+            engine.add_rule(r).await.unwrap();
+        }
+
+        engine.apply_rules().await.unwrap();
+
+        let pf_rules = mock.get_rules("aifw").await.unwrap();
+        let joined = pf_rules.join("\n");
+        assert!(
+            !joined.contains("\"gated\""),
+            "closed-window rule must not load: {joined}"
+        );
+        assert!(joined.contains("\"open\""));
+        assert!(joined.contains("\"disabled-sched\""));
+        assert!(joined.contains("\"dangling\""));
+        assert_eq!(pf_rules.len(), 3);
+    }
+
+    #[tokio::test]
     async fn test_engine_flush_rules() {
         let db = Database::new_in_memory().await.unwrap();
         let mock = Arc::new(aifw_pf::PfMock::new());
@@ -645,7 +712,8 @@ mod tests {
                 std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)),
                 24,
             ),
-        );
+        )
+        .unwrap();
         let id = tunnel.id;
         engine.add_wg_tunnel(tunnel).await.unwrap();
 
@@ -670,7 +738,8 @@ mod tests {
                 std::net::IpAddr::V4(std::net::Ipv4Addr::new(172, 16, 0, 1)),
                 24,
             ),
-        );
+        )
+        .unwrap();
         tunnel.dns = Some("1.1.1.1".to_string());
         tunnel.mtu = Some(1420);
         let id = tunnel.id;
@@ -697,7 +766,8 @@ mod tests {
                 std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)),
                 24,
             ),
-        );
+        )
+        .unwrap();
         let tid = tunnel.id;
         engine.add_wg_tunnel(tunnel).await.unwrap();
 
@@ -732,13 +802,15 @@ mod tests {
             Interface("wg0".to_string()),
             51820,
             Address::Any,
-        );
+        )
+        .unwrap();
         let t2 = WgTunnel::new(
             "wg1".to_string(),
             Interface("wg1".to_string()),
             51821,
             Address::Any,
-        );
+        )
+        .unwrap();
         let (id1, id2) = (t1.id, t2.id);
         engine.add_wg_tunnel(t1).await.unwrap();
         engine.add_wg_tunnel(t2).await.unwrap();
@@ -772,7 +844,8 @@ mod tests {
             Interface("wg0".to_string()),
             51820,
             Address::Any,
-        );
+        )
+        .unwrap();
         assert!(engine.add_wg_tunnel(t).await.is_err());
 
         // Zero port
@@ -781,7 +854,8 @@ mod tests {
             Interface("wg0".to_string()),
             51820,
             Address::Any,
-        );
+        )
+        .unwrap();
         t.listen_port = 0;
         assert!(engine.add_wg_tunnel(t).await.is_err());
 
@@ -791,7 +865,8 @@ mod tests {
             Interface("wg0".to_string()),
             51820,
             Address::Any,
-        );
+        )
+        .unwrap();
         engine.add_wg_tunnel(first).await.unwrap();
 
         let dup = WgTunnel::new(
@@ -799,7 +874,8 @@ mod tests {
             Interface("wg1".to_string()),
             51820,
             Address::Any,
-        );
+        )
+        .unwrap();
         assert!(
             engine.add_wg_tunnel(dup).await.is_err(),
             "second tunnel on the same port must be rejected"
@@ -811,7 +887,8 @@ mod tests {
             Interface("wg2".to_string()),
             51821,
             Address::Any,
-        );
+        )
+        .unwrap();
         assert!(engine.add_wg_tunnel(ok).await.is_ok());
     }
 
@@ -867,7 +944,8 @@ mod tests {
                 std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)),
                 24,
             ),
-        );
+        )
+        .unwrap();
         tunnel.status = VpnStatus::Up;
         engine.add_wg_tunnel(tunnel).await.unwrap();
 
@@ -911,15 +989,18 @@ mod tests {
 
         // Status defaults to Down — must not open the listen port or NAT
         engine
-            .add_wg_tunnel(WgTunnel::new(
-                "wg0".to_string(),
-                Interface("wg0".to_string()),
-                51820,
-                Address::Network(
-                    std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)),
-                    24,
-                ),
-            ))
+            .add_wg_tunnel(
+                WgTunnel::new(
+                    "wg0".to_string(),
+                    Interface("wg0".to_string()),
+                    51820,
+                    Address::Network(
+                        std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)),
+                        24,
+                    ),
+                )
+                .unwrap(),
+            )
             .await
             .unwrap();
 

--- a/aifw-daemon/src/main.rs
+++ b/aifw-daemon/src/main.rs
@@ -75,7 +75,8 @@ async fn main() -> anyhow::Result<()> {
     let db = Database::new(&args.db).await?;
     let pool = db.pool().clone();
     let pf: Arc<dyn aifw_pf::PfBackend> = Arc::from(aifw_pf::create_backend());
-    let engine = RuleEngine::new(pool.clone(), pf.clone()).with_anchor(args.anchor.clone());
+    let engine =
+        Arc::new(RuleEngine::new(pool.clone(), pf.clone()).with_anchor(args.anchor.clone()));
     let nat_engine = NatEngine::new(pool.clone(), pf.clone());
     let alias_engine = AliasEngine::new(pool.clone(), pf.clone());
 
@@ -109,6 +110,47 @@ async fn main() -> anyhow::Result<()> {
 
     if let Some(ref iface) = args.interface {
         info!(interface = %iface, "attached to interface");
+    }
+
+    // Schedule boundary watcher (#537) — apply_rules only compiles rules
+    // inside their schedule window, so something must reload the anchor when
+    // a window opens or closes. Re-evaluate every minute (same cadence
+    // pfSense/OPNsense use for schedule ticks; granularity is HH:MM) and
+    // reapply only when a scheduled rule's active/inactive state actually
+    // flips. Schedule CRUD is also picked up within one tick.
+    {
+        let engine = engine.clone();
+        let vpn_engine = aifw_core::VpnEngine::new(pool.clone(), pf.clone());
+        let baseline = schedule_fingerprint(&engine).await;
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(std::time::Duration::from_secs(60));
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            let mut last = baseline;
+            loop {
+                ticker.tick().await;
+                let fp = schedule_fingerprint(&engine).await;
+                if fp == last {
+                    continue;
+                }
+                info!("schedule boundary crossed; reloading firewall rules");
+                // Keep VPN pass rules in the anchor across the reload, same
+                // as the API's reload path.
+                match vpn_engine.collect_vpn_rules().await {
+                    Ok(extras) => engine.set_extra_rules(extras).await,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "schedule reload: collecting vpn rules failed")
+                    }
+                }
+                match engine.apply_rules().await {
+                    // Only advance the fingerprint on success so a failed
+                    // reload is retried on the next tick instead of leaving
+                    // the stale ruleset loaded silently.
+                    Ok(()) => last = fp,
+                    Err(e) => error!("schedule reload: apply_rules failed: {e}"),
+                }
+            }
+        });
+        info!("schedule watcher started");
     }
 
     // ========================================================
@@ -358,6 +400,40 @@ async fn main() -> anyhow::Result<()> {
 
     info!("AiFw daemon stopped");
     Ok(())
+}
+
+/// Current schedule gating state: (rule id, inside-window) for every active
+/// rule that references a schedule, sorted for stable comparison (#537).
+/// Returns an empty list on DB errors (logged) — comparison against the
+/// previous tick then goes through apply_rules, whose own error handling
+/// retries on the next tick.
+async fn schedule_fingerprint(engine: &RuleEngine) -> Vec<(String, bool)> {
+    let db = engine.db();
+    let (rules, schedules) =
+        match tokio::try_join!(db.list_active_rules(), db.list_schedule_specs()) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(error = %e, "schedule watcher: db read failed");
+                return Vec::new();
+            }
+        };
+    let now = chrono::Local::now().naive_local();
+    let mut fp: Vec<(String, bool)> = rules
+        .iter()
+        .filter(|r| r.schedule_id.is_some())
+        .map(|r| {
+            (
+                r.id.to_string(),
+                aifw_common::schedule::rule_schedule_active(
+                    r.schedule_id.as_deref(),
+                    &schedules,
+                    now,
+                ),
+            )
+        })
+        .collect();
+    fp.sort_unstable();
+    fp
 }
 
 /// Boot-time drift detection + auto-heal.

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.6",
+  "version": "5.99.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/docs/docs/firewall.md
+++ b/docs/docs/firewall.md
@@ -112,7 +112,14 @@ A schedule is a named time window with two fields:
 - `time_ranges` &mdash; one or more `HH:MM-HH:MM` ranges, e.g. `"08:00-12:00,13:00-17:00"`.
 - `days_of_week` &mdash; comma-separated short names, e.g. `"mon,tue,wed,thu,fri"`.
 
-Attach a `schedule_id` to a rule and the rule is only loaded into pf during the active window. Outside the window the rule is silently dropped from the compiled ruleset.
+Attach a `schedule_id` to a rule and the rule is only loaded into pf during the active window. Outside the window the rule is dropped from the compiled ruleset.
+
+Evaluation semantics:
+
+- Windows are evaluated against the appliance's **local time** (system timezone, including DST).
+- Range ends are exclusive (`08:00-17:00` deactivates at 17:00). A range that crosses midnight (`22:00-06:00`) belongs to the day it starts and runs into the next morning. `00:00-00:00` means the whole day.
+- The daemon re-evaluates schedules once per minute (the same cadence pfSense/OPNsense use) and reloads the ruleset when a rule crosses a window boundary; schedule edits via the API reload immediately.
+- A disabled schedule, or a `schedule_id` pointing at a deleted schedule, does not constrain the rule — it stays loaded as if unscheduled (fail-open is deliberate: rules can be `block` as well as `pass`, and unloading a block rule on a dangling reference would open the firewall).
 
 ## Traffic shaping
 


### PR DESCRIPTION
Fixes the three Critical findings from the 2026-07-18 audit sweep in one PR.

## #537 — Firewall schedules are now enforced

- `RuleEngine::apply_rules` resolves `schedule_id` and only compiles rules whose window is currently open (new pure evaluator in `aifw-common/src/schedule.rs`, tested with an injected clock — no wall-clock in tests).
- Semantics: appliance local time; end-exclusive ranges; overnight ranges (`22:00-06:00`) belong to the day they start; `00:00-00:00` = full day; disabled or dangling schedules fail open (deliberate — rules can be `block`, so unloading on a dangling reference could open the firewall). Documented in `docs/docs/firewall.md`.
- The daemon re-evaluates once per minute (same cadence as pfSense/OPNsense schedule ticks) and reloads the anchor only when a rule's window state flips; a failed reload is retried next tick. Schedule update/delete via the API reloads immediately.
- `schedules` table DDL added to `aifw-core` migrate so the daemon works on a DB the API never touched.

## #541 — WireGuard keys are real X25519 pairs

- `generate_wg_keypair` now generates in-process: 32 OS-CSPRNG bytes, clamped exactly like `wg genkey`, public key derived via `x25519-dalek`. The `wg` subprocess dance and the UUID-based fallback that fabricated **unrelated** pub/priv pairs are gone.
- Fails closed: keypair/PSK generation returns `Err` if the OS CSPRNG is unavailable; `WgTunnel::new` / `WgPeer::new_with_generated_key` propagate instead of persisting bad key material. PSKs come from the OS CSPRNG.
- Bonus fix of the same bug class: `POST /vpn/wg` accepted a caller-supplied `private_key` while keeping the previously generated, unrelated `public_key` — the pubkey is now re-derived from the supplied key.
- New `derive_wg_pubkey` helper + tests: pub-derives-from-priv, malformed-input rejection, and a cross-check against `wg pubkey` that runs when wireguard-tools is installed (FreeBSD CI/appliance) and self-skips elsewhere.

## #535 — Restore fails instead of reporting success after partial apply

- `apply_firewall_config` aborts on any failed required step (table clears, row inserts, engine migrates, auth config, shaping/TLS/HA, DHCP DB writes, final pf/NAT/GeoIP applies) instead of warn-and-continue. Intentional drops (interface-map exclusions, unparseable snapshot rows) still skip, now logged.
- Restore/import endpoints go through a new `apply_firewall_config_or_rollback` wrapper: capture current config → strict apply → on failure re-apply the snapshot. Three outcomes, all audited: applied, rolled back, or rollback-failed (logged high-severity). Never silent partial success; `mark_applied` and success responses only fire after a full apply.
- Kept best-effort (with comments explaining why): `/etc/resolv.conf` write, kernel route apply, `pf.max_states` (warn-only at boot too), rDHCP service regen — DB stays authoritative and boot reapplies.
- Strictness immediately exposed a latent bug it was designed to catch: shaping restore deleted from `queues`/`rate_limits`, which don't exist (`queue_configs`/`rate_limit_rules` are real) — the wipe silently never happened. Fixed.
- Full DB-transaction semantics remain tracked by #158; kernel-side effects can't be wrapped in SQL transactions, which is why snapshot/rollback is the mechanism here.

## Tests

- 700 passed / 0 failed across the workspace; `cargo check --workspace --all-targets` clean; clippy + fmt clean (pre-commit).
- New: 7 schedule-evaluation tests (injected clock), engine gating integration test against `PfMock`, 4 WireGuard key tests, strict-restore success + partial-apply-fails tests.

Closes #537. Closes #541. Addresses the core contract of #535 (leaves #158 open for single-transaction DB writes).