### PR TITLE
Pin companion component commits and GitHub Action SHAs (#538, partial #542)

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -21,9 +21,9 @@ jobs:
     name: Build Web UI (static export)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'
@@ -38,7 +38,7 @@ jobs:
         run: npm run build
 
       - name: Upload UI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ui-export
           path: aifw-ui/out/
@@ -49,10 +49,10 @@ jobs:
     needs: build-ui
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Download UI artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ui-export
           path: freebsd/ui-export
@@ -66,7 +66,7 @@ jobs:
             fi
 
       - name: Build in FreeBSD VM
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@77ed28d336d03fe19a3f4f7266c1d2c4714dd79d # v1.5.2
         with:
           release: "${{ env.FREEBSD_VERSION }}"
           usesh: true
@@ -96,13 +96,29 @@ jobs:
             visudo -cf /tmp/aifw-sudoers
             echo "sudoers OK"
 
-            # Build external repos from manifest
+            # Build external repos from manifest, pinned to the reviewed
+            # commit recorded there (#538). An unpinned or unresolvable
+            # revision fails the build — never fall back to branch HEAD.
             MANIFEST="freebsd/manifest.json"
             for row in $(jq -c '.external_repos[]' "$MANIFEST"); do
               NAME=$(echo "$row" | jq -r '.name')
               REPO=$(echo "$row" | jq -r '.repo')
-              echo "=== Building $NAME ==="
+              COMMIT=$(echo "$row" | jq -r '.commit // empty')
+              if [ -z "$COMMIT" ]; then
+                echo "ERROR: ${NAME} has no pinned commit in ${MANIFEST} (#538)" >&2
+                exit 1
+              fi
+              echo "=== Building $NAME @ $COMMIT ==="
               git clone "https://github.com/${REPO}.git" "/tmp/${NAME}"
+              git -C "/tmp/${NAME}" checkout --detach "$COMMIT" || {
+                echo "ERROR: pinned commit ${COMMIT} not found in ${REPO}" >&2
+                exit 1
+              }
+              ACTUAL=$(git -C "/tmp/${NAME}" rev-parse HEAD)
+              if [ "$ACTUAL" != "$COMMIT" ]; then
+                echo "ERROR: ${NAME} checked out ${ACTUAL}, expected ${COMMIT}" >&2
+                exit 1
+              fi
               cd "/tmp/${NAME}"
               cargo build --release
               cd /home/runner/work/AiFw/AiFw
@@ -122,8 +138,23 @@ jobs:
               done
             done
 
-            echo "=== Building update tarball ==="
+            echo "=== Recording component revisions (#538) ==="
+            # Machine-readable record of the exact source that produced this
+            # artifact set: AiFw commit + every pinned companion commit.
+            # Ships as a release asset and inside the update tarball.
             VERSION="${{ steps.version.outputs.version }}"
+            jq -n \
+              --arg version "$VERSION" \
+              --arg aifw_commit "${{ github.sha }}" \
+              --slurpfile manifest "$MANIFEST" \
+              '{version: $version, aifw_commit: $aifw_commit,
+                components: [$manifest[0].external_repos[] | {name, repo, commit}]}' \
+              > /tmp/aifw-components.json
+            cat /tmp/aifw-components.json
+            mkdir -p /usr/obj/aifw-iso/output
+            cp /tmp/aifw-components.json "/usr/obj/aifw-iso/output/aifw-components-${VERSION}.json"
+
+            echo "=== Building update tarball ==="
             TARBALL_DIR="/tmp/aifw-update-${VERSION}-amd64"
             mkdir -p "$TARBALL_DIR/bin" "$TARBALL_DIR/ui" "$TARBALL_DIR/rc.d" "$TARBALL_DIR/sbin" "$TARBALL_DIR/libexec"
             # Copy all binaries from freebsd/release/ into tarball
@@ -139,7 +170,7 @@ jobs:
             cp -a freebsd/overlay/usr/local/libexec/* "$TARBALL_DIR/libexec/"
             chmod 755 "$TARBALL_DIR"/rc.d/* "$TARBALL_DIR"/sbin/* "$TARBALL_DIR"/libexec/*
             echo "$VERSION" > "$TARBALL_DIR/version"
-            mkdir -p /usr/obj/aifw-iso/output
+            cp /tmp/aifw-components.json "$TARBALL_DIR/components.json"
             tar -C /tmp -cJf "/usr/obj/aifw-iso/output/aifw-update-${VERSION}-amd64.tar.xz" "aifw-update-${VERSION}-amd64"
             cd /usr/obj/aifw-iso/output
             sha256 "aifw-update-${VERSION}-amd64.tar.xz" > "aifw-update-${VERSION}-amd64.tar.xz.sha256"
@@ -165,24 +196,31 @@ jobs:
             cp /usr/obj/aifw-iso/output/* /home/runner/work/AiFw/AiFw/output/
 
       - name: Upload ISO artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: aifw-iso-amd64
           path: output/aifw-*.iso.xz
           retention-days: 5
 
       - name: Upload IMG artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: aifw-img-amd64
           path: output/aifw-*.img.xz
           retention-days: 5
 
       - name: Upload checksums
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: checksums
           path: output/*.sha256
+          retention-days: 5
+
+      - name: Upload component manifest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: components
+          path: output/aifw-components-*.json
           retention-days: 5
 
   release:
@@ -190,24 +228,30 @@ jobs:
     needs: build-iso
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Download ISO
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: aifw-iso-amd64
           path: release-assets/
 
       - name: Download IMG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: aifw-img-amd64
           path: release-assets/
 
       - name: Download checksums
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: checksums
+          path: release-assets/
+
+      - name: Download component manifest
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: components
           path: release-assets/
 
       - name: Extract version from tag
@@ -219,7 +263,7 @@ jobs:
             fi
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           name: "AiFw v${{ steps.version.outputs.version }}"
           draft: false

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,15 +21,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
           ruby-version: '3.2'
           bundler-cache: true
           working-directory: docs
 
-      - uses: actions/configure-pages@v4
+      - uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4.0.0
 
       - name: Build Jekyll
         working-directory: docs
@@ -37,7 +37,7 @@ jobs:
           JEKYLL_ENV: production
         run: bundle exec jekyll build --destination _site
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: docs/_site
 
@@ -49,4 +49,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -22,7 +22,7 @@ jobs:
     name: Rust (fmt + clippy + test)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install Rust toolchain
         run: |
@@ -31,7 +31,7 @@ jobs:
           rustc --version
           cargo --version
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
@@ -46,9 +46,9 @@ jobs:
     name: UI (lint + build)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: 'npm'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.7"
+version = "5.99.8"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -766,6 +766,26 @@ pub async fn install_from_path(
         }
     };
 
+    // Install the component-revision record (#538) next to the version file
+    // so an appliance can report exactly which AiFw + companion commits it
+    // runs. Best-effort: pre-#538 tarballs don't contain it.
+    {
+        let comp_src = update_dir.join("components.json");
+        if comp_src.exists() {
+            match comp_src.to_str() {
+                Some(comp_src_str) => {
+                    if let Some(err) = step_failure(
+                        &crate::sudo::cp(&[comp_src_str, "/usr/local/share/aifw/components.json"])
+                            .await,
+                    ) {
+                        warn!(error = %err, "update: components.json install failed");
+                    }
+                }
+                None => warn!("update: components.json path is not UTF-8; skipping"),
+            }
+        }
+    }
+
     // Strip stale AiFw version from MOTD template. Idempotent and respects
     // the marker file that `system_apply::apply_banner` sets when the admin
     // edits MOTD via the UI.

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.7",
+  "version": "5.99.8",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/freebsd/build-local.sh
+++ b/freebsd/build-local.sh
@@ -115,12 +115,18 @@ BIN_VER="$("$PROJECT_ROOT/target/release/aifw" --version 2>/dev/null | grep -oE 
 [ "$BIN_VER" = "$VERSION" ] || die "version mismatch: building v${VERSION} but target/release/aifw reports v${BIN_VER:-unknown}. Bump Cargo.toml and rebuild (try 'cargo clean -p aifw') before releasing."
 echo "--- Verified compiled aifw binary is v${VERSION} ---"
 
-# Helper: clone-or-update a companion repo and FAIL LOUDLY on pull errors.
-# Previous version used `git pull 2>/dev/null || true` which silently
-# swallowed stale-checkout / merge-conflict errors, causing releases to
-# ship with ancient bundled rDNS / rDHCP / rTIME binaries.
+# Helper: clone-or-update a companion repo and FAIL LOUDLY on errors.
+# Builds the exact commit pinned in manifest.json (#538) — never branch
+# HEAD, so a rebuild of the same AiFw commit always bundles the same
+# companion source. (The pre-#538 version reset to origin/main; before
+# that, `git pull 2>/dev/null || true` silently shipped stale binaries.)
 build_companion() {
     local name="$1" dir="$2" url="$3"
+    local pin
+    pin=$(jq -r --arg n "$name" \
+        '.external_repos[] | select(.name == $n) | .commit // empty' \
+        "$PROJECT_ROOT/freebsd/manifest.json")
+    [ -n "$pin" ] || die "no pinned commit for $name in manifest.json (#538)"
     if [ ! -d "$dir" ]; then
         echo "Cloning $name from $url ..."
         git clone "$url" "$dir" || {
@@ -128,16 +134,17 @@ build_companion() {
             exit 1
         }
     fi
-    echo "--- Updating $name ---"
+    echo "--- Checking out $name @ $pin ---"
     ( cd "$dir" && \
         git fetch --tags origin && \
-        git reset --hard origin/main ) || {
-        echo "ERROR: git update of $name ($dir) failed — refusing to build stale code" >&2
+        git checkout --detach "$pin" ) || {
+        echo "ERROR: pinned commit $pin not found in $name ($dir)" >&2
         exit 1
     }
-    local sha
-    sha=$(git -C "$dir" rev-parse --short HEAD)
-    echo "--- $name commit: $sha ---"
+    local actual
+    actual=$(git -C "$dir" rev-parse HEAD)
+    [ "$actual" = "$pin" ] || die "$name checked out $actual, expected pinned $pin"
+    echo "--- $name commit: $actual ---"
     ( cd "$dir" && cargo build --release ) || {
         echo "ERROR: cargo build of $name failed" >&2
         exit 1

--- a/freebsd/manifest.json
+++ b/freebsd/manifest.json
@@ -8,23 +8,28 @@
 
   "external_repos": [
     {
+      "_comment": "commit pins the exact revision built into appliance artifacts (#538). CI and build-local.sh check out and verify this SHA and fail if it is missing. To take a companion update: review the upstream diff, bump the SHA here, and land it through a PR.",
       "name": "TrafficCop",
       "repo": "ZerosAndOnesLLC/TrafficCop",
+      "commit": "3d4d96595bea1d4f29b8729a452c95dd1be0ed25",
       "binaries": ["trafficcop"]
     },
     {
       "name": "rDHCP",
       "repo": "ZerosAndOnesLLC/rDHCP",
+      "commit": "bddd4868df6f5931b614f8412071daf31af7d0dd",
       "binaries": ["rdhcpd"]
     },
     {
       "name": "rDNS",
       "repo": "ZerosAndOnesLLC/rDNS",
+      "commit": "7bd12e293536ec3adae09e340b572b87e0fe942b",
       "binaries": ["rdns", "rdns-control"]
     },
     {
       "name": "rTIME",
       "repo": "ZerosAndOnesLLC/rTIME",
+      "commit": "444e104db55fa33f6aded7a6b0b7752509bc0a6f",
       "binaries": ["rtime"]
     }
   ],

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-cp
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-cp
@@ -73,6 +73,7 @@ case "$DEST" in
     /usr/local/share/aifw/ui|/usr/local/share/aifw/ui/*) ;;
     /usr/local/share/aifw/backup|/usr/local/share/aifw/backup/*) ;;
     /usr/local/share/aifw/version) ;;
+    /usr/local/share/aifw/components.json) ;;
     /usr/local/etc/aifw/*) ;;
     /usr/local/etc/rdns/*) ;;
     /usr/local/etc/rdhcpd/*) ;;


### PR DESCRIPTION
Quick wins from the 2026-07-18 audit sweep: reproducible companion builds (#538) and the action-pinning slice of #542.

## #538 — Companion components pinned to reviewed commits

- `freebsd/manifest.json` external repos now carry a `commit` SHA (pinned to each repo's current default-branch HEAD — the de-facto build input as of today):
  - TrafficCop `3d4d965` (2026-07-05)
  - rDHCP `bddd486` (2026-07-14)
  - rDNS `7bd12e2` (2026-07-09)
  - rTIME `444e104` (2026-07-01)
- `build-iso.yml` and `freebsd/build-local.sh` check out exactly that revision, verify `rev-parse HEAD` matches, and **fail the build** on a missing or unresolvable pin — no fallback to branch HEAD. Rebuilding the same AiFw commit now always bundles the same companion source.
- CI generates `aifw-components-<version>.json` (AiFw commit + companion pins), publishes it as a release asset, and embeds it in the update tarball. The updater installs it to `/usr/local/share/aifw/components.json` so appliances can report their exact component set (best-effort; pre-#538 tarballs don't have it). The `aifw-sudo-cp` destination allowlist gained the new path — the helper ships embedded via `include_str!`, so it self-bootstraps like the other narrow-grant wrappers.
- `deploy.sh` (dev/test-VM flow) deliberately keeps tracking branch HEADs.
- Taking a companion update is now an explicit reviewed step: bump the SHA in the manifest via PR (procedure noted in the manifest comment).

## #542 (partial) — Actions pinned to full commit SHAs

All `uses:` across `build-iso.yml`, `lint-and-test.yml`, `gh-pages.yml` now reference full commit SHAs with trailing version comments (checkout v4.3.1, setup-node v4.4.0, upload/download-artifact v4.6.2/v4.3.0, vmactions/freebsd-vm v1.5.2, action-gh-release v2.6.2, rust-cache v2.9.1, setup-ruby v1.319.0, configure-pages v4.0.0, upload-pages-artifact v3.0.1, deploy-pages v4.0.5). SHAs resolved from each repo's newest tag matching the previously used major version.

**Not in scope** (rest of #542): artifact signing/attestation, SBOM generation, key management, updater signature verification. Remaining from #538: compatibility CI over the pinned set, automated dependency-update workflow, reproducibility comparison job.

## Verification

- `jq` validates the manifest; `sh -n` passes on `build-local.sh` and `aifw-sudo-cp`; all three workflows parse as YAML.
- `cargo check --workspace --all-targets` clean; aifw-core tests pass (updater change).
- Note: the build-iso workflow itself only runs on the next `v*` tag / manual dispatch — worth watching the first run after merge.

Closes #538.