### PR TITLE
Enforce Multi-WAN latency/dampening; rule policy routing; tower feature trim (#539, #540, #321)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.99.8"
+version = "5.100.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.100.0"
+version = "5.100.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"
@@ -34,7 +34,10 @@ aifw-ids = { path = "aifw-ids" }
 aifw-ids-ipc = { path = "aifw-ids-ipc" }
 aifw-metrics = { path = "aifw-metrics" }
 axum = { version = "0.8", features = ["ws", "multipart"] }
-tower = { version = "0.5", features = ["full"] }
+# Only ServiceBuilder (tower core) is used directly — see aifw-api/src/main.rs.
+# axum/tower-http pull their own tower features via cargo's per-graph union,
+# so nothing broader is needed here (SEC-L6 #321).
+tower = { version = "0.5", default-features = false }
 tower-http = { version = "0.7", features = ["cors", "trace", "fs", "set-header", "compression-gzip", "compression-br"] }
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 argon2 = { version = "0.5", features = ["std"] }

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -410,6 +410,8 @@ pub(crate) async fn capture_runtime_snapshot(state: &AppState) -> Result<String,
                 ip_version: r.ip_version,
                 src_invert: r.src_invert,
                 dst_invert: r.dst_invert,
+                schedule_id: r.schedule_id.clone(),
+                gateway: r.gateway.clone(),
             })
             .collect(),
         nat: nat_rules
@@ -681,6 +683,8 @@ pub(crate) async fn build_current_config(state: &AppState) -> Result<FirewallCon
                 ip_version: r.ip_version,
                 src_invert: r.src_invert,
                 dst_invert: r.dst_invert,
+                schedule_id: r.schedule_id.clone(),
+                gateway: r.gateway.clone(),
             })
             .collect(),
         nat: nat_rules
@@ -2288,13 +2292,13 @@ fn rule_from_config(rc: &aifw_core::config::RuleConfig) -> Option<aifw_common::R
         quick: rc.quick,
         label: rc.label.clone(),
         description: None,
-        gateway: None,
+        gateway: rc.gateway.clone(),
         state_options: StateOptions {
             tracking,
             ..Default::default()
         },
         status,
-        schedule_id: None,
+        schedule_id: rc.schedule_id.clone(),
         created_at: now,
         updated_at: now,
     })

--- a/aifw-api/src/multiwan.rs
+++ b/aifw-api/src/multiwan.rs
@@ -400,6 +400,8 @@ pub struct CreateGatewayRequest {
     pub timeout_ms: Option<u64>,
     pub loss_pct_down: Option<f64>,
     pub loss_pct_up: Option<f64>,
+    pub latency_ms_down: Option<u64>,
+    pub latency_ms_up: Option<u64>,
     pub consec_fail_down: Option<u32>,
     pub consec_ok_up: Option<u32>,
     pub weight: Option<u32>,
@@ -410,6 +412,27 @@ pub struct CreateGatewayRequest {
 
 fn req_to_gateway(req: CreateGatewayRequest, id: Option<Uuid>) -> Result<Gateway, StatusCode> {
     let instance_id = Uuid::parse_str(&req.instance_id).map_err(|_| bad_request())?;
+    // Threshold sanity (#539): recovery thresholds must sit at or below
+    // their degrade counterparts or the hysteresis band is inverted, and a
+    // latency recovery threshold without a degrade threshold is meaningless.
+    let loss_down = req.loss_pct_down.unwrap_or(20.0);
+    let loss_up = req.loss_pct_up.unwrap_or(5.0);
+    if !(0.0..=100.0).contains(&loss_down) || !(0.0..=100.0).contains(&loss_up) {
+        return Err(bad_request());
+    }
+    if loss_up > loss_down {
+        return Err(bad_request());
+    }
+    match (req.latency_ms_down, req.latency_ms_up) {
+        (None, Some(_)) => return Err(bad_request()),
+        (Some(0), _) => return Err(bad_request()),
+        (Some(down), Some(up)) if up > down => return Err(bad_request()),
+        _ => {}
+    }
+    // Hold-down longer than a day is almost certainly a unit mistake.
+    if req.dampening_secs.unwrap_or(10) > 86_400 {
+        return Err(bad_request());
+    }
     let now = Utc::now();
     Ok(Gateway {
         id: id.unwrap_or_else(Uuid::new_v4),
@@ -424,10 +447,10 @@ fn req_to_gateway(req: CreateGatewayRequest, id: Option<Uuid>) -> Result<Gateway
         monitor_expect: req.monitor_expect,
         interval_ms: req.interval_ms.unwrap_or(500),
         timeout_ms: req.timeout_ms.unwrap_or(1000),
-        loss_pct_down: req.loss_pct_down.unwrap_or(20.0),
-        loss_pct_up: req.loss_pct_up.unwrap_or(5.0),
-        latency_ms_down: None,
-        latency_ms_up: None,
+        loss_pct_down: loss_down,
+        loss_pct_up: loss_up,
+        latency_ms_down: req.latency_ms_down,
+        latency_ms_up: req.latency_ms_up,
         consec_fail_down: req.consec_fail_down.unwrap_or(3),
         consec_ok_up: req.consec_ok_up.unwrap_or(5),
         weight: req.weight.unwrap_or(1),
@@ -515,6 +538,19 @@ pub async fn delete_gateway(
         .delete(uuid)
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
+    // Unlink rules that policy-route through this gateway (#540) and reload
+    // so their route-to clauses drop out. On unlink failure the dangling
+    // reference fails open in the engine (default routing) — warn only.
+    if let Err(e) = sqlx::query("UPDATE rules SET gateway = NULL WHERE gateway = ?1")
+        .bind(uuid.to_string())
+        .execute(&state.pool)
+        .await
+    {
+        tracing::warn!(gateway = %uuid, error = %e, "gateway delete: rules unlink failed");
+    }
+    if let Err(e) = state.rule_engine.apply_rules().await {
+        tracing::warn!(gateway = %uuid, error = %e, "gateway delete: rules reload failed");
+    }
     Ok(Json(MessageResponse {
         message: format!("gateway {id} deleted"),
     }))

--- a/aifw-api/src/routes/rules.rs
+++ b/aifw-api/src/routes/rules.rs
@@ -27,6 +27,31 @@ pub struct CreateRuleRequest {
     pub state_tracking: Option<String>,
     pub status: Option<String>,
     pub schedule_id: Option<String>,
+    /// Multi-WAN gateway id for policy routing (#540). Empty string clears.
+    pub gateway: Option<String>,
+}
+
+/// Resolve the request's `gateway` field to a validated gateway id (#540):
+/// `None`/empty clears the association; anything else must parse as a UUID
+/// and reference an existing multiwan gateway or the request is rejected —
+/// unknown values must not be silently discarded again.
+async fn validate_gateway_ref(
+    state: &AppState,
+    gateway: Option<String>,
+) -> Result<Option<String>, StatusCode> {
+    let Some(gw) = gateway
+        .map(|g| g.trim().to_string())
+        .filter(|g| !g.is_empty())
+    else {
+        return Ok(None);
+    };
+    let uuid = Uuid::parse_str(&gw).map_err(|_| bad_request())?;
+    state
+        .gateway_engine
+        .get(uuid)
+        .await
+        .map_err(|_| bad_request())?;
+    Ok(Some(uuid.to_string()))
 }
 
 #[derive(Debug, Deserialize)]
@@ -165,6 +190,7 @@ pub async fn create_rule(
     }
 
     rule.schedule_id = req.schedule_id;
+    rule.gateway = validate_gateway_ref(&state, req.gateway).await?;
 
     // Validate label and interface to prevent pf rule injection
     if let Some(ref iface) = rule.interface {
@@ -256,6 +282,7 @@ pub async fn update_rule(
         };
     }
     rule.schedule_id = req.schedule_id;
+    rule.gateway = validate_gateway_ref(&state, req.gateway).await?;
     rule.updated_at = chrono::Utc::now();
 
     // Validate label and interface to prevent pf rule injection

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -2147,6 +2147,106 @@ mod tests {
     }
 
     // ============================================================
+    // Rule policy routing (#540)
+    // ============================================================
+
+    #[tokio::test]
+    async fn test_rule_gateway_round_trip_and_validation() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        // Default routing instance is seeded; hang a gateway off it.
+        let resp = server
+            .get("/api/v1/multiwan/instances")
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        let instance_id = body["data"][0]["id"].as_str().unwrap().to_string();
+
+        let resp = server
+            .post("/api/v1/multiwan/gateways")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "name": "wan1",
+                "instance_id": instance_id,
+                "interface": "igb1",
+                "next_hop": "203.0.113.1"
+            }))
+            .await;
+        resp.assert_status(StatusCode::CREATED);
+        let body: Value = resp.json();
+        let gw_id = body["data"]["id"].as_str().unwrap().to_string();
+
+        // Rule carrying the gateway: accepted, persisted, returned.
+        let resp = server
+            .post("/api/v1/rules")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "action": "pass",
+                "direction": "in",
+                "protocol": "tcp",
+                "dst_port_start": 443,
+                "dst_port_end": 443,
+                "label": "routed",
+                "gateway": gw_id
+            }))
+            .await;
+        resp.assert_status(StatusCode::CREATED);
+        let body: Value = resp.json();
+        assert_eq!(body["data"]["gateway"].as_str(), Some(gw_id.as_str()));
+        let rule_id = body["data"]["id"].as_str().unwrap().to_string();
+
+        let resp = server
+            .get(&format!("/api/v1/rules/{rule_id}"))
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["data"]["gateway"].as_str(), Some(gw_id.as_str()));
+
+        // Unknown gateway reference is rejected, not silently dropped (#540).
+        let resp = server
+            .post("/api/v1/rules")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "action": "pass",
+                "direction": "in",
+                "protocol": "tcp",
+                "gateway": uuid::Uuid::new_v4().to_string()
+            }))
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+
+        // Non-UUID gateway is rejected too.
+        let resp = server
+            .post("/api/v1/rules")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "action": "pass",
+                "direction": "in",
+                "protocol": "tcp",
+                "gateway": "not-a-uuid"
+            }))
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+
+        // Deleting the gateway unlinks the rule.
+        let resp = server
+            .delete(&format!("/api/v1/multiwan/gateways/{gw_id}"))
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        let resp = server
+            .get(&format!("/api/v1/rules/{rule_id}"))
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert!(body["data"]["gateway"].is_null());
+    }
+
+    // ============================================================
     // Backup/restore strict-apply contract (#535)
     // ============================================================
 

--- a/aifw-common/src/multiwan.rs
+++ b/aifw-common/src/multiwan.rs
@@ -109,9 +109,12 @@ pub struct Gateway {
     pub loss_pct_down: f64,
     /// Loss percentage the gateway must stay at or below to recover to up
     pub loss_pct_up: f64,
-    /// Latency threshold (ms) for degrading; stored but not yet evaluated by the probe loop
+    /// Latency threshold (ms): RTT at or above this degrades the gateway to
+    /// warning, even while probes succeed (#539)
     pub latency_ms_down: Option<u64>,
-    /// Latency threshold (ms) for recovery; stored but not yet evaluated by the probe loop
+    /// Latency recovery threshold (ms): RTT must fall to this or below before
+    /// the gateway can return to up; RTT between the two thresholds holds the
+    /// current state (hysteresis). Defaults to `latency_ms_down` when unset
     pub latency_ms_up: Option<u64>,
     /// Consecutive failed probes required to transition to down
     pub consec_fail_down: u32,

--- a/aifw-common/src/rule.rs
+++ b/aifw-common/src/rule.rs
@@ -320,8 +320,10 @@ pub struct Rule {
     /// Free-form admin note; not emitted into the pf rule
     #[serde(default)]
     pub description: Option<String>,
-    /// Gateway name for policy-based routing. Reserved: not persisted by the
-    /// DB layer and not emitted into the pf rule text by `to_pf_rule`.
+    /// Multi-WAN gateway id for policy-based routing (#540). Persisted, and
+    /// compiled into pf `route-to (iface next_hop)` by the rule engine after
+    /// resolving the gateway record. `None` uses default routing. A deleted
+    /// or down gateway falls back to default routing at compile time.
     #[serde(default)]
     pub gateway: Option<String>,
     /// State-tracking options (only emitted for pass rules)
@@ -376,6 +378,16 @@ impl Rule {
     /// state options are only emitted for pass rules. The `anchor` argument
     /// is unused here — callers place the rendered rule into the anchor.
     pub fn to_pf_rule(&self, anchor: &str) -> String {
+        self.to_pf_rule_routed(anchor, None)
+    }
+
+    /// Render with an optional resolved policy-routing gateway (#540):
+    /// emits pf `route-to (iface next_hop)` after the interface clause.
+    /// Only pass rules route — route-to is meaningless on block — and the
+    /// caller (rule engine) is responsible for resolving/validating the
+    /// gateway record before passing it here.
+    pub fn to_pf_rule_routed(&self, anchor: &str, route_to: Option<(&str, &str)>) -> String {
+        let _ = anchor;
         let mut parts = Vec::new();
 
         // action
@@ -401,6 +413,14 @@ impl Rule {
         // interface
         if let Some(ref iface) = self.interface {
             parts.push(format!("on {iface}"));
+        }
+
+        // policy routing (#540) — pf grammar places route-to after the
+        // interface clause and before the address family
+        if let Some((gw_iface, next_hop)) = route_to
+            && self.action == Action::Pass
+        {
+            parts.push(format!("route-to ({gw_iface} {next_hop})"));
         }
 
         // address family — must precede `proto` in pf grammar

--- a/aifw-common/src/tests.rs
+++ b/aifw-common/src/tests.rs
@@ -636,6 +636,57 @@ mod tests {
         assert!(IpsecProtocol::parse("bogus").is_err());
     }
 
+    // --- Policy routing render tests (#540) ---
+
+    #[test]
+    fn test_rule_route_to_rendering() {
+        let mut rule = Rule::new(
+            Action::Pass,
+            Direction::In,
+            Protocol::Tcp,
+            RuleMatch {
+                src_addr: Address::Any,
+                src_port: None,
+                dst_addr: Address::Any,
+                dst_port: Some(PortRange {
+                    start: 443,
+                    end: 443,
+                }),
+            },
+        );
+        rule.interface = Some(Interface("igb0".to_string()));
+        let pf = rule.to_pf_rule_routed("aifw", Some(("igb1", "203.0.113.1")));
+        assert_eq!(
+            pf,
+            "pass in quick on igb0 route-to (igb1 203.0.113.1) proto tcp to any port 443 keep state"
+        );
+        // Without a resolved gateway the rule renders unchanged
+        assert_eq!(
+            rule.to_pf_rule_routed("aifw", None),
+            rule.to_pf_rule("aifw")
+        );
+    }
+
+    #[test]
+    fn test_rule_route_to_ignored_on_block() {
+        let rule = Rule::new(
+            Action::Block,
+            Direction::In,
+            Protocol::Any,
+            RuleMatch {
+                src_addr: Address::Any,
+                src_port: None,
+                dst_addr: Address::Any,
+                dst_port: None,
+            },
+        );
+        let pf = rule.to_pf_rule_routed("aifw", Some(("igb1", "203.0.113.1")));
+        assert!(
+            !pf.contains("route-to"),
+            "block rules must not emit route-to: {pf}"
+        );
+    }
+
     // --- Schedule window tests (#537) ---
     // All evaluations use an injected NaiveDateTime — no wall clock.
     // 2026-07-15 is a Wednesday.

--- a/aifw-core/src/config.rs
+++ b/aifw-core/src/config.rs
@@ -433,6 +433,14 @@ pub struct RuleConfig {
     /// Negate the destination match (pf `!`)
     #[serde(default)]
     pub dst_invert: bool,
+    /// Schedule reference (#537). Older backups predate this field; restored
+    /// rules without it behave as unscheduled (always on).
+    #[serde(default)]
+    pub schedule_id: Option<String>,
+    /// Policy-routing gateway reference (#540); dangling references fall
+    /// back to default routing at compile time.
+    #[serde(default)]
+    pub gateway: Option<String>,
 }
 
 /// A NAT rule as stored in a config snapshot

--- a/aifw-core/src/db.rs
+++ b/aifw-core/src/db.rs
@@ -118,6 +118,7 @@ impl Database {
                 timeout_icmp INTEGER,
                 status TEXT NOT NULL DEFAULT 'active',
                 schedule_id TEXT,
+                gateway TEXT,
                 ip_version TEXT NOT NULL DEFAULT 'both',
                 src_invert INTEGER NOT NULL DEFAULT 0,
                 dst_invert INTEGER NOT NULL DEFAULT 0,
@@ -135,6 +136,8 @@ impl Database {
             "ALTER TABLE rules ADD COLUMN ip_version TEXT NOT NULL DEFAULT 'both'",
             "ALTER TABLE rules ADD COLUMN src_invert INTEGER NOT NULL DEFAULT 0",
             "ALTER TABLE rules ADD COLUMN dst_invert INTEGER NOT NULL DEFAULT 0",
+            // Policy-routing gateway reference (#540)
+            "ALTER TABLE rules ADD COLUMN gateway TEXT",
         ] {
             let _ = sqlx::query(stmt).execute(&self.pool).await;
         }
@@ -197,9 +200,9 @@ impl Database {
                 src_addr, src_port_start, src_port_end, dst_addr, dst_port_start, dst_port_end,
                 log, quick, label, state_tracking, state_policy, adaptive_start, adaptive_end,
                 timeout_tcp, timeout_udp, timeout_icmp, status, created_at, updated_at, schedule_id,
-                ip_version, src_invert, dst_invert)
+                ip_version, src_invert, dst_invert, gateway)
             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15,
-                    ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29)
+                    ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30)
             "#,
         )
         .bind(rule.id.to_string())
@@ -247,6 +250,7 @@ impl Database {
         .bind(format!("{:?}", rule.ip_version).to_lowercase())
         .bind(rule.src_invert)
         .bind(rule.dst_invert)
+        .bind(rule.gateway.as_deref())
         .execute(exec)
         .await?;
 
@@ -314,6 +318,42 @@ impl Database {
         Ok(map)
     }
 
+    /// Resolve multiwan gateways to (interface, next_hop, state) keyed by id,
+    /// for rule policy routing (#540). Returns an empty map when the multiwan
+    /// tables don't exist yet (fresh DB before the gateway engine migrated) —
+    /// rules referencing a gateway then fall back to default routing.
+    pub async fn list_gateway_routes(
+        &self,
+    ) -> std::collections::HashMap<String, (String, String, String)> {
+        let rows = sqlx::query_as::<_, (String, String, String, String)>(
+            "SELECT id, interface, next_hop, state FROM multiwan_gateways",
+        )
+        .fetch_all(&self.pool)
+        .await;
+        match rows {
+            Ok(rows) => rows
+                .into_iter()
+                .map(|(id, iface, hop, state)| (id, (iface, hop, state)))
+                .collect(),
+            Err(e) => {
+                tracing::debug!(error = %e, "gateway route lookup unavailable; rules fall back to default routing");
+                std::collections::HashMap::new()
+            }
+        }
+    }
+
+    /// Whether any rule references a policy-routing gateway (#540); used by
+    /// the daemon to skip rule reloads on gateway transitions nobody routes
+    /// through.
+    pub async fn has_gateway_rules(&self) -> Result<bool> {
+        let n = sqlx::query_scalar::<_, i64>(
+            "SELECT EXISTS(SELECT 1 FROM rules WHERE gateway IS NOT NULL AND gateway != '')",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(n == 1)
+    }
+
     /// Update a filter rule in place (refreshing `updated_at`). Fails with
     /// `NotFound` if the id doesn't exist
     pub async fn update_rule(&self, rule: &Rule) -> Result<()> {
@@ -336,7 +376,7 @@ impl Database {
                 adaptive_start = ?18, adaptive_end = ?19,
                 timeout_tcp = ?20, timeout_udp = ?21, timeout_icmp = ?22,
                 status = ?23, updated_at = ?24, schedule_id = ?25,
-                ip_version = ?26, src_invert = ?27, dst_invert = ?28
+                ip_version = ?26, src_invert = ?27, dst_invert = ?28, gateway = ?29
             WHERE id = ?1
             "#,
         )
@@ -384,6 +424,7 @@ impl Database {
         .bind(format!("{:?}", rule.ip_version).to_lowercase())
         .bind(rule.src_invert)
         .bind(rule.dst_invert)
+        .bind(rule.gateway.as_deref())
         .execute(exec)
         .await?;
 
@@ -491,7 +532,7 @@ const RULE_COLUMNS: &str = "id, priority, action, direction, interface, protocol
     src_addr, src_port_start, src_port_end, dst_addr, dst_port_start, dst_port_end, \
     log, quick, label, state_tracking, state_policy, adaptive_start, adaptive_end, \
     timeout_tcp, timeout_udp, timeout_icmp, status, created_at, updated_at, \
-    schedule_id, ip_version, src_invert, dst_invert";
+    schedule_id, ip_version, src_invert, dst_invert, gateway";
 
 #[derive(sqlx::FromRow)]
 struct RuleRow {
@@ -524,6 +565,7 @@ struct RuleRow {
     ip_version: String,
     src_invert: bool,
     dst_invert: bool,
+    gateway: Option<String>,
 }
 
 impl RuleRow {
@@ -572,7 +614,7 @@ impl RuleRow {
             quick: self.quick,
             label: self.label,
             description: None,
-            gateway: None,
+            gateway: self.gateway,
             state_options: StateOptions {
                 tracking: parse_state_tracking(&self.state_tracking),
                 policy: self.state_policy.as_deref().map(parse_state_policy),

--- a/aifw-core/src/engine.rs
+++ b/aifw-core/src/engine.rs
@@ -10,6 +10,40 @@ use crate::validation::validate_rule;
 
 const DEFAULT_ANCHOR: &str = "aifw";
 
+/// Resolve a rule's policy-routing gateway reference to the `(interface,
+/// next_hop)` pair `route-to` needs (#540). Falls back to default routing
+/// (None) with a warning when the gateway is missing or currently down —
+/// blackholing traffic at a dead next-hop would be worse than the default
+/// route — or when the stored record fails validation.
+fn resolve_rule_route<'a>(
+    rule: &aifw_common::Rule,
+    gateways: &'a std::collections::HashMap<String, (String, String, String)>,
+) -> Option<(&'a str, &'a str)> {
+    let gw_id = rule.gateway.as_deref()?;
+    let Some((iface, next_hop, state)) = gateways.get(gw_id) else {
+        tracing::warn!(rule_id = %rule.id, gateway = %gw_id,
+            "rule references a missing gateway; using default routing");
+        return None;
+    };
+    if state == "down" {
+        tracing::warn!(rule_id = %rule.id, gateway = %gw_id,
+            "policy-routing gateway is down; using default routing");
+        return None;
+    }
+    // Both values land in pf rule text — re-validate shape even though the
+    // gateway API validated them at creation.
+    let iface_ok = !iface.is_empty()
+        && iface
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+    if !iface_ok || next_hop.parse::<std::net::IpAddr>().is_err() {
+        tracing::warn!(rule_id = %rule.id, gateway = %gw_id,
+            "gateway record failed validation; using default routing");
+        return None;
+    }
+    Some((iface.as_str(), next_hop.as_str()))
+}
+
 /// Filter-rule engine: persists [`Rule`]s in the SQLite `rules` table and
 /// renders active ones into pf syntax loaded into the `aifw` anchor
 /// (override via [`Self::with_anchor`]). Every mutation commits its audit
@@ -133,6 +167,7 @@ impl RuleEngine {
     pub async fn apply_rules(&self) -> Result<()> {
         let rules = self.db.list_active_rules().await?;
         let schedules = self.db.list_schedule_specs().await?;
+        let gateways = self.db.list_gateway_routes().await;
         let now = chrono::Local::now().naive_local();
         let mut pf_rules: Vec<String> = rules
             .iter()
@@ -150,7 +185,10 @@ impl RuleEngine {
                     now,
                 )
             })
-            .map(|r| r.to_pf_rule(&self.anchor))
+            .map(|r| {
+                let route = resolve_rule_route(r, &gateways);
+                r.to_pf_rule_routed(&self.anchor, route)
+            })
             .collect();
 
         // Inject extra rules (VPN pass rules, etc.) before the first block rule

--- a/aifw-core/src/multiwan/gateway.rs
+++ b/aifw-core/src/multiwan/gateway.rs
@@ -86,7 +86,48 @@ fn mos_score(rtt_ms: f64, jitter_ms: f64, loss_pct: f64) -> f64 {
     }
 }
 
+/// How the configured latency thresholds judge the current RTT (#539).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LatencyVerdict {
+    /// RTT at or above `latency_ms_down` — degrade to warning
+    Degrade,
+    /// RTT at or below the recovery threshold (or latency unconfigured / no
+    /// sample yet) — latency does not constrain the state
+    Recover,
+    /// RTT inside the hysteresis band between the two thresholds — keep the
+    /// current latency-driven state
+    Hold,
+}
+
+fn latency_verdict(
+    latency_ms_down: Option<u64>,
+    latency_ms_up: Option<u64>,
+    rtt_ms: Option<f64>,
+) -> LatencyVerdict {
+    match (latency_ms_down, rtt_ms) {
+        (Some(down), Some(rtt)) => {
+            // The recovery threshold defaults to (and can never exceed) the
+            // degrade threshold, so the hysteresis band is well-formed.
+            let up = latency_ms_up.unwrap_or(down).min(down);
+            if rtt >= down as f64 {
+                LatencyVerdict::Degrade
+            } else if rtt <= up as f64 {
+                LatencyVerdict::Recover
+            } else {
+                LatencyVerdict::Hold
+            }
+        }
+        _ => LatencyVerdict::Recover,
+    }
+}
+
 /// Decide next state given current state, metrics, and gateway thresholds.
+///
+/// Precedence (#539): consecutive-failure Down detection always wins (never
+/// delayed by latency or dampening); a latency degrade forces Warning even
+/// while probes succeed; recovery to Up requires the consecutive-success
+/// count AND loss at/below `loss_pct_up` AND RTT out of the latency
+/// hysteresis band.
 pub fn evaluate_transition(
     current: GatewayState,
     metrics: &GatewayMetrics,
@@ -94,12 +135,21 @@ pub fn evaluate_transition(
     consec_ok_up: u32,
     loss_pct_down: f64,
     loss_pct_up: f64,
+    latency_ms_down: Option<u64>,
+    latency_ms_up: Option<u64>,
 ) -> GatewayState {
+    let lat = latency_verdict(latency_ms_down, latency_ms_up, metrics.last_rtt_ms);
     if metrics.consec_fail >= consec_fail_down {
         return GatewayState::Down;
     }
+    if lat == LatencyVerdict::Degrade {
+        return GatewayState::Warning;
+    }
     if metrics.consec_ok >= consec_ok_up {
         if metrics.recent_loss > loss_pct_up {
+            return GatewayState::Warning;
+        }
+        if lat == LatencyVerdict::Hold && current == GatewayState::Warning {
             return GatewayState::Warning;
         }
         return GatewayState::Up;
@@ -110,6 +160,51 @@ pub fn evaluate_transition(
     current
 }
 
+/// Human-readable trigger for a state transition, embedded in gateway
+/// events so operators can see which metric crossed which threshold (#539).
+fn transition_reason(to: GatewayState, metrics: &GatewayMetrics, gw: &Gateway) -> Option<String> {
+    match to {
+        GatewayState::Down => Some(format!(
+            "{} consecutive probe failures (threshold {})",
+            metrics.consec_fail, gw.consec_fail_down
+        )),
+        GatewayState::Warning => {
+            if latency_verdict(gw.latency_ms_down, gw.latency_ms_up, metrics.last_rtt_ms)
+                != LatencyVerdict::Recover
+            {
+                Some(format!(
+                    "rtt {:.0}ms crossed latency_ms_down {}ms",
+                    metrics.last_rtt_ms.unwrap_or(0.0),
+                    gw.latency_ms_down.unwrap_or(0)
+                ))
+            } else {
+                Some(format!(
+                    "loss {:.1}% above threshold ({}%/{}%)",
+                    metrics.recent_loss, gw.loss_pct_down, gw.loss_pct_up
+                ))
+            }
+        }
+        GatewayState::Up => Some(format!(
+            "recovered: {} consecutive successes",
+            metrics.consec_ok
+        )),
+        GatewayState::Unknown => None,
+    }
+}
+
+/// Whether a pending transition must be suppressed by the dampening
+/// hold-down (#539). Pure so tests can drive it with an arbitrary elapsed
+/// time. Transitions TO Down are never held — failure detection must not be
+/// delayed for flap suppression; recovery/degradation transitions are.
+pub fn dampening_holds(
+    elapsed_since_last_transition: std::time::Duration,
+    dampening_secs: u32,
+    to: GatewayState,
+) -> bool {
+    to != GatewayState::Down
+        && elapsed_since_last_transition < std::time::Duration::from_secs(u64::from(dampening_secs))
+}
+
 /// Multi-WAN gateway engine: CRUD over `multiwan_gateways`, per-gateway
 /// background probe monitors, hysteresis-based state transitions, and a
 /// broadcast channel of state-change events
@@ -118,6 +213,10 @@ pub struct GatewayEngine {
     metrics: Arc<RwLock<HashMap<Uuid, GatewayMetrics>>>,
     monitors: Arc<Mutex<HashMap<Uuid, JoinHandle<()>>>>,
     events_tx: broadcast::Sender<GatewayEvent>,
+    /// Monotonic timestamp of each gateway's last persisted state change,
+    /// driving the `dampening_secs` hold-down (#539). Instant, not wall
+    /// clock, so NTP steps can't break or extend the hold-down.
+    last_transition: Arc<RwLock<HashMap<Uuid, std::time::Instant>>>,
 }
 
 impl GatewayEngine {
@@ -130,6 +229,7 @@ impl GatewayEngine {
             metrics: Arc::new(RwLock::new(HashMap::new())),
             monitors: Arc::new(Mutex::new(HashMap::new())),
             events_tx: tx,
+            last_transition: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -385,16 +485,34 @@ impl GatewayEngine {
         let mut metrics_map = self.metrics.write().await;
         let m = metrics_map.entry(gw_id).or_default();
         m.ingest(&outcome, Utc::now());
-        let new_state = evaluate_transition(
+        let mut new_state = evaluate_transition(
             gw.state,
             m,
             gw.consec_fail_down,
             gw.consec_ok_up,
             gw.loss_pct_down,
             gw.loss_pct_up,
+            gw.latency_ms_down,
+            gw.latency_ms_up,
         );
         let metrics_snapshot = m.clone();
         drop(metrics_map);
+        // Dampening hold-down (#539): suppress a fresh transition that lands
+        // inside the hold-down window after the previous one, except
+        // escalation to Down, which is never delayed.
+        if new_state != gw.state
+            && let Some(last) = self.last_transition.read().await.get(&gw_id).copied()
+            && dampening_holds(last.elapsed(), gw.dampening_secs, new_state)
+        {
+            tracing::debug!(
+                gw = %gw.name,
+                from = ?gw.state,
+                to = ?new_state,
+                dampening_secs = gw.dampening_secs,
+                "gateway transition held by dampening"
+            );
+            new_state = gw.state;
+        }
         self.persist_state(&gw, new_state, &outcome, &metrics_snapshot)
             .await?;
         Ok(())
@@ -426,6 +544,17 @@ impl GatewayEngine {
         .map_err(|e| AifwError::Database(e.to_string()))?;
 
         if new_state != gw.state {
+            self.last_transition
+                .write()
+                .await
+                .insert(gw.id, std::time::Instant::now());
+            // Event reason names the metric and threshold that triggered the
+            // transition (#539); the raw probe error is appended when present.
+            let reason = match (transition_reason(new_state, metrics, gw), &outcome.error) {
+                (Some(r), Some(e)) => Some(format!("{r}; probe: {e}")),
+                (Some(r), None) => Some(r),
+                (None, e) => e.clone(),
+            };
             let snap = serde_json::json!({
                 "rtt_ms": metrics.last_rtt_ms,
                 "jitter_ms": metrics.last_jitter_ms,
@@ -433,6 +562,8 @@ impl GatewayEngine {
                 "mos": metrics.last_mos,
                 "consec_fail": metrics.consec_fail,
                 "consec_ok": metrics.consec_ok,
+                "latency_ms_down": gw.latency_ms_down,
+                "latency_ms_up": gw.latency_ms_up,
             })
             .to_string();
             sqlx::query(
@@ -443,7 +574,7 @@ impl GatewayEngine {
             .bind(now.to_rfc3339())
             .bind(gw.state.as_str())
             .bind(new_state.as_str())
-            .bind(outcome.error.clone())
+            .bind(reason.clone())
             .bind(&snap)
             .execute(&self.pool)
             .await
@@ -455,7 +586,7 @@ impl GatewayEngine {
                 ts: now,
                 from_state: Some(gw.state),
                 to_state: new_state,
-                reason: outcome.error.clone(),
+                reason,
                 probe_snapshot_json: Some(snap),
             };
             let _ = self.events_tx.send(event);
@@ -703,7 +834,7 @@ mod tests {
             consec_fail: 3,
             ..GatewayMetrics::default()
         };
-        let s = evaluate_transition(GatewayState::Up, &m, 3, 5, 20.0, 5.0);
+        let s = evaluate_transition(GatewayState::Up, &m, 3, 5, 20.0, 5.0, None, None);
         assert_eq!(s, GatewayState::Down);
     }
 
@@ -714,7 +845,203 @@ mod tests {
             recent_loss: 8.0,
             ..GatewayMetrics::default()
         };
-        let s = evaluate_transition(GatewayState::Down, &m, 3, 5, 20.0, 5.0);
+        let s = evaluate_transition(GatewayState::Down, &m, 3, 5, 20.0, 5.0, None, None);
         assert_eq!(s, GatewayState::Warning);
+    }
+
+    // --- Latency threshold + dampening tests (#539) ---
+
+    #[test]
+    fn latency_degrade_despite_successful_probes() {
+        // All probes succeed but RTT is over latency_ms_down → Warning.
+        let m = GatewayMetrics {
+            consec_ok: 10,
+            recent_loss: 0.0,
+            last_rtt_ms: Some(250.0),
+            ..GatewayMetrics::default()
+        };
+        let s = evaluate_transition(GatewayState::Up, &m, 3, 5, 20.0, 5.0, Some(200), Some(100));
+        assert_eq!(s, GatewayState::Warning);
+    }
+
+    #[test]
+    fn latency_hysteresis_band_holds_current_state() {
+        // RTT between latency_ms_up (100) and latency_ms_down (200): a
+        // Warning gateway stays Warning, an Up gateway stays Up.
+        let m = GatewayMetrics {
+            consec_ok: 10,
+            recent_loss: 0.0,
+            last_rtt_ms: Some(150.0),
+            ..GatewayMetrics::default()
+        };
+        let held = evaluate_transition(
+            GatewayState::Warning,
+            &m,
+            3,
+            5,
+            20.0,
+            5.0,
+            Some(200),
+            Some(100),
+        );
+        assert_eq!(held, GatewayState::Warning);
+        let up = evaluate_transition(GatewayState::Up, &m, 3, 5, 20.0, 5.0, Some(200), Some(100));
+        assert_eq!(up, GatewayState::Up);
+    }
+
+    #[test]
+    fn latency_recovery_below_up_threshold() {
+        let m = GatewayMetrics {
+            consec_ok: 10,
+            recent_loss: 0.0,
+            last_rtt_ms: Some(80.0),
+            ..GatewayMetrics::default()
+        };
+        let s = evaluate_transition(
+            GatewayState::Warning,
+            &m,
+            3,
+            5,
+            20.0,
+            5.0,
+            Some(200),
+            Some(100),
+        );
+        assert_eq!(s, GatewayState::Up);
+    }
+
+    #[test]
+    fn latency_unconfigured_never_constrains() {
+        let m = GatewayMetrics {
+            consec_ok: 10,
+            recent_loss: 0.0,
+            last_rtt_ms: Some(5000.0),
+            ..GatewayMetrics::default()
+        };
+        let s = evaluate_transition(GatewayState::Warning, &m, 3, 5, 20.0, 5.0, None, None);
+        assert_eq!(s, GatewayState::Up);
+    }
+
+    #[test]
+    fn dampening_holds_non_down_transitions_only() {
+        use std::time::Duration;
+        // Inside the hold-down window: recovery/degradation are suppressed,
+        // Down never is.
+        assert!(dampening_holds(
+            Duration::from_secs(3),
+            10,
+            GatewayState::Up
+        ));
+        assert!(dampening_holds(
+            Duration::from_secs(3),
+            10,
+            GatewayState::Warning
+        ));
+        assert!(!dampening_holds(
+            Duration::from_secs(3),
+            10,
+            GatewayState::Down
+        ));
+        // Window elapsed → nothing is held.
+        assert!(!dampening_holds(
+            Duration::from_secs(11),
+            10,
+            GatewayState::Up
+        ));
+        // Zero dampening disables the hold entirely.
+        assert!(!dampening_holds(Duration::ZERO, 0, GatewayState::Up));
+    }
+
+    #[tokio::test]
+    async fn dampening_suppresses_flapping_recovery() {
+        let (engine, inst) = setup().await;
+        let mut gw = make_gw("wan1", inst);
+        gw.latency_ms_down = Some(100);
+        gw.latency_ms_up = Some(50);
+        gw.consec_ok_up = 1;
+        gw.dampening_secs = 3600; // effectively forever for this test
+        let gw = engine.add(gw).await.unwrap();
+
+        // High-RTT success → Unknown → Warning (latency degrade)
+        engine
+            .inject_sample(
+                gw.id,
+                ProbeOutcome {
+                    success: true,
+                    rtt_ms: Some(150.0),
+                    error: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            engine.get(gw.id).await.unwrap().state,
+            GatewayState::Warning
+        );
+
+        // Immediate recovery sample: would flip to Up, but the hold-down
+        // suppresses it.
+        engine
+            .inject_sample(
+                gw.id,
+                ProbeOutcome {
+                    success: true,
+                    rtt_ms: Some(10.0),
+                    error: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            engine.get(gw.id).await.unwrap().state,
+            GatewayState::Warning,
+            "recovery inside the dampening window must be held"
+        );
+
+        // Hard failure escalation is never held by dampening.
+        for _ in 0..3 {
+            engine
+                .inject_sample(
+                    gw.id,
+                    ProbeOutcome {
+                        success: false,
+                        rtt_ms: None,
+                        error: Some("timeout".into()),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        assert_eq!(engine.get(gw.id).await.unwrap().state, GatewayState::Down);
+    }
+
+    #[tokio::test]
+    async fn latency_transition_event_names_metric() {
+        let (engine, inst) = setup().await;
+        let mut gw = make_gw("wan1", inst);
+        gw.latency_ms_down = Some(100);
+        gw.dampening_secs = 0;
+        let gw = engine.add(gw).await.unwrap();
+        engine
+            .inject_sample(
+                gw.id,
+                ProbeOutcome {
+                    success: true,
+                    rtt_ms: Some(150.0),
+                    error: None,
+                },
+            )
+            .await
+            .unwrap();
+        let events = engine.list_events(gw.id, 10).await.unwrap();
+        let warn_ev = events
+            .iter()
+            .find(|e| e.to_state == GatewayState::Warning)
+            .expect("warning transition event");
+        let reason = warn_ev.reason.as_deref().unwrap_or_default();
+        assert!(
+            reason.contains("latency_ms_down"),
+            "reason should name the triggering threshold, got: {reason}"
+        );
     }
 }

--- a/aifw-core/src/multiwan/mod.rs
+++ b/aifw-core/src/multiwan/mod.rs
@@ -16,7 +16,7 @@ pub mod preflight;
 pub mod probe;
 pub mod sla;
 
-pub use gateway::{GatewayEngine, GatewayMetrics, evaluate_transition};
+pub use gateway::{GatewayEngine, GatewayMetrics, dampening_holds, evaluate_transition};
 pub use group::{GroupEngine, Selection, select};
 pub use instance::InstanceEngine;
 pub use leak::{LEAK_ANCHOR, LeakEngine};

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -233,6 +233,91 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_engine_gateway_route_to() {
+        // Rules referencing a healthy gateway compile route-to; down or
+        // dangling gateway references fall back to default routing (#540).
+        let db = Database::new_in_memory().await.unwrap();
+        let mock = Arc::new(aifw_pf::PfMock::new());
+        let pf: Arc<dyn PfBackend> = mock.clone();
+        mock.set_fib_count(4).await;
+        let inst = crate::multiwan::InstanceEngine::new(db.pool().clone(), mock.clone());
+        inst.migrate().await.unwrap();
+        let gw_engine = crate::multiwan::GatewayEngine::new(db.pool().clone());
+        gw_engine.migrate().await.unwrap();
+        let engine = RuleEngine::new(db.pool().clone(), pf);
+
+        let insert_gw = |id: &str, name: &str, state: &str| {
+            let q = sqlx::query(
+                "INSERT INTO multiwan_gateways \
+                 (id, name, instance_id, interface, next_hop, state, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)",
+            )
+            .bind(id.to_string())
+            .bind(name.to_string())
+            .bind(aifw_common::DEFAULT_INSTANCE_ID.to_string())
+            .bind("igb1")
+            .bind("203.0.113.1")
+            .bind(state.to_string())
+            .bind("2026-01-01T00:00:00Z");
+            let pool = db.pool().clone();
+            async move { q.execute(&pool).await.unwrap() }
+        };
+        let up_id = uuid::Uuid::new_v4().to_string();
+        let down_id = uuid::Uuid::new_v4().to_string();
+        insert_gw(&up_id, "wan-up", "up").await;
+        insert_gw(&down_id, "wan-down", "down").await;
+
+        let mk = |label: &str, gw: Option<String>| {
+            let mut r = Rule::new(
+                Action::Pass,
+                Direction::In,
+                Protocol::Tcp,
+                RuleMatch {
+                    src_addr: Address::Any,
+                    src_port: None,
+                    dst_addr: Address::Any,
+                    dst_port: Some(PortRange { start: 80, end: 80 }),
+                },
+            );
+            r.label = Some(label.to_string());
+            r.gateway = gw;
+            r
+        };
+        engine
+            .add_rule(mk("routed", Some(up_id.clone())))
+            .await
+            .unwrap();
+        engine
+            .add_rule(mk("gw-down", Some(down_id.clone())))
+            .await
+            .unwrap();
+        engine
+            .add_rule(mk("gw-dangling", Some(uuid::Uuid::new_v4().to_string())))
+            .await
+            .unwrap();
+
+        engine.apply_rules().await.unwrap();
+        let pf_rules = mock.get_rules("aifw").await.unwrap();
+        let find = |label: &str| {
+            pf_rules
+                .iter()
+                .find(|r| r.contains(&format!("\"{label}\"")))
+                .unwrap_or_else(|| panic!("rule {label} missing"))
+        };
+        assert!(find("routed").contains("route-to (igb1 203.0.113.1)"));
+        assert!(!find("gw-down").contains("route-to"));
+        assert!(!find("gw-dangling").contains("route-to"));
+
+        // Round-trip: the gateway reference survives persistence
+        let rules = engine.list_rules().await.unwrap();
+        let routed = rules
+            .iter()
+            .find(|r| r.label.as_deref() == Some("routed"))
+            .unwrap();
+        assert_eq!(routed.gateway.as_deref(), Some(up_id.as_str()));
+    }
+
+    #[tokio::test]
     async fn test_engine_flush_rules() {
         let db = Database::new_in_memory().await.unwrap();
         let mock = Arc::new(aifw_pf::PfMock::new());
@@ -1437,6 +1522,8 @@ mod tests {
             ip_version: aifw_common::IpVersion::Both,
             src_invert: false,
             dst_invert: false,
+            schedule_id: None,
+            gateway: None,
         });
         assert_eq!(config.resource_count(), 1);
     }
@@ -1592,6 +1679,8 @@ mod tests {
             ip_version: aifw_common::IpVersion::Both,
             src_invert: false,
             dst_invert: false,
+            schedule_id: None,
+            gateway: None,
         });
         let v2 = mgr.save_version(&c2, "test", None).await.unwrap();
 

--- a/aifw-daemon/src/main.rs
+++ b/aifw-daemon/src/main.rs
@@ -209,6 +209,45 @@ async fn main() -> anyhow::Result<()> {
         info!(count = gateways.len(), "gateway monitors started");
     }
 
+    // Reload firewall rules when a gateway changes state (#540): rules with
+    // a policy-routing gateway compile to `route-to` while it's healthy and
+    // fall back to default routing while it's down, so state transitions
+    // must recompile the anchor. Skipped when no rule references a gateway.
+    {
+        let engine = engine.clone();
+        let vpn_engine = aifw_core::VpnEngine::new(pool.clone(), pf.clone());
+        let mut rx = gateway_engine.subscribe();
+        tokio::spawn(async move {
+            loop {
+                match rx.recv().await {
+                    Ok(ev) => {
+                        match engine.db().has_gateway_rules().await {
+                            Ok(false) => continue,
+                            Ok(true) => {}
+                            Err(e) => {
+                                tracing::warn!(error = %e, "gateway route watcher: db check failed");
+                                continue;
+                            }
+                        }
+                        info!(gateway = %ev.gateway_id, to = ?ev.to_state,
+                            "gateway transition; reloading policy-routed rules");
+                        match vpn_engine.collect_vpn_rules().await {
+                            Ok(extras) => engine.set_extra_rules(extras).await,
+                            Err(e) => tracing::warn!(error = %e,
+                                "gateway route reload: collecting vpn rules failed"),
+                        }
+                        if let Err(e) = engine.apply_rules().await {
+                            error!("gateway route reload: apply_rules failed: {e}");
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+        info!("gateway route watcher started");
+    }
+
     // SLA aggregation loop — 1-minute buckets, retention pruned daily
     {
         let sla = sla_engine.clone();

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.100.0",
+  "version": "5.100.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.8",
+  "version": "5.100.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/src/app/rules/components/RuleFormModal.tsx
+++ b/aifw-ui/src/app/rules/components/RuleFormModal.tsx
@@ -2,6 +2,7 @@
 
 import { Dispatch, SetStateAction } from "react";
 import type { InterfaceInfo, RuleForm, Schedule } from "@/lib/api/rules";
+import type { Gateway } from "@/lib/api/multiwan-policies";
 import {
   ACTIONS,
   IP_VERSIONS,
@@ -30,6 +31,7 @@ export function RuleFormModal({
   submitting,
   interfaces,
   schedules,
+  gateways,
   onSubmit,
   onCancel,
 }: {
@@ -39,6 +41,7 @@ export function RuleFormModal({
   submitting: boolean;
   interfaces: InterfaceInfo[];
   schedules: Schedule[];
+  gateways: Gateway[];
   onSubmit: () => void;
   onCancel: () => void;
 }) {
@@ -316,13 +319,23 @@ export function RuleFormModal({
             </div>
             <div>
               <label className={labelClass}>Gateway</label>
-              <input
-                type="text"
+              <select
                 value={form.gateway}
                 onChange={(e) => setForm((f) => ({ ...f, gateway: e.target.value }))}
-                placeholder="Policy routing gateway"
-                className={inputClass}
-              />
+                className={selectClass}
+              >
+                <option value="">Default routing</option>
+                {gateways.map((g) => (
+                  <option key={g.id} value={g.id}>
+                    {g.name} ({g.interface} → {g.next_hop})
+                  </option>
+                ))}
+              </select>
+              <p className="mt-1 text-xs text-gray-500">
+                Pass rules matching this rule are policy-routed via the
+                selected Multi-WAN gateway (pf route-to). Falls back to
+                default routing while the gateway is down.
+              </p>
             </div>
             <div>
               <label className={labelClass}>State Type</label>

--- a/aifw-ui/src/app/rules/page.tsx
+++ b/aifw-ui/src/app/rules/page.tsx
@@ -17,6 +17,7 @@ export default function RulesPage() {
     rules,
     interfaces,
     schedules,
+    gateways,
     systemRules,
     loading,
     error,
@@ -208,6 +209,7 @@ export default function RulesPage() {
           submitting={submitting}
           interfaces={interfaces}
           schedules={schedules}
+          gateways={gateways}
           onSubmit={handleSubmit}
           onCancel={handleCancel}
         />

--- a/aifw-ui/src/hooks/useRules.ts
+++ b/aifw-ui/src/hooks/useRules.ts
@@ -10,6 +10,7 @@ import {
   toggleStatusRequest,
   validateRuleForm,
 } from "@/lib/api/rules";
+import { Gateway, listGateways } from "@/lib/api/multiwan-policies";
 
 /// Data + actions for the firewall rules page (#428). Owns the rule,
 /// interface, schedule and live-pf-rule lists plus the create/update/
@@ -22,6 +23,7 @@ export function useRules() {
   const [rules, setRules] = useState<Rule[]>([]);
   const [interfaces, setInterfaces] = useState<InterfaceInfo[]>([]);
   const [schedules, setSchedules] = useState<Schedule[]>([]);
+  const [gateways, setGateways] = useState<Gateway[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [systemRules, setSystemRules] = useState<string[]>([]);
@@ -63,6 +65,11 @@ export function useRules() {
 
       api.listSchedules()
         .then((d) => setSchedules(d.data || []))
+        .catch(() => {});
+
+      // Multi-WAN gateways feed the policy-routing dropdown (#540)
+      listGateways()
+        .then((d) => setGateways(d || []))
         .catch(() => {});
     });
   }, [fetchRules]);
@@ -159,6 +166,7 @@ export function useRules() {
     rules,
     interfaces,
     schedules,
+    gateways,
     systemRules,
     loading,
     error,

--- a/docs/docs/firewall.md
+++ b/docs/docs/firewall.md
@@ -121,6 +121,15 @@ Evaluation semantics:
 - The daemon re-evaluates schedules once per minute (the same cadence pfSense/OPNsense use) and reloads the ruleset when a rule crosses a window boundary; schedule edits via the API reload immediately.
 - A disabled schedule, or a `schedule_id` pointing at a deleted schedule, does not constrain the rule — it stays loaded as if unscheduled (fail-open is deliberate: rules can be `block` as well as `pass`, and unloading a block rule on a dangling reference would open the firewall).
 
+## Policy routing (rule gateway)
+
+A pass rule can reference a Multi-WAN gateway by id (the `gateway` field; a dropdown in the rule form). Matching traffic is compiled with pf `route-to (interface next_hop)` so it egresses via that gateway instead of the default route.
+
+- Only `pass` rules route; the field is ignored on block rules.
+- The API rejects a gateway reference that isn't an existing Multi-WAN gateway — it is never silently discarded.
+- While the gateway is **down** (as judged by its health probes) the rule compiles without `route-to` and traffic falls back to default routing; the daemon reloads the ruleset on gateway state transitions. Deleting a gateway unlinks it from rules.
+- For weighted balancing or failover *groups*, use Multi-WAN policies instead; the rule gateway pins traffic to a single gateway.
+
 ## Traffic shaping
 
 Queue policy lives alongside rules. Three queue disciplines are supported via the `aifw queue` subcommand:


### PR DESCRIPTION
Batch 3 from the 2026-07-18 audit sweep: the two remaining silent-misconfiguration bugs, both "operator configures routing behavior that never happens."

## #539 — Latency thresholds and dampening now govern failover

- `evaluate_transition` applies `latency_ms_down`/`latency_ms_up` with a hysteresis band: RTT at/above `down` degrades the gateway to Warning **even while probes succeed**; recovery requires RTT at/below `up`; in between holds the current state. Unconfigured latency never constrains.
- `dampening_secs` is a real hold-down now, tracked with a monotonic clock (NTP-step immune): recovery/degradation transitions inside the window are suppressed; **escalation to Down is never delayed** — failure detection beats flap suppression.
- Transition events record the triggering metric and threshold ("rtt 250ms crossed latency_ms_down 200ms", "3 consecutive probe failures (threshold 3)") plus the probe error.
- Found while implementing: the gateway API **hardcoded `latency_ms_down/up` to `None`** — operators couldn't even set them. The request now accepts both, and validates threshold combos (recovery ≤ degrade for loss and latency, latency up without down rejected, dampening ≤ 24h).
- Tests: hysteresis band hold, degrade-despite-success, recovery, unconfigured, pure `dampening_holds` with injected elapsed time, engine-level flap-suppression + never-hold-Down, event-reason content.
- Note: the UI has never exposed latency/dampening fields (API-only config today) — left for the Multi-WAN UI to pick up separately.

## #540 — Rule Gateway field is real policy routing now

- `rules` gains a persisted, validated `gateway` column (idempotent migration). The API rejects unknown or malformed gateway references with 400 — the silent-discard path is gone; empty clears the association.
- The rule engine resolves the gateway at compile time and emits pf `route-to (iface next_hop)` on pass rules (block rules ignore it). Fail-open semantics, mirroring the #537 schedule design: a **down** gateway compiles without route-to (default routing beats blackholing at a dead next-hop), dangling references warn and fall back; both re-validated for pf-injection safety before emission.
- The daemon subscribes to gateway state transitions and reloads the ruleset when any rule policy-routes (skipped otherwise). Gateway deletion unlinks referencing rules and reloads.
- The UI Gateway field is a dropdown of actual Multi-WAN gateways ("name (iface → next_hop)") with a default-routing option, fed by the existing `listGateways()` API.
- Backup/restore round-trips the gateway reference — and **also `schedule_id`, which backups were silently dropping**: a restore would have detached every schedule and reintroduced the #537 always-on hazard. Both fields are `serde(default)` so older backups restore cleanly.
- Tests: pf render (route-to placement, block ignored), engine gating (up/down/dangling), API round-trip incl. rejection of unknown/malformed references and delete-unlink.

## Verification

711 tests passing / 0 failed workspace-wide; `cargo check --workspace --all-targets` zero warnings; clippy + fmt clean; `npm run build` + lint clean.

Known follow-ups: schedules and Multi-WAN gateway definitions are not themselves part of the backup snapshot (references survive; definitions must exist on the target box) — candidate for the backup-coverage work. Live FreeBSD route-to traffic validation belongs to CI epic #533.

Closes #539. Closes #540.

## #321 (SEC-L6) — tower feature trim (added)

`tower = { features = ["full"] }` → `default-features = false`: only `ServiceBuilder` (tower core) is used directly, and axum/tower-http pull their own tower features per build graph. This completes #321 — the tokio half was already done by PERF-H3 (#347). Verified: workspace check zero warnings, aifw-api tests pass.

Closes #321.