### PR TITLE
Docs honesty pass + IPS reactive-blocking rename (#529, #536)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.100.1"
+version = "5.100.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ High-performance firewall for FreeBSD built in Rust on top of pf. Optional AI/ML
 ## Features
 
 - **Stateful packet filtering** via FreeBSD's pf with anchor isolation
-- **NAT** — SNAT, DNAT/RDR, masquerade, binat, NAT64/NAT46
+- **NAT** — SNAT, DNAT/RDR, masquerade, binat (NAT64/NAT46 in development — rule types exist, cross-family translation data plane is being built, #531)
 - **Connection tracking** — real-time state table monitoring, top talkers, protocol breakdown
-- **Rate limiting & traffic shaping** — CoDel/HFSC/PriQ queues, per-IP overload tables, SYN flood protection
+- **Rate limiting & traffic shaping** — HFSC/PriQ queues, per-IP overload tables, SYN flood protection (CoDel via dummynet FQ-CoDel in development, #532)
 - **AI/ML threat detection** *(optional, WIP)* — experimental port scan, DDoS, brute force, C2 beacon, DNS tunnel detection with auto-response (disabled by default, not yet production-ready)
-- **VPN integration** — WireGuard tunnels + peers, IPsec SAs with pf rule generation
+- **VPN integration** — WireGuard tunnels + peers (IPsec in development: SA config + pf rules exist, kernel data plane/IKE being built, #530)
 - **Geo-IP filtering** — country-based block/allow with GeoLite2 CSV, CIDR aggregation
 - **TLS inspection** — JA3/JA3S fingerprinting, SNI filtering, cert validation, version enforcement
 - **Plugin system** — native Rust + WASM sandboxed plugins with 7 hook points

--- a/aifw-common/src/ids.rs
+++ b/aifw-common/src/ids.rs
@@ -11,7 +11,12 @@ use uuid::Uuid;
 pub enum IdsMode {
     /// Alert only — log detections, never block
     Ids,
-    /// Inline — drop/reject packets matching drop rules
+    /// Reactive source blocking (#536): a drop/reject verdict adds the
+    /// alert's source IP to the `aifw-ids-block` pf table, blocking
+    /// subsequent packets from that source. The triggering packet is NOT
+    /// stopped — this is not inline prevention (inline is tracked
+    /// separately via divert/netmap). Wire value stays "ips" for API
+    /// compatibility.
     Ips,
     /// Engine disabled
     #[default]
@@ -137,9 +142,9 @@ impl RuleSource {
 pub enum IdsAction {
     /// Log the detection only (IDS mode)
     Alert,
-    /// Silently discard the packet (IPS mode)
+    /// Block the source via the pf table (IPS reactive mode; the matching packet is not discarded)
     Drop,
-    /// Discard and send TCP RST / ICMP unreachable back (IPS mode)
+    /// Block the source via the pf table, reject-style rules included (IPS reactive mode)
     Reject,
     /// Explicitly allow the traffic, skipping further rules
     Pass,

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.100.1",
+  "version": "5.100.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/src/app/ids/page.tsx
+++ b/aifw-ui/src/app/ids/page.tsx
@@ -190,14 +190,14 @@ export default function IdsDashboardPage() {
                   ? "Engine Stopped"
                   : currentMode === "ids"
                   ? "IDS Running — Monitor Mode"
-                  : "IPS Running — Active Blocking"}
+                  : "IPS Running — Reactive Blocking"}
               </h3>
               <p className="text-xs text-[var(--text-muted)] mt-0.5">
                 {currentMode === "disabled"
                   ? "The intrusion detection engine is not running. Start it to begin monitoring network traffic."
                   : currentMode === "ids"
                   ? "Analyzing traffic and generating alerts. Threats are detected but not blocked."
-                  : "Analyzing traffic and actively blocking threats. Malicious packets are dropped."}
+                  : "Analyzing traffic and reactively blocking detected threat sources via a pf table. The triggering packet itself is not stopped (not inline prevention)."}
               </p>
             </div>
           </div>

--- a/aifw-ui/src/app/ids/settings/page.tsx
+++ b/aifw-ui/src/app/ids/settings/page.tsx
@@ -41,7 +41,7 @@ function FeedbackBanner({ feedback }: { feedback: SectionFeedback | null }) {
 const modeOptions = [
   { value: "disabled", label: "Disabled", desc: "IDS engine is not running" },
   { value: "ids", label: "IDS", desc: "Monitor and alert only" },
-  { value: "ips", label: "IPS", desc: "Actively block detected threats" },
+  { value: "ips", label: "IPS (reactive blocking)", desc: "Block detected threat sources after detection — the triggering packet is not stopped" },
 ];
 
 export default function IdsSettingsPage() {

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -42,7 +42,7 @@ breadcrumb:
 
 # AiFw vs OPNsense vs pfSense
 
-A fair, honest comparison. Where a competitor is stronger, we say so. This matrix is generated from reading the code — AiFw features are verified against the repo, OPNsense and pfSense from their official docs.
+A fair, honest comparison. Where a competitor is stronger, we say so. This matrix is generated from reading the code — AiFw features are verified against the repo, OPNsense and pfSense from their official docs. Cells marked *in development* have configuration surfaces but no working data plane yet; see the [feature maturity matrix]({{ '/maturity/' | relative_url }}) for the per-feature state.
 
 <div class="compare-wrapper" markdown="0">
 <table class="compare">
@@ -66,19 +66,21 @@ A fair, honest comparison. Where a competitor is stronger, we say so. This matri
 <tr><td>SNAT (outbound)</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>DNAT / port forwarding</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>1:1 NAT (binat)</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
-<tr><td>NAT64</td><td class="yes">✓</td><td class="partial">plugin</td><td class="yes">✓</td></tr>
-<tr><td>NAT46</td><td class="yes">✓</td><td class="no">—</td><td class="no">—</td></tr>
+<tr><td>NAT64</td><td class="partial">in development</td><td class="partial">plugin</td><td class="yes">✓</td></tr>
+<tr><td>NAT46</td><td class="partial">in development</td><td class="no">—</td><td class="no">—</td></tr>
 
 <tr class="section-row"><td colspan="4">VPN</td></tr>
 <tr><td>WireGuard</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
-<tr><td>IPsec</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
+<tr><td>IPsec</td><td class="partial">in development</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>OpenVPN</td><td class="no">—</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 
 <tr class="section-row"><td colspan="4">IDS / IPS</td></tr>
-<tr><td>Suricata rules</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">pkg</td></tr>
+<tr><td>Suricata rules</td><td class="partial">subset</td><td class="yes">✓</td><td class="partial">pkg</td></tr>
 <tr><td>Snort rules</td><td class="no">—</td><td class="no">—</td><td class="yes">✓</td></tr>
-<tr><td>Sigma rules</td><td class="yes">✓</td><td class="no">—</td><td class="no">—</td></tr>
-<tr><td>YARA rules</td><td class="yes">✓</td><td class="no">—</td><td class="no">—</td></tr>
+<tr><td>Sigma rules</td><td class="partial">subset</td><td class="no">—</td><td class="no">—</td></tr>
+<tr><td>YARA rules</td><td class="partial">subset</td><td class="no">—</td><td class="no">—</td></tr>
+<tr><td>Inline IPS (drops the triggering packet)</td><td class="partial">planned</td><td class="yes">✓</td><td class="yes">✓</td></tr>
+<tr><td>Reactive source blocking after detection</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>AI/ML threat detection</td><td class="yes">✓</td><td class="no">—</td><td class="no">—</td></tr>
 
 <tr class="section-row"><td colspan="4">DNS</td></tr>
@@ -95,7 +97,7 @@ A fair, honest comparison. Where a competitor is stronger, we say so. This matri
 <tr><td>DDNS</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 
 <tr class="section-row"><td colspan="4">Traffic shaping</td></tr>
-<tr><td>CoDel</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
+<tr><td>CoDel</td><td class="partial">in development</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>HFSC</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>PRIQ</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>CBQ</td><td class="no">—</td><td class="yes">✓</td><td class="yes">✓</td></tr>
@@ -115,7 +117,7 @@ A fair, honest comparison. Where a competitor is stronger, we say so. This matri
 <tr><td>TOTP 2FA</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">RADIUS</td></tr>
 <tr><td>LDAP</td><td class="no">—</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>RADIUS</td><td class="no">—</td><td class="yes">✓</td><td class="yes">✓</td></tr>
-<tr><td>OAuth / SSO</td><td class="yes">✓</td><td class="no">—</td><td class="no">—</td></tr>
+<tr><td>OAuth / SSO</td><td class="partial">in development</td><td class="no">—</td><td class="no">—</td></tr>
 <tr><td>API keys</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">community</td></tr>
 <tr><td>RBAC (granular perms)</td><td class="yes">37 perms</td><td class="yes">ACL</td><td class="partial">user/group</td></tr>
 
@@ -152,9 +154,7 @@ A fair, honest comparison. Where a competitor is stronger, we say so. This matri
 - **OPNsense config import** — drop-in migration. Parse the XML, preview the diff, apply atomically with rollback. Recently rewritten end-to-end (#230, #248–#252).
 - **Built-in reverse proxy + ACME** — TrafficCop runs HTTP, TCP, and UDP. ACME issuance pushes certs straight to the TLS store, file, or webhook. No HAProxy plugin install dance.
 - **AI/ML threat detection** — 5 built-in behavioural detectors (port scan, DDoS, brute force, C2 beacon, DNS tunneling) with auto-response and TTL blocks. Implemented in `aifw-ai/src/detectors/`.
-- **Sigma + YARA rule support** — modern rule formats neither OPNsense nor pfSense support. Full parsers in `aifw-ids/src/rules/`.
-- **NAT46** — IPv4→IPv6 translation. Nobody else has this out of the box.
-- **OAuth / SSO** — first-class auth method, not a plugin.
+- **Sigma + YARA rule support** — modern rule formats neither OPNsense nor pfSense support (practical subsets mapped to network flows, not full engine parity). Parsers in `aifw-ids/src/rules/`.
 - **Commit confirm** — auto-rollback if you lock yourself out. Default 300-second timeout, cancellable via oneshot channel. Both competitors have this as a years-open feature request.
 - **Modern React/Next.js UI** — static export, no Node.js runtime on the appliance. Not PHP.
 - **WebSocket live dashboard** — per-second metrics push, not poll-every-30s.
@@ -172,6 +172,10 @@ Honesty matters. Things you'll miss if you switch:
 - **No CBQ** traffic shaping (has CoDel, HFSC, PRIQ).
 - **No Snort rules** — Suricata-compatible only.
 - **No HAProxy / Nginx** — built-in TrafficCop instead.
+- **IPsec is in development** — SA configuration exists but no kernel data plane or IKE daemon yet; both competitors ship working strongSwan-based IPsec today.
+- **No inline IPS** — AiFw's prevention mode is reactive source blocking after detection; OPNsense/pfSense run Suricata/Snort inline. Inline (divert/netmap) is on the roadmap.
+- **NAT64/NAT46 and CoDel are in development** — configuration surfaces exist; the data planes are being built.
+- **OAuth/SSO login is in development** — provider config and the authorize flow exist, but the token exchange isn't finished yet.
 - **Young project** — OPNsense and pfSense have years of community knowledge, mature plugin ecosystems, and forum Q&A. AiFw is new.
 
 ## Should you switch?
@@ -184,7 +188,6 @@ Honesty matters. Things you'll miss if you switch:
 **Consider AiFw if:**
 - You want modern, AI-assisted threat detection out of the box
 - You've been burned by PHP-era admin interfaces
-- You need OAuth/SSO without writing custom FreeRADIUS configs
 - You care about commit-confirm safety
 - You run this professionally and want reproducible, auditable Rust code
 
@@ -192,6 +195,7 @@ Honesty matters. Things you'll miss if you switch:
 
 ## See also
 
+- [Feature maturity matrix →]({{ '/maturity/' | relative_url }})
 - [Full feature list →]({{ '/features' | relative_url }})
 - [Installation guide →]({{ '/install' | relative_url }})
 - [Source code →](https://github.com/ZerosAndOnesLLC/AiFw)

--- a/docs/docs/backup.md
+++ b/docs/docs/backup.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Backup & migration — AiFw config backup, S3, OPNsense import"
-description: "Back up AiFw config to JSON or S3. Import an OPNsense XML config with atomic rollback. Versioned config history and commit-confirm auto-revert."
+description: "Back up AiFw config to JSON or S3. Import an OPNsense XML config with automatic snapshot rollback. Versioned config history and commit-confirm auto-revert."
 permalink: /docs/backup/
 date: 2026-05-09
 breadcrumb:
@@ -14,7 +14,7 @@ breadcrumb:
   "@context": "https://schema.org",
   "@type": "TechArticle",
   "headline": "Backup & migration — AiFw config backup, S3, OPNsense import",
-  "description": "Back up AiFw config to JSON or S3. Import an OPNsense XML config with atomic rollback. Versioned config history and commit-confirm auto-revert.",
+  "description": "Back up AiFw config to JSON or S3. Import an OPNsense XML config with automatic snapshot rollback. Versioned config history and commit-confirm auto-revert.",
   "author": { "@type": "Organization", "name": "ZerosAndOnesLLC" },
   "datePublished": "2026-05-09",
   "dateModified": "2026-05-09",
@@ -91,7 +91,7 @@ Migrating from OPNsense or pfSense? Drop the appliance&rsquo;s `config.xml` stra
 
 1. **Parse first.** `quick-xml` walks the document. Every error that can be detected from the XML alone (malformed source/destination, unknown action, unparseable port range) surfaces in the preview &mdash; no half-applied state.
 2. **Preview the diff.** `POST /api/v1/config/preview-opnsense` returns aliases, NAT entries, rules, and static routes that will be created, plus a **skipped list** for rules that referenced network keywords (`lan`, `wanip`, `(self)`, &hellip;) that don&rsquo;t map cleanly. AiFw drops those to skipped instead of guessing &mdash; silent fidelity loss is the worst outcome.
-3. **Apply atomically.** `POST /api/v1/config/import-opnsense` runs the apply step inside a SQLite transaction that wraps every engine write. Aliases route through `AliasEngine`, NAT through `NatEngine`, rules through `RuleEngine`, static routes through the same `apply_route_to_system` path the manual REST endpoint uses, and DNS forwarders through the same path the rDNS resolver UI writes &mdash; not `/etc/resolv.conf` (see [#231](https://github.com/ZerosAndOnesLLC/AiFw/pull/231)).
+3. **Apply with rollback.** `POST /api/v1/config/import-opnsense` applies strictly — any failed required step aborts — and recovers by re-applying a pre-import snapshot rather than a single wrapping SQL transaction (kernel-side pf/route changes can't be rewound by SQLite; see the documented atomicity model in the importer source). Aliases route through `AliasEngine`, NAT through `NatEngine`, rules through `RuleEngine`, static routes through the same `apply_route_to_system` path the manual REST endpoint uses, and DNS forwarders through the same path the rDNS resolver UI writes &mdash; not `/etc/resolv.conf` (see [#231](https://github.com/ZerosAndOnesLLC/AiFw/pull/231)).
 4. **Snapshot &amp; commit-confirm.** Before any write the importer saves a `pre-OPNsense-import` config-history version, and after a successful apply it arms commit-confirm with a **600-second timeout**. If the admin loses access to the appliance before they confirm, AiFw rolls back automatically.
 5. **Reject &rarr; BlockReturn.** OPNsense&rsquo;s `reject` action maps to AiFw `Action::BlockReturn`, which produces the same per-protocol response (TCP RST, ICMP unreachable for UDP/ICMP) the original ruleset emitted.
 
@@ -169,7 +169,7 @@ curl -X POST https://aifw.local/api/v1/config/commit-confirm/confirm \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-If the timer expires, the snapshot taken at arm time is restored and the config that lost you access is rolled back &mdash; same engine writers, same atomic apply.
+If the timer expires, the snapshot taken at arm time is restored and the config that lost you access is rolled back &mdash; same engine writers, same snapshot-based apply.
 
 ## API endpoints
 

--- a/docs/docs/ids.md
+++ b/docs/docs/ids.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "IDS / IPS — AiFw Suricata, Sigma, and YARA"
-description: "Run Suricata, Sigma, and YARA rules on AiFw — three modes (Disabled / IDS alert-only / IPS inline drop), ET Open auto-update, alert classification, suppression, and AI behavioural detectors."
+description: "Run Suricata, Sigma, and YARA rule subsets on AiFw — three modes (Disabled / IDS alert-only / IPS reactive blocking), ET Open auto-update, alert classification, suppression, and AI behavioural detectors."
 permalink: /docs/ids/
 date: 2026-05-09
 breadcrumb:
@@ -14,7 +14,7 @@ breadcrumb:
   "@context": "https://schema.org",
   "@type": "TechArticle",
   "headline": "IDS / IPS — AiFw Suricata, Sigma, and YARA",
-  "description": "Run Suricata, Sigma, and YARA rules on AiFw — three modes (Disabled / IDS alert-only / IPS inline drop), ET Open auto-update, alert classification, suppression, and AI behavioural detectors.",
+  "description": "Run Suricata, Sigma, and YARA rule subsets on AiFw — three modes (Disabled / IDS alert-only / IPS reactive blocking), ET Open auto-update, alert classification, suppression, and AI behavioural detectors.",
   "author": { "@type": "Organization", "name": "ZerosAndOnesLLC" },
   "datePublished": "2026-05-09",
   "dateModified": "2026-05-09",
@@ -27,7 +27,9 @@ breadcrumb:
 
 # IDS / IPS
 
-AiFw ships an in-kernel intrusion detection / prevention engine that consumes three rule formats &mdash; Suricata-compatible, Sigma, and YARA &mdash; and runs in one of three modes: **Disabled**, **IDS** (alert-only), or **IPS** (inline drop). Behavioural AI detectors live alongside the rule engine and are opt-in. No Snort, no separate package install, no second daemon to babysit.
+AiFw ships an intrusion detection engine that consumes three rule formats &mdash; Suricata-compatible, Sigma, and YARA (practical subsets, see below) &mdash; and runs in one of three modes: **Disabled**, **IDS** (alert-only), or **IPS** (**reactive source blocking**). Behavioural AI detectors live alongside the rule engine and are opt-in. No Snort, no separate package install, no second daemon to babysit.
+
+> **What IPS mode does (and doesn't do).** Detection is passive (BPF capture). When a rule with a drop/reject verdict matches, the alert's **source IP** is added to the `aifw-ids-block` pf table, so **subsequent** packets from that source are blocked &mdash; the triggering packet itself is not stopped, and a few more packets may pass before the table update takes effect. Blocking is per-source-address, not per-flow. True inline prevention (dropping the triggering packet) is on the roadmap via divert/netmap interception.
 
 ## Quickstart
 
@@ -37,7 +39,7 @@ Open the Web UI and go to **IDS &rarr; Settings**. Pick a mode and an interface.
 |---|---|
 | `Disabled` | Engine off, no inspection |
 | `IDS` | Inspect and log alerts; never block |
-| `IPS` | Inspect, alert, and drop matching packets inline |
+| `IPS` | Inspect, alert, and reactively block the offending source IP via the `aifw-ids-block` pf table (the triggering packet is not stopped) |
 
 From the API:
 
@@ -60,7 +62,7 @@ curl -X POST https://aifw.local/api/v1/ids/reload \
 
 ## Rule formats
 
-**Suricata-compatible.** The native format. AiFw parses Suricata 7.x syntax directly &mdash; `alert`, `drop`, `pass`, plus the usual `content`, `pcre`, `flow`, `threshold`, and `metadata` keywords. Existing Suricata rulesets drop in unchanged.
+**Suricata-compatible.** The native format. AiFw parses Suricata 7.x syntax &mdash; `alert`, `drop`, `pass`, plus the common `content`, `pcre`, `flow`, `threshold`, and `metadata` keywords. This is a practical **subset**, not full Suricata engine parity: most ET Open-style rules drop in unchanged, but rules relying on unsupported keywords are skipped (visible in the ruleset parse stats).
 
 **Sigma.** YAML detection rules originally designed for log events. AiFw maps the detection section to network flow fields, so a Sigma rule that targets HTTP request URIs or DNS query names will fire on matching traffic. Sigma rules always alert &mdash; they never drop, regardless of mode.
 

--- a/docs/docs/nat.md
+++ b/docs/docs/nat.md
@@ -27,7 +27,9 @@ breadcrumb:
 
 # NAT
 
-AiFw supports six NAT types &mdash; SNAT, DNAT (port forwarding), Masquerade, 1:1 BiNAT, NAT64, and NAT46. NAT46 is unusual on consumer firewall distributions and lets you front legacy IPv4 clients onto an IPv6-only network. All NAT rules compile into the dedicated `aifw-nat` anchor and never touch the system pf config.
+AiFw supports four working NAT types today &mdash; SNAT, DNAT (port forwarding), Masquerade, and 1:1 BiNAT. All NAT rules compile into the dedicated `aifw-nat` anchor and never touch the system pf config.
+
+> **NAT64 and NAT46 are in development.** The rule types exist in the API/UI, but the rules they currently emit do **not** perform real cross-family (IPv6↔IPv4) translation &mdash; a proper translation data plane is committed and tracked in [#531](https://github.com/ZerosAndOnesLLC/AiFw/issues/531). Don't rely on these rule types until that lands.
 
 ## Quickstart
 

--- a/docs/docs/vpn.md
+++ b/docs/docs/vpn.md
@@ -27,7 +27,7 @@ breadcrumb:
 
 # VPN
 
-AiFw ships with two VPN protocols: **WireGuard** and **IPsec**. Both compile their pass rules into the dedicated `aifw-vpn` anchor and are managed entirely through the API or CLI &mdash; no hand-edited `wg-quick` or `ipsec.conf` files. OpenVPN is intentionally not shipped; see the [comparison page]({{ '/compare/' | relative_url }}) for the reasoning.
+AiFw ships **WireGuard** as its working VPN protocol today; **IPsec is in development** (see the callout below). Pass rules compile into the dedicated `aifw-vpn` anchor and everything is managed through the API or CLI &mdash; no hand-edited `wg-quick` files. OpenVPN is intentionally not shipped; see the [comparison page]({{ '/compare/' | relative_url }}) for the reasoning.
 
 ## WireGuard
 
@@ -90,7 +90,9 @@ WireGuard tunnels survive a CARP failover provided peers run with `PersistentKee
 
 ## IPsec
 
-AiFw supports IPsec Security Associations with ESP, AH, or ESP+AH protocols, in either tunnel or transport mode. Each SA gets a random SPI and sensible algorithm defaults (AES-256-GCM + HMAC-SHA256). When the SA is in tunnel mode the engine also emits a `pass quick on enc0` rule so encapsulated traffic flows.
+> **In development — configured SAs do not carry traffic yet.** AiFw currently persists IPsec SA configuration (ESP/AH/ESP+AH, tunnel/transport, algorithm selection) and opens the ESP/AH + IKE (UDP 500/4500) firewall ports, but the data plane &mdash; kernel Security Associations/policies and IKE negotiation &mdash; is **not implemented**. A real IPsec backend is committed and tracked in [#530](https://github.com/ZerosAndOnesLLC/AiFw/issues/530). Use WireGuard for working tunnels today.
+
+The configuration surface below describes what is stored and what will drive the future data plane. Each SA gets a random SPI and algorithm defaults (AES-256-GCM + HMAC-SHA256). In tunnel mode the engine also emits a `pass quick on enc0` rule.
 
 ### Quickstart
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,15 +32,15 @@ breadcrumb:
     { "@type": "Question", "name": "Can I import my existing OPNsense config?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. AiFw ships an OPNsense XML importer that parses your config, previews a diff of what will change, and applies atomically with rollback on failure. The importer was rewritten end-to-end in 2026 (PRs #230 and #248–#252)." } },
     { "@type": "Question", "name": "Does AiFw support Multi-WAN failover and load balancing?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. AiFw ships an enterprise-grade multi-WAN system with FIB isolation per WAN, gateway groups (failover, weighted, MOS-weighted adaptive), policy routing on 5-tuple plus DSCP plus geo-IP, and blast-radius preview. See the multi-WAN guide." } },
     { "@type": "Question", "name": "What hardware do I need to run AiFw?", "acceptedAnswer": { "@type": "Answer", "text": "Minimum: 1 amd64 core, 1 GB RAM, 4 GB disk, one NIC. Recommended: 2+ cores with AES-NI, 4 GB+ RAM, 16 GB SSD, 2+ NICs. IDS workloads benefit from more RAM. arm64 is planned but not yet supported." } },
-    { "@type": "Question", "name": "Is AiFw production-ready?", "acceptedAnswer": { "@type": "Answer", "text": "Core firewall, NAT, VPN, IDS, DHCP, DNS, multi-WAN, and HA are production-ready and stable. AI threat detection is opt-in / experimental, and the plugin system is in beta — check the relevant page on this site for the current status of each." } },
+    { "@type": "Question", "name": "Is AiFw production-ready?", "acceptedAnswer": { "@type": "Answer", "text": "AiFw is in active development (beta). The core firewall, NAT, WireGuard, IDS, DHCP, DNS, multi-WAN, and HA subsystems are implemented and run on real appliances, but automated FreeBSD live-traffic validation is still being built, and some advertised surfaces (IPsec, NAT64/46, CoDel shaping, OAuth login) are in development without a working data plane yet. See the feature maturity matrix for the per-feature state before depending on it in production." } },
     { "@type": "Question", "name": "How do I migrate from pfSense to AiFw?", "acceptedAnswer": { "@type": "Answer", "text": "Direct pfSense XML import is not supported. The recommended path is to export your pfSense config to OPNsense first (community tooling exists), then use AiFw's OPNsense importer. Or rebuild config from scratch — the AiFw web UI is fast." } },
     { "@type": "Question", "name": "Does AiFw have a paid version or paid tier?", "acceptedAnswer": { "@type": "Answer", "text": "No. Every feature is MIT-licensed and free. There is no paid tier, no gated features, and no telemetry or cloud dependency." } },
     { "@type": "Question", "name": "Where can I get help?", "acceptedAnswer": { "@type": "Answer", "text": "GitHub Discussions and Issues at https://github.com/ZerosAndOnesLLC/AiFw. The repo also includes detailed docs in CLAUDE.md and the docs/ directory." } },
-    { "@type": "Question", "name": "How does AiFw compare to OPNsense and pfSense?", "acceptedAnswer": { "@type": "Answer", "text": "AiFw wins on Sigma+YARA rules, AI threat detection, NAT46, OAuth/SSO, commit-confirm auto-rollback, modern React UI, multi-WAN with FIB isolation, OPNsense config import, and built-in reverse proxy with ACME. AiFw lags on OpenVPN, LDAP/RADIUS, captive portal, DDNS WAN client, and project age. See the full comparison page." } },
-    { "@type": "Question", "name": "Does AiFw support OpenVPN?", "acceptedAnswer": { "@type": "Answer", "text": "Not currently. AiFw supports WireGuard and IPsec only. If OpenVPN is a hard requirement, stay on pfSense or OPNsense." } },
+    { "@type": "Question", "name": "How does AiFw compare to OPNsense and pfSense?", "acceptedAnswer": { "@type": "Answer", "text": "AiFw wins on Sigma+YARA rule support, AI threat detection, commit-confirm auto-rollback, modern React UI, multi-WAN with FIB isolation, OPNsense config import, and built-in reverse proxy with ACME. AiFw lags on OpenVPN, IPsec (in development), inline IPS, LDAP/RADIUS, captive portal, DDNS WAN client, and project age. See the full comparison page." } },
+    { "@type": "Question", "name": "Does AiFw support OpenVPN?", "acceptedAnswer": { "@type": "Answer", "text": "Not currently. AiFw supports WireGuard today; IPsec is in development (configuration exists, the data plane is being built). If OpenVPN is a hard requirement, stay on pfSense or OPNsense." } },
     { "@type": "Question", "name": "Can I run AiFw in a VM (Proxmox, ESXi, KVM, bhyve)?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. AiFw runs anywhere FreeBSD runs — bare metal, KVM, Proxmox, VMware ESXi, bhyve. AWS and DigitalOcean FreeBSD images are untested but should work." } },
     { "@type": "Question", "name": "Does AiFw work with WireGuard mobile clients?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. AiFw generates per-peer .conf files you can scan as a QR code from the WireGuard mobile app. Persistent keepalive can be set per peer. The handshake status is shown live in the web UI." } },
-    { "@type": "Question", "name": "How does HA failover work?", "acceptedAnswer": { "@type": "Answer", "text": "AiFw runs an active-passive pair using CARP (virtual IP) and pfsync (state-table sync). TCP sessions survive a master reboot; WireGuard tunnels reconnect within ~5 seconds if peers have PersistentKeepalive set. Failover detection takes 1.5–3 seconds depending on the configured latency profile. See the HA cluster guide for details." } },
+    { "@type": "Question", "name": "How does HA failover work?", "acceptedAnswer": { "@type": "Answer", "text": "AiFw runs an active-passive pair using CARP (virtual IP) and pfsync (state-table sync), designed so TCP sessions survive a master failover and WireGuard reconnects within a few seconds with PersistentKeepalive set. These are design targets: automated two-node failover validation is still being built, so validate failover behavior in your own environment before relying on it. See the HA cluster guide." } },
     { "@type": "Question", "name": "Is the source code auditable / where do I read it?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. The full source is at https://github.com/ZerosAndOnesLLC/AiFw under the MIT license. The codebase is Rust workspace crates plus a Next.js web UI. CLAUDE.md in the repo root has an architectural overview." } }
   ]
 }
@@ -80,7 +80,7 @@ arm64 (Raspberry Pi, Ampere) is planned but not yet supported. AiFw runs anywher
 
 ## Is AiFw production-ready?
 
-Core firewall, NAT, VPN, IDS, DHCP, DNS, multi-WAN, and HA are production-ready and stable. **AI threat detection is opt-in / experimental**, and the **plugin system is in beta**. Check the relevant page on this site for the current status of each subsystem.
+AiFw is in **active development (beta)**. The core firewall, NAT, WireGuard, IDS, DHCP, DNS, multi-WAN, and HA subsystems are implemented and run on real appliances today, but automated FreeBSD live-traffic validation is still being built out, and some surfaces — **IPsec, NAT64/46, CoDel shaping, OAuth login** — are in development without a working data plane yet. **AI threat detection is opt-in / experimental** and the **plugin system is in beta**. Check the [feature maturity matrix]({{ '/maturity/' | relative_url }}) for the per-feature state before depending on a specific feature in production.
 
 ## How do I migrate from pfSense to AiFw?
 
@@ -96,15 +96,15 @@ GitHub Discussions and Issues at [https://github.com/ZerosAndOnesLLC/AiFw](https
 
 ## How does AiFw compare to OPNsense and pfSense?
 
-**AiFw wins on:** Sigma + YARA rules, AI threat detection, NAT46, OAuth/SSO, commit-confirm auto-rollback, modern React UI, multi-WAN with FIB isolation, OPNsense config import, built-in reverse proxy + ACME.
+**AiFw wins on:** Sigma + YARA rule support, AI threat detection, commit-confirm auto-rollback, modern React UI, multi-WAN with FIB isolation, OPNsense config import, built-in reverse proxy + ACME.
 
-**AiFw lags on:** OpenVPN, LDAP/RADIUS, captive portal, DDNS WAN client, project age.
+**AiFw lags on:** OpenVPN, IPsec (in development), inline IPS, LDAP/RADIUS, captive portal, DDNS WAN client, project age.
 
 See the [full comparison]({{ '/compare/' | relative_url }}).
 
 ## Does AiFw support OpenVPN?
 
-Not currently. AiFw supports **WireGuard** and **IPsec** only. If OpenVPN is a hard requirement, stay on pfSense or OPNsense.
+Not currently. AiFw supports **WireGuard** today; **IPsec is in development** (configuration exists, the data plane is being built). If OpenVPN is a hard requirement, stay on pfSense or OPNsense.
 
 ## Can I run AiFw in a VM?
 
@@ -116,7 +116,7 @@ Yes. AiFw generates per-peer `.conf` files you can scan as a QR code from the Wi
 
 ## How does HA failover work?
 
-AiFw runs an active-passive pair using **CARP** (virtual IP) and **pfsync** (state-table sync). TCP sessions survive a master reboot. WireGuard tunnels reconnect within ~5 seconds if peers have `PersistentKeepalive` set. Failover detection takes 1.5–3 seconds depending on the configured latency profile. See the [HA cluster guide]({{ '/ha/' | relative_url }}).
+AiFw runs an active-passive pair using **CARP** (virtual IP) and **pfsync** (state-table sync), designed so TCP sessions survive a master failover and WireGuard reconnects within a few seconds when peers set `PersistentKeepalive`. Treat the timing numbers as **design targets**: automated two-node failover validation is still being built ([#534](https://github.com/ZerosAndOnesLLC/AiFw/issues/534)), so validate failover in your own environment before relying on it. See the [HA cluster guide]({{ '/ha/' | relative_url }}).
 
 ## Is the source code auditable / where do I read it?
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,11 +20,11 @@ breadcrumb:
   "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"},
   "featureList": [
     "Stateful packet filtering via FreeBSD pf",
-    "WireGuard and IPsec VPN",
-    "Suricata IDS/IPS with Sigma and YARA rules",
+    "WireGuard VPN (IPsec in development)",
+    "IDS with Suricata, Sigma, and YARA rule subsets; reactive IPS blocking",
     "Multi-WAN with FIB isolation, SLA-driven failover, leak detection",
     "HA clustering with CARP",
-    "NAT including SNAT, DNAT, 1:1, NAT64, NAT46",
+    "NAT including SNAT, DNAT, 1:1 (NAT64/NAT46 in development)",
     "Geo-IP filtering",
     "DNS resolver and DHCP server",
     "OPNsense configuration importer",
@@ -40,7 +40,7 @@ breadcrumb:
 
 # Features
 
-A complete inventory of what AiFw ships with today. All features are MIT-licensed and included in the free download — no paid tiers, no gated features.
+A complete inventory of what AiFw ships with today. All features are MIT-licensed and included in the free download — no paid tiers, no gated features. Items marked *in development* have configuration surfaces but their data planes are still being built; the [feature maturity matrix]({{ '/maturity/' | relative_url }}) tracks the per-feature state.
 
 ## Firewall & filtering
 
@@ -50,7 +50,7 @@ A complete inventory of what AiFw ships with today. All features are MIT-license
 - **Aliases** — named IP/port groups reusable across rules
 - **VLAN support**, 802.1Q tagging
 - **Static routing** with per-route metrics
-- **Traffic shaping** — CoDel, HFSC, PRIQ queues
+- **Traffic shaping** — HFSC, PRIQ queues; CoDel (dummynet FQ-CoDel backend) *in development*
 - **Rate limiting** with overload tables
 
 ## NAT
@@ -59,8 +59,8 @@ A complete inventory of what AiFw ships with today. All features are MIT-license
 - **DNAT / port forwarding** with reflection
 - **Masquerading** (dynamic SNAT to interface address)
 - **1:1 NAT** (binat)
-- **NAT64** (IPv6 → IPv4)
-- **NAT46** (IPv4 → IPv6) — unique to AiFw
+- **NAT64** (IPv6 → IPv4) — *in development*: the rule type exists but real cross-family translation is being built
+- **NAT46** (IPv4 → IPv6) — *in development*, same status
 
 ## Multi-WAN
 
@@ -87,17 +87,13 @@ See the [multi-WAN setup guide]({{ '/multi-wan/' | relative_url }}) for FIB boot
 - Split or full tunnel support
 - Live tunnel status and transfer counters
 
-### IPsec
-- ESP, AH, ESP+AH protocols
-- Tunnel and transport modes
-- AES-256-GCM with HMAC-SHA256 by default
-- Automatic SPI generation
-- IKE (UDP 500, 4500) traffic rules
+### IPsec — *in development*
+IPsec SA configuration (ESP/AH, tunnel/transport, algorithm selection) exists in the API/UI, and the firewall opens the ESP/AH + IKE (UDP 500/4500) ports — but the data plane (kernel SAs/SPD, IKE negotiation) is **not implemented yet**, so configured SAs do not carry protected traffic. Implementation is committed and tracked in [#530](https://github.com/ZerosAndOnesLLC/AiFw/issues/530).
 
 ## IDS / IPS
 
-- **Three modes** — Disabled, IDS (alert-only), IPS (inline drop)
-- **Rule formats** — Suricata, Sigma, YARA
+- **Three modes** — Disabled, IDS (alert-only), IPS (**reactive source blocking**: after a drop-verdict detection the source IP is blocked via a pf table; the triggering packet itself is not stopped — true inline prevention is on the roadmap)
+- **Rule formats** — Suricata, Sigma, YARA (practical subsets mapped to network flows — not full engine parity; Sigma rules always alert, never drop)
 - **ET Open rule source integration** with auto-update
 - **Alert management** — severity levels, acknowledgment, classification, analyst notes
 - **Per-rule suppression** by source IP or destination IP
@@ -187,7 +183,7 @@ See the [reverse proxy guide]({{ '/docs/reverse-proxy/' | relative_url }}) for s
 
 - **Local users** with bcrypt password hashing
 - **TOTP 2FA** with recovery codes
-- **OAuth / SSO** — first-class auth method, not a plugin. Built-in providers for Google, GitHub, generic OIDC. See the [auth &amp; RBAC guide]({{ '/docs/auth/' | relative_url }}) for setup, the full 37-permission RBAC matrix, and TOTP / API-key flows.
+- **OAuth / SSO** — *in development*: provider configuration (Google, GitHub, generic OIDC) and the authorize flow exist, but the token exchange is not finished yet ([#170](https://github.com/ZerosAndOnesLLC/AiFw/issues/170)), so OAuth login cannot complete. See the [auth &amp; RBAC guide]({{ '/docs/auth/' | relative_url }}) for local users, the 37-permission RBAC matrix, and TOTP / API-key flows.
 - **API keys** for programmatic access
 - **JWT token sessions** with refresh tokens
 
@@ -201,9 +197,9 @@ Built-in roles: **admin**, **operator**, **viewer**. Custom roles supported.
 
 ## Backup &amp; migration
 
-- **JSON backup / restore** — entire config in one file, atomically replayable
+- **JSON backup / restore** — entire config in one file; restore is strict (fails rather than partially applying) with automatic snapshot rollback
 - **S3 backup destination** — configurable bucket and prefix; rotation policy
-- **OPNsense XML import** — recently rewritten end-to-end. Parse the XML, preview a diff of what'll change, apply atomically with rollback on failure
+- **OPNsense XML import** — parse the XML, preview a diff of what'll change, apply with automatic snapshot rollback on failure
 - **Versioned config history** — every change is snapshotted; diff and selective restore from the UI
 - **Commit confirm** — every apply auto-reverts on timeout unless explicitly confirmed; default 300-second window
 

--- a/docs/ha.md
+++ b/docs/ha.md
@@ -27,6 +27,8 @@ AiFw supports a two-node active-passive cluster: one master forwarding productio
 traffic, one backup with replicated pf state, ready to take over within seconds
 of any failure on the master.
 
+> **Validation status:** the failover behaviors and timing numbers on this page are design targets, verified interactively but not yet by an automated two-node test suite ([#534](https://github.com/ZerosAndOnesLLC/AiFw/issues/534)). Validate failover in your own environment before relying on it.
+
 ## What survives a master reboot
 
 | Component | Survives | Notes |

--- a/docs/index.html
+++ b/docs/index.html
@@ -95,8 +95,8 @@ date: 2026-05-09
         <div class="feature-icon" style="background: rgba(59,130,246,0.1); border-color: rgba(59,130,246,0.2); color: var(--accent);">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>
         </div>
-        <h3>WireGuard &amp; IPsec</h3>
-        <p>Native WireGuard with auto-keypair generation and per-peer config export. IPsec ESP/AH in tunnel or transport mode.</p>
+        <h3>WireGuard (IPsec in dev)</h3>
+        <p>Native WireGuard with auto-keypair generation and per-peer config export. IPsec is in development (config surface exists; kernel data plane being built).</p>
         <div class="feature-tags"><span class="tag">WireGuard</span><span class="tag">ESP</span><span class="tag">AH</span></div>
       </div>
 
@@ -132,7 +132,7 @@ date: 2026-05-09
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
         </div>
         <h3>Full NAT suite</h3>
-        <p>SNAT, DNAT/port forwarding, masquerade, 1:1 binat, <strong>NAT64</strong>, and <strong>NAT46</strong> — the last one is unique.</p>
+        <p>SNAT, DNAT/port forwarding, masquerade, and 1:1 binat. NAT64/NAT46 rule types are in development — cross-family translation is being built.</p>
         <div class="feature-tags"><span class="tag">snat</span><span class="tag">dnat</span><span class="tag">nat64</span><span class="tag">nat46</span></div>
       </div>
 
@@ -269,7 +269,7 @@ date: 2026-05-09
       <div class="row"><div class="feat-name">Suricata IDS</div><div><span class="ind yes">✓</span></div><div><span class="ind yes">✓</span></div><div><span class="ind partial">pkg</span></div></div>
       <div class="row"><div class="feat-name">Sigma + YARA rules</div><div><span class="ind yes">✓</span></div><div><span class="ind no">—</span></div><div><span class="ind no">—</span></div></div>
       <div class="row"><div class="feat-name">AI behavioural detection</div><div><span class="ind yes">✓</span></div><div><span class="ind no">—</span></div><div><span class="ind no">—</span></div></div>
-      <div class="row"><div class="feat-name">NAT46</div><div><span class="ind yes">✓</span></div><div><span class="ind no">—</span></div><div><span class="ind no">—</span></div></div>
+      <div class="row"><div class="feat-name">NAT46</div><div><span class="ind partial">in dev</span></div><div><span class="ind no">—</span></div><div><span class="ind no">—</span></div></div>
       <div class="row"><div class="feat-name">OAuth / SSO</div><div><span class="ind yes">✓</span></div><div><span class="ind no">—</span></div><div><span class="ind no">—</span></div></div>
       <div class="row"><div class="feat-name">Commit confirm (auto-rollback)</div><div><span class="ind yes">✓</span></div><div><span class="ind no">—</span></div><div><span class="ind no">—</span></div></div>
       <div class="row"><div class="feat-name">Modern UI stack</div><div>React/Next.js</div><div>PHP</div><div>PHP</div></div>

--- a/docs/maturity.md
+++ b/docs/maturity.md
@@ -1,0 +1,60 @@
+---
+layout: default
+title: Feature Maturity — AiFw firewall
+description: Per-feature maturity matrix for AiFw — what is implemented, what is validated on FreeBSD, and what is still in development. Updated with each release.
+permalink: /maturity/
+date: 2026-07-19
+breadcrumb:
+  - { title: "Maturity", url: "/maturity/" }
+---
+
+<div class="content-page">
+<article markdown="1">
+
+# Feature maturity
+
+AiFw is in **active development (beta)**. This matrix is the honest, per-feature answer to "does it work?" — a feature is not called supported just because its API, schema, or UI exists. Columns:
+
+- **Control plane** — config model, API, UI, persistence implemented.
+- **Data plane** — the FreeBSD kernel/service actually enforces it.
+- **Auto test** — automated FreeBSD functional test exercises live traffic (the CI epic tracking this is [#533](https://github.com/ZerosAndOnesLLC/AiFw/issues/533); most rows are ⏳ until it lands).
+- **Validated** — performance / multi-node validation with published, reproducible results.
+
+✓ done · ⏳ not yet · ✗ not implemented
+
+<div class="compare-wrapper" markdown="0">
+<table class="compare">
+<thead>
+<tr><th>Feature</th><th>Control plane</th><th>Data plane</th><th>Auto test</th><th>Validated</th><th>Status</th></tr>
+</thead>
+<tbody>
+<tr><td>Stateful filtering (pf)</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="partial">⏳</td><td>Beta — daily-driven on real appliances</td></tr>
+<tr><td>Rule scheduling</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="partial">⏳</td><td>Enforced since v5.99.7 (windows compiled into pf, minute-tick reload)</td></tr>
+<tr><td>Rule policy routing (route-to)</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="partial">⏳</td><td>Since v5.100.0</td></tr>
+<tr><td>SNAT / DNAT / masquerade / 1:1</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="partial">⏳</td><td>Beta</td></tr>
+<tr><td>NAT64 / NAT46</td><td class="yes">✓</td><td class="no">✗</td><td class="no">✗</td><td class="no">✗</td><td><strong>In development</strong> — current rules do not perform cross-family translation ([#531](https://github.com/ZerosAndOnesLLC/AiFw/issues/531))</td></tr>
+<tr><td>WireGuard</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="partial">⏳</td><td>Beta</td></tr>
+<tr><td>IPsec</td><td class="yes">✓</td><td class="no">✗</td><td class="no">✗</td><td class="no">✗</td><td><strong>In development</strong> — SA records and firewall ports only; no kernel SAs or IKE yet ([#530](https://github.com/ZerosAndOnesLLC/AiFw/issues/530))</td></tr>
+<tr><td>OAuth / SSO login</td><td class="yes">✓</td><td class="no">✗</td><td class="no">✗</td><td class="no">✗</td><td><strong>In development</strong> — provider config + authorize flow exist; token exchange not implemented ([#170](https://github.com/ZerosAndOnesLLC/AiFw/issues/170))</td></tr>
+<tr><td>IDS (Suricata/Sigma/YARA subsets)</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="partial">⏳</td><td>Beta — rule-language subsets, not full engine parity</td></tr>
+<tr><td>IPS — reactive source blocking</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="partial">⏳</td><td>Blocks the source after detection; the triggering packet is not stopped</td></tr>
+<tr><td>IPS — inline prevention</td><td class="no">✗</td><td class="no">✗</td><td class="no">✗</td><td class="no">✗</td><td><strong>Planned</strong> — divert/netmap roadmap</td></tr>
+<tr><td>Traffic shaping — CoDel</td><td class="yes">✓</td><td class="no">✗</td><td class="no">✗</td><td class="no">✗</td><td><strong>In development</strong> — real dummynet FQ-CoDel backend tracked in [#532](https://github.com/ZerosAndOnesLLC/AiFw/issues/532)</td></tr>
+<tr><td>Geo-IP filtering</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="partial">⏳</td><td>Beta</td></tr>
+<tr><td>Multi-WAN (FIB, gateways, policies)</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="partial">⏳</td><td>Beta — latency thresholds + dampening enforced since v5.100.0; needs environment-specific validation</td></tr>
+<tr><td>HA (CARP / pfsync / replication)</td><td class="yes">✓</td><td class="yes">✓</td><td class="no">✗</td><td class="no">✗</td><td>Beta — automated two-node failover validation tracked in [#534](https://github.com/ZerosAndOnesLLC/AiFw/issues/534); quantitative claims are design targets until then</td></tr>
+<tr><td>Backup / restore / OPNsense import</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="partial">⏳</td><td>Beta — snapshot + strict apply with automatic rollback (since v5.99.7); not a single DB+kernel transaction</td></tr>
+<tr><td>DHCP / DNS / NTP (companions)</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="partial">⏳</td><td>Beta — builds pinned to reviewed revisions since v5.99.8</td></tr>
+<tr><td>Reverse proxy + ACME (TrafficCop)</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="partial">⏳</td><td>Beta</td></tr>
+<tr><td>AI/ML threat detection</td><td class="yes">✓</td><td class="partial">⏳</td><td class="no">✗</td><td class="no">✗</td><td>Experimental, opt-in, disabled by default</td></tr>
+<tr><td>Plugin system</td><td class="yes">✓</td><td class="partial">⏳</td><td class="no">✗</td><td class="no">✗</td><td>Beta — WASM planned</td></tr>
+</tbody>
+</table>
+</div>
+
+Rows marked ⏳ under **Auto test** work on real appliances today but are verified by unit/integration tests against a mock pf backend, not yet by automated live-traffic tests on FreeBSD. Closing that gap is the project's current top engineering priority ([#533](https://github.com/ZerosAndOnesLLC/AiFw/issues/533)).
+
+Documentation on this site is kept in sync with this matrix — if a page and this table disagree, [file an issue](https://github.com/ZerosAndOnesLLC/AiFw/issues).
+
+</article>
+</div>


### PR DESCRIPTION
Batch 4 from the audit sweep: align every adoption-facing claim with what the code does, per the decisions to **implement** (not remove) IPsec (#530) and NAT64/46 (#531), and to **rename** the current IPS mode (#536).

## #529 — claims corrected

- **New [/maturity/ page](docs/maturity.md)**: per-feature matrix with separate control-plane / data-plane / automated-test / validated columns. Nothing is called supported solely because its schema/API/UI exists. Also records what improved since the audit (schedules enforced v5.99.7, strict restore + rollback, policy routing v5.100.0, pinned companions v5.99.8).
- **IPsec, NAT64/46, CoDel, OAuth login → "in development"** everywhere (compare table, features, FAQ, landing page, nat/vpn doc pages, README), with issue links. Framed as committed work, not vaporware removal, per decision.
- **Suricata/Sigma/YARA → "practical subsets"**, Sigma documented as alert-only.
- **Comparison page**: checkmarks downgraded (NAT64/46, IPsec, CoDel, OAuth, rule subsets), new "Inline IPS" row (AiFw: planned; competitors: ✓), "Where AiFw wins" no longer cites NAT46/OAuth, "Where AiFw is behind" gains the honest entries.
- **FAQ "Is AiFw production-ready?"** (markdown + JSON-LD): blanket "production-ready and stable" replaced with active-development/beta framing + maturity-matrix link.
- **HA quantitative claims** (session survival, ~5 s WG reconnect, 1.5–3 s failover) qualified as design targets pending automated two-node validation (#534), in FAQ + HA guide.
- **Backup docs** no longer claim the OPNsense import runs "inside a SQLite transaction that wraps every engine write" — corrected to the real model (strict apply + snapshot rollback; kernel-side changes can't be rewound by SQLite), closing that #535 criterion.

## #536 — IPS renamed to reactive source blocking

- IDS doc page rewritten: prominent callout explaining exactly what IPS mode does (drop-verdict ⇒ source IP added to `aifw-ids-block` pf table; triggering packet **not** stopped; a few packets may pass before the table update; per-source, not per-flow), mode table updated.
- UI: status banner "IPS Running — Reactive Blocking" with honest description; settings mode option relabeled "IPS (reactive blocking)".
- `IdsMode::Ips` rustdoc rewritten. **Wire value `"ips"` unchanged** — zero API/config compatibility impact.
- Inline prevention (divert → netmap) is referenced as roadmap; tracked in a follow-up issue.

No functional code changes — comments/labels/docs only (`cargo check` clean, UI build + lint clean). v5.100.2.

Closes #529. Closes #536.