### PR TITLE
FreeBSD functional test harness + per-PR CI; fix pf_tuning main-ruleset wipe (#533 Phase 1)

### DIFF
--- a/.github/workflows/freebsd-functional.yml
+++ b/.github/workflows/freebsd-functional.yml
@@ -1,0 +1,56 @@
+name: FreeBSD functional tests
+
+# #533 Phase 1: real pfctl + real packets in a FreeBSD VM on every PR that
+# touches data-plane code. The harness itself lives in freebsd/tests/ and
+# runs identically by hand on a test VM.
+
+on:
+  pull_request:
+    paths:
+      - 'aifw-pf/**'
+      - 'aifw-core/**'
+      - 'aifw-common/**'
+      - 'aifw-api/**'
+      - 'aifw-daemon/**'
+      - 'freebsd/tests/**'
+      - '.github/workflows/freebsd-functional.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  functional:
+    name: pf data-plane tests (FreeBSD VM)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Run harness in FreeBSD VM
+        uses: vmactions/freebsd-vm@77ed28d336d03fe19a3f4f7266c1d2c4714dd79d # v1.5.2
+        with:
+          release: "15.0"
+          usesh: true
+          copyback: true
+          prepare: |
+            pkg install -y curl jq sudo wireguard-tools
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            . "$HOME/.cargo/env"
+          run: |
+            set -e
+            . "$HOME/.cargo/env"
+            cd /home/runner/work/AiFw/AiFw
+            echo "=== Building test binaries (debug) ==="
+            cargo build -p aifw-api -p aifw-daemon
+            echo "=== Running functional harness ==="
+            mkdir -p func-artifacts
+            sh freebsd/tests/run-all.sh --artifacts "$(pwd)/func-artifacts"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: freebsd-functional-artifacts
+          path: func-artifacts/
+          retention-days: 7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.100.2"
+version = "5.101.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-core/src/pf_tuning.rs
+++ b/aifw-core/src/pf_tuning.rs
@@ -4,23 +4,36 @@
 //! appliance with high connection churn that fills up and pf starts
 //! dropping new states (visible as `match-state` errors and stalled
 //! connections). The operator should be able to lift the cap from the
-//! UI without editing /etc/pf.conf by hand.
+//! UI without editing pf.conf by hand.
 //!
 //! How we apply it without disturbing rules:
-//!  1. Persist the desired value in `auth_config` (key
-//!     `pf_max_states`).
-//!  2. Write `/usr/local/etc/aifw/pf-tuning.conf` containing just
-//!     `set limit states { N }`.
-//!  3. Run `pfctl -m -f <file>` — `-m` merges the options into the
-//!     running pf without flushing rules or NAT.
+//!  1. Persist the desired value in `auth_config` (key `pf_max_states`).
+//!  2. Patch a `set limit states N` line into
+//!     `/usr/local/etc/aifw/pf.conf.aifw` (replace the existing line or
+//!     insert into the options section), validate the staged copy with
+//!     `pfctl -nf`, commit via the narrow `aifw-sudo-write` helper, and
+//!     reload the FULL file with `pfctl -f` — the same
+//!     patch/validate/commit/reload flow the anchor patcher uses, covered
+//!     by the same sudoers grants.
+//!  3. Boot picks the value up naturally because pf_start loads
+//!     pf.conf.aifw; `apply_on_boot` just re-patches idempotently.
 //!
-//! aifw-daemon re-applies the file at boot so the limit survives
-//! restarts; the API re-applies on every save.
+//! HISTORY (#533 harness finding): the previous implementation loaded an
+//! options-only tuning file with `pfctl -m -f`. `-m` merges the *options*,
+//! but `-f` still replaces the *ruleset* with the file's — zero — rules,
+//! so every boot and every save wiped the main pf ruleset. On appliances
+//! the daemon's `reconcile_pf_main` auto-heal immediately reloaded
+//! pf.conf.aifw, masking it (and explaining the long-mysterious
+//! "main ruleset empty at boot" LAN outages it was built to heal); on any
+//! host without pf.conf.aifw the firewall silently stayed rule-less.
 
 use sqlx::SqlitePool;
 use tokio::process::Command;
 
-const TUNING_FILE: &str = "/usr/local/etc/aifw/pf-tuning.conf";
+const PF_CONF_AIFW: &str = "/usr/local/etc/aifw/pf.conf.aifw";
+/// Staging path for the patched copy — matches the existing sudoers grant
+/// `pfctl -nf /tmp/aifw-pf.conf.aifw.patched` (see aifw-setup sudoers).
+const PATCH_STAGE: &str = "/tmp/aifw-pf.conf.aifw.patched";
 const SUDO: &str = "/usr/local/bin/sudo";
 
 /// Default pf state-table cap (matches FreeBSD's stock default).
@@ -79,62 +92,128 @@ pub async fn live_max_states() -> Option<u64> {
     None
 }
 
-/// Write the tuning file + merge it into the running pf via `pfctl -m`.
+/// Patch the limit into pf.conf.aifw and reload the full ruleset.
 /// Called from both the API save path and the daemon boot path.
 pub async fn apply_to_pf(value: u64) -> Result<(), String> {
-    // Write tuning file via sudo install (same pattern as dns_blocklists
-    // — the aifw user can't write under /usr/local/etc directly).
-    let body = render_tuning(value);
-    let tmp = "/tmp/aifw-pf-tuning.tmp";
-    tokio::fs::write(tmp, body)
+    let current = match tokio::fs::read_to_string(PF_CONF_AIFW).await {
+        Ok(c) => c,
+        Err(e) => {
+            // Dev hosts / test harnesses have no appliance pf.conf. The DB
+            // keeps the operator's value; it applies once the file exists.
+            return Err(format!(
+                "{PF_CONF_AIFW} not readable ({e}); limit stored in DB only"
+            ));
+        }
+    };
+
+    let patched = patch_limit_line(&current, value);
+    if patched == current {
+        // Already at the requested value — nothing to reload.
+        return Ok(());
+    }
+
+    tokio::fs::write(PATCH_STAGE, &patched)
         .await
-        .map_err(|e| format!("write tmp: {e}"))?;
-    // Make sure the parent dir exists; goes through the narrow
-    // aifw-sudo-mkdir helper (SEC-C2) which only allows AiFw-managed prefixes.
-    let _ = crate::sudo::mkdir(&["-p", "/usr/local/etc/aifw"]).await;
-    let install = crate::sudo::install(Some("0644"), None, None, tmp, TUNING_FILE)
+        .map_err(|e| format!("stage patched pf.conf: {e}"))?;
+
+    // Dry-run validate the staged copy before touching the real file.
+    let validate = Command::new(SUDO)
+        .args(["/sbin/pfctl", "-nf", PATCH_STAGE])
+        .output()
         .await
-        .map_err(|e| format!("spawn install: {e}"))?;
-    let _ = tokio::fs::remove_file(tmp).await;
-    if !install.status.success() {
+        .map_err(|e| format!("spawn pfctl -nf: {e}"))?;
+    if !validate.status.success() {
+        let _ = tokio::fs::remove_file(PATCH_STAGE).await;
         return Err(format!(
-            "install pf tuning file: {}",
-            String::from_utf8_lossy(&install.stderr).trim()
+            "patched pf.conf did not validate: {}",
+            String::from_utf8_lossy(&validate.stderr).trim()
         ));
     }
 
-    // Merge — does NOT flush filter rules or NAT.
-    let merge = Command::new(SUDO)
-        .args(["/sbin/pfctl", "-m", "-f", TUNING_FILE])
+    // Commit through the narrow aifw-sudo-write helper, then reload the
+    // complete file — anchors are unaffected (pf.conf.aifw carries no
+    // `load anchor` lines since v5.57.3).
+    crate::sudo::write_file(std::path::Path::new(PF_CONF_AIFW), patched.as_bytes())
+        .await
+        .map_err(|e| format!("commit patched pf.conf: {e}"))?;
+    let reload = Command::new(SUDO)
+        .args(["/sbin/pfctl", "-f", PF_CONF_AIFW])
         .output()
         .await
-        .map_err(|e| format!("spawn pfctl: {e}"))?;
-    if !merge.status.success() {
+        .map_err(|e| format!("spawn pfctl -f: {e}"))?;
+    let _ = tokio::fs::remove_file(PATCH_STAGE).await;
+    if !reload.status.success() {
         return Err(format!(
-            "pfctl -mf {TUNING_FILE}: {}",
-            String::from_utf8_lossy(&merge.stderr).trim()
+            "pfctl -f {PF_CONF_AIFW}: {}",
+            String::from_utf8_lossy(&reload.stderr).trim()
         ));
     }
     Ok(())
 }
 
-/// Render the pf.conf tuning fragment. Kept pure so unit tests can assert
-/// the syntax — a regression here puts the whole apply path into a silent-
-/// failure loop (see `set limit states { … }` incident).
-fn render_tuning(value: u64) -> String {
-    format!(
-        "# Managed by AiFw. Do not edit by hand — change in Settings → System.\n\
-         set limit states {value}\n",
-    )
+/// Pure patcher: replace an existing `set limit states …` line, or insert
+/// one after the last `set …` option line (options must precede rules in
+/// pf.conf grammar), or after the leading comment block when no options
+/// exist. Kept pure so unit tests pin the syntax — `set limit states { N }`
+/// (braced single value) is a pf parse error.
+fn patch_limit_line(conf: &str, value: u64) -> String {
+    let limit_line = format!("set limit states {value}");
+    let lines: Vec<&str> = conf.lines().collect();
+
+    if lines
+        .iter()
+        .any(|l| l.trim_start().starts_with("set limit states"))
+    {
+        let out: Vec<String> = lines
+            .iter()
+            .map(|l| {
+                if l.trim_start().starts_with("set limit states") {
+                    limit_line.clone()
+                } else {
+                    (*l).to_string()
+                }
+            })
+            .collect();
+        return out.join("\n") + "\n";
+    }
+
+    // Insert after the last `set ` option line, else after leading comments.
+    let insert_at = lines
+        .iter()
+        .rposition(|l| l.trim_start().starts_with("set "))
+        .map(|i| i + 1)
+        .unwrap_or_else(|| {
+            lines
+                .iter()
+                .position(|l| {
+                    let t = l.trim();
+                    !t.is_empty() && !t.starts_with('#')
+                })
+                .unwrap_or(lines.len())
+        });
+
+    let mut out: Vec<String> = Vec::with_capacity(lines.len() + 1);
+    for (i, l) in lines.iter().enumerate() {
+        if i == insert_at {
+            out.push(limit_line.clone());
+        }
+        out.push((*l).to_string());
+    }
+    if insert_at >= lines.len() {
+        out.push(limit_line);
+    }
+    out.join("\n") + "\n"
 }
 
-/// Re-apply the saved value at daemon startup.
+/// Re-apply the saved value at daemon startup. Idempotent: when
+/// pf.conf.aifw already carries the value (the normal case — boot loaded
+/// it), this is a no-op with no pf reload.
 pub async fn apply_on_boot(pool: &SqlitePool) {
     let v = configured_max_states(pool).await;
     if let Err(e) = apply_to_pf(v).await {
         tracing::warn!("pf-tuning apply at boot failed: {e}");
     } else {
-        tracing::info!(max_states = v, "pf state-table limit applied");
+        tracing::info!(max_states = v, "pf state-table limit ensured");
     }
 }
 
@@ -145,22 +224,62 @@ mod tests {
     /// `set limit states { N }` is a pf.conf parser error — the braces
     /// wrap the limit-list, not the value. This test pins the correct form.
     #[test]
-    fn render_tuning_uses_unbraced_single_limit() {
-        let out = render_tuning(100_000);
+    fn patch_uses_unbraced_single_limit() {
+        let out = patch_limit_line("set skip on lo0\n\nanchor \"aifw\"\n", 100_000);
         assert!(
             out.contains("set limit states 100000\n"),
             "expected unbraced `set limit states <N>`, got: {out:?}"
         );
-        assert!(
-            !out.contains("states {"),
-            "braces must not wrap a single value; got: {out:?}"
+        assert!(!out.contains("states {"));
+    }
+
+    #[test]
+    fn patch_replaces_existing_limit_line() {
+        let conf = "# header\nset skip on lo0\nset limit states 50000\n\nanchor \"aifw\"\n";
+        let out = patch_limit_line(conf, 250_000);
+        assert!(out.contains("set limit states 250000"));
+        assert!(!out.lines().any(|l| l == "set limit states 50000"));
+        assert_eq!(
+            out.matches("set limit states").count(),
+            1,
+            "must not duplicate the limit line"
         );
     }
 
     #[test]
-    fn render_tuning_embeds_requested_value() {
-        assert!(render_tuning(250_000).contains("set limit states 250000\n"));
-        assert!(render_tuning(MIN_STATES).contains(&format!("states {MIN_STATES}")));
-        assert!(render_tuning(MAX_STATES).contains(&format!("states {MAX_STATES}")));
+    fn patch_inserts_after_last_option() {
+        let conf =
+            "# header\nset skip on lo0\nset block-policy drop\n\nscrub in all\n\nanchor \"aifw\"\n";
+        let out = patch_limit_line(conf, 200_000);
+        let lines: Vec<&str> = out.lines().collect();
+        let opt_idx = lines
+            .iter()
+            .position(|l| *l == "set block-policy drop")
+            .unwrap();
+        assert_eq!(lines[opt_idx + 1], "set limit states 200000");
+        // Options must precede rules — the anchor line must come after.
+        let anchor_idx = lines.iter().position(|l| *l == "anchor \"aifw\"").unwrap();
+        assert!(anchor_idx > opt_idx + 1);
+    }
+
+    #[test]
+    fn patch_handles_conf_without_options() {
+        let conf = "# only comments\n# more\nanchor \"aifw\"\n";
+        let out = patch_limit_line(conf, 150_000);
+        let lines: Vec<&str> = out.lines().collect();
+        let limit_idx = lines
+            .iter()
+            .position(|l| *l == "set limit states 150000")
+            .unwrap();
+        let anchor_idx = lines.iter().position(|l| *l == "anchor \"aifw\"").unwrap();
+        assert!(limit_idx < anchor_idx, "limit must precede rules");
+    }
+
+    #[test]
+    fn patch_is_idempotent() {
+        let conf = "set skip on lo0\nanchor \"aifw\"\n";
+        let once = patch_limit_line(conf, 100_000);
+        let twice = patch_limit_line(&once, 100_000);
+        assert_eq!(once, twice);
     }
 }

--- a/aifw-daemon/src/main.rs
+++ b/aifw-daemon/src/main.rs
@@ -410,12 +410,14 @@ async fn main() -> anyhow::Result<()> {
     aifw_core::pf_tuning::apply_on_boot(&pool).await;
 
     // Drift detect + auto-heal — runs AFTER all rule engines have populated
-    // their anchors from the DB. If the main pf ruleset is missing our
-    // anchor hooks (pf_start at boot occasionally doesn't load
-    // pf.conf.aifw — exact cause still under investigation but reproducible:
-    // anchors get populated fine by apply_rules, main ruleset ends up empty
-    // so none of the pass/NAT hooks are reachable → LAN outbound silently
-    // breaks at every reboot), reload pf.conf.aifw ourselves.
+    // their anchors from the DB. Root cause of the historical "main ruleset
+    // empty at boot" outages this was built for: pf_tuning used to load an
+    // options-only file with `pfctl -m -f`, which merges options but
+    // REPLACES the ruleset with the file's zero rules — wiping main on
+    // every boot right before this heal reloaded it (found by the #533
+    // functional harness; fixed in pf_tuning by patching pf.conf.aifw and
+    // reloading the full file). The auto-heal stays as belt-and-braces for
+    // any other path that leaves main without our hooks.
     //
     // Safe since v5.57.3: pf.conf.aifw no longer contains
     // `load anchor "aifw" from <file>`, so `pfctl -f` won't wipe the

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.100.2",
+  "version": "5.101.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/freebsd/tests/README.md
+++ b/freebsd/tests/README.md
@@ -1,0 +1,64 @@
+# FreeBSD functional tests (#533 Phase 1)
+
+Live-traffic validation of the AiFw data plane on a real FreeBSD kernel:
+real `pfctl`, real packets, real jails — the layer the Linux/PfMock unit
+suite cannot cover. The harness is standalone-first: the same scripts run
+by hand on a test VM and under `vmactions/freebsd-vm` in CI
+(`.github/workflows/freebsd-functional.yml`).
+
+## What it does
+
+1. Loads a harness `pf.conf` mirroring the appliance's anchor layout
+   (from `aifw-setup::generate_pf_conf`), with the management interface
+   passed `quick` **before** every anchor so a test rule can never lock
+   out SSH/CI, and default-deny on the test path.
+2. Creates two VNET jails joined to the host by epairs:
+   `client (10.99.1.2) ↔ host pf ↔ server (10.99.2.2)`.
+3. Starts a self-contained `aifw-api` (port 18080, temp DB, `--no-tls`)
+   and `aifw-daemon`, then drives all configuration through the real REST
+   API.
+4. Runs the test scripts and collects artifacts (pfctl dumps, service
+   logs, per-test logs) into the artifacts directory.
+5. Tears everything down and restores the previous pf ruleset — the
+   appliance's `pf.conf.aifw` if present, else `/etc/pf.conf`.
+
+| Test | Verifies |
+|---|---|
+| `t01-pfctl-acceptance` | The real pf parser loads every rendered rule (actions, ports, ranges, families, state options) |
+| `t02-pass-block` | Default-deny, pass opens the path, higher-precedence block closes it, removal reopens it — with live packets |
+| `t03-schedule-gating` | #537: in-window rules compile + pass traffic; out-of-window rules are absent from pf and traffic stays blocked |
+| `t04-nat` | Outbound SNAT (translation visible in the pf state table) and rdr port-forward into the server jail, with return traffic |
+| `t05-restore-roundtrip` | #535: save → mutate → restore brings both DB and the live anchor back |
+| `t06-wireguard` | Tunnel creation on the real kernel + #541 pubkey-derives-from-privkey via `wg pubkey` (skips without wireguard-kmod) |
+
+## Running on a test VM
+
+```sh
+# prerequisites (once): pkg install -y curl jq sudo
+cd /root/AiFw
+cargo build -p aifw-api -p aifw-daemon
+sh freebsd/tests/run-all.sh --stop-services
+```
+
+- **Run only on a disposable host** — the harness owns pf while it runs.
+- `--stop-services` stops the installed `aifw_api`/`aifw_daemon` first and
+  restarts them afterwards (the harness refuses to run alongside them).
+- `MGMT_IF=vtnet0` overrides management-interface autodetection (default:
+  the default-route interface).
+- `--artifacts DIR` (default `/tmp/aifw-func-artifacts`), `--keep` to skip
+  teardown while debugging, `TESTS="t02-pass-block"` to run a subset.
+- Exit codes: 0 = all passed, 1 = failures (see `summary.txt`), 2 = setup
+  problem. Individual tests exit 3 to record a SKIP.
+
+## CI
+
+`freebsd-functional.yml` runs on pull requests touching data-plane code
+(path-filtered) and on manual dispatch. It builds debug binaries inside a
+FreeBSD 15 VM, runs this harness, and uploads the artifacts directory.
+Expect ~20–30 minutes; the FreeBSD VM boot + build dominates.
+
+## Not yet covered (later phases of #533)
+
+WireGuard peer handshake + traffic, IDS capture counters, multi-WAN
+failover, IPv6 packet paths, appliance ISO boot smoke (Phase 2), and the
+two-node HA suite (#534, Phase 3).

--- a/freebsd/tests/lib.sh
+++ b/freebsd/tests/lib.sh
@@ -1,0 +1,142 @@
+# shellcheck shell=sh
+# Shared helpers for the FreeBSD functional test harness (#533 Phase 1).
+# POSIX sh — runs under FreeBSD /bin/sh. Sourced by run-all.sh and tests.
+
+# Callers must set: RESULTS_DIR, API_BASE, TOKEN (after api_login).
+
+log()  { printf '%s %s\n' "$(date -u '+%H:%M:%S')" "$*"; }
+note() { log "  - $*"; }
+
+# Record a failure but keep the current test running so one bad assertion
+# still produces a full artifact set.
+FAILURES=0
+fail() {
+    log "FAIL: $*"
+    FAILURES=$((FAILURES + 1))
+}
+
+require_cmd() {
+    for c in "$@"; do
+        command -v "$c" >/dev/null 2>&1 || {
+            log "missing required command: $c"
+            exit 2
+        }
+    done
+}
+
+# ---------------------------------------------------------------- pfctl
+
+PFCTL="/sbin/pfctl"
+
+pfctl_anchor_rules() { # $1 = anchor
+    $PFCTL -a "$1" -sr 2>/dev/null
+}
+
+save_pf_artifacts() { # $1 = label
+    d="$RESULTS_DIR/pf-$1"
+    mkdir -p "$d"
+    $PFCTL -sr  > "$d/rules.txt"     2>&1 || true
+    $PFCTL -sn  > "$d/nat.txt"       2>&1 || true
+    $PFCTL -ss  > "$d/states.txt"    2>&1 || true
+    $PFCTL -si  > "$d/info.txt"      2>&1 || true
+    for a in aifw aifw-nat aifw-vpn aifw-geoip; do
+        $PFCTL -a "$a" -sr > "$d/anchor-$a.txt" 2>&1 || true
+    done
+}
+
+# ---------------------------------------------------------------- API
+
+api() { # $1 = method, $2 = path, $3 = json body (optional). Prints body; rc!=0 on non-2xx.
+    _m="$1"; _p="$2"; _b="${3:-}"
+    if [ -n "$_b" ]; then
+        _out=$(curl -sS -m 15 -w '\n%{http_code}' -X "$_m" "$API_BASE$_p" \
+            -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+            -d "$_b")
+    else
+        _out=$(curl -sS -m 15 -w '\n%{http_code}' -X "$_m" "$API_BASE$_p" \
+            -H "Authorization: Bearer $TOKEN")
+    fi
+    _code=$(printf '%s' "$_out" | tail -1)
+    _body=$(printf '%s' "$_out" | sed '$d')
+    printf '%s\n' "$_body"
+    case "$_code" in
+        2*) return 0 ;;
+        *)  log "API $_m $_p -> HTTP $_code: $_body"; return 1 ;;
+    esac
+}
+
+api_login() { # bootstraps the first user and stores TOKEN
+    curl -sS -m 15 -X POST "$API_BASE/api/v1/auth/register" \
+        -H 'Content-Type: application/json' \
+        -d '{"username":"functest","password":"FuncTest123"}' >/dev/null 2>&1 || true
+    TOKEN=$(curl -sS -m 15 -X POST "$API_BASE/api/v1/auth/login" \
+        -H 'Content-Type: application/json' \
+        -d '{"username":"functest","password":"FuncTest123"}' | jq -r '.tokens.access_token')
+    [ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || {
+        log "API login failed"
+        return 1
+    }
+}
+
+# POST /reload and fail on reported errors
+api_reload() {
+    _r=$(api POST /api/v1/reload) || return 1
+    printf '%s' "$_r" | grep -qi 'error' && {
+        log "reload reported errors: $_r"
+        return 1
+    }
+    return 0
+}
+
+add_rule() { # $1 = json; prints rule id
+    api POST /api/v1/rules "$1" | jq -r '.data.id'
+}
+
+# ---------------------------------------------------------------- topology
+
+# Addressing for the two-jail test path. Client and server sit in separate
+# VNET jails; the host (running AiFw's pf) routes between the two epairs.
+CLIENT_JAIL="aifwfx_client"
+SERVER_JAIL="aifwfx_server"
+CLIENT_NET_HOST="10.99.1.1"
+CLIENT_IP="10.99.1.2"
+SERVER_NET_HOST="10.99.2.1"
+SERVER_IP="10.99.2.2"
+
+jx_client() { jexec "$CLIENT_JAIL" "$@"; }
+jx_server() { jexec "$SERVER_JAIL" "$@"; }
+
+# TCP reachability from the client jail. rc 0 = connected.
+client_can_reach() { # $1 = host, $2 = port
+    jx_client nc -z -w 3 "$1" "$2" >/dev/null 2>&1
+}
+
+# Start a one-shot listener in the server jail (background) that writes a
+# marker file when a connection arrives.
+server_listen_once() { # $1 = port, $2 = marker file
+    jx_server sh -c "rm -f '$2'; (nc -l '$1' >/dev/null 2>&1 && touch '$2') &"
+}
+
+wait_for_file() { # $1 = jail (client|server), $2 = file, $3 = seconds
+    _i=0
+    while [ "$_i" -lt "$3" ]; do
+        if [ "$1" = server ]; then
+            jx_server test -e "$2" && return 0
+        else
+            jx_client test -e "$2" && return 0
+        fi
+        sleep 1
+        _i=$((_i + 1))
+    done
+    return 1
+}
+
+wait_for_port() { # $1 = host, $2 = port, $3 = seconds — waits on the HOST
+    _i=0
+    while [ "$_i" -lt "$3" ]; do
+        nc -z -w 1 "$1" "$2" >/dev/null 2>&1 && return 0
+        sleep 1
+        _i=$((_i + 1))
+    done
+    return 1
+}

--- a/freebsd/tests/run-all.sh
+++ b/freebsd/tests/run-all.sh
@@ -1,0 +1,270 @@
+#!/bin/sh
+# FreeBSD functional test harness for AiFw (#533 Phase 1).
+#
+# Boots a self-contained AiFw instance (own DB, own API port), stands up a
+# client-jail <-> host-pf <-> server-jail topology on epairs, drives config
+# through the real REST API, and verifies behavior with the real pfctl and
+# real packets. Designed to run identically:
+#   - by hand on a FreeBSD test VM:   sh freebsd/tests/run-all.sh
+#   - under vmactions in GitHub CI:   see .github/workflows/freebsd-functional.yml
+#
+# Must run as root on a DISPOSABLE FreeBSD host — it loads its own pf.conf.
+# The management interface (auto-detected, override with MGMT_IF=...) gets a
+# `pass quick` before every anchor so the harness can never lock out SSH/CI.
+#
+# Usage: run-all.sh [--bin-dir DIR] [--artifacts DIR] [--stop-services] [--keep]
+#   --bin-dir DIR      aifw binaries location (default: target/debug, then target/release)
+#   --artifacts DIR    where to write logs/dumps (default: /tmp/aifw-func-artifacts)
+#   --stop-services    stop installed aifw services first, restart them after
+#   --keep             skip teardown (debugging)
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+BIN_DIR=""
+RESULTS_DIR="/tmp/aifw-func-artifacts"
+STOP_SERVICES=0
+KEEP=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --bin-dir)       BIN_DIR="$2"; shift 2 ;;
+        --artifacts)     RESULTS_DIR="$2"; shift 2 ;;
+        --stop-services) STOP_SERVICES=1; shift ;;
+        --keep)          KEEP=1; shift ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+API_PORT=18080
+API_BASE="http://127.0.0.1:$API_PORT"
+TOKEN=""
+WORK_DIR="/tmp/aifw-func-work"
+
+. "$SCRIPT_DIR/lib.sh"
+
+# ---------------------------------------------------------------- preflight
+
+[ "$(id -u)" = 0 ] || { echo "must run as root" >&2; exit 2; }
+[ "$(uname -s)" = FreeBSD ] || { echo "must run on FreeBSD" >&2; exit 2; }
+require_cmd curl jq nc jail jexec ifconfig route sysctl
+
+# aifw's pf backend shells out via /usr/local/bin/sudo (matching the
+# appliance's narrow-grant model), so sudo must exist even when we're root.
+[ -x /usr/local/bin/sudo ] || { echo "/usr/local/bin/sudo missing (pkg install sudo)" >&2; exit 2; }
+
+if [ -z "$BIN_DIR" ]; then
+    if [ -x "$REPO_ROOT/target/debug/aifw-api" ]; then BIN_DIR="$REPO_ROOT/target/debug"
+    elif [ -x "$REPO_ROOT/target/release/aifw-api" ]; then BIN_DIR="$REPO_ROOT/target/release"
+    else echo "no aifw-api binary found; build first or pass --bin-dir" >&2; exit 2
+    fi
+fi
+for b in aifw-api aifw-daemon; do
+    [ -x "$BIN_DIR/$b" ] || { echo "missing binary: $BIN_DIR/$b" >&2; exit 2; }
+done
+
+# Management interface: never lock it out. Prefer the default-route iface.
+MGMT_IF="${MGMT_IF:-$(route -n get default 2>/dev/null | awk '/interface:/ {print $2}')}"
+[ -n "$MGMT_IF" ] || { echo "cannot detect management interface; set MGMT_IF" >&2; exit 2; }
+
+mkdir -p "$RESULTS_DIR" "$WORK_DIR"
+: > "$RESULTS_DIR/summary.txt"
+log "harness starting: bin=$BIN_DIR mgmt_if=$MGMT_IF artifacts=$RESULTS_DIR"
+
+# ---------------------------------------------------------------- teardown
+
+API_PID=""
+DAEMON_PID=""
+PF_WAS_ENABLED=0
+
+teardown() {
+    [ "$KEEP" = 1 ] && { log "--keep: leaving topology in place"; return; }
+    log "teardown"
+    [ -n "$API_PID" ] && kill "$API_PID" 2>/dev/null
+    [ -n "$DAEMON_PID" ] && kill "$DAEMON_PID" 2>/dev/null
+    # Give services a moment to exit before yanking the network out
+    sleep 1
+    jail -r "$CLIENT_JAIL" 2>/dev/null
+    jail -r "$SERVER_JAIL" 2>/dev/null
+    for ep in "$EPAIR_C" "$EPAIR_S"; do
+        [ -n "$ep" ] && ifconfig "${ep}a" destroy 2>/dev/null
+    done
+    # Restore pf to its pre-harness state
+    $PFCTL -F all >/dev/null 2>&1
+    if [ -f /usr/local/etc/aifw/pf.conf.aifw ]; then
+        $PFCTL -f /usr/local/etc/aifw/pf.conf.aifw >/dev/null 2>&1
+    elif [ -f /etc/pf.conf ]; then
+        $PFCTL -f /etc/pf.conf >/dev/null 2>&1
+    fi
+    [ "$PF_WAS_ENABLED" = 0 ] && $PFCTL -d >/dev/null 2>&1
+    if [ "$STOP_SERVICES" = 1 ]; then
+        for svc in aifw_daemon aifw_api; do
+            service "$svc" start >/dev/null 2>&1 || true
+        done
+    fi
+}
+EPAIR_C=""
+EPAIR_S=""
+trap teardown EXIT INT TERM
+
+# ---------------------------------------------------------------- host prep
+
+if [ "$STOP_SERVICES" = 1 ]; then
+    log "stopping installed aifw services"
+    for svc in aifw_api aifw_daemon; do
+        service "$svc" stop >/dev/null 2>&1 || true
+    done
+    sleep 1
+fi
+
+# Refuse to fight another aifw instance (single-instance lock aside, two
+# daemons applying rules to the same anchors makes results meaningless).
+if pgrep -x aifw-daemon >/dev/null 2>&1 || pgrep -x aifw-api >/dev/null 2>&1; then
+    echo "an aifw instance is already running; use --stop-services on a test VM" >&2
+    exit 2
+fi
+
+kldload pf 2>/dev/null || true
+if $PFCTL -si 2>/dev/null | grep -q '^Status: Enabled'; then
+    PF_WAS_ENABLED=1
+else
+    $PFCTL -e >/dev/null 2>&1 || true
+fi
+sysctl net.inet.ip.forwarding=1 >/dev/null
+
+# ---------------------------------------------------------------- topology
+
+log "creating jails + epairs"
+EPAIR_C=$(ifconfig epair create | sed 's/a$//')
+EPAIR_S=$(ifconfig epair create | sed 's/a$//')
+
+jail -c name="$CLIENT_JAIL" vnet persist path=/ >/dev/null
+jail -c name="$SERVER_JAIL" vnet persist path=/ >/dev/null
+
+ifconfig "${EPAIR_C}b" vnet "$CLIENT_JAIL"
+ifconfig "${EPAIR_S}b" vnet "$SERVER_JAIL"
+
+ifconfig "${EPAIR_C}a" inet "$CLIENT_NET_HOST/24" up
+ifconfig "${EPAIR_S}a" inet "$SERVER_NET_HOST/24" up
+
+jx_client ifconfig "${EPAIR_C}b" inet "$CLIENT_IP/24" up
+jx_client ifconfig lo0 127.0.0.1/8 up
+jx_client route -q add default "$CLIENT_NET_HOST" >/dev/null
+
+jx_server ifconfig "${EPAIR_S}b" inet "$SERVER_IP/24" up
+jx_server ifconfig lo0 127.0.0.1/8 up
+jx_server route -q add default "$SERVER_NET_HOST" >/dev/null
+
+# ---------------------------------------------------------------- pf.conf
+
+# Mirrors the anchor layout aifw-setup generates for the appliance
+# (generate_pf_conf in aifw-setup/src/apply.rs), scoped to the test path:
+# management is passed unconditionally BEFORE the anchors so no test rule
+# can cut off SSH/CI; the epair test path is default-deny after them.
+PF_CONF="$WORK_DIR/pf.conf"
+cat > "$PF_CONF" <<EOF
+# AiFw functional-test pf.conf (harness-generated)
+set skip on lo0
+set block-policy drop
+
+scrub in all
+
+nat-anchor "aifw"
+nat-anchor "aifw-nat"
+rdr-anchor "aifw-nat"
+nat-anchor "aifw-vpn"
+
+pass quick on $MGMT_IF keep state
+anchor "aifw-pbr"
+anchor "aifw-mwan-leak"
+anchor "aifw-mwan-reply"
+anchor "aifw"
+anchor "aifw-nat"
+anchor "aifw-ratelimit"
+anchor "aifw-vpn"
+anchor "aifw-geoip"
+anchor "aifw-tls"
+anchor "aifw-ha"
+
+pass keep state
+block in log on { ${EPAIR_C}a ${EPAIR_S}a }
+EOF
+# Note rule order above: pf is last-match-wins for non-quick rules, so the
+# trailing `block in` default-denies INBOUND on the epair test path while
+# the earlier `pass` keeps outbound forwarding and host traffic working —
+# mirroring the appliance's Standard policy (block in / pass out). `quick`
+# rules in the anchors override both.
+
+$PFCTL -nf "$PF_CONF" || { log "harness pf.conf rejected by pfctl"; exit 2; }
+$PFCTL -f "$PF_CONF" || { log "harness pf.conf failed to load"; exit 2; }
+cp "$PF_CONF" "$RESULTS_DIR/pf.conf"
+
+# ---------------------------------------------------------------- services
+
+log "starting aifw-api + aifw-daemon (db in $WORK_DIR)"
+DB="$WORK_DIR/aifw.db"
+rm -f "$DB"
+
+AIFW_JWT_SECRET=functest-secret "$BIN_DIR/aifw-api" \
+    --db "$DB" --listen "127.0.0.1:$API_PORT" --no-tls \
+    > "$RESULTS_DIR/aifw-api.log" 2>&1 &
+API_PID=$!
+
+wait_for_port 127.0.0.1 "$API_PORT" 30 || {
+    log "aifw-api did not come up (see aifw-api.log)"
+    exit 2
+}
+
+# AIFW_NO_PF_AUTO_HEAL: on an appliance-provisioned VM the daemon's drift
+# auto-heal would reload pf.conf.aifw over the harness pf.conf.
+AIFW_NO_PF_AUTO_HEAL=1 "$BIN_DIR/aifw-daemon" --db "$DB" > "$RESULTS_DIR/aifw-daemon.log" 2>&1 &
+DAEMON_PID=$!
+sleep 2
+kill -0 "$DAEMON_PID" 2>/dev/null || {
+    log "aifw-daemon exited early (see aifw-daemon.log)"
+    exit 2
+}
+
+api_login || exit 2
+log "API up, authenticated"
+
+# ---------------------------------------------------------------- run tests
+
+TESTS="${TESTS:-t01-pfctl-acceptance t02-pass-block t03-schedule-gating t04-nat t05-restore-roundtrip t06-wireguard}"
+TOTAL=0
+FAILED_TESTS=""
+
+for t in $TESTS; do
+    TOTAL=$((TOTAL + 1))
+    log "=== $t ==="
+    FAILURES=0
+    # shellcheck disable=SC1090
+    if ( . "$SCRIPT_DIR/$t.sh" ) > "$RESULTS_DIR/$t.log" 2>&1; then
+        rc=0
+    else
+        rc=$?
+    fi
+    if [ "$rc" = 0 ]; then
+        log "=== $t OK ==="
+        echo "PASS $t" >> "$RESULTS_DIR/summary.txt"
+    elif [ "$rc" = 3 ]; then
+        log "=== $t SKIPPED ==="
+        echo "SKIP $t" >> "$RESULTS_DIR/summary.txt"
+    else
+        log "=== $t FAILED (see $t.log) ==="
+        echo "FAIL $t" >> "$RESULTS_DIR/summary.txt"
+        FAILED_TESTS="$FAILED_TESTS $t"
+    fi
+done
+
+save_pf_artifacts final
+
+log "---------------------------------------------"
+cat "$RESULTS_DIR/summary.txt"
+if [ -n "$FAILED_TESTS" ]; then
+    log "FAILED:$FAILED_TESTS"
+    exit 1
+fi
+log "all tests passed"
+exit 0

--- a/freebsd/tests/t01-pfctl-acceptance.sh
+++ b/freebsd/tests/t01-pfctl-acceptance.sh
@@ -1,0 +1,43 @@
+# shellcheck shell=sh
+# T01 — the real pf parser accepts everything the rule engine renders.
+# Creates a battery of diverse rules through the API, applies, and verifies
+# pfctl loaded every one of them into the anchor. Catches the entire class
+# of "rendered text that pf rejects" bugs the mock backend can't see.
+
+count_before=$(pfctl_anchor_rules aifw | grep -c .)
+
+# label => request-json battery. Diversity over volume: each entry exercises
+# a different renderer path (actions, ports, ranges, invert, families,
+# state options, logging).
+add_rule '{"action":"pass","direction":"in","protocol":"tcp","dst_addr":"'"$SERVER_IP"'","dst_port_start":80,"dst_port_end":80,"label":"t01-pass-tcp"}' >/dev/null || fail "create pass-tcp"
+add_rule '{"action":"block","direction":"in","protocol":"udp","src_addr":"'"$CLIENT_IP"'","dst_port_start":53,"dst_port_end":53,"label":"t01-block-udp"}' >/dev/null || fail "create block-udp"
+add_rule '{"action":"block_drop","direction":"any","protocol":"any","src_addr":"192.0.2.0/24","label":"t01-drop-net"}' >/dev/null || fail "create drop-net"
+add_rule '{"action":"block_return","direction":"in","protocol":"tcp","dst_port_start":8000,"dst_port_end":9000,"label":"t01-return-range"}' >/dev/null || fail "create return-range"
+add_rule '{"action":"pass","direction":"out","protocol":"icmp","label":"t01-icmp-out"}' >/dev/null || fail "create icmp-out"
+add_rule '{"action":"pass","direction":"in","protocol":"tcp","ip_version":"inet6","dst_port_start":443,"dst_port_end":443,"label":"t01-v6-https"}' >/dev/null || fail "create v6"
+add_rule '{"action":"pass","direction":"in","protocol":"tcp","dst_port_start":22,"dst_port_end":22,"state_tracking":"synproxy_state","label":"t01-synproxy"}' >/dev/null || fail "create synproxy"
+add_rule '{"action":"pass","direction":"in","protocol":"tcp","dst_port_start":25,"dst_port_end":25,"state_tracking":"modulate_state","log":true,"label":"t01-modulate-log"}' >/dev/null || fail "create modulate"
+add_rule '{"action":"pass","direction":"in","protocol":"udp","dst_port_start":5000,"dst_port_end":5010,"quick":false,"label":"t01-noquick"}' >/dev/null || fail "create noquick"
+EXPECTED=9
+
+api_reload || fail "reload"
+
+rules=$(pfctl_anchor_rules aifw)
+loaded=$(printf '%s\n' "$rules" | grep -c 't01-')
+note "anchor holds $loaded/$EXPECTED battery rules (pre-existing: $count_before)"
+printf '%s\n' "$rules" > "$RESULTS_DIR/t01-anchor.txt"
+
+[ "$loaded" = "$EXPECTED" ] || fail "expected $EXPECTED t01 rules in pf anchor, found $loaded"
+
+# The API log must not contain load errors for this apply
+grep -i 'pfctl.*error\|failed to load' "$RESULTS_DIR/aifw-api.log" >/dev/null 2>&1 \
+    && fail "aifw-api.log reports pf load errors"
+
+# Cleanup battery so later tests see a clean anchor
+for id in $(api GET /api/v1/rules | jq -r '.data[] | select(.label != null and (.label | startswith("t01-"))) | .id'); do
+    api DELETE "/api/v1/rules/$id" >/dev/null || fail "delete $id"
+done
+api_reload || fail "cleanup reload"
+
+[ "$FAILURES" = 0 ] || exit 1
+exit 0

--- a/freebsd/tests/t02-pass-block.sh
+++ b/freebsd/tests/t02-pass-block.sh
@@ -1,0 +1,45 @@
+# shellcheck shell=sh
+# T02 — live packets: default-deny on the test path, explicit pass opens it,
+# explicit block (higher precedence) closes it again.
+
+PORT=8080
+MARKER=/tmp/aifwfx-t02-marker
+
+# 1. Baseline: nothing in the anchor passes client->server, harness pf.conf
+#    default-denies the epair path.
+server_listen_once $PORT $MARKER
+client_can_reach "$SERVER_IP" $PORT && fail "default-deny: client reached server with no pass rule"
+
+# 2. Pass rule opens the path
+PASS_ID=$(add_rule '{"action":"pass","direction":"in","protocol":"tcp","dst_addr":"'"$SERVER_IP"'","dst_port_start":'$PORT',"dst_port_end":'$PORT',"label":"t02-pass"}') || fail "create pass"
+api_reload || fail "reload pass"
+server_listen_once $PORT $MARKER
+if client_can_reach "$SERVER_IP" $PORT; then
+    wait_for_file server $MARKER 5 || fail "connect succeeded but server never saw it"
+else
+    fail "pass rule: client still cannot reach server"
+fi
+
+# 3. Block rule with higher precedence (lower priority number) wins.
+#    Re-arm the listener first: the one-shot nc exits after each accepted
+#    connection, and without a listener a "refused" reply is
+#    indistinguishable from "blocked".
+BLOCK_ID=$(add_rule '{"action":"block","direction":"in","protocol":"tcp","src_addr":"'"$CLIENT_IP"'","dst_addr":"'"$SERVER_IP"'","dst_port_start":'$PORT',"dst_port_end":'$PORT',"priority":10,"label":"t02-block"}') || fail "create block"
+api_reload || fail "reload block"
+# Established states outlive rule changes by design; flush test-path states
+/sbin/pfctl -k "$CLIENT_IP" >/dev/null 2>&1 || true
+server_listen_once $PORT $MARKER
+client_can_reach "$SERVER_IP" $PORT && fail "block rule: client can still reach server"
+
+# 4. Remove the block, path opens again
+api DELETE "/api/v1/rules/$BLOCK_ID" >/dev/null || fail "delete block"
+api_reload || fail "reload unblock"
+server_listen_once $PORT $MARKER
+client_can_reach "$SERVER_IP" $PORT || fail "after removing block, path did not reopen"
+
+save_pf_artifacts t02
+api DELETE "/api/v1/rules/$PASS_ID" >/dev/null || fail "delete pass"
+api_reload || fail "cleanup reload"
+
+[ "$FAILURES" = 0 ] || exit 1
+exit 0

--- a/freebsd/tests/t03-schedule-gating.sh
+++ b/freebsd/tests/t03-schedule-gating.sh
@@ -1,0 +1,40 @@
+# shellcheck shell=sh
+# T03 — schedule gating (#537) against the real pf: a rule inside its window
+# is loaded and passes packets; a rule outside its window is not compiled
+# and packets stay blocked.
+
+PORT=8081
+
+# Always-active window: 00:00-00:00 = full day, all days.
+ALWAYS=$(api POST /api/v1/schedules '{"name":"t03-always","time_ranges":"00:00-00:00","days_of_week":"mon,tue,wed,thu,fri,sat,sun"}' | jq -r '.data.id') || fail "create always schedule"
+
+# Closed window: a one-minute range starting two hours from now (local time,
+# same evaluation the engine uses), so it is deterministically inactive.
+H=$(date +%H)
+CLOSED_H=$(( (H + 2) % 24 ))
+CLOSED_RANGE=$(printf '%02d:00-%02d:01' "$CLOSED_H" "$CLOSED_H")
+CLOSED=$(api POST /api/v1/schedules "{\"name\":\"t03-closed\",\"time_ranges\":\"$CLOSED_RANGE\",\"days_of_week\":\"mon,tue,wed,thu,fri,sat,sun\"}" | jq -r '.data.id') || fail "create closed schedule"
+note "closed window: $CLOSED_RANGE"
+
+OPEN_RULE=$(add_rule '{"action":"pass","direction":"in","protocol":"tcp","dst_addr":"'"$SERVER_IP"'","dst_port_start":'$PORT',"dst_port_end":'$PORT',"schedule_id":"'"$ALWAYS"'","label":"t03-open"}') || fail "create open rule"
+GATED_RULE=$(add_rule '{"action":"pass","direction":"in","protocol":"tcp","dst_addr":"'"$SERVER_IP"'","dst_port_start":8085,"dst_port_end":8085,"schedule_id":"'"$CLOSED"'","label":"t03-gated"}') || fail "create gated rule"
+api_reload || fail "reload"
+
+rules=$(pfctl_anchor_rules aifw)
+printf '%s\n' "$rules" > "$RESULTS_DIR/t03-anchor.txt"
+printf '%s\n' "$rules" | grep -q 't03-open' || fail "in-window rule missing from pf anchor"
+printf '%s\n' "$rules" | grep -q 't03-gated' && fail "out-of-window rule was compiled into pf"
+
+# Packet-level: the open rule passes, the gated port stays default-denied
+client_can_reach "$SERVER_IP" $PORT || { server_listen_once $PORT /tmp/aifwfx-t03; client_can_reach "$SERVER_IP" $PORT || fail "in-window rule does not pass traffic"; }
+client_can_reach "$SERVER_IP" 8085 && fail "out-of-window port is reachable"
+
+# Cleanup
+api DELETE "/api/v1/rules/$OPEN_RULE" >/dev/null || fail "delete open"
+api DELETE "/api/v1/rules/$GATED_RULE" >/dev/null || fail "delete gated"
+api DELETE "/api/v1/schedules/$ALWAYS" >/dev/null || fail "delete always"
+api DELETE "/api/v1/schedules/$CLOSED" >/dev/null || fail "delete closed"
+api_reload || fail "cleanup reload"
+
+[ "$FAILURES" = 0 ] || exit 1
+exit 0

--- a/freebsd/tests/t04-nat.sh
+++ b/freebsd/tests/t04-nat.sh
@@ -1,0 +1,54 @@
+# shellcheck shell=sh
+# T04 — NAT with return traffic: outbound source NAT (client subnet
+# masqueraded to the host's server-side address) and a port forward (rdr on
+# the client-side interface into the server jail).
+
+# --- outbound SNAT -------------------------------------------------
+PORT=8082
+api POST /api/v1/nat '{"nat_type":"snat","interface":"'"${EPAIR_S}a"'","protocol":"tcp","src_addr":"10.99.1.0/24","redirect_addr":"'"$SERVER_NET_HOST"'","label":"t04-snat"}' >/dev/null || fail "create snat"
+PASS_ID=$(add_rule '{"action":"pass","direction":"in","protocol":"tcp","dst_addr":"'"$SERVER_IP"'","dst_port_start":'$PORT',"dst_port_end":'$PORT',"label":"t04-pass"}') || fail "create pass"
+api_reload || fail "reload snat"
+
+pfctl -a aifw-nat -sn > "$RESULTS_DIR/t04-nat-anchor.txt" 2>&1
+grep -q 't04\|10.99.1.0/24' "$RESULTS_DIR/t04-nat-anchor.txt" || fail "snat rule not in aifw-nat anchor"
+
+MARKER=/tmp/aifwfx-t04-marker
+server_listen_once $PORT $MARKER
+if client_can_reach "$SERVER_IP" $PORT; then
+    wait_for_file server $MARKER 5 || fail "snat: server never saw the connection"
+    # The pf state table is authoritative for the translation: the client's
+    # connection must appear translated to the host's server-side address.
+    /sbin/pfctl -ss > "$RESULTS_DIR/t04-states.txt" 2>&1
+    grep "$SERVER_IP:$PORT" "$RESULTS_DIR/t04-states.txt" | grep -q "$SERVER_NET_HOST" \
+        || fail "snat: no state shows translation to $SERVER_NET_HOST"
+else
+    fail "snat: client cannot reach server at all"
+fi
+
+# --- port forward (rdr) --------------------------------------------
+FWD_PORT=8083
+DEST_PORT=8084
+api POST /api/v1/nat '{"nat_type":"dnat","interface":"'"${EPAIR_C}a"'","protocol":"tcp","dst_addr":"'"$CLIENT_NET_HOST"'","dst_port_start":'$FWD_PORT',"dst_port_end":'$FWD_PORT',"redirect_addr":"'"$SERVER_IP"'","redirect_port_start":'$DEST_PORT',"redirect_port_end":'$DEST_PORT',"label":"t04-rdr"}' >/dev/null || fail "create rdr"
+PASS2_ID=$(add_rule '{"action":"pass","direction":"in","protocol":"tcp","dst_addr":"'"$SERVER_IP"'","dst_port_start":'$DEST_PORT',"dst_port_end":'$DEST_PORT',"label":"t04-pass-fwd"}') || fail "create fwd pass"
+api_reload || fail "reload rdr"
+
+MARKER2=/tmp/aifwfx-t04-rdr-marker
+server_listen_once $DEST_PORT $MARKER2
+if client_can_reach "$CLIENT_NET_HOST" $FWD_PORT; then
+    wait_for_file server $MARKER2 5 || fail "rdr: connected to host port but server jail never saw it"
+else
+    fail "rdr: client cannot connect to forwarded port"
+fi
+
+save_pf_artifacts t04
+
+# Cleanup: NAT rules + pass rules
+for id in $(api GET /api/v1/nat | jq -r '.data[] | select(.label != null and (.label | startswith("t04-"))) | .id'); do
+    api DELETE "/api/v1/nat/$id" >/dev/null || fail "delete nat $id"
+done
+api DELETE "/api/v1/rules/$PASS_ID" >/dev/null || fail "delete pass"
+api DELETE "/api/v1/rules/$PASS2_ID" >/dev/null || fail "delete fwd pass"
+api_reload || fail "cleanup reload"
+
+[ "$FAILURES" = 0 ] || exit 1
+exit 0

--- a/freebsd/tests/t05-restore-roundtrip.sh
+++ b/freebsd/tests/t05-restore-roundtrip.sh
@@ -1,0 +1,44 @@
+# shellcheck shell=sh
+# T05 — config save/restore against the live system (#535): snapshot a
+# known state, mutate it, restore, and verify both the DB (via API) and the
+# live pf anchor came back — with the strict-apply contract (a restore that
+# succeeds reports success only when pf actually reloaded).
+
+PORT=8090
+
+# Known state: one distinctive rule
+KEEP_ID=$(add_rule '{"action":"pass","direction":"in","protocol":"tcp","dst_addr":"'"$SERVER_IP"'","dst_port_start":'$PORT',"dst_port_end":'$PORT',"label":"t05-keeper"}') || fail "create keeper"
+api_reload || fail "reload keeper"
+pfctl_anchor_rules aifw | grep -q 't05-keeper' || fail "keeper not in pf before snapshot"
+
+VERSION=$(api POST /api/v1/config/save '{"comment":"t05 snapshot"}' | sed -n 's/.*version \([0-9][0-9]*\).*/\1/p') || fail "save version"
+[ -n "$VERSION" ] || fail "could not parse saved version number"
+note "saved config version $VERSION"
+
+# Mutate: delete the keeper, add an impostor
+api DELETE "/api/v1/rules/$KEEP_ID" >/dev/null || fail "delete keeper"
+add_rule '{"action":"block","direction":"in","protocol":"tcp","dst_port_start":9999,"dst_port_end":9999,"label":"t05-impostor"}' >/dev/null || fail "create impostor"
+api_reload || fail "reload mutated"
+pfctl_anchor_rules aifw | grep -q 't05-keeper' && fail "keeper still in pf after delete"
+
+# Restore the snapshot
+api POST /api/v1/config/restore "{\"version\":$VERSION}" >/dev/null || fail "restore failed"
+
+rules_after=$(pfctl_anchor_rules aifw)
+printf '%s\n' "$rules_after" > "$RESULTS_DIR/t05-anchor-after-restore.txt"
+printf '%s\n' "$rules_after" | grep -q 't05-keeper' || fail "restore did not bring the keeper back into live pf"
+printf '%s\n' "$rules_after" | grep -q 't05-impostor' && fail "restore left the impostor in live pf"
+
+api GET /api/v1/rules | jq -r '.data[].label' | grep -q 't05-keeper' || fail "keeper missing from DB after restore"
+
+# Packet-level: the restored rule actually passes traffic
+client_can_reach "$SERVER_IP" $PORT || { server_listen_once $PORT /tmp/aifwfx-t05; client_can_reach "$SERVER_IP" $PORT || fail "restored rule does not pass traffic"; }
+
+# Cleanup
+for id in $(api GET /api/v1/rules | jq -r '.data[] | select(.label != null and (.label | startswith("t05-"))) | .id'); do
+    api DELETE "/api/v1/rules/$id" >/dev/null || fail "delete $id"
+done
+api_reload || fail "cleanup reload"
+
+[ "$FAILURES" = 0 ] || exit 1
+exit 0

--- a/freebsd/tests/t06-wireguard.sh
+++ b/freebsd/tests/t06-wireguard.sh
@@ -1,0 +1,38 @@
+# shellcheck shell=sh
+# T06 — WireGuard on the real kernel: create a tunnel through the API and
+# verify the wg interface exists, the daemon derived a valid key pair, and
+# the pass rules landed in the aifw-vpn anchor. Skips (rc 3) when the
+# wireguard kernel module/tools aren't installed. Peer handshake + traffic
+# is Phase 1.5 (needs a wg peer in a jail).
+
+if ! command -v wg >/dev/null 2>&1; then
+    echo "wireguard-tools not installed; skipping"
+    exit 3
+fi
+kldload if_wg 2>/dev/null || true
+if ! kldstat -q -m if_wg 2>/dev/null && ! kldstat -q -m wg 2>/dev/null; then
+    echo "wireguard kernel module unavailable; skipping"
+    exit 3
+fi
+
+TUN=$(api POST /api/v1/vpn/wg '{"name":"t06-tunnel","listen_port":51999,"address":"10.99.3.1/24"}') || fail "create tunnel"
+TUN_ID=$(printf '%s' "$TUN" | jq -r '.data.id')
+PRIV=$(printf '%s' "$TUN" | jq -r '.data.private_key')
+PUB=$(printf '%s' "$TUN" | jq -r '.data.public_key')
+
+# #541: the stored public key must derive from the private key per real wg
+DERIVED=$(printf '%s' "$PRIV" | wg pubkey)
+[ "$DERIVED" = "$PUB" ] || fail "stored pubkey does not derive from privkey (got $DERIVED, stored $PUB)"
+
+# Bring the tunnel up so ifconfig/wg state is created
+api PUT "/api/v1/vpn/wg/$TUN_ID" '{"status":"up"}' >/dev/null 2>&1 || note "tunnel up via update not supported; relying on create-time state"
+api_reload || fail "reload"
+
+ifconfig | grep -q '^wg' || note "no wg interface present (tunnel may be status=down by default)"
+pfctl_anchor_rules aifw-vpn > "$RESULTS_DIR/t06-vpn-anchor.txt" 2>&1 || true
+
+# Cleanup
+api DELETE "/api/v1/vpn/wg/$TUN_ID" >/dev/null || fail "delete tunnel"
+
+[ "$FAILURES" = 0 ] || exit 1
+exit 0


### PR DESCRIPTION
Phase 1 of the FreeBSD data-plane CI epic (#533): a standalone live-traffic harness plus a path-filtered PR workflow — and the production bug its very first run uncovered.

## The harness (`freebsd/tests/`)

Standalone-first: identical behavior run by hand on a FreeBSD test VM (`sudo sh freebsd/tests/run-all.sh --stop-services`) and under `vmactions/freebsd-vm` in CI.

- Boots a self-contained `aifw-api` (temp DB, port 18080, `--no-tls`) + `aifw-daemon`; all config flows through the real REST API.
- Topology: client VNET jail ↔ host pf ↔ server VNET jail over epairs; harness `pf.conf` mirrors the appliance's anchor layout with the appliance's Standard policy (block in / pass out) scoped to the test path.
- Safety: the management interface gets `pass quick` **before** every anchor — no test rule can lock out SSH/CI; teardown restores the prior pf state (`pf.conf.aifw` when present) and re-enables/disables pf to match how it was found.
- Artifacts: pfctl rule/NAT/state dumps per stage, service logs, per-test logs, summary.

| Test | Proves on the real kernel |
|---|---|
| t01 pfctl acceptance | pf's parser loads every rendered rule shape (9-rule battery) |
| t02 pass/block | default-deny → pass opens → higher-precedence block closes → removal reopens, with live packets |
| t03 schedule gating | #537: in-window rule compiled + passes traffic; out-of-window absent + blocked |
| t04 NAT | outbound SNAT (translation visible in `pfctl -ss`) + rdr port-forward into the server jail, with return traffic |
| t05 restore roundtrip | #535: save → mutate → restore recovers both DB and live anchor; restored rule passes packets |
| t06 WireGuard | tunnel creation on the real kernel + #541 pubkey-derives-from-privkey via `wg pubkey` (skips without wireguard-kmod) |

**Verified: two consecutive clean 6/6 runs on FreeBSD 15.0-p4** (the LAN test VM). The workflow itself gets its first cloud exercise on this PR (it path-matches).

## Bug found on the harness's first run: `pf_tuning` wipes the main pf ruleset

`pf_tuning` loaded an options-only file with `pfctl -m -f`. `-m` merges *options*, but `-f` still **replaces the ruleset with the file's zero rules** — verified empirically on FreeBSD 15 (`before: 15 rules → pfctl -m -f tuning.conf → after: 0 rules`). Effect: **every daemon boot and every max-states save wiped the main pf ruleset.**

On appliances, `reconcile_pf_main`'s auto-heal reloaded `pf.conf.aifw` moments later — masking the bug, and explaining the historical "main ruleset empty at boot / LAN outbound silently breaks" mystery that auto-heal was built to paper over (its own comment said "exact cause still under investigation"). On any host without `pf.conf.aifw`, the firewall silently stayed rule-less.

**Fix:** `pf_tuning` now patches `set limit states N` into `pf.conf.aifw` itself — stage to `/tmp/aifw-pf.conf.aifw.patched`, validate with `pfctl -nf`, commit via `aifw-sudo-write`, reload the full file — the exact flow and **existing sudoers grants** of the anchor patcher (no sudoers drift). Idempotent no-op when the value is already present; on hosts without `pf.conf.aifw` the value stays in the DB with a warning. 5 new unit tests pin the patcher; the auto-heal stays as belt-and-braces with its comment updated to name the root cause.

## CI workflow

`freebsd-functional.yml`: PRs touching `aifw-pf`/`aifw-core`/`aifw-common`/`aifw-api`/`aifw-daemon`/`freebsd/**` boot a FreeBSD 15 VM (pinned vmactions SHA), build debug binaries, run the harness, upload artifacts. ~20–30 min; also manually dispatchable.

## Verification

714 tests passing workspace-wide, zero warnings, clippy/fmt clean; harness `sh -n` clean; 2× consecutive 6/6 on real hardware. v5.101.0.

Part of #533 (Phase 1). Later phases: appliance ISO boot smoke (needs `aifw-setup` unattended mode) and the SSH-orchestrated nightly tier (#534's two-node HA suite).