### PR TITLE
Force postcss >= 8.5.10 via npm override (Dependabot #11)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.101.0"
+version = "5.101.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.99.4",
+  "version": "5.101.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.99.4",
+      "version": "5.101.0",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",
@@ -5204,9 +5204,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -5295,34 +5295,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-exports-info": {
@@ -5615,10 +5587,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "funding": [
         {
           "type": "opencollective",
@@ -5635,7 +5606,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.101.0",
+  "version": "5.101.1",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -13,7 +13,8 @@
     "lucide-react": "^1.20.0",
     "next": "^16.2.9",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7"  },
+    "react-dom": "^19.2.7"
+  },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.1",
     "@types/node": "^25.9.3",
@@ -24,5 +25,8 @@
     "postcss": "^8.5.15",
     "tailwindcss": "^4.3.1",
     "typescript": "^6.0.3"
+  },
+  "overrides": {
+    "postcss": "^8.5.15"
   }
 }


### PR DESCRIPTION
Resolves Dependabot alert #11 (GHSA-qx2v-qp2m-jg93, medium): `next@16.2.9` pins a nested `postcss@8.4.31`, vulnerable to XSS via unescaped `</style>` in its stringify output. The direct dependency was already 8.5.15 — only Next's nested copy was affected.

Fix: npm `overrides` entry forcing `postcss: ^8.5.15`; everything now dedupes to 8.5.20 and `npm audit` reports 0 vulnerabilities. `npm run build` (static export) and lint verified. v5.101.1.