### PR TITLE
Unattended setup via seed file (#533 Phase 2 prerequisite)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.101.1"
+version = "5.102.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -4,6 +4,46 @@ use crate::tuning::{self, TuningItem};
 use aifw_common::{CarpVip, ClusterNode, ClusterRole, Interface, PfsyncConfig};
 
 /// Apply the setup configuration: write files, init DB, start services
+/// Set the root password non-interactively (unattended seed, #533 Phase 2)
+/// via `pw usermod root -h 0` reading the password on stdin — the same
+/// mechanism the interactive wizard uses.
+#[cfg(target_os = "freebsd")]
+pub fn set_root_password_noninteractive(password: &str) -> Result<(), String> {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+    if password.len() < 8 {
+        return Err("root_password must be at least 8 characters".to_string());
+    }
+    let mut child = Command::new("/usr/sbin/pw")
+        .args(["usermod", "root", "-h", "0"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("spawn pw: {e}"))?;
+    if let Some(ref mut stdin) = child.stdin {
+        stdin
+            .write_all(password.as_bytes())
+            .map_err(|e| format!("write pw stdin: {e}"))?;
+    }
+    let out = child
+        .wait_with_output()
+        .map_err(|e| format!("pw wait: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "pw usermod root failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
+/// Non-FreeBSD stub so the unattended path compiles on dev hosts.
+#[cfg(not(target_os = "freebsd"))]
+pub fn set_root_password_noninteractive(_password: &str) -> Result<(), String> {
+    Err("root password can only be set on FreeBSD".to_string())
+}
+
 pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<(), String> {
     console::header("Applying Configuration");
 

--- a/aifw-setup/src/config.rs
+++ b/aifw-setup/src/config.rs
@@ -49,9 +49,128 @@ pub struct SetupConfig {
     pub db_path: String,
     pub config_dir: String,
 
+    // Unattended-seed-only secrets (#533 Phase 2). Accepted when loading a
+    // seed file via `aifw-setup --config`, converted by
+    // `resolve_seed_secrets()`, and NEVER serialized back into aifw.conf
+    // (`skip_serializing`) so plaintext never lands on disk post-setup.
+    /// Plaintext admin password; hashed into `admin_password_hash` at load.
+    /// Ignored when `admin_password_hash` is already set.
+    #[serde(default, skip_serializing)]
+    pub admin_password: Option<String>,
+    /// Plaintext root password, applied non-interactively during setup.
+    #[serde(default, skip_serializing)]
+    pub root_password: Option<String>,
+
     // HA cluster (set by wizard; not persisted in aifw.conf JSON)
     #[serde(skip)]
     pub cluster: Option<WizardClusterConfig>,
+}
+
+impl SetupConfig {
+    /// Convert seed-file secrets into their applied form: hash a plaintext
+    /// `admin_password` into `admin_password_hash` (unless a hash was
+    /// already provided, which wins) and drop the plaintext. Errors when
+    /// the seed carries neither, or the password is under 8 characters
+    /// (matching the wizard's policy).
+    pub fn resolve_seed_secrets(&mut self) -> Result<(), String> {
+        if self.admin_password_hash.is_empty() {
+            match self.admin_password.take() {
+                Some(p) if p.len() >= 8 => {
+                    self.admin_password_hash = hash_password(&p);
+                    if self.admin_password_hash.is_empty() {
+                        return Err("failed to hash admin_password".to_string());
+                    }
+                }
+                Some(_) => {
+                    return Err("admin_password must be at least 8 characters".to_string());
+                }
+                None => {
+                    return Err(
+                        "seed must provide admin_password or admin_password_hash".to_string()
+                    );
+                }
+            }
+        } else {
+            // Hash present — discard any plaintext so it can't leak onward.
+            self.admin_password = None;
+        }
+        Ok(())
+    }
+
+    /// Sanity checks for an unattended seed before applying it.
+    pub fn validate_seed(&self) -> Result<(), String> {
+        if self.admin_username.trim().is_empty() {
+            return Err("admin_username must not be empty".to_string());
+        }
+        if self.hostname.trim().is_empty() {
+            return Err("hostname must not be empty".to_string());
+        }
+        if self.wan_interface.trim().is_empty() {
+            return Err("wan_interface must not be empty".to_string());
+        }
+        if matches!(self.wan_mode, WanMode::Static)
+            && (self.wan_ip.is_none() || self.wan_gateway.is_none())
+        {
+            return Err("static wan_mode requires wan_ip and wan_gateway".to_string());
+        }
+        if self.lan_ip.is_some() && self.lan_interface.is_none() {
+            return Err("lan_ip requires lan_interface".to_string());
+        }
+        if self.api_port == 0 {
+            return Err("api_port must not be 0".to_string());
+        }
+        Ok(())
+    }
+
+    /// Example seed file for `aifw-setup --config` (unattended setup).
+    /// Placeholder values are deliberately invalid-looking so an unedited
+    /// template can't produce a silently misconfigured appliance.
+    pub fn seed_template() -> String {
+        serde_json::to_string_pretty(&serde_json::json!({
+            "hostname": "aifw",
+            "wan_interface": "CHANGE-ME-eg-vtnet0",
+            "wan_mode": "dhcp",
+            "wan_ip": null,
+            "wan_gateway": null,
+            "lan_interface": null,
+            "lan_ip": null,
+            "admin_username": "admin",
+            "admin_password": "CHANGE-ME-min-8-chars",
+            "admin_password_hash": "",
+            "root_password": null,
+            "totp_secret": "",
+            "totp_enabled": false,
+            "recovery_codes": [],
+            "api_listen": "0.0.0.0",
+            "api_port": 8080,
+            "ui_enabled": true,
+            "dns_servers": ["9.9.9.9", "1.1.1.1"],
+            "dhcp_enabled": false,
+            "default_policy": "standard",
+            "nat_enabled": true,
+            "ssh_auth_method": "password",
+            "ssh_github_user": null,
+            "ssh_authorized_keys": [],
+            "db_path": "/var/db/aifw/aifw.db",
+            "config_dir": "/usr/local/etc/aifw"
+        }))
+        .unwrap_or_default()
+            + "\n"
+    }
+}
+
+/// Argon2id password hashing — same algorithm and parameters as
+/// `aifw-api/src/auth/password.rs`. Shared by the wizard and the
+/// unattended seed loader.
+pub fn hash_password(password: &str) -> String {
+    use argon2::{
+        Argon2, PasswordHasher, password_hash::SaltString, password_hash::rand_core::OsRng,
+    };
+    let salt = SaltString::generate(&mut OsRng);
+    Argon2::default()
+        .hash_password(password.as_bytes(), &salt)
+        .map(|h| h.to_string())
+        .unwrap_or_default()
 }
 
 fn default_ram_mb() -> u64 {
@@ -166,6 +285,8 @@ impl Default for SetupConfig {
             ssh_authorized_keys: Vec::new(),
             ram_mb: 1024,
             db_path: "/var/db/aifw/aifw.db".to_string(),
+            admin_password: None,
+            root_password: None,
             config_dir: "/usr/local/etc/aifw".to_string(),
             cluster: None,
         }

--- a/aifw-setup/src/main.rs
+++ b/aifw-setup/src/main.rs
@@ -32,6 +32,11 @@ struct Args {
     /// `visudo -cf -` for syntax validation (#204).
     #[arg(long)]
     print_sudoers: bool,
+
+    /// Print an example seed file for unattended setup (--config) and exit.
+    /// Edit the CHANGE-ME placeholders, then: aifw-setup --config seed.json
+    #[arg(long)]
+    print_seed_template: bool,
 }
 
 #[tokio::main]
@@ -43,7 +48,14 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // If --config provided, load from file instead of wizard
+    if args.print_seed_template {
+        print!("{}", config::SetupConfig::seed_template());
+        return Ok(());
+    }
+
+    // If --config provided, load from file instead of wizard (unattended
+    // setup, #533 Phase 2). The seed may carry plaintext admin/root
+    // passwords; they are hashed/applied here and never written back out.
     if let Some(ref config_path) = args.config {
         let content = std::fs::read_to_string(config_path)?;
         let mut config: config::SetupConfig = serde_json::from_str(&content)?;
@@ -55,6 +67,23 @@ async fn main() -> anyhow::Result<()> {
         if args.pf_only {
             println!("{}", apply::generate_pf_conf(&config));
             return Ok(());
+        }
+
+        config
+            .resolve_seed_secrets()
+            .map_err(|e| anyhow::anyhow!("seed config: {e}"))?;
+        config
+            .validate_seed()
+            .map_err(|e| anyhow::anyhow!("seed config: {e}"))?;
+        if config.wan_interface.starts_with("CHANGE-ME") {
+            anyhow::bail!("seed config: template placeholders not filled in");
+        }
+
+        if let Some(root_pw) = config.root_password.take() {
+            match apply::set_root_password_noninteractive(&root_pw) {
+                Ok(()) => println!("Root password set."),
+                Err(e) => eprintln!("WARNING: root password not set: {e}"),
+            }
         }
 
         apply::apply(&config, &[])

--- a/aifw-setup/src/tests.rs
+++ b/aifw-setup/src/tests.rs
@@ -417,4 +417,82 @@ mod let_underscore_tests {
             violations.join("\n")
         );
     }
+
+    // --- Unattended seed (#533 Phase 2) ---
+
+    #[test]
+    fn seed_template_parses_and_flags_placeholders() {
+        let tpl = crate::config::SetupConfig::seed_template();
+        let mut cfg: crate::config::SetupConfig =
+            serde_json::from_str(&tpl).expect("seed template must deserialize into SetupConfig");
+        // The unedited template must be rejected by the placeholder guard,
+        // never applied as-is.
+        assert!(cfg.wan_interface.starts_with("CHANGE-ME"));
+        // After filling in the placeholders it must resolve + validate.
+        cfg.wan_interface = "vtnet0".to_string();
+        cfg.resolve_seed_secrets().expect("plaintext pw resolves");
+        cfg.validate_seed().expect("filled template validates");
+        assert!(cfg.admin_password_hash.starts_with("$argon2"));
+        assert!(cfg.admin_password.is_none(), "plaintext must be dropped");
+    }
+
+    #[test]
+    fn seed_secrets_hash_wins_over_plaintext() {
+        let mut cfg: crate::config::SetupConfig =
+            serde_json::from_str(&crate::config::SetupConfig::seed_template()).unwrap();
+        cfg.admin_password_hash = "$argon2id$preexisting".to_string();
+        cfg.admin_password = Some("SomethingElse123".to_string());
+        cfg.resolve_seed_secrets().unwrap();
+        assert_eq!(cfg.admin_password_hash, "$argon2id$preexisting");
+        assert!(cfg.admin_password.is_none());
+    }
+
+    #[test]
+    fn seed_secrets_reject_missing_or_short_password() {
+        let mut cfg: crate::config::SetupConfig =
+            serde_json::from_str(&crate::config::SetupConfig::seed_template()).unwrap();
+        cfg.admin_password = None;
+        assert!(cfg.resolve_seed_secrets().is_err(), "neither pw nor hash");
+
+        let mut cfg: crate::config::SetupConfig =
+            serde_json::from_str(&crate::config::SetupConfig::seed_template()).unwrap();
+        cfg.admin_password = Some("short".to_string());
+        assert!(cfg.resolve_seed_secrets().is_err(), "short password");
+    }
+
+    #[test]
+    fn seed_validation_catches_incoherent_network_config() {
+        let mk = || -> crate::config::SetupConfig {
+            let mut c: crate::config::SetupConfig =
+                serde_json::from_str(&crate::config::SetupConfig::seed_template()).unwrap();
+            c.wan_interface = "vtnet0".to_string();
+            c
+        };
+        let mut c = mk();
+        c.wan_mode = crate::config::WanMode::Static;
+        assert!(c.validate_seed().is_err(), "static without ip/gateway");
+
+        let mut c = mk();
+        c.lan_ip = Some("192.168.1.1/24".to_string());
+        c.lan_interface = None;
+        assert!(c.validate_seed().is_err(), "lan_ip without lan_interface");
+
+        let mut c = mk();
+        c.admin_username = String::new();
+        assert!(c.validate_seed().is_err(), "empty admin username");
+    }
+
+    #[test]
+    fn seed_secrets_never_serialize_back() {
+        let mut cfg: crate::config::SetupConfig =
+            serde_json::from_str(&crate::config::SetupConfig::seed_template()).unwrap();
+        cfg.admin_password = Some("SuperSecret99".to_string());
+        cfg.root_password = Some("RootSecret99".to_string());
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(
+            !json.contains("SuperSecret99") && !json.contains("RootSecret99"),
+            "plaintext seed secrets must never serialize (aifw.conf safety)"
+        );
+        assert!(!json.contains("admin_password\""), "field itself skipped");
+    }
 }

--- a/aifw-setup/src/wizard.rs
+++ b/aifw-setup/src/wizard.rs
@@ -746,13 +746,5 @@ fn fetch_github_keys(username: &str) -> Result<Vec<String>, String> {
     Ok(keys)
 }
 
-fn hash_password(password: &str) -> String {
-    use argon2::{
-        Argon2, PasswordHasher, password_hash::SaltString, password_hash::rand_core::OsRng,
-    };
-    let salt = SaltString::generate(&mut OsRng);
-    Argon2::default()
-        .hash_password(password.as_bytes(), &salt)
-        .map(|h| h.to_string())
-        .unwrap_or_default()
-}
+// hash_password moved to config.rs so the unattended seed loader shares it.
+use crate::config::hash_password;

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.101.1",
+  "version": "5.102.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/docs/install.md
+++ b/docs/install.md
@@ -93,6 +93,18 @@ Once done, reach the web UI at:
 https://<lan-ip>:8080
 ```
 
+### Unattended (headless) setup
+
+For scripted installs, VM farms, and CI, skip the wizard entirely with a seed file:
+
+```sh
+aifw-setup --print-seed-template > seed.json
+# edit the CHANGE-ME placeholders (interfaces, admin_password, …)
+aifw-setup --config seed.json
+```
+
+On first boot the `aifw_firstboot` service also looks for a seed at `/usr/local/etc/aifw/seed.json` or `/aifw-seed.json` (drop one into the image or attached media) and runs non-interactive setup from it, falling back to the console wizard if the seed fails. The seed file is **deleted after use** — it may contain plaintext `admin_password` / `root_password` values, which are hashed/applied during setup and never written back to disk. If you prefer, supply `admin_password_hash` (Argon2id) instead of the plaintext field.
+
 ### Multi-WAN setup later
 
 Multi-WAN can be enabled from the web UI at any time after install — no need to edit `/boot/loader.conf` by hand. See the [multi-WAN guide]({{ '/multi-wan/' | relative_url }}).

--- a/freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot
+++ b/freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot
@@ -29,8 +29,25 @@ aifw_firstboot_start()
     echo ""
 
     if [ -x "$AIFW_SETUP" ]; then
-        # Run the setup wizard on the console
-        $AIFW_SETUP </dev/console >/dev/console 2>&1
+        # Unattended seed (#533 Phase 2): when a seed file is present, run
+        # non-interactive setup from it instead of the console wizard. The
+        # seed is deleted afterwards — it may carry plaintext passwords.
+        for seed in /usr/local/etc/aifw/seed.json /aifw-seed.json; do
+            if [ -f "$seed" ]; then
+                echo "Unattended seed found at $seed — running non-interactive setup"
+                if $AIFW_SETUP --config "$seed" >/dev/console 2>&1; then
+                    rm -f "$seed"
+                else
+                    echo "Unattended setup FAILED — falling back to the interactive wizard"
+                    rm -f "$seed"
+                fi
+                break
+            fi
+        done
+
+        # Run the setup wizard on the console (skipped when the seed above
+        # already produced aifw.conf)
+        [ -f "$AIFW_CONF" ] || $AIFW_SETUP </dev/console >/dev/console 2>&1
 
         # If setup succeeded, enable and start services
         if [ -f "$AIFW_CONF" ]; then


### PR DESCRIPTION
The `aifw-setup` unattended mode needed before #533 Phase 2 (booting the built ISO in CI) — and independently useful for scripted VM provisioning.

## What's new

- **`aifw-setup --print-seed-template`** emits an example seed JSON. Placeholders are deliberately invalid (`CHANGE-ME-…`) and the loader refuses an unedited template, so a forgotten edit can't produce a silently misconfigured appliance.
- **`aifw-setup --config seed.json`** (existing flag, now completed for real unattended use):
  - accepts plaintext `admin_password`, hashed at load with Argon2id (same algorithm/policy as the wizard; ≥ 8 chars); a supplied `admin_password_hash` still works and wins;
  - accepts optional plaintext `root_password`, applied non-interactively via `pw usermod root -h 0` — the wizard's own mechanism;
  - validates seed coherence before applying (static WAN requires ip+gateway, `lan_ip` requires `lan_interface`, non-empty hostname/admin/interface, sane port).
- **Secrets never persist**: the seed-only fields are `serde(skip_serializing)`, so plaintext can never be written back into `aifw.conf`; a guard test asserts serialization never contains them.
- **First-boot integration**: `aifw_firstboot` checks `/usr/local/etc/aifw/seed.json` and `/aifw-seed.json` before starting the console wizard; on a hit it runs `aifw-setup --config` and **deletes the seed** (it may carry secrets), falling back to the interactive wizard on failure.
- `hash_password` deduplicated out of `wizard.rs` into `config.rs`.
- `docs/install.md` gains an "Unattended (headless) setup" section.

## Verification

- 5 new unit tests: template round-trip + placeholder guard, hash-wins-over-plaintext, missing/short password rejection, network-coherence validation, secrets-never-serialize.
- 719 tests passing workspace-wide, zero warnings, fmt/clippy clean; `--print-seed-template` verified on the CLI; rc.d script passes `sh -n`.
- v5.102.0.

Next step this unblocks: #533 Phase 2 — boot the built ISO/IMG under qemu-kvm in `build-iso.yml` with a seed dropped into the image, and verify services + one packet path.