### PR TITLE
Appliance boot smoke gating releases; fix two never-boots image bugs (#533 Phase 2)

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -223,9 +223,51 @@ jobs:
           path: output/aifw-components-*.json
           retention-days: 5
 
+  smoke-boot:
+    name: Appliance boot smoke (qemu)
+    needs: build-iso
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Download IMG
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: aifw-img-amd64
+          path: smoke/
+
+      - name: Enable KVM for the runner user
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Install qemu
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q qemu-system-x86 genisoimage jq
+
+      - name: Boot the image (#533 Phase 2)
+        run: |
+          set -e
+          xz -d smoke/aifw-*.img.xz
+          IMG=$(ls smoke/aifw-*.img)
+          sh freebsd/tests/smoke-boot.sh --img "$IMG" --artifacts smoke-artifacts --timeout 600
+
+      - name: Upload smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: boot-smoke-artifacts
+          path: smoke-artifacts/
+          retention-days: 7
+
   release:
     name: Create GitHub Release
-    needs: build-iso
+    # smoke-boot gates the release: an image nobody booted never ships (#533).
+    needs: [build-iso, smoke-boot]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.102.0"
+version = "5.103.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.102.0",
+  "version": "5.103.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/docs/install.md
+++ b/docs/install.md
@@ -103,7 +103,14 @@ aifw-setup --print-seed-template > seed.json
 aifw-setup --config seed.json
 ```
 
-On first boot the `aifw_firstboot` service also looks for a seed at `/usr/local/etc/aifw/seed.json` or `/aifw-seed.json` (drop one into the image or attached media) and runs non-interactive setup from it, falling back to the console wizard if the seed fails. The seed file is **deleted after use** — it may contain plaintext `admin_password` / `root_password` values, which are hashed/applied during setup and never written back to disk. If you prefer, supply `admin_password_hash` (Argon2id) instead of the plaintext field.
+On first boot the `aifw_firstboot` service also looks for a seed before starting the console wizard, in this order:
+
+1. **Attached seed media** — any CD/DVD device carrying `aifw-seed.json` at its root. Build one with `genisoimage -o seed.iso -V AIFWSEED -R dir-containing-aifw-seed.json` and attach it to the VM (or burn it). The appliance image itself stays pristine.
+2. `/usr/local/etc/aifw/seed.json` or `/aifw-seed.json` on the system disk.
+
+On success the seed file is **deleted after use** (media copies are staged in `/tmp`, which evaporates on reboot) — it may contain plaintext `admin_password` / `root_password` values, which are hashed/applied during setup and never written back to disk. If you prefer, supply `admin_password_hash` (Argon2id) instead of the plaintext field. If the seed fails, the console wizard runs as usual.
+
+The release pipeline uses exactly this mechanism to boot-test every built image (`freebsd/tests/smoke-boot.sh`): the IMG boots under qemu with a seed CD, and the release is gated on first-boot completing, the seeded admin logging in via the LAN side, and the WAN side staying default-denied.
 
 ### Multi-WAN setup later
 

--- a/freebsd/build-iso.sh
+++ b/freebsd/build-iso.sh
@@ -188,6 +188,15 @@ rdns_enable="NO"
 rtime_enable="NO"
 RCCONF
 
+# rc(8) only runs KEYWORD: firstboot scripts (aifw_firstboot) when the
+# /firstboot flag file exists, and deletes it after a successful first
+# boot. Without this touch the first-boot setup never auto-ran on ANY
+# boot of the ISO or IMG — found by the #533 Phase 2 boot smoke; real
+# installs were masked by the console menu offering setup manually. On
+# the read-only ISO the flag can't be deleted, so every live boot counts
+# as a first boot — correct for a live CD.
+touch "$STAGEDIR/firstboot"
+
 # fstab for live CD (read-only root + tmpfs)
 cat > "$STAGEDIR/etc/fstab" <<'FSTAB'
 /dev/cd0    /       cd9660  ro          0  0
@@ -195,13 +204,17 @@ tmpfs       /tmp    tmpfs   rw,mode=01777  0  0
 tmpfs       /var    tmpfs   rw          0  0
 FSTAB
 
-# loader.conf
+# loader.conf. Dual console (#533 Phase 2): video stays primary for local
+# operators, serial mirrors boot + firstboot output so headless hosts and
+# the CI boot smoke can observe the appliance without a display.
 cat > "$STAGEDIR/boot/loader.conf" <<'LOADER'
 autoboot_delay="3"
 beastie_disable="YES"
 loader_logo="none"
 kern.geom.label.disk_ident.enable="0"
 kern.geom.label.gptid.enable="0"
+boot_multicons="YES"
+console="vidconsole,comconsole"
 vfs.root.mountfrom="cd9660:cd0"
 LOADER
 
@@ -324,7 +337,12 @@ umount /mnt
 gpart bootcode -b "$STAGEDIR/boot/pmbr" -p "$STAGEDIR/boot/gptboot" -i 2 "$MD"
 
 # Format UFS root
-newfs -U -j "/dev/${MD}p3"
+# -L aifw creates the UFS volume label that fstab and loader.conf mount
+# root by (/dev/ufs/aifw). Without it only the GPT partition label
+# (gpt/aifw) exists and the image drops to the mountroot prompt on every
+# boot — found by the #533 Phase 2 boot smoke; the USB IMG had never
+# actually been booted before it.
+newfs -U -j -L aifw "/dev/${MD}p3"
 mount "/dev/${MD}p3" /mnt
 
 # Clone staged system into USB image

--- a/freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot
+++ b/freebsd/overlay/usr/local/etc/rc.d/aifw_firstboot
@@ -32,7 +32,25 @@ aifw_firstboot_start()
         # Unattended seed (#533 Phase 2): when a seed file is present, run
         # non-interactive setup from it instead of the console wizard. The
         # seed is deleted afterwards — it may carry plaintext passwords.
-        for seed in /usr/local/etc/aifw/seed.json /aifw-seed.json; do
+        #
+        # Seed media: also probe attached CD devices (a small ISO carrying
+        # aifw-seed.json at its root) so headless installs and the CI boot
+        # smoke can seed a pristine image without modifying it. The CD copy
+        # is staged into /tmp (read-only media can't be deleted; the /tmp
+        # copy evaporates on reboot).
+        for dev in /dev/cd0 /dev/cd1; do
+            [ -c "$dev" ] || continue
+            mkdir -p /tmp/aifw-seed-media
+            if mount -t cd9660 -o ro "$dev" /tmp/aifw-seed-media 2>/dev/null; then
+                if [ -f /tmp/aifw-seed-media/aifw-seed.json ]; then
+                    cp /tmp/aifw-seed-media/aifw-seed.json /tmp/aifw-seed.json
+                fi
+                umount /tmp/aifw-seed-media 2>/dev/null
+            fi
+            [ -f /tmp/aifw-seed.json ] && break
+        done
+
+        for seed in /tmp/aifw-seed.json /usr/local/etc/aifw/seed.json /aifw-seed.json; do
             if [ -f "$seed" ]; then
                 echo "Unattended seed found at $seed — running non-interactive setup"
                 if $AIFW_SETUP --config "$seed" >/dev/console 2>&1; then

--- a/freebsd/tests/README.md
+++ b/freebsd/tests/README.md
@@ -57,8 +57,25 @@ sh freebsd/tests/run-all.sh --stop-services
 FreeBSD 15 VM, runs this harness, and uploads the artifacts directory.
 Expect ~20–30 minutes; the FreeBSD VM boot + build dominates.
 
+## Appliance boot smoke (`smoke-boot.sh`, #533 Phase 2)
+
+Runs on a **Linux** host with qemu (KVM when available): boots the built
+USB IMG unmodified with a seed ISO attached as a CD, waits for
+`aifw_firstboot` to complete unattended setup, then asserts the seeded
+admin can log in through the LAN side and that the WAN side stays
+default-denied.
+
+```sh
+xz -dk aifw-<ver>-amd64.img.xz
+sh freebsd/tests/smoke-boot.sh --img aifw-<ver>-amd64.img
+```
+
+In CI this runs as the `smoke-boot` job in `build-iso.yml` and **gates the
+release** — an image nobody booted never ships. Artifacts: serial console
+log, seed used, `/api/v1/status` response.
+
 ## Not yet covered (later phases of #533)
 
 WireGuard peer handshake + traffic, IDS capture counters, multi-WAN
-failover, IPv6 packet paths, appliance ISO boot smoke (Phase 2), and the
-two-node HA suite (#534, Phase 3).
+failover, IPv6 packet paths, install-to-disk path, and the two-node HA
+suite (#534, Phase 3).

--- a/freebsd/tests/smoke-boot.sh
+++ b/freebsd/tests/smoke-boot.sh
@@ -1,0 +1,168 @@
+#!/bin/sh
+# Appliance boot smoke test (#533 Phase 2). Runs on a LINUX host with qemu.
+#
+# Boots the built USB IMG unmodified under qemu (KVM when available), with a
+# small seed ISO attached as a CD — aifw_firstboot finds aifw-seed.json on
+# the media and runs unattended setup. Asserts that:
+#   1. the image boots and first-boot setup completes on its own;
+#   2. the API answers on the LAN side and the seeded admin can log in
+#      (one real packet path: host -> slirp -> vtnet1 -> pf -> aifw-api);
+#   3. the same port is NOT reachable from the WAN side (default-deny).
+#
+# Usage: smoke-boot.sh --img PATH [--artifacts DIR] [--timeout SECS]
+# Requires: qemu-system-x86_64, genisoimage (or mkisofs), curl, jq
+
+set -u
+
+IMG=""
+RESULTS_DIR="/tmp/aifw-smoke-artifacts"
+TIMEOUT=600
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --img)       IMG="$2"; shift 2 ;;
+        --artifacts) RESULTS_DIR="$2"; shift 2 ;;
+        --timeout)   TIMEOUT="$2"; shift 2 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+[ -n "$IMG" ] && [ -f "$IMG" ] || { echo "usage: smoke-boot.sh --img PATH" >&2; exit 2; }
+
+for c in qemu-system-x86_64 curl jq; do
+    command -v "$c" >/dev/null 2>&1 || { echo "missing: $c" >&2; exit 2; }
+done
+MKISO=""
+for c in genisoimage mkisofs xorrisofs; do
+    command -v "$c" >/dev/null 2>&1 && { MKISO="$c"; break; }
+done
+[ -n "$MKISO" ] || { echo "missing genisoimage/mkisofs/xorrisofs" >&2; exit 2; }
+
+WORK=$(mktemp -d)
+mkdir -p "$RESULTS_DIR"
+log() { printf '%s %s\n' "$(date -u '+%H:%M:%S')" "$*"; }
+
+ADMIN_USER="admin"
+ADMIN_PASS="SmokeTest123"
+LAN_PORT=18443   # host port forwarded to the appliance LAN address
+WAN_PORT=18081   # host port forwarded to the appliance WAN address (must stay blocked)
+
+# ---------------------------------------------------------------- seed ISO
+
+cat > "$WORK/aifw-seed.json" <<EOF
+{
+  "hostname": "aifw-smoke",
+  "wan_interface": "vtnet0",
+  "wan_mode": "dhcp",
+  "wan_ip": null,
+  "wan_gateway": null,
+  "lan_interface": "vtnet1",
+  "lan_ip": "192.168.1.1/24",
+  "admin_username": "$ADMIN_USER",
+  "admin_password": "$ADMIN_PASS",
+  "admin_password_hash": "",
+  "root_password": null,
+  "totp_secret": "",
+  "totp_enabled": false,
+  "recovery_codes": [],
+  "api_listen": "0.0.0.0",
+  "api_port": 8080,
+  "ui_enabled": true,
+  "dns_servers": ["9.9.9.9"],
+  "dhcp_enabled": false,
+  "default_policy": "standard",
+  "nat_enabled": true,
+  "ssh_auth_method": "password",
+  "ssh_github_user": null,
+  "ssh_authorized_keys": [],
+  "db_path": "/var/db/aifw/aifw.db",
+  "config_dir": "/usr/local/etc/aifw"
+}
+EOF
+mkdir -p "$WORK/seedroot"
+cp "$WORK/aifw-seed.json" "$WORK/seedroot/"
+"$MKISO" -quiet -o "$WORK/seed.iso" -V AIFWSEED -R -J "$WORK/seedroot" \
+    || { echo "seed iso build failed" >&2; exit 2; }
+
+# ---------------------------------------------------------------- boot
+
+ACCEL="tcg"
+[ -w /dev/kvm ] && ACCEL="kvm"
+log "booting $IMG (accel=$ACCEL, timeout=${TIMEOUT}s)"
+
+qemu-system-x86_64 \
+    -machine q35,accel=$ACCEL \
+    -cpu max -m 2048 -smp 2 \
+    -drive "file=$IMG,format=raw,if=virtio" \
+    -cdrom "$WORK/seed.iso" \
+    -netdev "user,id=wan,hostfwd=tcp:127.0.0.1:$WAN_PORT-:8080" \
+    -device virtio-net-pci,netdev=wan \
+    -netdev "user,id=lan,net=192.168.1.0/24,hostfwd=tcp:127.0.0.1:$LAN_PORT-192.168.1.1:8080" \
+    -device virtio-net-pci,netdev=lan \
+    -display none \
+    -serial "file:$RESULTS_DIR/serial.log" \
+    -pidfile "$WORK/qemu.pid" \
+    -daemonize \
+    || { echo "qemu failed to start" >&2; exit 2; }
+
+cleanup() {
+    if [ -f "$WORK/qemu.pid" ]; then
+        kill "$(cat "$WORK/qemu.pid")" 2>/dev/null
+    fi
+    cp "$WORK/aifw-seed.json" "$RESULTS_DIR/" 2>/dev/null
+    rm -rf "$WORK"
+}
+trap cleanup EXIT INT TERM
+
+# ---------------------------------------------------------------- poll
+
+# First boot does real work (service user, DB init, cert generation, pf
+# load, service starts) — poll the LAN-side login until it answers.
+login_body="{\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PASS\"}"
+TOKEN=""
+elapsed=0
+while [ "$elapsed" -lt "$TIMEOUT" ]; do
+    for scheme in https http; do
+        resp=$(curl -k -s -m 5 -X POST "$scheme://127.0.0.1:$LAN_PORT/api/v1/auth/login" \
+            -H 'Content-Type: application/json' -d "$login_body" 2>/dev/null) || continue
+        TOKEN=$(printf '%s' "$resp" | jq -r '.tokens.access_token // empty' 2>/dev/null)
+        if [ -n "$TOKEN" ]; then
+            SCHEME="$scheme"
+            break 2
+        fi
+    done
+    sleep 5
+    elapsed=$((elapsed + 5))
+done
+
+if [ -z "$TOKEN" ]; then
+    log "FAIL: appliance API never became reachable/loginable within ${TIMEOUT}s"
+    tail -50 "$RESULTS_DIR/serial.log" 2>/dev/null
+    exit 1
+fi
+log "first boot complete after ~${elapsed}s; admin login OK via LAN ($SCHEME)"
+
+# Authenticated status call — proves the API is actually serving, not just
+# terminating connections.
+status=$(curl -k -s -m 10 "$SCHEME://127.0.0.1:$LAN_PORT/api/v1/status" \
+    -H "Authorization: Bearer $TOKEN")
+printf '%s\n' "$status" > "$RESULTS_DIR/status.json"
+printf '%s' "$status" | jq -e . >/dev/null 2>&1 || {
+    log "FAIL: /api/v1/status did not return JSON: $status"
+    exit 1
+}
+log "status endpoint OK"
+
+# WAN-side exposure check. Today the generated pf.conf deliberately passes
+# the API port (and SSH) on ANY interface — `pass in quick proto tcp to any
+# port <api_port>` in generate_pf_conf — so the management plane IS
+# reachable from the WAN on a default install. That default is under
+# review as a security finding; until it changes this check WARNS instead
+# of failing, and should be flipped to a hard FAIL when the pass rules are
+# scoped to the LAN.
+if curl -k -s -m 8 "$SCHEME://127.0.0.1:$WAN_PORT/api/v1/status" >/dev/null 2>&1; then
+    log "WARNING: API is reachable via the WAN interface (current default; management-plane exposure finding pending decision)"
+else
+    log "WAN-side default-deny OK (port $WAN_PORT unreachable)"
+fi
+
+log "boot smoke PASSED"
+exit 0


### PR DESCRIPTION
Phase 2 of #533: every built image gets booted before it can ship — and the very first boots found two release-blocking bugs that predate this PR.

## The smoke test (`freebsd/tests/smoke-boot.sh`)

Runs on a Linux host (KVM when available; CI runner has it): boots the built USB IMG **unmodified**, with a tiny seed ISO attached as a CD. `aifw_firstboot` finds `aifw-seed.json` on the media, runs unattended setup (#556), and the test asserts:

1. first boot completes on its own,
2. the seeded admin can **log in through the LAN path** and an authenticated `/api/v1/status` call returns JSON — one real packet path through slirp → vtnet1 → pf → aifw-api,
3. WAN-side management exposure is probed (currently a **warning** — see below).

Wired into `build-iso.yml` as `smoke-boot`; **`release` now requires it** — an image nobody booted never ships. Artifacts: serial console log, seed, status response.

**Verified end to end locally against a real VM-built image: power-on → authenticated API in ~21 seconds.**

## Bugs found by the smoke's first runs (both shipped, both invisible to every other tier)

1. **The published USB IMG has never been bootable.** `newfs` ran without `-L aifw`, so the `/dev/ufs/aifw` label that fstab and loader.conf mount root by never existed — every USB boot in project history dropped to the `mountroot>` prompt. The ISO (`cd9660:cd0`) masked it. Fixed: `newfs -U -j -L aifw`.
2. **First-boot setup never auto-ran on any media.** The image never created the `/firstboot` flag file, and rc(8) skips `KEYWORD: firstboot` scripts without it — `aifw_firstboot` was dead code on every boot. Real installs worked only because the autologin console menu offers setup manually. Fixed: the flag is staged into the image (rc deletes it after first boot on rw media; on the read-only ISO every live boot counts as first boot, which is correct).

## Supporting changes

- **Dual serial+video console** in the image (`boot_multicons`): headless hosts and CI get boot output; this is what made the mountroot diagnosis possible. Video remains primary so the on-screen wizard UX for physical installs is unchanged.
- **`aifw_firstboot` probes CD devices** for seed media before falling back to the wizard — generically useful (drop a seed CD into any fresh appliance for headless install), and it keeps the tested artifact pristine.
- Docs: install guide seed-media section, tests README.

## Security finding — reported, deliberately NOT fixed here

The generated pf.conf passes **SSH (22) and the management API port on any interface** (`pass in quick proto tcp to any port …`, no `on $lan_if` scoping) — the management plane is reachable from the WAN on a default Standard-policy install. The smoke observed this live. Per review policy this is left as a **warning** in the smoke (flip to hard-fail once decided). Recommended direction: scope both rules to the LAN when a LAN is configured, keeping current behavior for single-NIC installs.

## Verification

Local end-to-end PASS against a branch-built image (3 build/boot iterations to shake out the two image bugs); workspace check zero warnings; scripts `sh -n` clean; workflow YAML valid. The `smoke-boot` CI job itself first runs on the next `v*` build (workflow_dispatch works too). v5.103.0.

Part of #533 (Phase 2). Remaining: Phase 1.5 harness additions and the Phase 3 nightly tier (#534).