### PR TITLE
Scope SSH + management API to the LAN by default (#560)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.103.0"
+version = "5.104.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -1875,18 +1875,44 @@ pub fn generate_pf_conf(config: &SetupConfig) -> String {
     }
     lines.push(String::new());
 
-    // Allow SSH from anywhere (management access)
-    lines.push("# SSH access".to_string());
-    lines.push("pass in quick proto tcp to any port 22 keep state label \"ssh\"".to_string());
-    lines.push(String::new());
-
-    // Allow API/UI access
-    lines.push("# AiFw API/UI access".to_string());
-    lines.push(format!(
-        "pass in quick proto tcp to any port {} keep state label \"aifw-api\"",
-        config.api_port
-    ));
-    lines.push(String::new());
+    // Management access (SSH + API/UI). Scoped to the LAN interface when one
+    // is configured so the control plane is not exposed on the WAN by
+    // default (#560). A box with no LAN (single-NIC / WAN-only) keeps the
+    // any-interface rule — otherwise the operator would have no way in.
+    match config.lan_interface.as_deref() {
+        Some(lan) => {
+            lines.push("# SSH access (LAN only)".to_string());
+            lines.push(format!(
+                "pass in quick on {lan} proto tcp to any port 22 keep state label \"ssh\""
+            ));
+            lines.push(String::new());
+            lines.push("# AiFw API/UI access (LAN only)".to_string());
+            lines.push(format!(
+                "pass in quick on {lan} proto tcp to any port {} keep state label \"aifw-api\"",
+                config.api_port
+            ));
+            lines.push(String::new());
+        }
+        None => {
+            // WAN-only appliance: management must remain reachable on the
+            // single interface or the operator locks themselves out.
+            lines
+                .push("# SSH access (no LAN configured — reachable on all interfaces)".to_string());
+            lines.push(
+                "pass in quick proto tcp to any port 22 keep state label \"ssh\"".to_string(),
+            );
+            lines.push(String::new());
+            lines.push(
+                "# AiFw API/UI access (no LAN configured — reachable on all interfaces)"
+                    .to_string(),
+            );
+            lines.push(format!(
+                "pass in quick proto tcp to any port {} keep state label \"aifw-api\"",
+                config.api_port
+            ));
+            lines.push(String::new());
+        }
+    }
 
     // LAN to WAN pass rule
     if config.lan_interface.is_some() {

--- a/aifw-setup/src/tests.rs
+++ b/aifw-setup/src/tests.rs
@@ -96,6 +96,63 @@ mod tests {
         assert!(pf.contains("set skip on pfsync0"));
         assert!(pf.contains("set state-policy floating"));
         assert!(!pf.contains("if-bound"));
+        // #560: management is scoped to the LAN interface, not passed on any.
+        assert!(
+            pf.contains("pass in quick on em1 proto tcp to any port 22"),
+            "ssh should be LAN-scoped: {pf}"
+        );
+        assert!(
+            pf.contains("pass in quick on em1 proto tcp to any port 8080"),
+            "api should be LAN-scoped: {pf}"
+        );
+        assert!(
+            !pf.contains("pass in quick proto tcp to any port 22"),
+            "ssh must NOT be passed on all interfaces when a LAN exists: {pf}"
+        );
+    }
+
+    #[test]
+    fn test_pf_conf_mgmt_scoped_to_lan() {
+        let config = SetupConfig {
+            wan_interface: "vtnet0".to_string(),
+            lan_interface: Some("vtnet1".to_string()),
+            lan_ip: Some("192.168.1.1/24".to_string()),
+            api_port: 8443,
+            ..Default::default()
+        };
+        let pf = apply::generate_pf_conf(&config);
+        assert!(pf.contains("pass in quick on vtnet1 proto tcp to any port 22"));
+        assert!(pf.contains("pass in quick on vtnet1 proto tcp to any port 8443"));
+        // No unscoped management pass rule anywhere.
+        for line in pf.lines() {
+            if line.contains("port 22") || line.contains("port 8443") {
+                assert!(
+                    line.contains("on vtnet1"),
+                    "unscoped management rule leaked to all interfaces: {line}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_pf_conf_mgmt_wan_only_stays_open() {
+        // Single-NIC / WAN-only: management must remain reachable on the
+        // only interface, so the any-interface rule is retained (#560).
+        let config = SetupConfig {
+            wan_interface: "vtnet0".to_string(),
+            lan_interface: None,
+            api_port: 8080,
+            ..Default::default()
+        };
+        let pf = apply::generate_pf_conf(&config);
+        assert!(
+            pf.contains("pass in quick proto tcp to any port 22 keep state label \"ssh\""),
+            "WAN-only box must keep SSH reachable: {pf}"
+        );
+        assert!(
+            pf.contains("pass in quick proto tcp to any port 8080"),
+            "WAN-only box must keep API reachable: {pf}"
+        );
     }
 
     #[test]

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.103.0",
+  "version": "5.104.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/docs/install.md
+++ b/docs/install.md
@@ -93,6 +93,8 @@ Once done, reach the web UI at:
 https://<lan-ip>:8080
 ```
 
+> **Management access is LAN-only by default.** When you configure a LAN interface, the generated firewall rules allow SSH and the web UI / API **only on the LAN** — the control plane is not exposed to the WAN. A single-NIC (WAN-only) install keeps management reachable on its one interface. To allow management from the WAN on a LAN-equipped box, add an explicit `pass` rule for port 22 / your API port on the WAN interface via **Firewall → Rules**.
+
 ### Unattended (headless) setup
 
 For scripted installs, VM farms, and CI, skip the wizard entirely with a seed file:

--- a/freebsd/tests/smoke-boot.sh
+++ b/freebsd/tests/smoke-boot.sh
@@ -151,18 +151,15 @@ printf '%s' "$status" | jq -e . >/dev/null 2>&1 || {
 }
 log "status endpoint OK"
 
-# WAN-side exposure check. Today the generated pf.conf deliberately passes
-# the API port (and SSH) on ANY interface — `pass in quick proto tcp to any
-# port <api_port>` in generate_pf_conf — so the management plane IS
-# reachable from the WAN on a default install. That default is under
-# review as a security finding; until it changes this check WARNS instead
-# of failing, and should be flipped to a hard FAIL when the pass rules are
-# scoped to the LAN.
+# Default-deny on WAN: the management API port via the WAN interface must
+# NOT answer — the seed configures a LAN, so generate_pf_conf scopes the
+# SSH/API pass rules to it (#560). A reachable WAN-side API means that
+# scoping regressed.
 if curl -k -s -m 8 "$SCHEME://127.0.0.1:$WAN_PORT/api/v1/status" >/dev/null 2>&1; then
-    log "WARNING: API is reachable via the WAN interface (current default; management-plane exposure finding pending decision)"
-else
-    log "WAN-side default-deny OK (port $WAN_PORT unreachable)"
+    log "FAIL: management API is reachable via the WAN interface — LAN scoping regressed (#560)"
+    exit 1
 fi
+log "WAN-side default-deny OK (port $WAN_PORT unreachable)"
 
 log "boot smoke PASSED"
 exit 0


### PR DESCRIPTION
Fixes the management-plane WAN exposure the #533 Phase 2 boot smoke caught live (#560).

## The problem

`aifw-setup::generate_pf_conf` emitted the management pass rules unscoped:

```
pass in quick proto tcp to any port 22 keep state label "ssh"
pass in quick proto tcp to any port <api_port> keep state label "aifw-api"
```

`to any` with no `on $lan_if` → SSH and the web UI/REST API answered on **every** interface, including the WAN, on a default Standard-policy install. The boot smoke observed this against a real booted image.

## The fix

Scope both rules to the LAN interface when one is configured:

```
pass in quick on $lan_if proto tcp to any port 22 ...
pass in quick on $lan_if proto tcp to any port <api_port> ...
```

A **single-NIC / WAN-only** install (no LAN configured) keeps the any-interface rule — otherwise the operator would have no way in. The Phase 2 smoke's WAN-side check is flipped back from WARN to a **hard failure** (`smoke-boot.sh`), so a regression can't ship.

## Scope: fresh installs only — by design

`generate_pf_conf` runs at setup. Existing appliances' `pf.conf.aifw` is written once and thereafter only anchor-patched / state-tuned, never regenerated — so **upgrading does not rewrite the rules**. This is deliberate: silently re-scoping the management plane on an in-service box would sever any admin currently managing it over the WAN, mid-upgrade. Existing installs are remediated by operator action (documented in `install.md`: add an explicit WAN `pass` rule if WAN management is actually wanted; otherwise the exposure is closed by adding a LAN-scoped rule and removing the broad one via the UI). A non-destructive boot-time *detect-and-warn* (mirroring the daemon's existing DNS-backend drift check) is a reasonable follow-up if you want existing boxes to flag themselves — happy to add it.

## Verification

- 2 new unit tests: management scoped to LAN when configured (asserts no unscoped `port 22`/api rule leaks anywhere), and WAN-only install keeps management reachable. Existing `test_pf_conf_standard` extended.
- 42 aifw-setup tests pass; workspace check zero warnings; fmt/clippy clean; smoke script `sh -n` clean.
- v5.104.0.

Closes #560.