### PR TITLE
IPsec: real IKEv2 data plane via strongSwan (#530)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.104.0"
+version = "5.105.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.107.0"
+version = "5.108.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.105.0"
+version = "5.106.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.106.0"
+version = "5.107.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.108.0"
+version = "5.109.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.109.0"
+version = "5.109.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -283,7 +283,15 @@ pub async fn check_config(
         info.push(format!("{} WireGuard tunnel(s)", wg.len()));
     }
     if !ipsec.is_empty() {
-        info.push(format!("{} IPsec SA(s)", ipsec.len()));
+        info.push(format!("{} legacy IPsec SA record(s)", ipsec.len()));
+    }
+    let ipsec_tunnels = state
+        .ipsec_engine
+        .list_tunnels()
+        .await
+        .map_err(|_| internal())?;
+    if !ipsec_tunnels.is_empty() {
+        info.push(format!("{} IPsec tunnel(s)", ipsec_tunnels.len()));
     }
 
     // Check DNS
@@ -575,6 +583,11 @@ pub(crate) async fn build_current_config(state: &AppState) -> Result<FirewallCon
         .list_ipsec_sas()
         .await
         .map_err(|_| internal())?;
+    let ipsec_tunnels = state
+        .ipsec_engine
+        .list_tunnels()
+        .await
+        .map_err(|_| internal())?;
 
     let queues = state.shaping_engine.list_queues().await.unwrap_or_default();
     let rate_limits = state
@@ -753,6 +766,7 @@ pub(crate) async fn build_current_config(state: &AppState) -> Result<FirewallCon
                     auth_algo: s.auth_algo.clone(),
                 })
                 .collect(),
+            ipsec_tunnels,
         },
         geoip: geoip_rules
             .iter()
@@ -1576,6 +1590,7 @@ pub(crate) async fn apply_firewall_config(
         "wg_peers",
         "wg_tunnels",
         "ipsec_sas",
+        "ipsec_tunnels",
         "geoip_rules",
         "rules",
         "nat_rules",
@@ -1791,6 +1806,22 @@ pub(crate) async fn apply_firewall_config(
             .add_ipsec_sa(sa)
             .await
             .map_err(|e| apply_fail(&format!("ipsec SA {sa_name} restore"), e))?;
+    }
+
+    // Real IPsec tunnels (#530): restore records first, then one apply to
+    // re-render swanctl config and reload charon.
+    for tunnel in &config.vpn.ipsec_tunnels {
+        let name = tunnel.name.clone();
+        state
+            .ipsec_engine
+            .add_tunnel(tunnel.clone())
+            .await
+            .map_err(|e| apply_fail(&format!("ipsec tunnel {name} restore"), e))?;
+    }
+    if !config.vpn.ipsec_tunnels.is_empty()
+        && let Err(e) = state.ipsec_engine.apply_all().await
+    {
+        tracing::warn!(error = %e, "restored IPsec tunnels but swanctl apply failed — tunnels stay down until re-applied");
     }
 
     if !config.system.dns_servers.is_empty() {

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -157,6 +157,7 @@ pub struct AppState {
     pub rule_engine: Arc<RuleEngine>,
     pub nat_engine: Arc<NatEngine>,
     pub vpn_engine: Arc<VpnEngine>,
+    pub ipsec_engine: Arc<aifw_core::IpsecEngine>,
     pub geoip_engine: Arc<GeoIpEngine>,
     pub multiwan_engine: Arc<InstanceEngine>,
     pub gateway_engine: Arc<GatewayEngine>,
@@ -730,6 +731,11 @@ async fn create_state_from_db(
     let nat_engine =
         Arc::new(NatEngine::new(pool.clone(), pf.clone()).with_anchor("aifw-nat".to_string()));
     let vpn_engine = Arc::new(VpnEngine::new(pool.clone(), pf.clone()));
+    let ipsec_engine = Arc::new(aifw_core::IpsecEngine::new(
+        pool.clone(),
+        aifw_core::create_ike_control(),
+        aifw_core::create_conf_store(),
+    ));
     let geoip_engine = Arc::new(GeoIpEngine::new(pool.clone(), pf.clone()));
     let multiwan_engine = Arc::new(InstanceEngine::new(pool.clone(), pf.clone()));
     let gateway_engine = Arc::new(GatewayEngine::new(pool.clone()));
@@ -751,6 +757,7 @@ async fn create_state_from_db(
     tokio::try_join!(
         async { nat_engine.migrate().await.map_err(anyhow::Error::from) },
         async { vpn_engine.migrate().await.map_err(anyhow::Error::from) },
+        async { ipsec_engine.migrate().await.map_err(anyhow::Error::from) },
         async { geoip_engine.migrate().await.map_err(anyhow::Error::from) },
         async {
             multiwan_engine
@@ -1012,6 +1019,7 @@ async fn create_state_from_db(
         rule_engine,
         nat_engine,
         vpn_engine,
+        ipsec_engine,
         geoip_engine,
         multiwan_engine,
         gateway_engine,
@@ -1475,6 +1483,13 @@ async fn main() -> anyhow::Result<()> {
 
     // Apply all enabled static routes from DB (survives reboot)
     routes::apply_all_routes(&state.pool).await;
+
+    // Re-render IPsec swanctl config from the DB and reload charon (#530).
+    // Covers reboot, restore-from-backup, and upgrade; no-op on boxes that
+    // never configured IPsec tunnels.
+    if let Err(e) = state.ipsec_engine.ensure_applied().await {
+        warn!(error = %e, "IPsec ensure_applied failed — tunnels may need a manual re-apply");
+    }
 
     // One-time migration: appliances upgraded from a version that wrote DNS
     // settings to /etc/resolv.conf still have their list in the legacy

--- a/aifw-api/src/router.rs
+++ b/aifw-api/src/router.rs
@@ -109,6 +109,16 @@ pub(crate) fn vpn_read() -> Router<AppState> {
         )
         .route("/api/v1/vpn/wg/{id}/status", get(routes::wg_tunnel_status))
         .route("/api/v1/vpn/ipsec", get(routes::list_ipsec_sas))
+        .route("/api/v1/vpn/ipsec/status", get(routes::ipsec_status_all))
+        .route("/api/v1/vpn/ipsec/tunnels", get(routes::list_ipsec_tunnels))
+        .route(
+            "/api/v1/vpn/ipsec/tunnels/{id}",
+            get(routes::get_ipsec_tunnel),
+        )
+        .route(
+            "/api/v1/vpn/ipsec/tunnels/{id}/status",
+            get(routes::ipsec_tunnel_status),
+        )
         .layer(middleware::from_fn(perm_check!(Permission::VpnRead)))
 }
 
@@ -126,8 +136,26 @@ pub(crate) fn vpn_write() -> Router<AppState> {
             "/api/v1/vpn/wg/{tid}/peers/{pid}",
             put(routes::update_wg_peer).delete(routes::delete_wg_peer),
         )
-        .route("/api/v1/vpn/ipsec", post(routes::create_ipsec_sa))
+        // Legacy SA records (#530): creation is gone, deletion still
+        // allowed so operators can clean the read-only leftovers up.
+        .route("/api/v1/vpn/ipsec", post(routes::create_ipsec_sa_gone))
         .route("/api/v1/vpn/ipsec/{id}", delete(routes::delete_ipsec_sa))
+        .route(
+            "/api/v1/vpn/ipsec/tunnels",
+            post(routes::create_ipsec_tunnel),
+        )
+        .route(
+            "/api/v1/vpn/ipsec/tunnels/{id}",
+            put(routes::update_ipsec_tunnel).delete(routes::delete_ipsec_tunnel),
+        )
+        .route(
+            "/api/v1/vpn/ipsec/tunnels/{id}/start",
+            post(routes::start_ipsec_tunnel),
+        )
+        .route(
+            "/api/v1/vpn/ipsec/tunnels/{id}/stop",
+            post(routes::stop_ipsec_tunnel),
+        )
         .layer(middleware::from_fn(perm_check!(Permission::VpnWrite)))
 }
 

--- a/aifw-api/src/routes/mod.rs
+++ b/aifw-api/src/routes/mod.rs
@@ -18,9 +18,8 @@ use uuid::Uuid;
 
 use crate::AppState;
 use aifw_common::{
-    Action, Address, Direction, Interface, IpsecMode, IpsecProtocol, IpsecSa, NatRedirect, NatRule,
-    NatStatus, NatType, PortRange, Protocol, Rule, RuleMatch, RuleStatus, StateTracking, WgPeer,
-    WgTunnel,
+    Action, Address, Direction, Interface, IpsecSa, NatRedirect, NatRule, NatStatus, NatType,
+    PortRange, Protocol, Rule, RuleMatch, RuleStatus, StateTracking, WgPeer, WgTunnel,
 };
 
 pub mod ai;

--- a/aifw-api/src/routes/vpn.rs
+++ b/aifw-api/src/routes/vpn.rs
@@ -374,46 +374,45 @@ pub async fn delete_wg_peer(
     }))
 }
 
-// --- VPN: IPsec ---
+// --- VPN: IPsec (legacy ipsec_sas records — read/delete only, #530) ---
 
-#[derive(Debug, Deserialize)]
-pub struct CreateIpsecSaRequest {
-    pub name: String,
-    pub local_addr: String,
-    pub remote_addr: String,
-    pub protocol: String,
-    pub mode: String,
+/// Legacy SA record plus an explicit legacy marker so no client can
+/// mistake these configuration-only rows for live tunnels.
+#[derive(Debug, Serialize)]
+pub struct LegacyIpsecSa {
+    #[serde(flatten)]
+    pub sa: IpsecSa,
+    /// Always true: this record predates the real data plane and
+    /// carries no traffic.
+    pub legacy: bool,
 }
 
 pub async fn list_ipsec_sas(
     State(state): State<AppState>,
-) -> Result<Json<ApiResponse<Vec<IpsecSa>>>, StatusCode> {
+) -> Result<Json<ApiResponse<Vec<LegacyIpsecSa>>>, StatusCode> {
     let sas = state
         .vpn_engine
         .list_ipsec_sas()
         .await
         .map_err(|_| internal())?;
+    let sas = sas
+        .into_iter()
+        .map(|sa| LegacyIpsecSa { sa, legacy: true })
+        .collect();
     Ok(Json(ApiResponse { data: sas }))
 }
 
-pub async fn create_ipsec_sa(
-    State(state): State<AppState>,
-    Json(req): Json<CreateIpsecSaRequest>,
-) -> Result<(StatusCode, Json<ApiResponse<IpsecSa>>), StatusCode> {
-    let src = Address::parse(&req.local_addr).map_err(|_| bad_request())?;
-    let dst = Address::parse(&req.remote_addr).map_err(|_| bad_request())?;
-    let protocol = IpsecProtocol::parse(&req.protocol).map_err(|_| bad_request())?;
-    let mode = match req.mode.as_str() {
-        "transport" => IpsecMode::Transport,
-        _ => IpsecMode::Tunnel,
-    };
-    let sa = IpsecSa::new(req.name, src, dst, protocol, mode);
-    let sa = state
-        .vpn_engine
-        .add_ipsec_sa(sa)
-        .await
-        .map_err(|_| bad_request())?;
-    Ok((StatusCode::CREATED, Json(ApiResponse { data: sa })))
+/// POST /vpn/ipsec is gone (#530): the pre-data-plane SA records could
+/// never carry traffic, so creating more of them is not allowed. Point
+/// callers at the tunnel API.
+pub async fn create_ipsec_sa_gone() -> (StatusCode, Json<MessageResponse>) {
+    (
+        StatusCode::GONE,
+        Json(MessageResponse {
+            message: "legacy IPsec SA records are read-only; use /api/v1/vpn/ipsec/tunnels"
+                .to_string(),
+        }),
+    )
 }
 
 pub async fn delete_ipsec_sa(
@@ -429,4 +428,296 @@ pub async fn delete_ipsec_sa(
     Ok(Json(MessageResponse {
         message: format!("IPsec SA {id} deleted"),
     }))
+}
+
+// --- VPN: IPsec tunnels (real data plane, #530) ---
+
+type IpsecError = (StatusCode, Json<MessageResponse>);
+
+/// Map engine errors to a status + message so validation problems and
+/// charon's negotiation/load diagnostics reach the caller instead of a
+/// bare 500.
+fn ipsec_err(e: aifw_common::AifwError) -> IpsecError {
+    use aifw_common::AifwError;
+    let status = match &e {
+        AifwError::Validation(_) => StatusCode::BAD_REQUEST,
+        AifwError::NotFound(_) => StatusCode::NOT_FOUND,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    (
+        status,
+        Json(MessageResponse {
+            message: e.to_string(),
+        }),
+    )
+}
+
+fn ipsec_bad_request(msg: &str) -> IpsecError {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(MessageResponse {
+            message: msg.to_string(),
+        }),
+    )
+}
+
+/// Create/update payload. Omitted optional fields keep defaults on
+/// create and keep current values on update; `psk`/`local_key_pem`
+/// equal to the redaction marker (or omitted) keep the stored secret.
+#[derive(Debug, Deserialize)]
+pub struct IpsecTunnelRequest {
+    pub name: String,
+    pub remote_addr: String,
+    pub local_ts: Vec<String>,
+    pub remote_ts: Vec<String>,
+    pub enabled: Option<bool>,
+    pub local_addr: Option<String>,
+    pub local_id: Option<String>,
+    pub remote_id: Option<String>,
+    pub auth_method: Option<String>,
+    pub psk: Option<String>,
+    pub cert_source: Option<String>,
+    pub acme_cert_id: Option<i64>,
+    pub local_cert_pem: Option<String>,
+    pub local_key_pem: Option<String>,
+    pub ca_cert_pem: Option<String>,
+    pub ike_proposal: Option<String>,
+    pub esp_proposal: Option<String>,
+    pub ike_lifetime_secs: Option<u32>,
+    pub esp_lifetime_secs: Option<u32>,
+    pub dpd_delay_secs: Option<u32>,
+    pub start_action: Option<String>,
+}
+
+/// Fold a request into a tunnel record. Secrets are only overwritten
+/// when the request carries a real (non-redacted) value.
+fn apply_tunnel_request(
+    tunnel: &mut aifw_common::IpsecTunnel,
+    req: IpsecTunnelRequest,
+) -> Result<(), IpsecError> {
+    use aifw_common::{IpsecAuthMethod, IpsecCertSource, IpsecStartAction};
+
+    tunnel.name = req.name;
+    tunnel.remote_addr = req.remote_addr;
+    tunnel.local_ts = req.local_ts;
+    tunnel.remote_ts = req.remote_ts;
+    if let Some(enabled) = req.enabled {
+        tunnel.enabled = enabled;
+    }
+    if let Some(v) = req.local_addr {
+        tunnel.local_addr = v;
+    }
+    if let Some(v) = req.local_id {
+        tunnel.local_id = v;
+    }
+    if let Some(v) = req.remote_id {
+        tunnel.remote_id = v;
+    }
+    if let Some(ref v) = req.auth_method {
+        tunnel.auth_method = IpsecAuthMethod::parse(v).map_err(ipsec_err)?;
+    }
+    if let Some(psk) = req.psk
+        && psk != "REDACTED"
+    {
+        tunnel.psk = psk;
+    }
+    if let Some(ref v) = req.cert_source {
+        tunnel.cert_source = if v.is_empty() {
+            None
+        } else {
+            Some(IpsecCertSource::parse(v).map_err(ipsec_err)?)
+        };
+    }
+    if req.acme_cert_id.is_some() {
+        tunnel.acme_cert_id = req.acme_cert_id;
+    }
+    if let Some(v) = req.local_cert_pem {
+        tunnel.local_cert_pem = v;
+    }
+    if let Some(key) = req.local_key_pem
+        && key != "REDACTED"
+    {
+        tunnel.local_key_pem = key;
+    }
+    if let Some(v) = req.ca_cert_pem {
+        tunnel.ca_cert_pem = v;
+    }
+    if let Some(v) = req.ike_proposal {
+        tunnel.ike_proposal = v;
+    }
+    if let Some(v) = req.esp_proposal {
+        tunnel.esp_proposal = v;
+    }
+    if let Some(v) = req.ike_lifetime_secs {
+        tunnel.ike_lifetime_secs = v;
+    }
+    if let Some(v) = req.esp_lifetime_secs {
+        tunnel.esp_lifetime_secs = v;
+    }
+    if let Some(v) = req.dpd_delay_secs {
+        tunnel.dpd_delay_secs = v;
+    }
+    if let Some(ref v) = req.start_action {
+        tunnel.start_action = IpsecStartAction::parse(v).map_err(ipsec_err)?;
+    }
+    if tunnel.auth_method == IpsecAuthMethod::Cert && tunnel.cert_source.is_none() {
+        return Err(ipsec_bad_request("cert auth requires cert_source"));
+    }
+    Ok(())
+}
+
+/// Refresh the pass rules the aifw anchor mirrors from the VPN engines
+/// after any IPsec apply (same dance the WG start/stop handlers do).
+async fn refresh_vpn_pf(state: &AppState) {
+    let _ = state.vpn_engine.apply_vpn_rules().await;
+    if let Ok(vpn_rules) = state.vpn_engine.collect_vpn_rules().await {
+        state.rule_engine.set_extra_rules(vpn_rules).await;
+        let _ = state.rule_engine.apply_rules().await;
+    }
+}
+
+pub async fn list_ipsec_tunnels(
+    State(state): State<AppState>,
+) -> Result<Json<ApiResponse<Vec<aifw_common::IpsecTunnel>>>, StatusCode> {
+    let tunnels = state
+        .ipsec_engine
+        .list_tunnels()
+        .await
+        .map_err(|_| internal())?;
+    let tunnels = tunnels.iter().map(|t| t.redacted()).collect();
+    Ok(Json(ApiResponse { data: tunnels }))
+}
+
+pub async fn get_ipsec_tunnel(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<ApiResponse<aifw_common::IpsecTunnel>>, StatusCode> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| bad_request())?;
+    let tunnel = state
+        .ipsec_engine
+        .get_tunnel(uuid)
+        .await
+        .map_err(|_| StatusCode::NOT_FOUND)?;
+    Ok(Json(ApiResponse {
+        data: tunnel.redacted(),
+    }))
+}
+
+pub async fn create_ipsec_tunnel(
+    State(state): State<AppState>,
+    Json(req): Json<IpsecTunnelRequest>,
+) -> Result<(StatusCode, Json<ApiResponse<aifw_common::IpsecTunnel>>), IpsecError> {
+    let mut tunnel = aifw_common::IpsecTunnel::new(
+        String::new(),
+        String::new(),
+        String::new(),
+        Vec::new(),
+        Vec::new(),
+    );
+    apply_tunnel_request(&mut tunnel, req)?;
+    let tunnel = state
+        .ipsec_engine
+        .create_tunnel_applied(tunnel)
+        .await
+        .map_err(ipsec_err)?;
+    refresh_vpn_pf(&state).await;
+    Ok((
+        StatusCode::CREATED,
+        Json(ApiResponse {
+            data: tunnel.redacted(),
+        }),
+    ))
+}
+
+pub async fn update_ipsec_tunnel(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(req): Json<IpsecTunnelRequest>,
+) -> Result<Json<ApiResponse<aifw_common::IpsecTunnel>>, IpsecError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ipsec_bad_request("invalid tunnel id"))?;
+    let mut tunnel = state
+        .ipsec_engine
+        .get_tunnel(uuid)
+        .await
+        .map_err(ipsec_err)?;
+    apply_tunnel_request(&mut tunnel, req)?;
+    let tunnel = state
+        .ipsec_engine
+        .update_tunnel_applied(tunnel)
+        .await
+        .map_err(ipsec_err)?;
+    refresh_vpn_pf(&state).await;
+    Ok(Json(ApiResponse {
+        data: tunnel.redacted(),
+    }))
+}
+
+pub async fn delete_ipsec_tunnel(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<MessageResponse>, IpsecError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ipsec_bad_request("invalid tunnel id"))?;
+    state
+        .ipsec_engine
+        .delete_tunnel_applied(uuid)
+        .await
+        .map_err(ipsec_err)?;
+    refresh_vpn_pf(&state).await;
+    Ok(Json(MessageResponse {
+        message: format!("IPsec tunnel {id} deleted"),
+    }))
+}
+
+pub async fn start_ipsec_tunnel(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<MessageResponse>, IpsecError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ipsec_bad_request("invalid tunnel id"))?;
+    state
+        .ipsec_engine
+        .start_tunnel(uuid)
+        .await
+        .map_err(ipsec_err)?;
+    Ok(Json(MessageResponse {
+        message: "Tunnel initiated".to_string(),
+    }))
+}
+
+pub async fn stop_ipsec_tunnel(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<MessageResponse>, IpsecError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| ipsec_bad_request("invalid tunnel id"))?;
+    state
+        .ipsec_engine
+        .stop_tunnel(uuid)
+        .await
+        .map_err(ipsec_err)?;
+    Ok(Json(MessageResponse {
+        message: "Tunnel terminated".to_string(),
+    }))
+}
+
+pub async fn ipsec_tunnel_status(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<ApiResponse<aifw_common::IpsecLiveStatus>>, StatusCode> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| bad_request())?;
+    let status = state
+        .ipsec_engine
+        .tunnel_status(uuid)
+        .await
+        .map_err(|_| StatusCode::NOT_FOUND)?;
+    Ok(Json(ApiResponse { data: status }))
+}
+
+pub async fn ipsec_status_all(
+    State(state): State<AppState>,
+) -> Result<Json<ApiResponse<Vec<aifw_common::IpsecLiveStatus>>>, StatusCode> {
+    let statuses = state
+        .ipsec_engine
+        .live_status()
+        .await
+        .map_err(|_| internal())?;
+    Ok(Json(ApiResponse { data: statuses }))
 }

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -2295,4 +2295,154 @@ mod tests {
         let res = crate::backup::apply_firewall_config(&state, &config, &Default::default()).await;
         assert!(res.is_err(), "partial apply must not report success");
     }
+
+    // --- IPsec tunnels (#530) ---
+
+    fn ipsec_tunnel_body() -> Value {
+        json!({
+            "name": "site-a",
+            "remote_addr": "203.0.113.10",
+            "psk": "correct-horse-battery-staple",
+            "local_ts": ["10.0.0.0/24"],
+            "remote_ts": ["10.1.0.0/24"],
+        })
+    }
+
+    #[tokio::test]
+    async fn test_ipsec_tunnel_crud_and_redaction() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        // Create — PSK must come back redacted
+        let resp = server
+            .post("/api/v1/vpn/ipsec/tunnels")
+            .authorization_bearer(&token)
+            .json(&ipsec_tunnel_body())
+            .await;
+        resp.assert_status(StatusCode::CREATED);
+        let body: Value = resp.json();
+        assert_eq!(body["data"]["name"], "site-a");
+        assert_eq!(body["data"]["psk"], "REDACTED");
+        assert_eq!(body["data"]["ike_proposal"], "aes256gcm16-prfsha256-ecp256");
+        let id = body["data"]["id"].as_str().unwrap().to_string();
+
+        // List
+        let resp = server
+            .get("/api/v1/vpn/ipsec/tunnels")
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["data"].as_array().unwrap().len(), 1);
+        assert_eq!(body["data"][0]["psk"], "REDACTED");
+
+        // Update with redacted PSK keeps the stored secret and applies
+        // the remote change
+        let mut update = ipsec_tunnel_body();
+        update["psk"] = json!("REDACTED");
+        update["remote_addr"] = json!("203.0.113.99");
+        let resp = server
+            .put(&format!("/api/v1/vpn/ipsec/tunnels/{id}"))
+            .authorization_bearer(&token)
+            .json(&update)
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["data"]["remote_addr"], "203.0.113.99");
+
+        // Live status: mock control has no SAs → DOWN
+        let resp = server
+            .get(&format!("/api/v1/vpn/ipsec/tunnels/{id}/status"))
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["data"]["ike_state"], "DOWN");
+
+        // Delete
+        let resp = server
+            .delete(&format!("/api/v1/vpn/ipsec/tunnels/{id}"))
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        let resp = server
+            .get("/api/v1/vpn/ipsec/tunnels")
+            .authorization_bearer(&token)
+            .await;
+        let body: Value = resp.json();
+        assert!(body["data"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_ipsec_tunnel_validation_surfaces_message() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        let mut body = ipsec_tunnel_body();
+        body["psk"] = json!("short");
+        let resp = server
+            .post("/api/v1/vpn/ipsec/tunnels")
+            .authorization_bearer(&token)
+            .json(&body)
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+        let body: Value = resp.json();
+        assert!(
+            body["message"]
+                .as_str()
+                .unwrap()
+                .contains("PSK must be at least 16 characters"),
+            "validation detail must reach the client: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_legacy_ipsec_sa_creation_gone() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        let resp = server
+            .post("/api/v1/vpn/ipsec")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "name": "legacy",
+                "local_addr": "1.2.3.4",
+                "remote_addr": "5.6.7.8",
+                "protocol": "esp",
+                "mode": "tunnel",
+            }))
+            .await;
+        resp.assert_status(StatusCode::GONE);
+        let body: Value = resp.json();
+        assert!(body["message"].as_str().unwrap().contains("tunnels"));
+    }
+
+    #[tokio::test]
+    async fn test_ipsec_status_endpoint_lists_all() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        server
+            .post("/api/v1/vpn/ipsec/tunnels")
+            .authorization_bearer(&token)
+            .json(&ipsec_tunnel_body())
+            .await
+            .assert_status(StatusCode::CREATED);
+
+        let resp = server
+            .get("/api/v1/vpn/ipsec/status")
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        let statuses = body["data"].as_array().unwrap();
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses[0]["ike_state"], "DOWN");
+        assert!(
+            statuses[0]["conn_name"]
+                .as_str()
+                .unwrap()
+                .starts_with("aifw-")
+        );
+    }
 }

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -1,7 +1,7 @@
 use aifw_common::{
     Action, Address, Bandwidth, CountryCode, Direction, GeoIpAction, GeoIpRule, Interface,
-    IpsecMode, IpsecProtocol, IpsecSa, NatRedirect, NatRule, NatType, PortRange, Protocol,
-    QueueConfig, QueueType, RateLimitRule, Rule, RuleMatch, TrafficClass, WgPeer, WgTunnel,
+    NatRedirect, NatRule, NatType, PortRange, Protocol, QueueConfig, QueueType, RateLimitRule,
+    Rule, RuleMatch, TrafficClass, WgPeer, WgTunnel,
 };
 use aifw_core::{
     Database, GatewayEngine, GeoIpEngine, GroupEngine, InstanceEngine, LeakEngine, NatEngine,
@@ -727,34 +727,114 @@ pub async fn vpn_wg_peer_add(
     Ok(())
 }
 
+async fn create_ipsec_engine(db_path: &Path) -> anyhow::Result<aifw_core::IpsecEngine> {
+    let db = Database::new(db_path).await?;
+    let engine = aifw_core::IpsecEngine::new(
+        db.pool().clone(),
+        aifw_core::create_ike_control(),
+        aifw_core::create_conf_store(),
+    );
+    engine.migrate().await?;
+    Ok(engine)
+}
+
+fn split_ts(list: &str) -> Vec<String> {
+    list.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
+}
+
 pub async fn vpn_ipsec_add(
     db_path: &Path,
     name: &str,
-    src: &str,
-    dst: &str,
-    proto: &str,
-    mode: &str,
+    remote: &str,
+    psk: &str,
+    local_ts: &str,
+    remote_ts: &str,
+    local: Option<&str>,
 ) -> anyhow::Result<()> {
-    let engine = create_vpn_engine(db_path).await?;
+    let engine = create_ipsec_engine(db_path).await?;
 
-    let ipsec_mode = match mode {
-        "transport" => IpsecMode::Transport,
-        _ => IpsecMode::Tunnel,
-    };
-
-    let sa = IpsecSa::new(
+    let mut tunnel = aifw_common::IpsecTunnel::new(
         name.to_string(),
-        Address::parse(src)?,
-        Address::parse(dst)?,
-        IpsecProtocol::parse(proto)?,
-        ipsec_mode,
+        remote.to_string(),
+        psk.to_string(),
+        split_ts(local_ts),
+        split_ts(remote_ts),
     );
-    let sa = engine.add_ipsec_sa(sa).await?;
-    println!("Added IPsec SA {}", sa.id);
-    println!("  Name:     {}", sa.name);
-    println!("  SPI:      0x{:08x}", sa.spi);
-    println!("  Protocol: {}", sa.protocol);
-    println!("  Mode:     {}", sa.mode);
+    if let Some(local) = local {
+        tunnel.local_addr = local.to_string();
+    }
+    let tunnel = engine.create_tunnel_applied(tunnel).await?;
+    println!("Added IPsec tunnel {}", tunnel.id);
+    println!("  Name:      {}", tunnel.name);
+    println!("  Remote:    {}", tunnel.remote_addr);
+    println!("  Local TS:  {}", tunnel.local_ts.join(","));
+    println!("  Remote TS: {}", tunnel.remote_ts.join(","));
+    println!("  IKE:       v2, {}", tunnel.ike_proposal);
+    println!("  ESP:       {}", tunnel.esp_proposal);
+    Ok(())
+}
+
+pub async fn vpn_ipsec_start(db_path: &Path, id: &str) -> anyhow::Result<()> {
+    let engine = create_ipsec_engine(db_path).await?;
+    let uuid = Uuid::parse_str(id)?;
+    engine.start_tunnel(uuid).await?;
+    println!("IPsec tunnel {id} initiated");
+    Ok(())
+}
+
+pub async fn vpn_ipsec_stop(db_path: &Path, id: &str) -> anyhow::Result<()> {
+    let engine = create_ipsec_engine(db_path).await?;
+    let uuid = Uuid::parse_str(id)?;
+    engine.stop_tunnel(uuid).await?;
+    println!("IPsec tunnel {id} terminated");
+    Ok(())
+}
+
+pub async fn vpn_ipsec_status(db_path: &Path, json: bool) -> anyhow::Result<()> {
+    let engine = create_ipsec_engine(db_path).await?;
+    let statuses = engine.live_status().await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&statuses)?);
+        return Ok(());
+    }
+    if statuses.is_empty() {
+        println!("No IPsec tunnels configured");
+        return Ok(());
+    }
+    println!(
+        "{:<38} {:<14} {:<20} {:<10}",
+        "TUNNEL", "IKE STATE", "REMOTE", "UPTIME"
+    );
+    println!("{}", "-".repeat(85));
+    for s in &statuses {
+        let uptime = s
+            .established_secs
+            .map(|secs| format!("{}m{}s", secs / 60, secs % 60))
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "{:<38} {:<14} {:<20} {:<10}",
+            s.tunnel_id,
+            s.ike_state,
+            s.remote_host.as_deref().unwrap_or("-"),
+            uptime,
+        );
+        for c in &s.child_sas {
+            println!(
+                "  child {}: {} in={}B out={}B rekey_in={}s ts={} <-> {}",
+                c.name,
+                c.state,
+                c.bytes_in,
+                c.bytes_out,
+                c.rekey_in_secs.unwrap_or(0),
+                c.local_ts.join(","),
+                c.remote_ts.join(","),
+            );
+        }
+    }
     Ok(())
 }
 
@@ -762,11 +842,15 @@ pub async fn vpn_remove(db_path: &Path, id: &str) -> anyhow::Result<()> {
     let engine = create_vpn_engine(db_path).await?;
     let uuid = Uuid::parse_str(id)?;
 
-    // Try WG tunnel first, then IPsec SA
+    // Try WG tunnel first, then IPsec tunnel, legacy SA, WG peer
     if engine.delete_wg_tunnel(uuid).await.is_ok() {
         println!("Removed WireGuard tunnel {id}");
+    } else if let Ok(ipsec) = create_ipsec_engine(db_path).await
+        && ipsec.delete_tunnel_applied(uuid).await.is_ok()
+    {
+        println!("Removed IPsec tunnel {id}");
     } else if engine.delete_ipsec_sa(uuid).await.is_ok() {
-        println!("Removed IPsec SA {id}");
+        println!("Removed legacy IPsec SA record {id}");
     } else if engine.delete_wg_peer(uuid).await.is_ok() {
         println!("Removed WireGuard peer {id}");
     } else {
@@ -780,11 +864,17 @@ pub async fn vpn_list(db_path: &Path, json: bool) -> anyhow::Result<()> {
 
     let tunnels = engine.list_wg_tunnels().await?;
     let sas = engine.list_ipsec_sas().await?;
+    let ipsec_engine = create_ipsec_engine(db_path).await?;
+    let ipsec_tunnels = ipsec_engine.list_tunnels().await?;
 
     if json {
         let data = serde_json::json!({
             "wireguard": tunnels,
-            "ipsec": sas,
+            "ipsec_tunnels": ipsec_tunnels
+                .iter()
+                .map(|t| t.redacted())
+                .collect::<Vec<_>>(),
+            "ipsec_legacy_sas": sas,
         });
         println!("{}", serde_json::to_string_pretty(&data)?);
         return Ok(());
@@ -828,11 +918,37 @@ pub async fn vpn_list(db_path: &Path, json: bool) -> anyhow::Result<()> {
 
     println!();
 
-    // IPsec
-    if sas.is_empty() {
-        println!("No IPsec SAs configured");
+    // IPsec tunnels (#530 real data plane)
+    if ipsec_tunnels.is_empty() {
+        println!("No IPsec tunnels configured");
     } else {
-        println!("IPsec Security Associations:");
+        println!("IPsec Tunnels:");
+        println!(
+            "{:<38} {:<14} {:<20} {:<8} {:<6} {:<24}",
+            "ID", "NAME", "REMOTE", "AUTH", "ON", "TRAFFIC"
+        );
+        println!("{}", "-".repeat(115));
+        for t in &ipsec_tunnels {
+            println!(
+                "{:<38} {:<14} {:<20} {:<8} {:<6} {:<24}",
+                t.id,
+                t.name,
+                t.remote_addr,
+                t.auth_method,
+                if t.enabled { "yes" } else { "no" },
+                format!("{} <-> {}", t.local_ts.join(","), t.remote_ts.join(",")),
+            );
+        }
+        println!("\n{} tunnel(s)", ipsec_tunnels.len());
+    }
+
+    println!();
+
+    // Legacy IPsec SA records (configuration-only, no data plane)
+    if sas.is_empty() {
+        println!("No legacy IPsec SA records");
+    } else {
+        println!("Legacy IPsec SA records (inactive — no data plane):");
         println!(
             "{:<38} {:<12} {:<20} {:<20} {:<8} {:<10} {:<8}",
             "ID", "NAME", "SOURCE", "DESTINATION", "PROTO", "MODE", "STATUS"

--- a/aifw-cli/src/main.rs
+++ b/aifw-cli/src/main.rs
@@ -463,23 +463,42 @@ enum VpnAction {
         #[arg(long)]
         keepalive: Option<u16>,
     },
-    /// Add an IPsec SA
+    /// Add an IPsec IKEv2 site-to-site tunnel (PSK auth; use the web
+    /// UI/API for certificate auth)
     IpsecAdd {
-        /// SA name
+        /// Tunnel name
         #[arg(long)]
         name: String,
-        /// Source address
+        /// Remote IKE endpoint (IP address or DNS name)
         #[arg(long)]
-        src: String,
-        /// Destination address
+        remote: String,
+        /// Pre-shared key (at least 16 printable characters)
         #[arg(long)]
-        dst: String,
-        /// Protocol: esp, ah, esp+ah
-        #[arg(long, default_value = "esp")]
-        proto: String,
-        /// Mode: tunnel, transport
-        #[arg(long, default_value = "tunnel")]
-        mode: String,
+        psk: String,
+        /// Local subnets behind this firewall (comma-separated CIDRs)
+        #[arg(long)]
+        local_ts: String,
+        /// Remote subnets behind the peer (comma-separated CIDRs)
+        #[arg(long)]
+        remote_ts: String,
+        /// Local IKE endpoint address (default: any local address)
+        #[arg(long)]
+        local: Option<String>,
+    },
+    /// Initiate an IPsec tunnel's child SA
+    IpsecStart {
+        /// Tunnel ID
+        id: String,
+    },
+    /// Terminate an IPsec tunnel's IKE SA
+    IpsecStop {
+        /// Tunnel ID
+        id: String,
+    },
+    /// Show live IPsec tunnel status (negotiated state from charon)
+    IpsecStatus {
+        #[arg(long)]
+        json: bool,
     },
     /// Remove a VPN tunnel or SA by ID
     Remove {
@@ -1041,12 +1060,31 @@ async fn main() -> anyhow::Result<()> {
             }
             VpnAction::IpsecAdd {
                 name,
-                src,
-                dst,
-                proto,
-                mode,
+                remote,
+                psk,
+                local_ts,
+                remote_ts,
+                local,
             } => {
-                commands::vpn_ipsec_add(&cli.db, &name, &src, &dst, &proto, &mode).await?;
+                commands::vpn_ipsec_add(
+                    &cli.db,
+                    &name,
+                    &remote,
+                    &psk,
+                    &local_ts,
+                    &remote_ts,
+                    local.as_deref(),
+                )
+                .await?;
+            }
+            VpnAction::IpsecStart { id } => {
+                commands::vpn_ipsec_start(&cli.db, &id).await?;
+            }
+            VpnAction::IpsecStop { id } => {
+                commands::vpn_ipsec_stop(&cli.db, &id).await?;
+            }
+            VpnAction::IpsecStatus { json } => {
+                commands::vpn_ipsec_status(&cli.db, json).await?;
             }
             VpnAction::Remove { id } => {
                 commands::vpn_remove(&cli.db, &id).await?;

--- a/aifw-common/src/ipsec.rs
+++ b/aifw-common/src/ipsec.rs
@@ -1,0 +1,677 @@
+//! IPsec tunnel types for the real data plane (#530).
+//!
+//! An [`IpsecTunnel`] is the desired configuration for one IKEv2
+//! site-to-site tunnel, rendered by `aifw-core` into a swanctl conn +
+//! secrets file and negotiated by strongSwan (charon). Live negotiated
+//! state is reported separately as [`IpsecLiveStatus`] parsed from
+//! `swanctl --list-sas` — the database never stores an "up/down" column.
+//!
+//! The older [`crate::IpsecSa`]/[`crate::IpsecSp`] types describe the
+//! pre-#530 CRUD-only records (`ipsec_sas` table); those rows are kept as
+//! read-only legacy data and cannot carry traffic.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::types::Address;
+
+/// How the two IKE endpoints authenticate each other (wire values snake_case)
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum IpsecAuthMethod {
+    /// Pre-shared key
+    Psk,
+    /// X.509 certificate (pubkey auth)
+    Cert,
+}
+
+impl std::fmt::Display for IpsecAuthMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IpsecAuthMethod::Psk => write!(f, "psk"),
+            IpsecAuthMethod::Cert => write!(f, "cert"),
+        }
+    }
+}
+
+impl IpsecAuthMethod {
+    /// Parse from the stored/wire string, case-insensitively.
+    pub fn parse(s: &str) -> crate::Result<Self> {
+        match s.to_lowercase().as_str() {
+            "psk" => Ok(IpsecAuthMethod::Psk),
+            "cert" | "pubkey" => Ok(IpsecAuthMethod::Cert),
+            _ => Err(crate::AifwError::Validation(format!(
+                "unknown IPsec auth method: {s}"
+            ))),
+        }
+    }
+}
+
+/// Where certificate material for a cert-auth tunnel comes from
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum IpsecCertSource {
+    /// Reference an issued cert in the ACME store by id
+    Acme,
+    /// Operator-supplied PEM material stored on the tunnel record
+    Manual,
+}
+
+impl std::fmt::Display for IpsecCertSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IpsecCertSource::Acme => write!(f, "acme"),
+            IpsecCertSource::Manual => write!(f, "manual"),
+        }
+    }
+}
+
+impl IpsecCertSource {
+    /// Parse from the stored/wire string, case-insensitively.
+    pub fn parse(s: &str) -> crate::Result<Self> {
+        match s.to_lowercase().as_str() {
+            "acme" => Ok(IpsecCertSource::Acme),
+            "manual" => Ok(IpsecCertSource::Manual),
+            _ => Err(crate::AifwError::Validation(format!(
+                "unknown IPsec cert source: {s}"
+            ))),
+        }
+    }
+}
+
+/// What charon does with the tunnel's child SA when config is loaded
+/// (swanctl `start_action`)
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum IpsecStartAction {
+    /// Initiate immediately on load and keep up (dpd restart)
+    Start,
+    /// Install a trap policy; negotiate on first matching traffic
+    Trap,
+    /// Load only; wait for an explicit start or the peer to initiate
+    None,
+}
+
+impl std::fmt::Display for IpsecStartAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IpsecStartAction::Start => write!(f, "start"),
+            IpsecStartAction::Trap => write!(f, "trap"),
+            IpsecStartAction::None => write!(f, "none"),
+        }
+    }
+}
+
+impl IpsecStartAction {
+    /// Parse from the stored/wire string, case-insensitively.
+    pub fn parse(s: &str) -> crate::Result<Self> {
+        match s.to_lowercase().as_str() {
+            "start" => Ok(IpsecStartAction::Start),
+            "trap" => Ok(IpsecStartAction::Trap),
+            "none" => Ok(IpsecStartAction::None),
+            _ => Err(crate::AifwError::Validation(format!(
+                "unknown IPsec start action: {s}"
+            ))),
+        }
+    }
+}
+
+/// Default IKE (phase 1) proposal — AEAD + PRF + ECDH group.
+pub const DEFAULT_IKE_PROPOSAL: &str = "aes256gcm16-prfsha256-ecp256";
+/// Default ESP (phase 2) proposal — AEAD + ECDH group for PFS.
+pub const DEFAULT_ESP_PROPOSAL: &str = "aes256gcm16-ecp256";
+/// Default IKE SA rekey time (4h).
+pub const DEFAULT_IKE_LIFETIME_SECS: u32 = 14_400;
+/// Default child SA rekey time (1h).
+pub const DEFAULT_ESP_LIFETIME_SECS: u32 = 3_600;
+/// Default dead-peer-detection probe interval.
+pub const DEFAULT_DPD_DELAY_SECS: u32 = 30;
+
+/// Proposal tokens accepted by FreeBSD's strongSwan build. Curated
+/// subset — modern AEAD/hash/DH choices only; validated so a typo fails
+/// at create time instead of as a charon parse error at load time.
+const PROPOSAL_TOKENS: &[&str] = &[
+    // encryption (AEAD)
+    "aes128gcm16",
+    "aes256gcm16",
+    "chacha20poly1305",
+    // encryption (CBC, for interop with non-AEAD peers)
+    "aes128",
+    "aes256",
+    // integrity (only meaningful with CBC ciphers)
+    "sha256",
+    "sha384",
+    "sha512",
+    // PRF (required in IKE proposals when the cipher is AEAD)
+    "prfsha256",
+    "prfsha384",
+    "prfsha512",
+    // DH groups
+    "ecp256",
+    "ecp384",
+    "ecp521",
+    "curve25519",
+    "modp2048",
+    "modp3072",
+    "modp4096",
+];
+
+/// Validate a swanctl proposal string: dash-separated tokens, each from
+/// the curated allowlist. `kind` names the field in error messages.
+pub fn validate_proposal(kind: &str, proposal: &str) -> crate::Result<()> {
+    if proposal.is_empty() {
+        return Err(crate::AifwError::Validation(format!(
+            "{kind} proposal must not be empty"
+        )));
+    }
+    for token in proposal.split('-') {
+        if !PROPOSAL_TOKENS.contains(&token) {
+            return Err(crate::AifwError::Validation(format!(
+                "{kind} proposal token not supported: {token:?} (allowed: {})",
+                PROPOSAL_TOKENS.join(", ")
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// One desired IKEv2 site-to-site tunnel (tunnel mode).
+///
+/// Secret fields (`psk`, `local_key_pem`) must be redacted before the
+/// struct leaves the API — see `IpsecTunnel::redacted`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IpsecTunnel {
+    /// Unique identifier; also the basis of the swanctl conn name
+    /// (`aifw-<id>`)
+    pub id: Uuid,
+    /// Human-readable tunnel name (UI/label only, not the conn name)
+    pub name: String,
+    /// Disabled tunnels are not rendered into swanctl config at all
+    pub enabled: bool,
+    /// Local IKE endpoint address; empty = any local address (`%any`)
+    pub local_addr: String,
+    /// Remote IKE endpoint — IP address or DNS name
+    pub remote_addr: String,
+    /// Local IKE identity; empty = derive from `local_addr`
+    pub local_id: String,
+    /// Remote IKE identity; empty = derive from `remote_addr`
+    pub remote_id: String,
+    /// PSK or certificate authentication
+    pub auth_method: IpsecAuthMethod,
+    /// Pre-shared key (auth_method = psk). Redacted in API output.
+    pub psk: String,
+    /// Certificate source (auth_method = cert)
+    pub cert_source: Option<IpsecCertSource>,
+    /// ACME store certificate id (cert_source = acme)
+    pub acme_cert_id: Option<Uuid>,
+    /// Local certificate PEM (cert_source = manual)
+    pub local_cert_pem: String,
+    /// Local private key PEM (cert_source = manual). Redacted in API output.
+    pub local_key_pem: String,
+    /// CA certificate PEM used to verify the peer (cert auth)
+    pub ca_cert_pem: String,
+    /// IKE (phase 1) proposal string
+    pub ike_proposal: String,
+    /// ESP (phase 2) proposal string
+    pub esp_proposal: String,
+    /// Local traffic selectors — subnets behind this side
+    pub local_ts: Vec<String>,
+    /// Remote traffic selectors — subnets behind the peer
+    pub remote_ts: Vec<String>,
+    /// IKE SA rekey time in seconds
+    pub ike_lifetime_secs: u32,
+    /// Child SA rekey time in seconds
+    pub esp_lifetime_secs: u32,
+    /// DPD probe interval in seconds; 0 disables DPD
+    pub dpd_delay_secs: u32,
+    /// Behavior on config load
+    pub start_action: IpsecStartAction,
+    /// Creation timestamp
+    pub created_at: DateTime<Utc>,
+    /// Last modification timestamp
+    pub updated_at: DateTime<Utc>,
+}
+
+impl IpsecTunnel {
+    /// Create a PSK tunnel with defaults (AES-256-GCM proposals, 4h/1h
+    /// lifetimes, DPD 30s, start on load). Callers adjust fields then run
+    /// [`IpsecTunnel::validate`].
+    pub fn new(
+        name: String,
+        remote_addr: String,
+        psk: String,
+        local_ts: Vec<String>,
+        remote_ts: Vec<String>,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::new_v4(),
+            name,
+            enabled: true,
+            local_addr: String::new(),
+            remote_addr,
+            local_id: String::new(),
+            remote_id: String::new(),
+            auth_method: IpsecAuthMethod::Psk,
+            psk,
+            cert_source: None,
+            acme_cert_id: None,
+            local_cert_pem: String::new(),
+            local_key_pem: String::new(),
+            ca_cert_pem: String::new(),
+            ike_proposal: DEFAULT_IKE_PROPOSAL.to_string(),
+            esp_proposal: DEFAULT_ESP_PROPOSAL.to_string(),
+            local_ts,
+            remote_ts,
+            ike_lifetime_secs: DEFAULT_IKE_LIFETIME_SECS,
+            esp_lifetime_secs: DEFAULT_ESP_LIFETIME_SECS,
+            dpd_delay_secs: DEFAULT_DPD_DELAY_SECS,
+            start_action: IpsecStartAction::Start,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// swanctl connection name for this tunnel. The `aifw-` prefix is
+    /// load-bearing: the `aifw-sudo-swanctl` wrapper only permits
+    /// operations on names in this namespace.
+    pub fn conn_name(&self) -> String {
+        format!("aifw-{}", self.id)
+    }
+
+    /// swanctl child SA name for this tunnel's (single) child.
+    pub fn child_name(&self) -> String {
+        format!("aifw-{}-1", self.id)
+    }
+
+    /// Copy with secret material blanked, safe for API responses.
+    /// Non-secret cert PEMs are kept (they're public material).
+    pub fn redacted(&self) -> Self {
+        let mut t = self.clone();
+        if !t.psk.is_empty() {
+            t.psk = "REDACTED".to_string();
+        }
+        if !t.local_key_pem.is_empty() {
+            t.local_key_pem = "REDACTED".to_string();
+        }
+        t
+    }
+
+    /// Validate the whole tunnel config. Everything here ends up inside
+    /// a root-parsed swanctl config file, so the checks double as
+    /// injection guards (no quotes/newlines in any rendered value).
+    pub fn validate(&self) -> crate::Result<()> {
+        let fail = |msg: String| Err(crate::AifwError::Validation(msg));
+
+        if self.name.is_empty() || self.name.len() > 64 {
+            return fail("tunnel name must be 1-64 characters".into());
+        }
+        if !self
+            .name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || " _-.".contains(c))
+        {
+            return fail(format!(
+                "tunnel name contains invalid characters (allowed: alphanumeric, space, _, -, .): {:?}",
+                self.name
+            ));
+        }
+
+        validate_endpoint("remote_addr", &self.remote_addr)?;
+        if self.remote_addr.is_empty() {
+            return fail("remote_addr is required".into());
+        }
+        if !self.local_addr.is_empty() {
+            // Local side must be a concrete address, not a DNS name.
+            if self.local_addr.parse::<std::net::IpAddr>().is_err() {
+                return fail(format!(
+                    "local_addr must be an IP address or empty: {:?}",
+                    self.local_addr
+                ));
+            }
+        }
+        validate_ike_id("local_id", &self.local_id)?;
+        validate_ike_id("remote_id", &self.remote_id)?;
+
+        match self.auth_method {
+            IpsecAuthMethod::Psk => {
+                if self.psk.len() < 16 {
+                    return fail("PSK must be at least 16 characters".into());
+                }
+                if !self.psk.chars().all(|c| c.is_ascii_graphic()) || self.psk.contains('"') {
+                    return fail(
+                        "PSK must be printable ASCII without spaces or double quotes".into(),
+                    );
+                }
+            }
+            IpsecAuthMethod::Cert => match self.cert_source {
+                Some(IpsecCertSource::Acme) => {
+                    if self.acme_cert_id.is_none() {
+                        return fail("cert_source acme requires acme_cert_id".into());
+                    }
+                }
+                Some(IpsecCertSource::Manual) => {
+                    validate_pem("local_cert_pem", &self.local_cert_pem, "CERTIFICATE")?;
+                    validate_pem_key("local_key_pem", &self.local_key_pem)?;
+                    if !self.ca_cert_pem.is_empty() {
+                        validate_pem("ca_cert_pem", &self.ca_cert_pem, "CERTIFICATE")?;
+                    }
+                }
+                None => return fail("auth_method cert requires cert_source".into()),
+            },
+        }
+
+        validate_proposal("ike", &self.ike_proposal)?;
+        validate_proposal("esp", &self.esp_proposal)?;
+
+        for (field, list) in [("local_ts", &self.local_ts), ("remote_ts", &self.remote_ts)] {
+            if list.is_empty() {
+                return fail(format!("{field} requires at least one subnet"));
+            }
+            for ts in list {
+                match Address::parse(ts) {
+                    Ok(Address::Single(_)) | Ok(Address::Network(_, _)) => {}
+                    _ => {
+                        return fail(format!(
+                            "{field} entry must be an IP or CIDR subnet: {ts:?}"
+                        ));
+                    }
+                }
+            }
+        }
+
+        if !(600..=604_800).contains(&self.ike_lifetime_secs) {
+            return fail("ike_lifetime_secs must be between 600 and 604800".into());
+        }
+        if !(300..=86_400).contains(&self.esp_lifetime_secs) {
+            return fail("esp_lifetime_secs must be between 300 and 86400".into());
+        }
+        if self.dpd_delay_secs > 3_600 {
+            return fail("dpd_delay_secs must be at most 3600".into());
+        }
+
+        Ok(())
+    }
+}
+
+/// Endpoint: IP address or DNS hostname (letters/digits/dot/hyphen).
+fn validate_endpoint(field: &str, value: &str) -> crate::Result<()> {
+    if value.is_empty() {
+        return Ok(());
+    }
+    if value.parse::<std::net::IpAddr>().is_ok() {
+        return Ok(());
+    }
+    let hostname_ok = value.len() <= 253
+        && !value.starts_with('-')
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-');
+    if !hostname_ok {
+        return Err(crate::AifwError::Validation(format!(
+            "{field} must be an IP address or DNS name: {value:?}"
+        )));
+    }
+    Ok(())
+}
+
+/// IKE identity: FQDN, IP, email-style, or DN-style string. Rendered
+/// double-quoted into swanctl config, so quotes/control chars are the
+/// injection surface and are rejected.
+fn validate_ike_id(field: &str, value: &str) -> crate::Result<()> {
+    if value.is_empty() {
+        return Ok(());
+    }
+    if value.len() > 128 {
+        return Err(crate::AifwError::Validation(format!(
+            "{field} must be at most 128 characters"
+        )));
+    }
+    if !value.chars().all(|c| c.is_ascii_graphic() || c == ' ')
+        || value.contains('"')
+        || value.contains('\\')
+    {
+        return Err(crate::AifwError::Validation(format!(
+            "{field} contains invalid characters (printable ASCII, no quotes/backslash): {value:?}"
+        )));
+    }
+    Ok(())
+}
+
+/// A PEM blob with the expected BEGIN tag and no stray characters that
+/// could smuggle content into an adjacent config context.
+fn validate_pem(field: &str, value: &str, tag: &str) -> crate::Result<()> {
+    let begin = format!("-----BEGIN {tag}-----");
+    if !value.contains(&begin) {
+        return Err(crate::AifwError::Validation(format!(
+            "{field} does not look like a {tag} PEM block"
+        )));
+    }
+    if !value
+        .chars()
+        .all(|c| c.is_ascii_graphic() || c == '\n' || c == '\r' || c == ' ')
+    {
+        return Err(crate::AifwError::Validation(format!(
+            "{field} contains non-PEM characters"
+        )));
+    }
+    Ok(())
+}
+
+/// Private keys come in several PEM flavors (PRIVATE KEY, RSA PRIVATE
+/// KEY, EC PRIVATE KEY) — accept any `... PRIVATE KEY-----` header.
+fn validate_pem_key(field: &str, value: &str) -> crate::Result<()> {
+    if !value.contains("PRIVATE KEY-----") || !value.contains("-----BEGIN") {
+        return Err(crate::AifwError::Validation(format!(
+            "{field} does not look like a private key PEM block"
+        )));
+    }
+    if !value
+        .chars()
+        .all(|c| c.is_ascii_graphic() || c == '\n' || c == '\r' || c == ' ')
+    {
+        return Err(crate::AifwError::Validation(format!(
+            "{field} contains non-PEM characters"
+        )));
+    }
+    Ok(())
+}
+
+/// Live negotiated state of one tunnel, parsed from `swanctl --list-sas`.
+/// Absence of a matching IKE SA means the tunnel is down/not negotiated.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IpsecLiveStatus {
+    /// Tunnel this status belongs to
+    pub tunnel_id: Uuid,
+    /// swanctl conn name (`aifw-<id>`)
+    pub conn_name: String,
+    /// IKE SA state as reported by charon (e.g. `ESTABLISHED`,
+    /// `CONNECTING`); `DOWN` when no SA exists
+    pub ike_state: String,
+    /// Seconds since the IKE SA was established
+    pub established_secs: Option<u64>,
+    /// Peer address the SA is actually talking to
+    pub remote_host: Option<String>,
+    /// IKE version in use (2 for everything AiFw configures)
+    pub ike_version: Option<u8>,
+    /// Negotiated child SAs (normally exactly one)
+    pub child_sas: Vec<ChildSaStatus>,
+}
+
+impl IpsecLiveStatus {
+    /// A "no SA present" status for a tunnel charon knows nothing about.
+    pub fn down(tunnel_id: Uuid, conn_name: String) -> Self {
+        Self {
+            tunnel_id,
+            conn_name,
+            ike_state: "DOWN".to_string(),
+            established_secs: None,
+            remote_host: None,
+            ike_version: None,
+            child_sas: Vec::new(),
+        }
+    }
+}
+
+/// Live state of one child (ESP) SA.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChildSaStatus {
+    /// Child SA name (`aifw-<id>-1`)
+    pub name: String,
+    /// Child SA state (e.g. `INSTALLED`, `REKEYING`)
+    pub state: String,
+    /// Negotiated local traffic selectors
+    pub local_ts: Vec<String>,
+    /// Negotiated remote traffic selectors
+    pub remote_ts: Vec<String>,
+    /// Bytes received over this SA
+    pub bytes_in: u64,
+    /// Bytes sent over this SA
+    pub bytes_out: u64,
+    /// Seconds until charon rekeys this SA
+    pub rekey_in_secs: Option<u64>,
+    /// Negotiated encryption algorithm (e.g. `AES_GCM_16-256`)
+    pub enc_alg: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_tunnel() -> IpsecTunnel {
+        IpsecTunnel::new(
+            "site-a".to_string(),
+            "203.0.113.10".to_string(),
+            "correct-horse-battery-staple".to_string(),
+            vec!["10.0.0.0/24".to_string()],
+            vec!["10.1.0.0/24".to_string()],
+        )
+    }
+
+    #[test]
+    fn default_tunnel_validates() {
+        base_tunnel().validate().unwrap();
+    }
+
+    #[test]
+    fn conn_names_are_in_wrapper_namespace() {
+        let t = base_tunnel();
+        assert!(t.conn_name().starts_with("aifw-"));
+        assert!(t.child_name().starts_with("aifw-"));
+        assert!(
+            t.conn_name()
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-')
+        );
+    }
+
+    #[test]
+    fn short_psk_rejected() {
+        let mut t = base_tunnel();
+        t.psk = "short".to_string();
+        assert!(t.validate().is_err());
+    }
+
+    #[test]
+    fn psk_with_quote_rejected() {
+        let mut t = base_tunnel();
+        t.psk = "aaaaaaaaaaaaaaa\"injection".to_string();
+        assert!(t.validate().is_err());
+    }
+
+    #[test]
+    fn bad_proposal_rejected() {
+        let mut t = base_tunnel();
+        t.ike_proposal = "des-md5-modp768".to_string();
+        assert!(t.validate().is_err());
+        t.ike_proposal = "aes256gcm16-prfsha256-ecp256".to_string();
+        t.esp_proposal = "aes256gcm16\nevil".to_string();
+        assert!(t.validate().is_err());
+    }
+
+    #[test]
+    fn hostname_remote_accepted_garbage_rejected() {
+        let mut t = base_tunnel();
+        t.remote_addr = "vpn.example.com".to_string();
+        t.validate().unwrap();
+        t.remote_addr = "peer;rm -rf /".to_string();
+        assert!(t.validate().is_err());
+        t.remote_addr = String::new();
+        assert!(t.validate().is_err());
+    }
+
+    #[test]
+    fn ike_id_injection_rejected() {
+        let mut t = base_tunnel();
+        t.local_id = "C=US, O=AiFw, CN=site-a".to_string();
+        t.validate().unwrap();
+        t.remote_id = "peer\"\n}\nsecrets {".to_string();
+        assert!(t.validate().is_err());
+    }
+
+    #[test]
+    fn traffic_selectors_validated() {
+        let mut t = base_tunnel();
+        t.local_ts = vec![];
+        assert!(t.validate().is_err());
+        t.local_ts = vec!["any".to_string()];
+        assert!(t.validate().is_err());
+        t.local_ts = vec!["10.0.0.0/24".to_string(), "192.168.5.1".to_string()];
+        t.validate().unwrap();
+    }
+
+    #[test]
+    fn cert_auth_requires_material() {
+        let mut t = base_tunnel();
+        t.auth_method = IpsecAuthMethod::Cert;
+        t.psk = String::new();
+        assert!(t.validate().is_err()); // no cert_source
+
+        t.cert_source = Some(IpsecCertSource::Acme);
+        assert!(t.validate().is_err()); // no acme_cert_id
+        t.acme_cert_id = Some(Uuid::new_v4());
+        t.validate().unwrap();
+
+        t.cert_source = Some(IpsecCertSource::Manual);
+        assert!(t.validate().is_err()); // no PEM material
+        t.local_cert_pem = "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----".into();
+        t.local_key_pem = "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----".into();
+        t.validate().unwrap();
+    }
+
+    #[test]
+    fn redacted_blanks_secrets_only() {
+        let mut t = base_tunnel();
+        t.local_key_pem = "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----".into();
+        t.local_cert_pem = "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----".into();
+        let r = t.redacted();
+        assert_eq!(r.psk, "REDACTED");
+        assert_eq!(r.local_key_pem, "REDACTED");
+        assert_eq!(r.local_cert_pem, t.local_cert_pem);
+        assert_eq!(r.remote_addr, t.remote_addr);
+    }
+
+    #[test]
+    fn lifetimes_bounded() {
+        let mut t = base_tunnel();
+        t.ike_lifetime_secs = 10;
+        assert!(t.validate().is_err());
+        t.ike_lifetime_secs = DEFAULT_IKE_LIFETIME_SECS;
+        t.esp_lifetime_secs = 100_000_000;
+        assert!(t.validate().is_err());
+    }
+
+    #[test]
+    fn start_action_roundtrip() {
+        for (s, v) in [
+            ("start", IpsecStartAction::Start),
+            ("trap", IpsecStartAction::Trap),
+            ("none", IpsecStartAction::None),
+        ] {
+            assert_eq!(IpsecStartAction::parse(s).unwrap(), v);
+            assert_eq!(v.to_string(), s);
+        }
+        assert!(IpsecStartAction::parse("bogus").is_err());
+    }
+}

--- a/aifw-common/src/ipsec.rs
+++ b/aifw-common/src/ipsec.rs
@@ -203,8 +203,9 @@ pub struct IpsecTunnel {
     pub psk: String,
     /// Certificate source (auth_method = cert)
     pub cert_source: Option<IpsecCertSource>,
-    /// ACME store certificate id (cert_source = acme)
-    pub acme_cert_id: Option<Uuid>,
+    /// ACME store certificate id (cert_source = acme; the ACME store
+    /// uses integer row ids)
+    pub acme_cert_id: Option<i64>,
     /// Local certificate PEM (cert_source = manual)
     pub local_cert_pem: String,
     /// Local private key PEM (cert_source = manual). Redacted in API output.
@@ -283,6 +284,15 @@ impl IpsecTunnel {
     /// swanctl child SA name for this tunnel's (single) child.
     pub fn child_name(&self) -> String {
         format!("aifw-{}-1", self.id)
+    }
+
+    /// pf pass rules admitting this tunnel's control and data traffic:
+    /// IKE (UDP 500 + 4500 for NAT-T), ESP between the endpoints, and
+    /// decapsulated traffic on `enc0`. Loaded into the `aifw-vpn` anchor.
+    /// Labels use the conn name (validated charset) — never the free-form
+    /// tunnel name.
+    pub fn to_pf_rules(&self) -> Vec<String> {
+        endpoint_pf_rules(&self.conn_name(), &self.local_addr, &self.remote_addr)
     }
 
     /// Copy with secret material blanked, safe for API responses.
@@ -393,6 +403,30 @@ impl IpsecTunnel {
 
         Ok(())
     }
+}
+
+/// pf pass rules for one IPsec tunnel's endpoints (used by
+/// [`IpsecTunnel::to_pf_rules`] and by `VpnEngine`'s scoped
+/// `ipsec_tunnels` query which avoids hydrating full tunnel structs).
+/// `label` must be the conn name (validated charset), never the
+/// free-form tunnel name; empty `local` renders as pf `any`.
+pub fn endpoint_pf_rules(label: &str, local: &str, remote: &str) -> Vec<String> {
+    let local = if local.is_empty() { "any" } else { local };
+    vec![
+        format!(
+            "pass in quick proto esp from {remote} to {local} keep state label \"ipsec-{label}-in\""
+        ),
+        format!(
+            "pass out quick proto esp from {local} to {remote} keep state label \"ipsec-{label}-out\""
+        ),
+        format!(
+            "pass in quick proto udp from {remote} to {local} port {{ 500 4500 }} keep state label \"ike-{label}-in\""
+        ),
+        format!(
+            "pass out quick proto udp from {local} to {remote} port {{ 500 4500 }} keep state label \"ike-{label}-out\""
+        ),
+        format!("pass quick on enc0 keep state label \"ipsec-{label}-enc0\""),
+    ]
 }
 
 /// Endpoint: IP address or DNS hostname (letters/digits/dot/hyphen).
@@ -630,7 +664,7 @@ mod tests {
 
         t.cert_source = Some(IpsecCertSource::Acme);
         assert!(t.validate().is_err()); // no acme_cert_id
-        t.acme_cert_id = Some(Uuid::new_v4());
+        t.acme_cert_id = Some(1);
         t.validate().unwrap();
 
         t.cert_source = Some(IpsecCertSource::Manual);
@@ -660,6 +694,25 @@ mod tests {
         t.ike_lifetime_secs = DEFAULT_IKE_LIFETIME_SECS;
         t.esp_lifetime_secs = 100_000_000;
         assert!(t.validate().is_err());
+    }
+
+    #[test]
+    fn pf_rules_cover_ike_esp_enc0() {
+        let mut t = base_tunnel();
+        t.local_addr = "198.51.100.1".to_string();
+        let rules = t.to_pf_rules();
+        assert_eq!(rules.len(), 5);
+        let label = t.conn_name();
+        assert!(rules[0].contains("proto esp from 203.0.113.10 to 198.51.100.1"));
+        assert!(rules[2].contains("port { 500 4500 }"));
+        assert!(rules[4].contains("on enc0"));
+        assert!(rules.iter().all(|r| r.contains(&label)));
+        // free-form tunnel name must never reach pf rule text
+        assert!(rules.iter().all(|r| !r.contains("site-a")));
+
+        t.local_addr = String::new();
+        let rules = t.to_pf_rules();
+        assert!(rules[0].contains("to any keep state"));
     }
 
     #[test]

--- a/aifw-common/src/lib.rs
+++ b/aifw-common/src/lib.rs
@@ -26,6 +26,7 @@ pub mod geoip;
 pub mod ha;
 /// Intrusion detection types: config, rulesets, rules, alerts, suppressions
 pub mod ids;
+pub mod ipsec;
 /// Multi-WAN types: routing instances, gateways, groups, policies, SLA, leak detection
 pub mod multiwan;
 /// NAT types: SNAT/DNAT/masquerade/binat/NAT64/NAT46 rules and pf rendering
@@ -64,6 +65,9 @@ pub use ha::{
 pub use ids::{
     AlertClassification, IdsAction, IdsAlert, IdsConfig, IdsMode, IdsRule, IdsRuleMatch,
     IdsRuleset, IdsSeverity, IdsStats, IdsSuppression, RuleFormat, RuleSource, SuppressType,
+};
+pub use ipsec::{
+    ChildSaStatus, IpsecAuthMethod, IpsecCertSource, IpsecLiveStatus, IpsecStartAction, IpsecTunnel,
 };
 pub use multiwan::{
     DEFAULT_FIB_NUMBER, DEFAULT_INSTANCE_ID, DEFAULT_INSTANCE_NAME, Gateway, GatewayEvent,

--- a/aifw-core/src/config.rs
+++ b/aifw-core/src/config.rs
@@ -530,13 +530,18 @@ pub struct RateLimitEntry {
     pub status: RateLimitStatus,
 }
 
-/// VPN section: WireGuard tunnels and IPsec SAs
+/// VPN section: WireGuard tunnels, IPsec tunnels, and legacy IPsec SAs
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct VpnConfig {
     /// WireGuard tunnel definitions (including peers)
     pub wireguard: Vec<WireguardTunnelConfig>,
-    /// IPsec security association definitions
+    /// Legacy pre-#530 IPsec SA records (configuration-only, no data plane)
     pub ipsec: Vec<IpsecSaConfig>,
+    /// Real IPsec tunnels (#530). Full records including PSKs/private
+    /// keys, so exports must be treated as secrets (same as WireGuard).
+    /// Defaults empty so pre-#530 backups import cleanly.
+    #[serde(default)]
+    pub ipsec_tunnels: Vec<aifw_common::IpsecTunnel>,
 }
 
 /// A WireGuard tunnel as stored in a config snapshot. Contains the

--- a/aifw-core/src/ipsec.rs
+++ b/aifw-core/src/ipsec.rs
@@ -1,0 +1,763 @@
+//! IPsec data-plane engine (#530).
+//!
+//! [`IpsecEngine`] owns the `ipsec_tunnels` table (desired config) and
+//! renders each enabled tunnel into a swanctl config file that strongSwan
+//! (charon) negotiates into kernel SAs/SPs. All charon interaction goes
+//! through the [`IkeControl`] trait: [`SwanctlControl`] shells out via
+//! `sudo::swanctl` on a real appliance, [`MockIkeControl`] backs tests and
+//! Linux development — mirroring the `PfBackend` mock/ioctl split.
+//!
+//! Live tunnel state is never stored: it is parsed from
+//! `swanctl --list-sas` on demand (see `status` in the apply layer).
+
+use std::sync::{Arc, Mutex};
+
+use aifw_common::{AifwError, IpsecTunnel, Result};
+use async_trait::async_trait;
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+/// Directory charon reads per-connection config from. Files are named
+/// `aifw-<id>.conf` and owned by root (they contain PSKs).
+pub const SWANCTL_CONF_DIR: &str = "/usr/local/etc/swanctl/conf.d";
+/// Private key PEMs for cert-auth tunnels (`aifw-<id>.pem`).
+pub const SWANCTL_PRIVATE_DIR: &str = "/usr/local/etc/swanctl/private";
+/// Local certificate PEMs (`aifw-<id>.pem`).
+pub const SWANCTL_X509_DIR: &str = "/usr/local/etc/swanctl/x509";
+/// CA certificate PEMs (`aifw-<id>.pem`).
+pub const SWANCTL_X509CA_DIR: &str = "/usr/local/etc/swanctl/x509ca";
+
+/// Control-plane interface to the IKE daemon. Implementations must be
+/// cheap to clone behind an `Arc` and safe to call concurrently.
+#[async_trait]
+pub trait IkeControl: Send + Sync {
+    /// (Re)load all connections and credentials from swanctl config.
+    /// Removes conns that disappeared from config.
+    async fn load_all(&self) -> Result<()>;
+    /// Initiate the named child SA (`aifw-<id>-1`), blocking up to
+    /// `timeout_secs` for the negotiation outcome.
+    async fn initiate(&self, child: &str, timeout_secs: u32) -> Result<()>;
+    /// Terminate the named IKE SA and its children.
+    async fn terminate_ike(&self, ike: &str, force: bool) -> Result<()>;
+    /// Raw `swanctl --list-sas --raw` output for status parsing.
+    async fn list_sas_raw(&self) -> Result<String>;
+    /// Raw `swanctl --list-conns --raw` output.
+    async fn list_conns_raw(&self) -> Result<String>;
+}
+
+/// Real control plane: drives charon through the `aifw-sudo-swanctl`
+/// narrow wrapper. Constructed on FreeBSD appliances.
+pub struct SwanctlControl;
+
+/// Run a swanctl invocation and convert a non-zero exit into a
+/// `Vpn`-flavored error carrying stderr (charon's diagnostics are the
+/// only useful failure detail).
+async fn swanctl_checked(args: &[&str]) -> Result<std::process::Output> {
+    let output = crate::sudo::swanctl(args).await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(AifwError::Config(format!(
+            "swanctl {} failed: {}",
+            args.first().copied().unwrap_or("?"),
+            stderr.trim()
+        )));
+    }
+    Ok(output)
+}
+
+#[async_trait]
+impl IkeControl for SwanctlControl {
+    async fn load_all(&self) -> Result<()> {
+        swanctl_checked(&["--load-all", "--noprompt"]).await?;
+        Ok(())
+    }
+
+    async fn initiate(&self, child: &str, timeout_secs: u32) -> Result<()> {
+        let timeout = timeout_secs.to_string();
+        swanctl_checked(&["--initiate", "--child", child, "--timeout", &timeout]).await?;
+        Ok(())
+    }
+
+    async fn terminate_ike(&self, ike: &str, force: bool) -> Result<()> {
+        let mut args = vec!["--terminate", "--ike", ike];
+        if force {
+            args.push("--force");
+        }
+        swanctl_checked(&args).await?;
+        Ok(())
+    }
+
+    async fn list_sas_raw(&self) -> Result<String> {
+        let output = swanctl_checked(&["--list-sas", "--raw"]).await?;
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+
+    async fn list_conns_raw(&self) -> Result<String> {
+        let output = swanctl_checked(&["--list-conns", "--raw"]).await?;
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+}
+
+/// Recorded state of a [`MockIkeControl`], inspectable from tests.
+#[derive(Debug, Default)]
+pub struct MockIkeState {
+    /// Number of `load_all` calls
+    pub load_all_calls: u32,
+    /// Child names passed to `initiate`, in order
+    pub initiated: Vec<String>,
+    /// IKE names passed to `terminate_ike`, in order
+    pub terminated: Vec<String>,
+    /// Canned `--list-sas --raw` output returned by `list_sas_raw`
+    pub sas_raw: String,
+    /// Canned `--list-conns --raw` output
+    pub conns_raw: String,
+    /// When set, `load_all` fails with this message (rollback testing)
+    pub fail_load: Option<String>,
+}
+
+/// In-memory IKE control for tests and Linux/WSL development.
+#[derive(Debug, Default)]
+pub struct MockIkeControl {
+    state: Mutex<MockIkeState>,
+}
+
+impl MockIkeControl {
+    /// Fresh mock with empty recorded state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Run `f` against the recorded state (assert or arrange).
+    pub fn with_state<R>(&self, f: impl FnOnce(&mut MockIkeState) -> R) -> R {
+        let mut guard = self.state.lock().expect("mock ike state lock poisoned");
+        f(&mut guard)
+    }
+}
+
+#[async_trait]
+impl IkeControl for MockIkeControl {
+    async fn load_all(&self) -> Result<()> {
+        self.with_state(|s| {
+            s.load_all_calls += 1;
+            match &s.fail_load {
+                Some(msg) => Err(AifwError::Config(msg.clone())),
+                None => Ok(()),
+            }
+        })
+    }
+
+    async fn initiate(&self, child: &str, _timeout_secs: u32) -> Result<()> {
+        self.with_state(|s| s.initiated.push(child.to_string()));
+        Ok(())
+    }
+
+    async fn terminate_ike(&self, ike: &str, _force: bool) -> Result<()> {
+        self.with_state(|s| s.terminated.push(ike.to_string()));
+        Ok(())
+    }
+
+    async fn list_sas_raw(&self) -> Result<String> {
+        Ok(self.with_state(|s| s.sas_raw.clone()))
+    }
+
+    async fn list_conns_raw(&self) -> Result<String> {
+        Ok(self.with_state(|s| s.conns_raw.clone()))
+    }
+}
+
+/// Render one tunnel into its swanctl config file content: a
+/// `connections` section plus, for PSK auth, a matching `secrets`
+/// section. Cert-auth material lives in the swanctl x509/private
+/// directories and is loaded implicitly by `--load-all`.
+///
+/// Every interpolated value is constrained by `IpsecTunnel::validate`
+/// (no quotes, no newlines), so the rendered text cannot escape its
+/// section — callers must validate before rendering.
+pub fn render_swanctl_conf(t: &IpsecTunnel) -> String {
+    use aifw_common::IpsecAuthMethod;
+
+    let conn = t.conn_name();
+    let child = t.child_name();
+    let mut out = String::new();
+    let push = |out: &mut String, line: &str| {
+        out.push_str(line);
+        out.push('\n');
+    };
+
+    push(&mut out, "# Managed by AiFw (#530 IPsec). Do not edit —");
+    push(
+        &mut out,
+        "# regenerated from the AiFw database on every apply.",
+    );
+    push(&mut out, "connections {");
+    push(&mut out, &format!("    {conn} {{"));
+    push(&mut out, "        version = 2");
+    if !t.local_addr.is_empty() {
+        push(&mut out, &format!("        local_addrs = {}", t.local_addr));
+    }
+    push(
+        &mut out,
+        &format!("        remote_addrs = {}", t.remote_addr),
+    );
+    push(&mut out, &format!("        proposals = {}", t.ike_proposal));
+    push(
+        &mut out,
+        &format!("        rekey_time = {}s", t.ike_lifetime_secs),
+    );
+    if t.dpd_delay_secs > 0 {
+        push(
+            &mut out,
+            &format!("        dpd_delay = {}s", t.dpd_delay_secs),
+        );
+    }
+
+    // local auth block
+    push(&mut out, "        local {");
+    match t.auth_method {
+        IpsecAuthMethod::Psk => push(&mut out, "            auth = psk"),
+        IpsecAuthMethod::Cert => {
+            push(&mut out, "            auth = pubkey");
+            push(&mut out, &format!("            certs = {conn}.pem"));
+        }
+    }
+    if !t.local_id.is_empty() {
+        push(&mut out, &format!("            id = \"{}\"", t.local_id));
+    }
+    push(&mut out, "        }");
+
+    // remote auth block
+    push(&mut out, "        remote {");
+    match t.auth_method {
+        IpsecAuthMethod::Psk => push(&mut out, "            auth = psk"),
+        IpsecAuthMethod::Cert => push(&mut out, "            auth = pubkey"),
+    }
+    if !t.remote_id.is_empty() {
+        push(&mut out, &format!("            id = \"{}\"", t.remote_id));
+    }
+    push(&mut out, "        }");
+
+    // single child SA carrying all traffic selectors
+    push(&mut out, "        children {");
+    push(&mut out, &format!("            {child} {{"));
+    push(
+        &mut out,
+        &format!("                local_ts = {}", t.local_ts.join(",")),
+    );
+    push(
+        &mut out,
+        &format!("                remote_ts = {}", t.remote_ts.join(",")),
+    );
+    push(
+        &mut out,
+        &format!("                esp_proposals = {}", t.esp_proposal),
+    );
+    push(
+        &mut out,
+        &format!("                rekey_time = {}s", t.esp_lifetime_secs),
+    );
+    push(
+        &mut out,
+        &format!("                start_action = {}", t.start_action),
+    );
+    if t.dpd_delay_secs > 0 {
+        // Keep persistent tunnels up across dead peers; on-demand (trap)
+        // tunnels fall back to the trap policy instead.
+        let dpd_action = match t.start_action {
+            aifw_common::IpsecStartAction::Start => "restart",
+            aifw_common::IpsecStartAction::Trap => "trap",
+            aifw_common::IpsecStartAction::None => "clear",
+        };
+        push(
+            &mut out,
+            &format!("                dpd_action = {dpd_action}"),
+        );
+    }
+    push(&mut out, "            }");
+    push(&mut out, "        }");
+    push(&mut out, "    }");
+    push(&mut out, "}");
+
+    if t.auth_method == IpsecAuthMethod::Psk {
+        push(&mut out, "secrets {");
+        push(&mut out, &format!("    ike-{conn} {{"));
+        push(&mut out, &format!("        secret = \"{}\"", t.psk));
+        // Bind the secret to the peer identities so multiple PSK tunnels
+        // to different peers can't cross-match.
+        let local_ident = if t.local_id.is_empty() {
+            t.local_addr.as_str()
+        } else {
+            t.local_id.as_str()
+        };
+        let remote_ident = if t.remote_id.is_empty() {
+            t.remote_addr.as_str()
+        } else {
+            t.remote_id.as_str()
+        };
+        if !local_ident.is_empty() {
+            push(&mut out, &format!("        id-1 = \"{local_ident}\""));
+        }
+        push(&mut out, &format!("        id-2 = \"{remote_ident}\""));
+        push(&mut out, "    }");
+        push(&mut out, "}");
+    }
+
+    out
+}
+
+/// Explicit column list for `IpsecTunnelRow` selects. Keep in `CREATE
+/// TABLE` schema order.
+const IPSEC_TUNNEL_COLUMNS: &str = "id, name, enabled, local_addr, remote_addr, local_id, \
+     remote_id, auth_method, psk, cert_source, acme_cert_id, local_cert_pem, local_key_pem, \
+     ca_cert_pem, ike_proposal, esp_proposal, local_ts, remote_ts, ike_lifetime_secs, \
+     esp_lifetime_secs, dpd_delay_secs, start_action, created_at, updated_at";
+
+#[derive(sqlx::FromRow)]
+struct IpsecTunnelRow {
+    id: String,
+    name: String,
+    enabled: i64,
+    local_addr: String,
+    remote_addr: String,
+    local_id: String,
+    remote_id: String,
+    auth_method: String,
+    psk: String,
+    cert_source: Option<String>,
+    acme_cert_id: Option<String>,
+    local_cert_pem: String,
+    local_key_pem: String,
+    ca_cert_pem: String,
+    ike_proposal: String,
+    esp_proposal: String,
+    local_ts: String,
+    remote_ts: String,
+    ike_lifetime_secs: i64,
+    esp_lifetime_secs: i64,
+    dpd_delay_secs: i64,
+    start_action: String,
+    created_at: String,
+    updated_at: String,
+}
+
+fn split_csv(s: &str) -> Vec<String> {
+    s.split(',')
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+fn parse_ts(field: &str, s: &str) -> Result<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .map_err(|e| AifwError::Database(format!("bad {field} timestamp {s:?}: {e}")))
+}
+
+impl IpsecTunnelRow {
+    fn into_tunnel(self) -> Result<IpsecTunnel> {
+        use aifw_common::{IpsecAuthMethod, IpsecCertSource, IpsecStartAction};
+        Ok(IpsecTunnel {
+            id: Uuid::parse_str(&self.id)
+                .map_err(|e| AifwError::Database(format!("bad tunnel id {:?}: {e}", self.id)))?,
+            name: self.name,
+            enabled: self.enabled != 0,
+            local_addr: self.local_addr,
+            remote_addr: self.remote_addr,
+            local_id: self.local_id,
+            remote_id: self.remote_id,
+            auth_method: IpsecAuthMethod::parse(&self.auth_method)?,
+            psk: self.psk,
+            cert_source: match self.cert_source.as_deref() {
+                None | Some("") => None,
+                Some(s) => Some(IpsecCertSource::parse(s)?),
+            },
+            acme_cert_id: match self.acme_cert_id.as_deref() {
+                None | Some("") => None,
+                Some(s) => Some(
+                    Uuid::parse_str(s)
+                        .map_err(|e| AifwError::Database(format!("bad acme_cert_id {s:?}: {e}")))?,
+                ),
+            },
+            local_cert_pem: self.local_cert_pem,
+            local_key_pem: self.local_key_pem,
+            ca_cert_pem: self.ca_cert_pem,
+            ike_proposal: self.ike_proposal,
+            esp_proposal: self.esp_proposal,
+            local_ts: split_csv(&self.local_ts),
+            remote_ts: split_csv(&self.remote_ts),
+            ike_lifetime_secs: self.ike_lifetime_secs as u32,
+            esp_lifetime_secs: self.esp_lifetime_secs as u32,
+            dpd_delay_secs: self.dpd_delay_secs as u32,
+            start_action: IpsecStartAction::parse(&self.start_action)?,
+            created_at: parse_ts("created_at", &self.created_at)?,
+            updated_at: parse_ts("updated_at", &self.updated_at)?,
+        })
+    }
+}
+
+/// Engine owning desired IPsec tunnel config and the IKE control plane.
+pub struct IpsecEngine {
+    pool: SqlitePool,
+    ike: Arc<dyn IkeControl>,
+}
+
+impl IpsecEngine {
+    /// Build the engine over the shared pool and an IKE control backend
+    /// (SwanctlControl on FreeBSD, MockIkeControl elsewhere).
+    pub fn new(pool: SqlitePool, ike: Arc<dyn IkeControl>) -> Self {
+        Self { pool, ike }
+    }
+
+    /// The IKE control backend (used by the apply/status layer).
+    pub fn ike(&self) -> &Arc<dyn IkeControl> {
+        &self.ike
+    }
+
+    /// Create the `ipsec_tunnels` table if missing.
+    pub async fn migrate(&self) -> Result<()> {
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS ipsec_tunnels (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                local_addr TEXT NOT NULL DEFAULT '',
+                remote_addr TEXT NOT NULL,
+                local_id TEXT NOT NULL DEFAULT '',
+                remote_id TEXT NOT NULL DEFAULT '',
+                auth_method TEXT NOT NULL,
+                psk TEXT NOT NULL DEFAULT '',
+                cert_source TEXT,
+                acme_cert_id TEXT,
+                local_cert_pem TEXT NOT NULL DEFAULT '',
+                local_key_pem TEXT NOT NULL DEFAULT '',
+                ca_cert_pem TEXT NOT NULL DEFAULT '',
+                ike_proposal TEXT NOT NULL,
+                esp_proposal TEXT NOT NULL,
+                local_ts TEXT NOT NULL,
+                remote_ts TEXT NOT NULL,
+                ike_lifetime_secs INTEGER NOT NULL,
+                esp_lifetime_secs INTEGER NOT NULL,
+                dpd_delay_secs INTEGER NOT NULL,
+                start_action TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Validate and persist a new tunnel.
+    pub async fn add_tunnel(&self, tunnel: IpsecTunnel) -> Result<IpsecTunnel> {
+        tunnel.validate()?;
+        sqlx::query(
+            r#"
+            INSERT INTO ipsec_tunnels (
+                id, name, enabled, local_addr, remote_addr, local_id, remote_id,
+                auth_method, psk, cert_source, acme_cert_id, local_cert_pem,
+                local_key_pem, ca_cert_pem, ike_proposal, esp_proposal, local_ts,
+                remote_ts, ike_lifetime_secs, esp_lifetime_secs, dpd_delay_secs,
+                start_action, created_at, updated_at
+            ) VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
+                ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24
+            )
+            "#,
+        )
+        .bind(tunnel.id.to_string())
+        .bind(&tunnel.name)
+        .bind(tunnel.enabled as i64)
+        .bind(&tunnel.local_addr)
+        .bind(&tunnel.remote_addr)
+        .bind(&tunnel.local_id)
+        .bind(&tunnel.remote_id)
+        .bind(tunnel.auth_method.to_string())
+        .bind(&tunnel.psk)
+        .bind(tunnel.cert_source.map(|s| s.to_string()))
+        .bind(tunnel.acme_cert_id.map(|u| u.to_string()))
+        .bind(&tunnel.local_cert_pem)
+        .bind(&tunnel.local_key_pem)
+        .bind(&tunnel.ca_cert_pem)
+        .bind(&tunnel.ike_proposal)
+        .bind(&tunnel.esp_proposal)
+        .bind(tunnel.local_ts.join(","))
+        .bind(tunnel.remote_ts.join(","))
+        .bind(tunnel.ike_lifetime_secs as i64)
+        .bind(tunnel.esp_lifetime_secs as i64)
+        .bind(tunnel.dpd_delay_secs as i64)
+        .bind(tunnel.start_action.to_string())
+        .bind(tunnel.created_at.to_rfc3339())
+        .bind(tunnel.updated_at.to_rfc3339())
+        .execute(&self.pool)
+        .await?;
+        Ok(tunnel)
+    }
+
+    /// All tunnels, oldest first.
+    pub async fn list_tunnels(&self) -> Result<Vec<IpsecTunnel>> {
+        let rows = sqlx::query_as::<_, IpsecTunnelRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {IPSEC_TUNNEL_COLUMNS} FROM ipsec_tunnels ORDER BY created_at ASC"
+        )))
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(IpsecTunnelRow::into_tunnel).collect()
+    }
+
+    /// One tunnel by id.
+    pub async fn get_tunnel(&self, id: Uuid) -> Result<IpsecTunnel> {
+        let row = sqlx::query_as::<_, IpsecTunnelRow>(sqlx::AssertSqlSafe(format!(
+            "SELECT {IPSEC_TUNNEL_COLUMNS} FROM ipsec_tunnels WHERE id = ?1"
+        )))
+        .bind(id.to_string())
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| AifwError::NotFound(format!("IPsec tunnel {id} not found")))?;
+        row.into_tunnel()
+    }
+
+    /// Validate and persist changes to an existing tunnel (matched by
+    /// `tunnel.id`); bumps `updated_at`.
+    pub async fn update_tunnel(&self, mut tunnel: IpsecTunnel) -> Result<IpsecTunnel> {
+        tunnel.validate()?;
+        tunnel.updated_at = chrono::Utc::now();
+        let result = sqlx::query(
+            r#"
+            UPDATE ipsec_tunnels SET
+                name = ?2, enabled = ?3, local_addr = ?4, remote_addr = ?5,
+                local_id = ?6, remote_id = ?7, auth_method = ?8, psk = ?9,
+                cert_source = ?10, acme_cert_id = ?11, local_cert_pem = ?12,
+                local_key_pem = ?13, ca_cert_pem = ?14, ike_proposal = ?15,
+                esp_proposal = ?16, local_ts = ?17, remote_ts = ?18,
+                ike_lifetime_secs = ?19, esp_lifetime_secs = ?20,
+                dpd_delay_secs = ?21, start_action = ?22, updated_at = ?23
+            WHERE id = ?1
+            "#,
+        )
+        .bind(tunnel.id.to_string())
+        .bind(&tunnel.name)
+        .bind(tunnel.enabled as i64)
+        .bind(&tunnel.local_addr)
+        .bind(&tunnel.remote_addr)
+        .bind(&tunnel.local_id)
+        .bind(&tunnel.remote_id)
+        .bind(tunnel.auth_method.to_string())
+        .bind(&tunnel.psk)
+        .bind(tunnel.cert_source.map(|s| s.to_string()))
+        .bind(tunnel.acme_cert_id.map(|u| u.to_string()))
+        .bind(&tunnel.local_cert_pem)
+        .bind(&tunnel.local_key_pem)
+        .bind(&tunnel.ca_cert_pem)
+        .bind(&tunnel.ike_proposal)
+        .bind(&tunnel.esp_proposal)
+        .bind(tunnel.local_ts.join(","))
+        .bind(tunnel.remote_ts.join(","))
+        .bind(tunnel.ike_lifetime_secs as i64)
+        .bind(tunnel.esp_lifetime_secs as i64)
+        .bind(tunnel.dpd_delay_secs as i64)
+        .bind(tunnel.start_action.to_string())
+        .bind(tunnel.updated_at.to_rfc3339())
+        .execute(&self.pool)
+        .await?;
+        if result.rows_affected() == 0 {
+            return Err(AifwError::NotFound(format!(
+                "IPsec tunnel {} not found",
+                tunnel.id
+            )));
+        }
+        Ok(tunnel)
+    }
+
+    /// Delete a tunnel record. (The apply layer is responsible for
+    /// terminating any live SA and removing rendered config first.)
+    pub async fn delete_tunnel(&self, id: Uuid) -> Result<()> {
+        let result = sqlx::query("DELETE FROM ipsec_tunnels WHERE id = ?1")
+            .bind(id.to_string())
+            .execute(&self.pool)
+            .await?;
+        if result.rows_affected() == 0 {
+            return Err(AifwError::NotFound(format!("IPsec tunnel {id} not found")));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+    use aifw_common::{IpsecAuthMethod, IpsecCertSource, IpsecStartAction};
+
+    async fn engine() -> (IpsecEngine, Arc<MockIkeControl>) {
+        let db = Database::new_in_memory().await.unwrap();
+        let ike = Arc::new(MockIkeControl::new());
+        let engine = IpsecEngine::new(db.pool().clone(), ike.clone());
+        engine.migrate().await.unwrap();
+        (engine, ike)
+    }
+
+    fn tunnel(name: &str) -> IpsecTunnel {
+        IpsecTunnel::new(
+            name.to_string(),
+            "203.0.113.10".to_string(),
+            "correct-horse-battery-staple".to_string(),
+            vec!["10.0.0.0/24".to_string()],
+            vec!["10.1.0.0/24".to_string()],
+        )
+    }
+
+    #[tokio::test]
+    async fn crud_roundtrip() {
+        let (engine, _) = engine().await;
+        let t = engine.add_tunnel(tunnel("site-a")).await.unwrap();
+
+        let fetched = engine.get_tunnel(t.id).await.unwrap();
+        assert_eq!(fetched.name, "site-a");
+        assert_eq!(fetched.remote_addr, "203.0.113.10");
+        assert_eq!(fetched.local_ts, vec!["10.0.0.0/24"]);
+        assert_eq!(fetched.auth_method, IpsecAuthMethod::Psk);
+        assert_eq!(fetched.start_action, IpsecStartAction::Start);
+
+        let mut updated = fetched.clone();
+        updated.remote_ts = vec!["10.2.0.0/16".to_string(), "10.3.0.0/24".to_string()];
+        updated.enabled = false;
+        engine.update_tunnel(updated).await.unwrap();
+        let fetched = engine.get_tunnel(t.id).await.unwrap();
+        assert_eq!(fetched.remote_ts.len(), 2);
+        assert!(!fetched.enabled);
+        assert!(fetched.updated_at >= fetched.created_at);
+
+        engine.delete_tunnel(t.id).await.unwrap();
+        assert!(matches!(
+            engine.get_tunnel(t.id).await,
+            Err(AifwError::NotFound(_))
+        ));
+        assert!(engine.list_tunnels().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn duplicate_name_rejected() {
+        let (engine, _) = engine().await;
+        engine.add_tunnel(tunnel("dup")).await.unwrap();
+        assert!(engine.add_tunnel(tunnel("dup")).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn invalid_tunnel_rejected_before_persist() {
+        let (engine, _) = engine().await;
+        let mut t = tunnel("bad");
+        t.psk = "short".to_string();
+        assert!(matches!(
+            engine.add_tunnel(t).await,
+            Err(AifwError::Validation(_))
+        ));
+        assert!(engine.list_tunnels().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn update_missing_tunnel_is_not_found() {
+        let (engine, _) = engine().await;
+        assert!(matches!(
+            engine.update_tunnel(tunnel("ghost")).await,
+            Err(AifwError::NotFound(_))
+        ));
+        assert!(matches!(
+            engine.delete_tunnel(Uuid::new_v4()).await,
+            Err(AifwError::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn cert_tunnel_roundtrip() {
+        let (engine, _) = engine().await;
+        let mut t = tunnel("cert-site");
+        t.auth_method = IpsecAuthMethod::Cert;
+        t.psk = String::new();
+        t.cert_source = Some(IpsecCertSource::Manual);
+        t.local_cert_pem =
+            "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----".to_string();
+        t.local_key_pem = "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----".to_string();
+        let t = engine.add_tunnel(t).await.unwrap();
+        let fetched = engine.get_tunnel(t.id).await.unwrap();
+        assert_eq!(fetched.auth_method, IpsecAuthMethod::Cert);
+        assert_eq!(fetched.cert_source, Some(IpsecCertSource::Manual));
+        assert!(fetched.local_key_pem.contains("PRIVATE KEY"));
+    }
+
+    #[test]
+    fn render_psk_conf_golden() {
+        let mut t = tunnel("site-a");
+        t.id = Uuid::nil();
+        t.local_addr = "198.51.100.1".to_string();
+        let conf = render_swanctl_conf(&t);
+        let conn = "aifw-00000000-0000-0000-0000-000000000000";
+        assert!(conf.contains(&format!("    {conn} {{")));
+        assert!(conf.contains("version = 2"));
+        assert!(conf.contains("local_addrs = 198.51.100.1"));
+        assert!(conf.contains("remote_addrs = 203.0.113.10"));
+        assert!(conf.contains("proposals = aes256gcm16-prfsha256-ecp256"));
+        assert!(conf.contains("rekey_time = 14400s"));
+        assert!(conf.contains("dpd_delay = 30s"));
+        assert!(conf.contains("auth = psk"));
+        assert!(conf.contains(&format!("{conn}-1 {{")));
+        assert!(conf.contains("local_ts = 10.0.0.0/24"));
+        assert!(conf.contains("remote_ts = 10.1.0.0/24"));
+        assert!(conf.contains("esp_proposals = aes256gcm16-ecp256"));
+        assert!(conf.contains("rekey_time = 3600s"));
+        assert!(conf.contains("start_action = start"));
+        assert!(conf.contains("dpd_action = restart"));
+        assert!(conf.contains(&format!("ike-{conn} {{")));
+        assert!(conf.contains("secret = \"correct-horse-battery-staple\""));
+        assert!(conf.contains("id-1 = \"198.51.100.1\""));
+        assert!(conf.contains("id-2 = \"203.0.113.10\""));
+    }
+
+    #[test]
+    fn render_cert_conf_has_no_secrets_section() {
+        let mut t = tunnel("cert-site");
+        t.auth_method = IpsecAuthMethod::Cert;
+        t.psk = String::new();
+        t.cert_source = Some(IpsecCertSource::Manual);
+        t.local_cert_pem =
+            "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----".to_string();
+        t.local_key_pem = "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----".to_string();
+        t.local_id = "CN=site-a".to_string();
+        t.remote_id = "CN=site-b".to_string();
+        t.validate().unwrap();
+        let conf = render_swanctl_conf(&t);
+        assert!(conf.contains("auth = pubkey"));
+        assert!(conf.contains(&format!("certs = {}.pem", t.conn_name())));
+        assert!(conf.contains("id = \"CN=site-a\""));
+        assert!(conf.contains("id = \"CN=site-b\""));
+        assert!(!conf.contains("secrets {"));
+        assert!(!conf.contains("PRIVATE KEY")); // key material never in conf
+    }
+
+    #[test]
+    fn render_multi_ts_and_trap() {
+        let mut t = tunnel("multi");
+        t.local_ts = vec!["10.0.0.0/24".to_string(), "10.5.0.0/24".to_string()];
+        t.start_action = IpsecStartAction::Trap;
+        let conf = render_swanctl_conf(&t);
+        assert!(conf.contains("local_ts = 10.0.0.0/24,10.5.0.0/24"));
+        assert!(conf.contains("start_action = trap"));
+        assert!(conf.contains("dpd_action = trap"));
+    }
+
+    #[tokio::test]
+    async fn mock_ike_records_calls() {
+        let (_, ike) = engine().await;
+        ike.load_all().await.unwrap();
+        ike.initiate("aifw-x-1", 30).await.unwrap();
+        ike.terminate_ike("aifw-x", false).await.unwrap();
+        ike.with_state(|s| {
+            assert_eq!(s.load_all_calls, 1);
+            assert_eq!(s.initiated, vec!["aifw-x-1"]);
+            assert_eq!(s.terminated, vec!["aifw-x"]);
+        });
+        ike.with_state(|s| s.fail_load = Some("boom".to_string()));
+        assert!(ike.load_all().await.is_err());
+    }
+}

--- a/aifw-core/src/ipsec.rs
+++ b/aifw-core/src/ipsec.rs
@@ -165,6 +165,137 @@ impl IkeControl for MockIkeControl {
     }
 }
 
+/// Storage for AiFw-managed swanctl files (conn configs, certs, keys).
+/// Abstracted so the apply/rollback lifecycle is fully testable on
+/// Linux: the real store writes root-owned files through the narrow
+/// sudo helpers, the mock keeps a HashMap.
+#[async_trait]
+pub trait IpsecConfStore: Send + Sync {
+    /// Atomically write `content` to the absolute `path` (root-owned,
+    /// mode fixed by the write helper's per-path policy).
+    async fn write(&self, path: &str, content: &[u8]) -> Result<()>;
+    /// Remove the file at `path`.
+    async fn remove(&self, path: &str) -> Result<()>;
+    /// All AiFw-managed swanctl file paths currently on disk
+    /// (`aifw-*` files across conf.d/private/x509/x509ca).
+    async fn list_managed(&self) -> Result<Vec<String>>;
+}
+
+/// Real store: writes via `aifw-sudo-write`, removes via `aifw-sudo-rm`.
+/// Listing uses plain readdir — the swanctl dirs are root-owned but
+/// world-listable; file *contents* stay root-only.
+pub struct SystemConfStore;
+
+/// The four swanctl directories AiFw manages files in.
+const SWANCTL_DIRS: &[&str] = &[
+    SWANCTL_CONF_DIR,
+    SWANCTL_PRIVATE_DIR,
+    SWANCTL_X509_DIR,
+    SWANCTL_X509CA_DIR,
+];
+
+#[async_trait]
+impl IpsecConfStore for SystemConfStore {
+    async fn write(&self, path: &str, content: &[u8]) -> Result<()> {
+        crate::sudo::write_file(std::path::Path::new(path), content)
+            .await
+            .map_err(|e| AifwError::Config(format!("write {path} failed: {e}")))
+    }
+
+    async fn remove(&self, path: &str) -> Result<()> {
+        let output = crate::sudo::rm(&[path]).await?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(AifwError::Config(format!(
+                "remove {path} failed: {}",
+                stderr.trim()
+            )));
+        }
+        Ok(())
+    }
+
+    async fn list_managed(&self) -> Result<Vec<String>> {
+        let mut paths = Vec::new();
+        for dir in SWANCTL_DIRS {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                continue; // dir absent (strongswan not installed yet)
+            };
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if name.starts_with("aifw-") {
+                    paths.push(format!("{dir}/{name}"));
+                }
+            }
+        }
+        Ok(paths)
+    }
+}
+
+/// In-memory conf store for tests and Linux development.
+#[derive(Debug, Default)]
+pub struct MemConfStore {
+    files: Mutex<std::collections::HashMap<String, Vec<u8>>>,
+}
+
+impl MemConfStore {
+    /// Fresh empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Current content of `path`, if present.
+    pub fn get(&self, path: &str) -> Option<Vec<u8>> {
+        self.files
+            .lock()
+            .expect("mem conf store lock poisoned")
+            .get(path)
+            .cloned()
+    }
+
+    /// Number of stored files.
+    pub fn len(&self) -> usize {
+        self.files
+            .lock()
+            .expect("mem conf store lock poisoned")
+            .len()
+    }
+
+    /// True when no files are stored.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[async_trait]
+impl IpsecConfStore for MemConfStore {
+    async fn write(&self, path: &str, content: &[u8]) -> Result<()> {
+        self.files
+            .lock()
+            .expect("mem conf store lock poisoned")
+            .insert(path.to_string(), content.to_vec());
+        Ok(())
+    }
+
+    async fn remove(&self, path: &str) -> Result<()> {
+        self.files
+            .lock()
+            .expect("mem conf store lock poisoned")
+            .remove(path);
+        Ok(())
+    }
+
+    async fn list_managed(&self) -> Result<Vec<String>> {
+        Ok(self
+            .files
+            .lock()
+            .expect("mem conf store lock poisoned")
+            .keys()
+            .cloned()
+            .collect())
+    }
+}
+
 /// Render one tunnel into its swanctl config file content: a
 /// `connections` section plus, for PSK auth, a matching `secrets`
 /// section. Cert-auth material lives in the swanctl x509/private
@@ -323,7 +454,7 @@ struct IpsecTunnelRow {
     auth_method: String,
     psk: String,
     cert_source: Option<String>,
-    acme_cert_id: Option<String>,
+    acme_cert_id: Option<i64>,
     local_cert_pem: String,
     local_key_pem: String,
     ca_cert_pem: String,
@@ -371,13 +502,7 @@ impl IpsecTunnelRow {
                 None | Some("") => None,
                 Some(s) => Some(IpsecCertSource::parse(s)?),
             },
-            acme_cert_id: match self.acme_cert_id.as_deref() {
-                None | Some("") => None,
-                Some(s) => Some(
-                    Uuid::parse_str(s)
-                        .map_err(|e| AifwError::Database(format!("bad acme_cert_id {s:?}: {e}")))?,
-                ),
-            },
+            acme_cert_id: self.acme_cert_id,
             local_cert_pem: self.local_cert_pem,
             local_key_pem: self.local_key_pem,
             ca_cert_pem: self.ca_cert_pem,
@@ -399,13 +524,15 @@ impl IpsecTunnelRow {
 pub struct IpsecEngine {
     pool: SqlitePool,
     ike: Arc<dyn IkeControl>,
+    store: Arc<dyn IpsecConfStore>,
 }
 
 impl IpsecEngine {
-    /// Build the engine over the shared pool and an IKE control backend
-    /// (SwanctlControl on FreeBSD, MockIkeControl elsewhere).
-    pub fn new(pool: SqlitePool, ike: Arc<dyn IkeControl>) -> Self {
-        Self { pool, ike }
+    /// Build the engine over the shared pool, an IKE control backend and
+    /// a conf store (SwanctlControl + SystemConfStore on FreeBSD,
+    /// mocks elsewhere).
+    pub fn new(pool: SqlitePool, ike: Arc<dyn IkeControl>, store: Arc<dyn IpsecConfStore>) -> Self {
+        Self { pool, ike, store }
     }
 
     /// The IKE control backend (used by the apply/status layer).
@@ -428,7 +555,7 @@ impl IpsecEngine {
                 auth_method TEXT NOT NULL,
                 psk TEXT NOT NULL DEFAULT '',
                 cert_source TEXT,
-                acme_cert_id TEXT,
+                acme_cert_id INTEGER,
                 local_cert_pem TEXT NOT NULL DEFAULT '',
                 local_key_pem TEXT NOT NULL DEFAULT '',
                 ca_cert_pem TEXT NOT NULL DEFAULT '',
@@ -477,7 +604,7 @@ impl IpsecEngine {
         .bind(tunnel.auth_method.to_string())
         .bind(&tunnel.psk)
         .bind(tunnel.cert_source.map(|s| s.to_string()))
-        .bind(tunnel.acme_cert_id.map(|u| u.to_string()))
+        .bind(tunnel.acme_cert_id)
         .bind(&tunnel.local_cert_pem)
         .bind(&tunnel.local_key_pem)
         .bind(&tunnel.ca_cert_pem)
@@ -546,7 +673,7 @@ impl IpsecEngine {
         .bind(tunnel.auth_method.to_string())
         .bind(&tunnel.psk)
         .bind(tunnel.cert_source.map(|s| s.to_string()))
-        .bind(tunnel.acme_cert_id.map(|u| u.to_string()))
+        .bind(tunnel.acme_cert_id)
         .bind(&tunnel.local_cert_pem)
         .bind(&tunnel.local_key_pem)
         .bind(&tunnel.ca_cert_pem)
@@ -582,6 +709,222 @@ impl IpsecEngine {
         }
         Ok(())
     }
+
+    // ============================================================
+    // Apply lifecycle — DB is the source of truth; swanctl files are
+    // derived state, regenerated wholesale on every apply.
+    // ============================================================
+
+    /// The complete set of swanctl files the current DB state demands:
+    /// conn config per enabled tunnel, plus cert/key material for
+    /// cert-auth tunnels (resolved from the ACME store or the stored
+    /// PEM fields).
+    async fn desired_files(
+        &self,
+        tunnels: &[IpsecTunnel],
+    ) -> Result<std::collections::HashMap<String, Vec<u8>>> {
+        use aifw_common::{IpsecAuthMethod, IpsecCertSource};
+
+        let mut files = std::collections::HashMap::new();
+        for t in tunnels.iter().filter(|t| t.enabled) {
+            let conn = t.conn_name();
+            files.insert(
+                format!("{SWANCTL_CONF_DIR}/{conn}.conf"),
+                render_swanctl_conf(t).into_bytes(),
+            );
+
+            if t.auth_method == IpsecAuthMethod::Cert {
+                let (cert_pem, key_pem, chain_pem) = match t.cert_source {
+                    Some(IpsecCertSource::Manual) => {
+                        (t.local_cert_pem.clone(), t.local_key_pem.clone(), None)
+                    }
+                    Some(IpsecCertSource::Acme) => {
+                        let id = t.acme_cert_id.ok_or_else(|| {
+                            AifwError::Config(format!("tunnel {} has no acme_cert_id", t.name))
+                        })?;
+                        let cert =
+                            crate::acme::load_cert(&self.pool, id)
+                                .await
+                                .ok_or_else(|| {
+                                    AifwError::Config(format!(
+                                        "ACME cert {id} referenced by tunnel {} not found",
+                                        t.name
+                                    ))
+                                })?;
+                        let cert_pem = cert.cert_pem.unwrap_or_default();
+                        let key_pem = cert.key_pem.unwrap_or_default();
+                        if cert_pem.is_empty() || key_pem.is_empty() {
+                            return Err(AifwError::Config(format!(
+                                "ACME cert {id} for tunnel {} has no issued material yet",
+                                t.name
+                            )));
+                        }
+                        (cert_pem, key_pem, cert.chain_pem.filter(|c| !c.is_empty()))
+                    }
+                    None => {
+                        return Err(AifwError::Config(format!(
+                            "tunnel {} uses cert auth without a cert source",
+                            t.name
+                        )));
+                    }
+                };
+                files.insert(
+                    format!("{SWANCTL_X509_DIR}/{conn}.pem"),
+                    cert_pem.into_bytes(),
+                );
+                files.insert(
+                    format!("{SWANCTL_PRIVATE_DIR}/{conn}.pem"),
+                    key_pem.into_bytes(),
+                );
+                if let Some(chain) = chain_pem {
+                    files.insert(
+                        format!("{SWANCTL_X509CA_DIR}/{conn}-chain.pem"),
+                        chain.into_bytes(),
+                    );
+                }
+            }
+            if !t.ca_cert_pem.is_empty() {
+                files.insert(
+                    format!("{SWANCTL_X509CA_DIR}/{conn}-ca.pem"),
+                    t.ca_cert_pem.clone().into_bytes(),
+                );
+            }
+        }
+        Ok(files)
+    }
+
+    /// Regenerate every AiFw-managed swanctl file from the DB, remove
+    /// stale ones, and `--load-all`. charon diffs the loaded config:
+    /// changed conns are replaced, vanished conns are unloaded, and
+    /// `start_action = start` children are (re)initiated.
+    pub async fn apply_all(&self) -> Result<()> {
+        let tunnels = self.list_tunnels().await?;
+        let desired = self.desired_files(&tunnels).await?;
+        let existing = self.store.list_managed().await?;
+
+        for path in &existing {
+            if !desired.contains_key(path)
+                && let Err(e) = self.store.remove(path).await
+            {
+                tracing::warn!(path, error = %e, "ipsec: failed to remove stale swanctl file");
+            }
+        }
+        for (path, content) in &desired {
+            self.store.write(path, content).await?;
+        }
+        if desired.is_empty() && existing.is_empty() {
+            // Nothing managed and nothing to clean up — don't poke charon
+            // (it may not even be installed on a box that never used IPsec).
+            return Ok(());
+        }
+        self.ensure_service().await;
+        self.ike.load_all().await
+    }
+
+    /// Validate, persist, and apply a new tunnel. If the apply fails the
+    /// record is rolled back and the previous rendered state restored,
+    /// so a bad tunnel can't take down working ones.
+    pub async fn create_tunnel_applied(&self, tunnel: IpsecTunnel) -> Result<IpsecTunnel> {
+        let tunnel = self.add_tunnel(tunnel).await?;
+        if let Err(e) = self.apply_all().await {
+            tracing::warn!(tunnel = %tunnel.name, error = %e, "ipsec: apply failed — rolling back create");
+            if let Err(re) = self.delete_tunnel(tunnel.id).await {
+                tracing::warn!(error = %re, "ipsec: rollback delete failed");
+            }
+            if let Err(re) = self.apply_all().await {
+                tracing::warn!(error = %re, "ipsec: rollback re-apply failed");
+            }
+            return Err(e);
+        }
+        Ok(tunnel)
+    }
+
+    /// Validate, persist, and apply changes to a tunnel. On apply
+    /// failure the previous record is restored and re-applied.
+    pub async fn update_tunnel_applied(&self, tunnel: IpsecTunnel) -> Result<IpsecTunnel> {
+        let previous = self.get_tunnel(tunnel.id).await?;
+        let updated = self.update_tunnel(tunnel).await?;
+        if let Err(e) = self.apply_all().await {
+            tracing::warn!(tunnel = %updated.name, error = %e, "ipsec: apply failed — restoring previous config");
+            if let Err(re) = self.update_tunnel(previous).await {
+                tracing::warn!(error = %re, "ipsec: rollback restore failed");
+            }
+            if let Err(re) = self.apply_all().await {
+                tracing::warn!(error = %re, "ipsec: rollback re-apply failed");
+            }
+            return Err(e);
+        }
+        Ok(updated)
+    }
+
+    /// Terminate any live SA, delete the record, and apply (which
+    /// removes the rendered files and unloads the conn).
+    pub async fn delete_tunnel_applied(&self, id: Uuid) -> Result<()> {
+        let tunnel = self.get_tunnel(id).await?;
+        if let Err(e) = self.ike.terminate_ike(&tunnel.conn_name(), true).await {
+            // Not fatal: the SA may simply not be up.
+            tracing::debug!(tunnel = %tunnel.name, error = %e, "ipsec: terminate before delete failed");
+        }
+        self.delete_tunnel(id).await?;
+        self.apply_all().await
+    }
+
+    /// Manually initiate a tunnel's child SA (negotiation outcome
+    /// surfaces as the error string on failure).
+    pub async fn start_tunnel(&self, id: Uuid) -> Result<()> {
+        let tunnel = self.get_tunnel(id).await?;
+        if !tunnel.enabled {
+            return Err(AifwError::Validation(format!(
+                "tunnel {} is disabled",
+                tunnel.name
+            )));
+        }
+        self.ike.initiate(&tunnel.child_name(), 30).await
+    }
+
+    /// Tear down a tunnel's IKE SA (and children). The config stays
+    /// loaded; the peer or a manual start can bring it back up.
+    pub async fn stop_tunnel(&self, id: Uuid) -> Result<()> {
+        let tunnel = self.get_tunnel(id).await?;
+        self.ike.terminate_ike(&tunnel.conn_name(), false).await
+    }
+
+    /// Reconcile rendered state with the DB at service startup — covers
+    /// reboot, restore-from-backup, and upgrades. No-op when the box has
+    /// never had IPsec tunnels.
+    pub async fn ensure_applied(&self) -> Result<()> {
+        let have_tunnels = !self.list_tunnels().await?.is_empty();
+        let have_files = !self.store.list_managed().await?.is_empty();
+        if have_tunnels || have_files {
+            self.apply_all().await?;
+        }
+        Ok(())
+    }
+
+    /// Make sure the strongSwan service is enabled and running before we
+    /// talk to it (FreeBSD only; best-effort — a failure surfaces
+    /// naturally as the subsequent `--load-all` error).
+    async fn ensure_service(&self) {
+        if !cfg!(target_os = "freebsd") {
+            return;
+        }
+        let status = crate::sudo::service("strongswan", "status").await;
+        let running = status.map(|o| o.status.success()).unwrap_or(false);
+        if running {
+            return;
+        }
+        if let Err(e) = crate::sudo::sysrc(&["strongswan_enable=YES"]).await {
+            tracing::warn!(error = %e, "ipsec: failed to set strongswan_enable");
+        }
+        match crate::sudo::service("strongswan", "start").await {
+            Ok(o) if !o.status.success() => {
+                let stderr = String::from_utf8_lossy(&o.stderr);
+                tracing::warn!(stderr = %stderr.trim(), "ipsec: strongswan start failed");
+            }
+            Err(e) => tracing::warn!(error = %e, "ipsec: strongswan start failed"),
+            Ok(_) => {}
+        }
+    }
 }
 
 #[cfg(test)]
@@ -590,12 +933,13 @@ mod tests {
     use crate::db::Database;
     use aifw_common::{IpsecAuthMethod, IpsecCertSource, IpsecStartAction};
 
-    async fn engine() -> (IpsecEngine, Arc<MockIkeControl>) {
+    async fn engine() -> (IpsecEngine, Arc<MockIkeControl>, Arc<MemConfStore>) {
         let db = Database::new_in_memory().await.unwrap();
         let ike = Arc::new(MockIkeControl::new());
-        let engine = IpsecEngine::new(db.pool().clone(), ike.clone());
+        let store = Arc::new(MemConfStore::new());
+        let engine = IpsecEngine::new(db.pool().clone(), ike.clone(), store.clone());
         engine.migrate().await.unwrap();
-        (engine, ike)
+        (engine, ike, store)
     }
 
     fn tunnel(name: &str) -> IpsecTunnel {
@@ -610,7 +954,7 @@ mod tests {
 
     #[tokio::test]
     async fn crud_roundtrip() {
-        let (engine, _) = engine().await;
+        let (engine, _, _) = engine().await;
         let t = engine.add_tunnel(tunnel("site-a")).await.unwrap();
 
         let fetched = engine.get_tunnel(t.id).await.unwrap();
@@ -639,14 +983,14 @@ mod tests {
 
     #[tokio::test]
     async fn duplicate_name_rejected() {
-        let (engine, _) = engine().await;
+        let (engine, _, _) = engine().await;
         engine.add_tunnel(tunnel("dup")).await.unwrap();
         assert!(engine.add_tunnel(tunnel("dup")).await.is_err());
     }
 
     #[tokio::test]
     async fn invalid_tunnel_rejected_before_persist() {
-        let (engine, _) = engine().await;
+        let (engine, _, _) = engine().await;
         let mut t = tunnel("bad");
         t.psk = "short".to_string();
         assert!(matches!(
@@ -658,7 +1002,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_missing_tunnel_is_not_found() {
-        let (engine, _) = engine().await;
+        let (engine, _, _) = engine().await;
         assert!(matches!(
             engine.update_tunnel(tunnel("ghost")).await,
             Err(AifwError::NotFound(_))
@@ -671,7 +1015,7 @@ mod tests {
 
     #[tokio::test]
     async fn cert_tunnel_roundtrip() {
-        let (engine, _) = engine().await;
+        let (engine, _, _) = engine().await;
         let mut t = tunnel("cert-site");
         t.auth_method = IpsecAuthMethod::Cert;
         t.psk = String::new();
@@ -747,8 +1091,193 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn apply_writes_conf_and_loads() {
+        let (engine, ike, store) = engine().await;
+        let t = engine
+            .create_tunnel_applied(tunnel("site-a"))
+            .await
+            .unwrap();
+        let conf_path = format!("{SWANCTL_CONF_DIR}/{}.conf", t.conn_name());
+        let conf = String::from_utf8(store.get(&conf_path).unwrap()).unwrap();
+        assert!(conf.contains("remote_addrs = 203.0.113.10"));
+        ike.with_state(|s| assert_eq!(s.load_all_calls, 1));
+    }
+
+    #[tokio::test]
+    async fn disabled_tunnel_not_rendered() {
+        let (engine, _, store) = engine().await;
+        let mut t = tunnel("off");
+        t.enabled = false;
+        engine.create_tunnel_applied(t).await.unwrap();
+        assert!(store.is_empty());
+    }
+
+    #[tokio::test]
+    async fn failed_apply_rolls_back_create() {
+        let (engine, ike, store) = engine().await;
+        engine.create_tunnel_applied(tunnel("good")).await.unwrap();
+        assert_eq!(store.len(), 1);
+
+        ike.with_state(|s| s.fail_load = Some("charon rejected config".to_string()));
+        let err = engine
+            .create_tunnel_applied(tunnel("bad"))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("charon rejected config"));
+
+        // Record rolled back; only the good tunnel's file remains after
+        // the (also failing, but file-restoring) rollback re-apply.
+        ike.with_state(|s| s.fail_load = None);
+        let tunnels = engine.list_tunnels().await.unwrap();
+        assert_eq!(tunnels.len(), 1);
+        assert_eq!(tunnels[0].name, "good");
+        assert_eq!(store.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn failed_apply_rolls_back_update() {
+        let (engine, ike, _) = engine().await;
+        let t = engine
+            .create_tunnel_applied(tunnel("site-a"))
+            .await
+            .unwrap();
+
+        ike.with_state(|s| s.fail_load = Some("boom".to_string()));
+        let mut changed = t.clone();
+        changed.remote_addr = "203.0.113.99".to_string();
+        assert!(engine.update_tunnel_applied(changed).await.is_err());
+
+        let fetched = engine.get_tunnel(t.id).await.unwrap();
+        assert_eq!(fetched.remote_addr, "203.0.113.10");
+    }
+
+    #[tokio::test]
+    async fn delete_terminates_and_removes_files() {
+        let (engine, ike, store) = engine().await;
+        let t = engine
+            .create_tunnel_applied(tunnel("site-a"))
+            .await
+            .unwrap();
+        assert_eq!(store.len(), 1);
+
+        engine.delete_tunnel_applied(t.id).await.unwrap();
+        assert!(store.is_empty());
+        ike.with_state(|s| {
+            assert_eq!(s.terminated, vec![t.conn_name()]);
+            assert_eq!(s.load_all_calls, 2);
+        });
+        assert!(engine.list_tunnels().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn cert_tunnel_renders_material_files() {
+        let (engine, _, store) = engine().await;
+        let mut t = tunnel("cert-site");
+        t.auth_method = IpsecAuthMethod::Cert;
+        t.psk = String::new();
+        t.cert_source = Some(IpsecCertSource::Manual);
+        t.local_cert_pem =
+            "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----".to_string();
+        t.local_key_pem = "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----".to_string();
+        t.ca_cert_pem = "-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----".to_string();
+        let t = engine.create_tunnel_applied(t).await.unwrap();
+
+        let conn = t.conn_name();
+        assert!(
+            store
+                .get(&format!("{SWANCTL_CONF_DIR}/{conn}.conf"))
+                .is_some()
+        );
+        assert!(
+            store
+                .get(&format!("{SWANCTL_X509_DIR}/{conn}.pem"))
+                .is_some()
+        );
+        assert!(
+            store
+                .get(&format!("{SWANCTL_PRIVATE_DIR}/{conn}.pem"))
+                .is_some()
+        );
+        assert!(
+            store
+                .get(&format!("{SWANCTL_X509CA_DIR}/{conn}-ca.pem"))
+                .is_some()
+        );
+
+        engine.delete_tunnel_applied(t.id).await.unwrap();
+        assert!(store.is_empty());
+    }
+
+    #[tokio::test]
+    async fn acme_cert_source_missing_cert_fails_apply() {
+        let (engine, _, _) = engine().await;
+        crate::acme::migrate(&engine.pool).await.unwrap();
+        let mut t = tunnel("acme-site");
+        t.auth_method = IpsecAuthMethod::Cert;
+        t.psk = String::new();
+        t.cert_source = Some(IpsecCertSource::Acme);
+        t.acme_cert_id = Some(999);
+        let err = engine.create_tunnel_applied(t).await.unwrap_err();
+        assert!(err.to_string().contains("not found"));
+        assert!(engine.list_tunnels().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn start_stop_drive_ike_control() {
+        let (engine, ike, _) = engine().await;
+        let t = engine
+            .create_tunnel_applied(tunnel("site-a"))
+            .await
+            .unwrap();
+        engine.start_tunnel(t.id).await.unwrap();
+        engine.stop_tunnel(t.id).await.unwrap();
+        ike.with_state(|s| {
+            assert_eq!(s.initiated, vec![t.child_name()]);
+            assert_eq!(s.terminated, vec![t.conn_name()]);
+        });
+
+        let mut disabled = t.clone();
+        disabled.enabled = false;
+        engine.update_tunnel_applied(disabled).await.unwrap();
+        assert!(engine.start_tunnel(t.id).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn ensure_applied_noop_when_untouched() {
+        let (engine, ike, _) = engine().await;
+        engine.ensure_applied().await.unwrap();
+        ike.with_state(|s| assert_eq!(s.load_all_calls, 0));
+
+        engine
+            .create_tunnel_applied(tunnel("site-a"))
+            .await
+            .unwrap();
+        engine.ensure_applied().await.unwrap();
+        ike.with_state(|s| assert_eq!(s.load_all_calls, 2));
+    }
+
+    #[tokio::test]
+    async fn stale_files_removed_on_apply() {
+        let (engine, _, store) = engine().await;
+        store
+            .write(&format!("{SWANCTL_CONF_DIR}/aifw-stale.conf"), b"leftover")
+            .await
+            .unwrap();
+        engine
+            .create_tunnel_applied(tunnel("site-a"))
+            .await
+            .unwrap();
+        assert!(
+            store
+                .get(&format!("{SWANCTL_CONF_DIR}/aifw-stale.conf"))
+                .is_none()
+        );
+        assert_eq!(store.len(), 1);
+    }
+
+    #[tokio::test]
     async fn mock_ike_records_calls() {
-        let (_, ike) = engine().await;
+        let (_, ike, _) = engine().await;
         ike.load_all().await.unwrap();
         ike.initiate("aifw-x-1", 30).await.unwrap();
         ike.terminate_ike("aifw-x", false).await.unwrap();

--- a/aifw-core/src/ipsec.rs
+++ b/aifw-core/src/ipsec.rs
@@ -12,7 +12,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use aifw_common::{AifwError, IpsecTunnel, Result};
+use aifw_common::{AifwError, IpsecLiveStatus, IpsecTunnel, Result};
 use async_trait::async_trait;
 use sqlx::SqlitePool;
 use uuid::Uuid;
@@ -96,6 +96,34 @@ impl IkeControl for SwanctlControl {
         let output = swanctl_checked(&["--list-conns", "--raw"]).await?;
         Ok(String::from_utf8_lossy(&output.stdout).into_owned())
     }
+}
+
+/// Platform-appropriate IKE control, mirroring `aifw_pf::create_backend`:
+/// swanctl on FreeBSD, in-memory mock everywhere else.
+#[cfg(target_os = "freebsd")]
+pub fn create_ike_control() -> Arc<dyn IkeControl> {
+    Arc::new(SwanctlControl)
+}
+
+/// Platform-appropriate IKE control, mirroring `aifw_pf::create_backend`:
+/// swanctl on FreeBSD, in-memory mock everywhere else.
+#[cfg(not(target_os = "freebsd"))]
+pub fn create_ike_control() -> Arc<dyn IkeControl> {
+    Arc::new(MockIkeControl::new())
+}
+
+/// Platform-appropriate swanctl conf store: real root-owned files on
+/// FreeBSD, in-memory map everywhere else.
+#[cfg(target_os = "freebsd")]
+pub fn create_conf_store() -> Arc<dyn IpsecConfStore> {
+    Arc::new(SystemConfStore)
+}
+
+/// Platform-appropriate swanctl conf store: real root-owned files on
+/// FreeBSD, in-memory map everywhere else.
+#[cfg(not(target_os = "freebsd"))]
+pub fn create_conf_store() -> Arc<dyn IpsecConfStore> {
+    Arc::new(MemConfStore::new())
 }
 
 /// Recorded state of a [`MockIkeControl`], inspectable from tests.
@@ -899,6 +927,49 @@ impl IpsecEngine {
             self.apply_all().await?;
         }
         Ok(())
+    }
+
+    /// Live negotiated status for every tunnel, ordered like
+    /// `list_tunnels`. Tunnels charon has no SA for — including disabled
+    /// ones — report as `DOWN`. A failing `list-sas` (charon not
+    /// running) degrades to all-down rather than erroring: status pages
+    /// must render on a box where IPsec never started.
+    pub async fn live_status(&self) -> Result<Vec<IpsecLiveStatus>> {
+        let tunnels = self.list_tunnels().await?;
+        if tunnels.is_empty() {
+            return Ok(Vec::new());
+        }
+        let raw = match self.ike.list_sas_raw().await {
+            Ok(raw) => raw,
+            Err(e) => {
+                tracing::warn!(error = %e, "ipsec: list-sas failed — reporting all tunnels down");
+                String::new()
+            }
+        };
+        let mut live = crate::ipsec_status::parse_list_sas(&raw);
+        Ok(tunnels
+            .iter()
+            .map(|t| {
+                live.remove(&t.conn_name())
+                    .unwrap_or_else(|| IpsecLiveStatus::down(t.id, t.conn_name()))
+            })
+            .collect())
+    }
+
+    /// Live negotiated status for one tunnel.
+    pub async fn tunnel_status(&self, id: Uuid) -> Result<IpsecLiveStatus> {
+        let tunnel = self.get_tunnel(id).await?;
+        let raw = match self.ike.list_sas_raw().await {
+            Ok(raw) => raw,
+            Err(e) => {
+                tracing::warn!(error = %e, "ipsec: list-sas failed — reporting tunnel down");
+                String::new()
+            }
+        };
+        let mut live = crate::ipsec_status::parse_list_sas(&raw);
+        Ok(live
+            .remove(&tunnel.conn_name())
+            .unwrap_or_else(|| IpsecLiveStatus::down(tunnel.id, tunnel.conn_name())))
     }
 
     /// Make sure the strongSwan service is enabled and running before we

--- a/aifw-core/src/ipsec_status.rs
+++ b/aifw-core/src/ipsec_status.rs
@@ -23,22 +23,41 @@ enum Node {
 }
 
 /// Tokenize: whitespace-separated atoms, with `{ } [ ]` split off token
-/// edges. A bare `=` token is the key/value separator; `=` inside an
-/// atom (DN identities like `C=US`) stays part of the atom.
+/// edges. The real appliance emits the compact form `key=value` with no
+/// spaces (verified on FreeBSD 15 / strongSwan 5.9), so a fragment
+/// containing `=` splits at the FIRST `=` into key / `=` / value —
+/// later `=` chars stay in the value (DN identities like `C=US`). The
+/// indented `key = value` form tokenizes naturally via the standalone
+/// `=` word.
 fn tokenize(input: &str) -> Vec<String> {
     let mut tokens = Vec::new();
+    let push_fragment = |frag: &str, tokens: &mut Vec<String>| {
+        if frag.is_empty() {
+            return;
+        }
+        if frag == "=" {
+            tokens.push("=".to_string());
+            return;
+        }
+        match frag.split_once('=') {
+            Some((key, value)) if !key.is_empty() => {
+                tokens.push(key.to_string());
+                tokens.push("=".to_string());
+                if !value.is_empty() {
+                    tokens.push(value.to_string());
+                }
+            }
+            _ => tokens.push(frag.to_string()),
+        }
+    };
     for word in input.split_whitespace() {
         let mut rest = word;
         loop {
             let Some(pos) = rest.find(['{', '}', '[', ']']) else {
-                if !rest.is_empty() {
-                    tokens.push(rest.to_string());
-                }
+                push_fragment(rest, &mut tokens);
                 break;
             };
-            if pos > 0 {
-                tokens.push(rest[..pos].to_string());
-            }
+            push_fragment(&rest[..pos], &mut tokens);
             tokens.push(rest[pos..pos + 1].to_string());
             rest = &rest[pos + 1..];
         }
@@ -70,7 +89,7 @@ fn parse_entries(tokens: &[String], pos: &mut usize) -> Vec<(String, Node)> {
                     }
                     *pos += 1; // consume "]"
                     entries.push((key, Node::List(items)));
-                } else if *pos < tokens.len() {
+                } else if *pos < tokens.len() && tokens[*pos] != "{" && tokens[*pos] != "}" {
                     entries.push((key, Node::Value(tokens[*pos].clone())));
                     *pos += 1;
                 }
@@ -306,6 +325,25 @@ mod tests {
             .get("aifw-11111111-2222-3333-4444-555555555555")
             .unwrap();
         assert_eq!(sa.ike_state, "CONNECTING");
+        assert!(sa.child_sas.is_empty());
+    }
+
+    // Captured verbatim from FreeBSD 15.0 / strongSwan 5.9.14
+    // (`aifw-sudo-swanctl --list-sas --raw`, tunnel initiating toward an
+    // unreachable peer). The real compact form has NO spaces around `=`.
+    const RAW_REAL: &str = "list-sa event {aifw-2034aa9d-ef08-4c9f-a4c4-f6d80c888823 {uniqueid=1 version=2 state=CONNECTING local-host=172.29.50.220 local-port=500 local-id=%any remote-host=203.0.113.10 remote-port=500 remote-id=%any initiator=yes initiator-spi=00f1cbca60dae3e7 responder-spi=0000000000000000 tasks-active=[IKE_VENDOR IKE_INIT IKE_NATD IKE_CERT_PRE IKE_AUTH IKE_CERT_POST IKE_CONFIG IKE_AUTH_LIFETIME IKE_MOBIKE IKE_ESTABLISH CHILD_CREATE] child-sas {}}}\nlist-sas reply {}\n";
+
+    #[test]
+    fn real_freebsd_compact_output_parses() {
+        let map = parse_list_sas(RAW_REAL);
+        assert_eq!(map.len(), 1);
+        let sa = map
+            .get("aifw-2034aa9d-ef08-4c9f-a4c4-f6d80c888823")
+            .unwrap();
+        assert_eq!(sa.ike_state, "CONNECTING");
+        assert_eq!(sa.ike_version, Some(2));
+        assert_eq!(sa.remote_host.as_deref(), Some("203.0.113.10"));
+        assert_eq!(sa.established_secs, None);
         assert!(sa.child_sas.is_empty());
     }
 }

--- a/aifw-core/src/ipsec_status.rs
+++ b/aifw-core/src/ipsec_status.rs
@@ -1,0 +1,311 @@
+//! Parser for `swanctl --list-sas --raw` output (#530).
+//!
+//! `--raw` prints the vici `list-sa` message as an indented tree of
+//! `name {` sections, `key = value` pairs and `key = [ ... ]` lists.
+//! This module parses that tree generically and extracts
+//! [`IpsecLiveStatus`] for AiFw-managed conns (`aifw-*`). The parser is
+//! deliberately tolerant: unknown keys are ignored, stray atoms are
+//! skipped, and a malformed document yields whatever entries were
+//! recovered — status reporting must degrade, not error, when charon
+//! adds fields.
+
+use std::collections::HashMap;
+
+use aifw_common::{ChildSaStatus, IpsecLiveStatus};
+use uuid::Uuid;
+
+/// One parsed node: a nested section, a scalar, or a list.
+#[derive(Debug, Clone)]
+enum Node {
+    Section(Vec<(String, Node)>),
+    Value(String),
+    List(Vec<String>),
+}
+
+/// Tokenize: whitespace-separated atoms, with `{ } [ ]` split off token
+/// edges. A bare `=` token is the key/value separator; `=` inside an
+/// atom (DN identities like `C=US`) stays part of the atom.
+fn tokenize(input: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    for word in input.split_whitespace() {
+        let mut rest = word;
+        loop {
+            let Some(pos) = rest.find(['{', '}', '[', ']']) else {
+                if !rest.is_empty() {
+                    tokens.push(rest.to_string());
+                }
+                break;
+            };
+            if pos > 0 {
+                tokens.push(rest[..pos].to_string());
+            }
+            tokens.push(rest[pos..pos + 1].to_string());
+            rest = &rest[pos + 1..];
+        }
+    }
+    tokens
+}
+
+/// Parse a token stream into entries until the matching `}` (or end).
+fn parse_entries(tokens: &[String], pos: &mut usize) -> Vec<(String, Node)> {
+    let mut entries = Vec::new();
+    let mut pending: Option<String> = None;
+    while *pos < tokens.len() {
+        let tok = tokens[*pos].as_str();
+        *pos += 1;
+        match tok {
+            "{" => {
+                let name = pending.take().unwrap_or_default();
+                entries.push((name, Node::Section(parse_entries(tokens, pos))));
+            }
+            "}" => break,
+            "=" => {
+                let Some(key) = pending.take() else { continue };
+                if *pos < tokens.len() && tokens[*pos] == "[" {
+                    *pos += 1;
+                    let mut items = Vec::new();
+                    while *pos < tokens.len() && tokens[*pos] != "]" {
+                        items.push(tokens[*pos].clone());
+                        *pos += 1;
+                    }
+                    *pos += 1; // consume "]"
+                    entries.push((key, Node::List(items)));
+                } else if *pos < tokens.len() {
+                    entries.push((key, Node::Value(tokens[*pos].clone())));
+                    *pos += 1;
+                }
+            }
+            atom => {
+                // A new atom displaces any stray previous one (e.g. the
+                // "list-sa event" preamble atoms before the first brace).
+                pending = Some(atom.to_string());
+            }
+        }
+    }
+    entries
+}
+
+fn get<'a>(entries: &'a [(String, Node)], key: &str) -> Option<&'a Node> {
+    entries.iter().find(|(k, _)| k == key).map(|(_, v)| v)
+}
+
+fn get_value(entries: &[(String, Node)], key: &str) -> Option<String> {
+    match get(entries, key) {
+        Some(Node::Value(v)) => Some(v.clone()),
+        _ => None,
+    }
+}
+
+fn get_u64(entries: &[(String, Node)], key: &str) -> Option<u64> {
+    get_value(entries, key).and_then(|v| v.parse().ok())
+}
+
+fn get_list(entries: &[(String, Node)], key: &str) -> Vec<String> {
+    match get(entries, key) {
+        Some(Node::List(items)) => items.clone(),
+        // Single-element lists sometimes render as plain values.
+        Some(Node::Value(v)) => vec![v.clone()],
+        _ => Vec::new(),
+    }
+}
+
+/// Recursively collect every section whose name starts with `aifw-`,
+/// skipping `child-sas` containers (children are handled per-conn).
+fn collect_aifw_sections<'a>(
+    entries: &'a [(String, Node)],
+    out: &mut Vec<(&'a str, &'a [(String, Node)])>,
+) {
+    for (name, node) in entries {
+        if let Node::Section(inner) = node {
+            if name.starts_with("aifw-") {
+                out.push((name.as_str(), inner));
+            } else {
+                collect_aifw_sections(inner, out);
+            }
+        }
+    }
+}
+
+fn parse_child(section_key: &str, entries: &[(String, Node)]) -> ChildSaStatus {
+    let enc_alg =
+        get_value(entries, "enc-alg").map(|alg| match get_value(entries, "enc-keysize") {
+            Some(bits) => format!("{alg}-{bits}"),
+            None => alg,
+        });
+    ChildSaStatus {
+        // vici keys child sections by "<name>-<uniqueid>"; the inner
+        // `name` field is the configured child name.
+        name: get_value(entries, "name").unwrap_or_else(|| section_key.to_string()),
+        state: get_value(entries, "state").unwrap_or_else(|| "UNKNOWN".to_string()),
+        local_ts: get_list(entries, "local-ts"),
+        remote_ts: get_list(entries, "remote-ts"),
+        bytes_in: get_u64(entries, "bytes-in").unwrap_or(0),
+        bytes_out: get_u64(entries, "bytes-out").unwrap_or(0),
+        rekey_in_secs: get_u64(entries, "rekey-time"),
+        enc_alg,
+    }
+}
+
+/// Parse raw `--list-sas` output into per-conn live statuses, keyed by
+/// conn name (`aifw-<id>`). Conns absent from the output are simply not
+/// in the map — callers report those as down.
+pub fn parse_list_sas(raw: &str) -> HashMap<String, IpsecLiveStatus> {
+    let tokens = tokenize(raw);
+    let mut pos = 0;
+    let root = parse_entries(&tokens, &mut pos);
+
+    let mut sections = Vec::new();
+    collect_aifw_sections(&root, &mut sections);
+
+    let mut result = HashMap::new();
+    for (conn_name, entries) in sections {
+        // Child sections also start with aifw- — only IKE SA sections
+        // have a `state` at this level AND a parseable tunnel id.
+        let Some(tunnel_id) = conn_name
+            .strip_prefix("aifw-")
+            .and_then(|rest| Uuid::parse_str(rest).ok())
+        else {
+            continue;
+        };
+        let mut child_sas = Vec::new();
+        if let Some(Node::Section(children)) = get(entries, "child-sas") {
+            for (key, node) in children {
+                if let Node::Section(child_entries) = node {
+                    child_sas.push(parse_child(key, child_entries));
+                }
+            }
+        }
+        let status = IpsecLiveStatus {
+            tunnel_id,
+            conn_name: conn_name.to_string(),
+            ike_state: get_value(entries, "state").unwrap_or_else(|| "UNKNOWN".to_string()),
+            established_secs: get_u64(entries, "established"),
+            remote_host: get_value(entries, "remote-host"),
+            ike_version: get_value(entries, "version").and_then(|v| v.parse().ok()),
+            child_sas,
+        };
+        result.insert(conn_name.to_string(), status);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Shaped like vici_dump output from `swanctl --list-sas --raw`
+    // (indented sections, key = value, lists in brackets). Phase 6
+    // replaces this with a fixture captured from the real appliance.
+    const RAW: &str = r#"list-sa event {
+  aifw-11111111-2222-3333-4444-555555555555 {
+    uniqueid = 4
+    version = 2
+    state = ESTABLISHED
+    local-host = 198.51.100.1
+    local-port = 4500
+    local-id = 198.51.100.1
+    remote-host = 203.0.113.10
+    remote-port = 4500
+    remote-id = C=US, O=AiFw, CN=site-b
+    initiator = yes
+    nat-remote = yes
+    encr-alg = AES_GCM_16
+    encr-keysize = 256
+    established = 773
+    rekey-time = 13627
+    child-sas {
+      aifw-11111111-2222-3333-4444-555555555555-1-4 {
+        name = aifw-11111111-2222-3333-4444-555555555555-1
+        uniqueid = 4
+        reqid = 1
+        state = INSTALLED
+        mode = TUNNEL
+        protocol = ESP
+        encap = yes
+        spi-in = c9a21f0c
+        spi-out = cbdec299
+        enc-alg = AES_GCM_16
+        enc-keysize = 256
+        bytes-in = 1234
+        packets-in = 5
+        bytes-out = 5678
+        packets-out = 6
+        rekey-time = 3229
+        life-time = 3922
+        install-time = 38
+        local-ts = [
+          10.0.0.0/24
+        ]
+        remote-ts = [
+          10.1.0.0/24
+          10.2.0.0/24
+        ]
+      }
+    }
+  }
+}
+"#;
+
+    #[test]
+    fn parses_established_sa() {
+        let map = parse_list_sas(RAW);
+        assert_eq!(map.len(), 1);
+        let sa = map
+            .get("aifw-11111111-2222-3333-4444-555555555555")
+            .unwrap();
+        assert_eq!(sa.ike_state, "ESTABLISHED");
+        assert_eq!(sa.established_secs, Some(773));
+        assert_eq!(sa.remote_host.as_deref(), Some("203.0.113.10"));
+        assert_eq!(sa.ike_version, Some(2));
+        assert_eq!(
+            sa.tunnel_id.to_string(),
+            "11111111-2222-3333-4444-555555555555"
+        );
+
+        assert_eq!(sa.child_sas.len(), 1);
+        let child = &sa.child_sas[0];
+        assert_eq!(child.name, "aifw-11111111-2222-3333-4444-555555555555-1");
+        assert_eq!(child.state, "INSTALLED");
+        assert_eq!(child.bytes_in, 1234);
+        assert_eq!(child.bytes_out, 5678);
+        assert_eq!(child.rekey_in_secs, Some(3229));
+        assert_eq!(child.enc_alg.as_deref(), Some("AES_GCM_16-256"));
+        assert_eq!(child.local_ts, vec!["10.0.0.0/24"]);
+        assert_eq!(child.remote_ts, vec!["10.1.0.0/24", "10.2.0.0/24"]);
+    }
+
+    #[test]
+    fn dn_identities_with_equals_do_not_break_structure() {
+        // The DN `remote-id = C=US, O=AiFw, CN=site-b` contains atoms
+        // with embedded `=`; the parser must not lose the section tree.
+        let map = parse_list_sas(RAW);
+        let sa = map
+            .get("aifw-11111111-2222-3333-4444-555555555555")
+            .unwrap();
+        assert_eq!(sa.ike_state, "ESTABLISHED");
+    }
+
+    #[test]
+    fn empty_and_garbage_inputs_yield_empty() {
+        assert!(parse_list_sas("").is_empty());
+        assert!(parse_list_sas("no sas found").is_empty());
+        assert!(parse_list_sas("}{ ] [ = = {").is_empty());
+        // non-aifw conns are ignored
+        let other = "list-sa event {\n  corporate {\n    state = ESTABLISHED\n  }\n}\n";
+        assert!(parse_list_sas(other).is_empty());
+        // aifw- prefixed but not a uuid (not ours) is ignored
+        let bad = "list-sa event {\n  aifw-notauuid {\n    state = ESTABLISHED\n  }\n}\n";
+        assert!(parse_list_sas(bad).is_empty());
+    }
+
+    #[test]
+    fn compact_single_line_form_parses_too() {
+        let compact = "list-sa event {aifw-11111111-2222-3333-4444-555555555555 {version = 2 state = CONNECTING child-sas {}}}";
+        let map = parse_list_sas(compact);
+        let sa = map
+            .get("aifw-11111111-2222-3333-4444-555555555555")
+            .unwrap();
+        assert_eq!(sa.ike_state, "CONNECTING");
+        assert!(sa.child_sas.is_empty());
+    }
+}

--- a/aifw-core/src/lib.rs
+++ b/aifw-core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod error;
 pub mod geoip;
 /// [`ClusterEngine`] and CARP role helpers for high-availability clustering
 pub mod ha;
+pub mod ipsec;
 pub mod migrations;
 pub mod multiwan;
 /// [`NatEngine`] — SNAT/DNAT/masquerade rule CRUD and application to pf
@@ -68,6 +69,7 @@ pub use engine::RuleEngine;
 pub use error::{CoreError, Result};
 pub use geoip::GeoIpEngine;
 pub use ha::{ClusterEngine, current_local_role, is_local_master, sha256_hex};
+pub use ipsec::{IkeControl, IpsecEngine, MockIkeControl, SwanctlControl, render_swanctl_conf};
 pub use multiwan::{
     GatewayEngine, GroupEngine, InstanceEngine, LeakEngine, PolicyEngine, PreflightEngine,
     SlaEngine,

--- a/aifw-core/src/lib.rs
+++ b/aifw-core/src/lib.rs
@@ -69,7 +69,10 @@ pub use engine::RuleEngine;
 pub use error::{CoreError, Result};
 pub use geoip::GeoIpEngine;
 pub use ha::{ClusterEngine, current_local_role, is_local_master, sha256_hex};
-pub use ipsec::{IkeControl, IpsecEngine, MockIkeControl, SwanctlControl, render_swanctl_conf};
+pub use ipsec::{
+    IkeControl, IpsecConfStore, IpsecEngine, MemConfStore, MockIkeControl, SwanctlControl,
+    SystemConfStore, render_swanctl_conf,
+};
 pub use multiwan::{
     GatewayEngine, GroupEngine, InstanceEngine, LeakEngine, PolicyEngine, PreflightEngine,
     SlaEngine,

--- a/aifw-core/src/lib.rs
+++ b/aifw-core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod geoip;
 /// [`ClusterEngine`] and CARP role helpers for high-availability clustering
 pub mod ha;
 pub mod ipsec;
+pub mod ipsec_status;
 pub mod migrations;
 pub mod multiwan;
 /// [`NatEngine`] — SNAT/DNAT/masquerade rule CRUD and application to pf
@@ -71,7 +72,7 @@ pub use geoip::GeoIpEngine;
 pub use ha::{ClusterEngine, current_local_role, is_local_master, sha256_hex};
 pub use ipsec::{
     IkeControl, IpsecConfStore, IpsecEngine, MemConfStore, MockIkeControl, SwanctlControl,
-    SystemConfStore, render_swanctl_conf,
+    SystemConfStore, create_conf_store, create_ike_control, render_swanctl_conf,
 };
 pub use multiwan::{
     GatewayEngine, GroupEngine, InstanceEngine, LeakEngine, PolicyEngine, PreflightEngine,

--- a/aifw-core/src/sudo.rs
+++ b/aifw-core/src/sudo.rs
@@ -79,6 +79,7 @@ const HELPER_MKDIR: &str = "/usr/local/libexec/aifw-sudo-mkdir";
 const HELPER_CP: &str = "/usr/local/libexec/aifw-sudo-cp";
 const HELPER_TAR: &str = "/usr/local/libexec/aifw-sudo-tar";
 const HELPER_TCPDUMP: &str = "/usr/local/libexec/aifw-sudo-tcpdump";
+const HELPER_SWANCTL: &str = "/usr/local/libexec/aifw-sudo-swanctl";
 
 /// Atomically write `contents` to `path`, as root, via the
 /// `aifw-sudo-write` helper script.
@@ -370,6 +371,22 @@ pub async fn tar(args: &[&str]) -> std::io::Result<std::process::Output> {
     let mut fallback: Vec<&str> = vec!["/usr/bin/tar"];
     fallback.extend_from_slice(args);
     sudo_with_fallback(&narrow, &fallback).await
+}
+
+/// Run `swanctl <verb> [args...]` as root via the `aifw-sudo-swanctl`
+/// helper (#530 IPsec data plane).
+///
+/// The helper restricts the verb to `--load-all` / `--initiate` /
+/// `--terminate` / `--list-sas` / `--list-conns` and pins every conn or
+/// child name to the `aifw-*` namespace. Unlike the pre-#204 wrappers
+/// there is no broad-grant fallback: no legacy sudoers ever granted
+/// swanctl, so a refusal means the box's sudoers predates this feature
+/// and simply hasn't been refreshed yet (aifw-restart.sh does that on
+/// the next service bounce).
+pub async fn swanctl(args: &[&str]) -> std::io::Result<std::process::Output> {
+    let mut argv: Vec<&str> = vec![HELPER_SWANCTL];
+    argv.extend_from_slice(args);
+    Command::new(SUDO).args(&argv).output().await
 }
 
 /// Run tcpdump via `aifw-sudo-tcpdump`. The helper rejects `-z` (postrotate

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -1034,6 +1034,8 @@ mod tests {
         tunnel.status = VpnStatus::Up;
         engine.add_wg_tunnel(tunnel).await.unwrap();
 
+        // Legacy CRUD-only SA (#530): must NOT emit pf rules — it has no
+        // data plane, so its pf holes were pure attack surface.
         engine
             .add_ipsec_sa(IpsecSa::new(
                 "ipsec0".to_string(),
@@ -1045,16 +1047,37 @@ mod tests {
             .await
             .unwrap();
 
+        // Real IPsec tunnel (#530 ipsec_tunnels): emits IKE/ESP/enc0 rules.
+        let ipsec_engine = crate::ipsec::IpsecEngine::new(
+            db.pool().clone(),
+            std::sync::Arc::new(crate::ipsec::MockIkeControl::new()),
+            std::sync::Arc::new(crate::ipsec::MemConfStore::new()),
+        );
+        ipsec_engine.migrate().await.unwrap();
+        ipsec_engine
+            .add_tunnel(aifw_common::IpsecTunnel::new(
+                "site-a".to_string(),
+                "203.0.113.10".to_string(),
+                "correct-horse-battery-staple".to_string(),
+                vec!["10.0.0.0/24".to_string()],
+                vec!["10.1.0.0/24".to_string()],
+            ))
+            .await
+            .unwrap();
+
         engine.apply_vpn_rules().await.unwrap();
 
         let pf_rules = mock.get_rules("aifw-vpn").await.unwrap();
-        // 1 NAT rule + 2 WG rules + 5 IPsec rules (tunnel mode)
+        // 1 NAT rule + 2 WG rules + 5 tunnel rules; legacy SA contributes 0
         assert_eq!(pf_rules.len(), 8);
         // NAT must precede filter rules or pfctl rejects the ruleset
         assert_eq!(pf_rules[0], "nat on em0 from 10.0.0.0/24 to any -> (em0)");
         assert!(pf_rules.iter().any(|r| r.contains("port 51820")));
         assert!(pf_rules.iter().any(|r| r.contains("proto esp")));
         assert!(pf_rules.iter().any(|r| r.contains("on enc0")));
+        assert!(pf_rules.iter().any(|r| r.contains("203.0.113.10")));
+        // legacy SA endpoints must not appear anywhere
+        assert!(!pf_rules.iter().any(|r| r.contains("5.6.7.8")));
     }
 
     #[tokio::test]

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -108,6 +108,10 @@ const EMBEDDED_SUDO_HELPERS: &[(&str, &str)] = &[
         "aifw-sudo-tcpdump",
         include_str!("../../freebsd/overlay/usr/local/libexec/aifw-sudo-tcpdump"),
     ),
+    (
+        "aifw-sudo-swanctl",
+        include_str!("../../freebsd/overlay/usr/local/libexec/aifw-sudo-swanctl"),
+    ),
 ];
 
 #[derive(Deserialize)]
@@ -121,6 +125,12 @@ struct Manifest {
     #[serde(default)]
     libexec_scripts: Vec<String>,
     directories: Vec<String>,
+    /// OS packages the appliance needs at runtime. Installed by
+    /// build-iso.sh at image build; the updater installs any that are
+    /// missing so in-place upgrades pick up new dependencies (#530
+    /// added strongswan this way).
+    #[serde(default)]
+    packages: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -611,8 +621,11 @@ pub async fn install_from_path(
     // artifact shipped by the update tarball / ISO / deploy.sh, written by
     // a privileged installer step.
 
-    // Ensure required packages are installed (older installs may be missing curl)
-    for pkg in &["curl"] {
+    // Ensure required packages are installed — older installs may predate a
+    // dependency (curl pre-5.x, strongswan pre-#530). Driven by the
+    // manifest `packages` list so new deps flow to upgraded boxes.
+    for pkg in &load_manifest().packages {
+        let pkg = pkg.as_str();
         let check = Command::new("pkg").args(["info", "-q", pkg]).output().await;
         let pkg_installed = check.map(|o| o.status.success()).unwrap_or(false);
         if !pkg_installed {
@@ -1533,6 +1546,42 @@ mod tests {
                 "{} exists in the overlay but is missing from \
                  EMBEDDED_SUDO_HELPERS in updater.rs",
                 name
+            );
+        }
+    }
+
+    // manifest.json `packages` is the source of truth for runtime OS
+    // dependencies, but build-iso.sh and deploy.sh carry hardcoded copies
+    // (no jq in the ISO build chroot). Keep them in sync (#530 added
+    // strongswan this way).
+    #[test]
+    fn test_manifest_packages_synced_with_build_scripts() {
+        let manifest = load_manifest();
+        assert!(
+            !manifest.packages.is_empty(),
+            "manifest.json packages list is empty"
+        );
+        let build_iso = include_str!("../../freebsd/build-iso.sh");
+        let deploy = include_str!("../../freebsd/deploy.sh");
+        let iso_line = build_iso
+            .lines()
+            .find(|l| l.contains("pkg install -y"))
+            .expect("build-iso.sh has a pkg install line");
+        let deploy_line = deploy
+            .lines()
+            .find(|l| l.trim_start().starts_with("for pkg in "))
+            .expect("deploy.sh has a dependency for-loop");
+        for pkg in &manifest.packages {
+            let pkg = pkg.as_str();
+            assert!(
+                iso_line.split_whitespace().any(|w| w == pkg),
+                "package {pkg:?} from manifest.json missing from build-iso.sh pkg install line: {iso_line}"
+            );
+            assert!(
+                deploy_line
+                    .split_whitespace()
+                    .any(|w| w.trim_end_matches(';') == pkg),
+                "package {pkg:?} from manifest.json missing from deploy.sh dependency loop: {deploy_line}"
             );
         }
     }

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -779,16 +779,36 @@ impl VpnEngine {
 
     /// Collect VPN pf filter (pass) rules without loading them. Only tunnels
     /// marked up contribute rules — a stopped tunnel must not hold its
-    /// listen-port open. IPsec SAs are always included.
+    /// listen-port open. Enabled IPsec tunnels (#530 `ipsec_tunnels`)
+    /// contribute IKE/ESP/enc0 rules; legacy `ipsec_sas` records are
+    /// configuration-only and deliberately emit nothing — they never had a
+    /// data plane, so their pf holes were pure attack surface.
     pub async fn collect_vpn_rules(&self) -> Result<Vec<String>> {
         let mut pf_rules = Vec::new();
         let tunnels = self.list_wg_tunnels().await?;
         for t in tunnels.iter().filter(|t| t.status == VpnStatus::Up) {
             pf_rules.extend(t.to_pf_rules());
         }
-        let sas = self.list_ipsec_sas().await?;
-        for sa in &sas {
-            pf_rules.extend(sa.to_pf_rules());
+        // Tolerate a missing ipsec_tunnels table: some callers (daemon
+        // early boot, partial restores) run before IpsecEngine::migrate.
+        match sqlx::query_as::<_, (String, String, String)>(
+            "SELECT id, local_addr, remote_addr FROM ipsec_tunnels WHERE enabled = 1 ORDER BY created_at ASC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        {
+            Ok(rows) => {
+                for (id, local, remote) in &rows {
+                    pf_rules.extend(aifw_common::ipsec::endpoint_pf_rules(
+                        &format!("aifw-{id}"),
+                        local,
+                        remote,
+                    ));
+                }
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "ipsec_tunnels not readable (pre-migration?) — no IPsec pf rules");
+            }
         }
         Ok(pf_rules)
     }

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -2559,6 +2559,7 @@ aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-mkdir *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-cp *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-tar *
 aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-tcpdump *
+aifw ALL=(root) NOPASSWD: /usr/local/libexec/aifw-sudo-swanctl *
 
 # --- Broad compat grants ---
 # Kept alongside the narrow helpers above for upgrade compat: in-place
@@ -2785,6 +2786,7 @@ mod sudoers_tests {
             "/usr/local/libexec/aifw-sudo-cp",
             "/usr/local/libexec/aifw-sudo-tar",
             "/usr/local/libexec/aifw-sudo-tcpdump",
+            "/usr/local/libexec/aifw-sudo-swanctl",
         ] {
             assert!(
                 content.contains(helper),

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.104.0",
+  "version": "5.105.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.109.0",
+  "version": "5.109.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.108.0",
+  "version": "5.109.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.106.0",
+  "version": "5.107.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.105.0",
+  "version": "5.106.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.107.0",
+  "version": "5.108.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/aifw-ui/src/app/vpn/components/IpsecForm.tsx
+++ b/aifw-ui/src/app/vpn/components/IpsecForm.tsx
@@ -1,94 +1,319 @@
 "use client";
 
+import { useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
-import type { IpsecFormState } from "@/lib/api/vpn";
+import type { IpsecFormState, AcmeCertOption } from "@/lib/api/vpn";
 import { inputCls, selectCls, labelCls, btnPrimary, btnCancel } from "./styles";
 
 interface IpsecFormProps {
   ipsecForm: IpsecFormState;
   setIpsecForm: Dispatch<SetStateAction<IpsecFormState>>;
+  editingIpsecId: string | null;
   ipsecSubmitting: boolean;
+  acmeCerts: AcmeCertOption[];
   onSubmit: () => void;
   onCancel: () => void;
 }
 
-/* ────────────────────────── IPsec form ────────────────────────── */
+const textareaCls =
+  "w-full px-2.5 py-1.5 bg-gray-800 border border-gray-600 rounded-md text-xs font-mono text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 min-h-20";
 
-export function IpsecForm({ ipsecForm, setIpsecForm, ipsecSubmitting, onSubmit, onCancel }: IpsecFormProps) {
+/* ────────────────────────── IPsec tunnel form ────────────────────────── */
+
+export function IpsecForm({
+  ipsecForm,
+  setIpsecForm,
+  editingIpsecId,
+  ipsecSubmitting,
+  acmeCerts,
+  onSubmit,
+  onCancel,
+}: IpsecFormProps) {
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const set = (patch: Partial<IpsecFormState>) => setIpsecForm((f) => ({ ...f, ...patch }));
+
+  const tsOk = (s: string) => s.split(",").some((p) => p.trim().length > 0);
+  const secretOk =
+    ipsecForm.auth_method === "psk"
+      ? !!editingIpsecId || ipsecForm.psk.trim().length >= 16
+      : ipsecForm.cert_source === "acme"
+        ? !!ipsecForm.acme_cert_id
+        : !!editingIpsecId || (!!ipsecForm.local_cert_pem.trim() && !!ipsecForm.local_key_pem.trim());
+  const canSubmit =
+    !ipsecSubmitting &&
+    ipsecForm.name.trim() &&
+    ipsecForm.remote_addr.trim() &&
+    tsOk(ipsecForm.local_ts) &&
+    tsOk(ipsecForm.remote_ts) &&
+    secretOk;
+
   return (
-    <div className="px-4 py-4 bg-gray-900/50 border-b border-gray-700">
-      <h3 className="text-sm font-semibold text-white mb-3">New IPsec SA</h3>
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+    <div className="px-4 py-4 bg-gray-900/50 border-b border-gray-700 space-y-4">
+      <h3 className="text-sm font-semibold text-white">
+        {editingIpsecId ? "Edit IPsec Tunnel" : "New IPsec Tunnel"}
+        <span className="ml-2 text-xs font-normal text-gray-500">
+          IKEv2 site-to-site (tunnel mode)
+        </span>
+      </h3>
+
+      {/* Endpoints */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
         <div>
           <label className={labelCls}>Name</label>
           <input
             type="text"
             value={ipsecForm.name}
-            onChange={(e) => setIpsecForm((f) => ({ ...f, name: e.target.value }))}
-            placeholder="e.g. office-vpn"
+            onChange={(e) => set({ name: e.target.value })}
+            placeholder="e.g. branch-office"
             className={inputCls}
           />
         </div>
         <div>
-          <label className={labelCls}>Local Address</label>
-          <input
-            type="text"
-            value={ipsecForm.local_addr}
-            onChange={(e) => setIpsecForm((f) => ({ ...f, local_addr: e.target.value }))}
-            placeholder="203.0.113.1"
-            className={inputCls}
-          />
-        </div>
-        <div>
-          <label className={labelCls}>Remote Address</label>
+          <label className={labelCls}>Remote Endpoint</label>
           <input
             type="text"
             value={ipsecForm.remote_addr}
-            onChange={(e) => setIpsecForm((f) => ({ ...f, remote_addr: e.target.value }))}
-            placeholder="198.51.100.1"
+            onChange={(e) => set({ remote_addr: e.target.value })}
+            placeholder="198.51.100.1 or vpn.example.com"
             className={inputCls}
           />
         </div>
         <div>
-          <label className={labelCls}>Protocol</label>
-          <select
-            value={ipsecForm.protocol}
-            onChange={(e) => setIpsecForm((f) => ({ ...f, protocol: e.target.value }))}
-            className={selectCls}
-          >
-            <option value="esp">ESP</option>
-            <option value="ah">AH</option>
-          </select>
+          <label className={labelCls}>Local Subnets</label>
+          <input
+            type="text"
+            value={ipsecForm.local_ts}
+            onChange={(e) => set({ local_ts: e.target.value })}
+            placeholder="10.0.0.0/24, 10.5.0.0/24"
+            className={inputCls}
+          />
         </div>
         <div>
-          <label className={labelCls}>Mode</label>
-          <select
-            value={ipsecForm.mode}
-            onChange={(e) => setIpsecForm((f) => ({ ...f, mode: e.target.value }))}
-            className={selectCls}
-          >
-            <option value="tunnel">Tunnel</option>
-            <option value="transport">Transport</option>
-          </select>
+          <label className={labelCls}>Remote Subnets</label>
+          <input
+            type="text"
+            value={ipsecForm.remote_ts}
+            onChange={(e) => set({ remote_ts: e.target.value })}
+            placeholder="10.1.0.0/24"
+            className={inputCls}
+          />
         </div>
       </div>
-      <div className="flex gap-2 mt-3">
-        <button
-          onClick={onSubmit}
-          disabled={
-            ipsecSubmitting ||
-            !ipsecForm.name.trim() ||
-            !ipsecForm.local_addr.trim() ||
-            !ipsecForm.remote_addr.trim()
-          }
-          className={btnPrimary}
-        >
-          {ipsecSubmitting ? "Creating..." : "Create SA"}
+
+      {/* Authentication */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <div>
+          <label className={labelCls}>Authentication</label>
+          <select
+            value={ipsecForm.auth_method}
+            onChange={(e) => set({ auth_method: e.target.value as "psk" | "cert" })}
+            className={selectCls}
+          >
+            <option value="psk">Pre-shared key</option>
+            <option value="cert">Certificate (X.509)</option>
+          </select>
+        </div>
+
+        {ipsecForm.auth_method === "psk" ? (
+          <div className="col-span-2">
+            <label className={labelCls}>Pre-shared Key</label>
+            <input
+              type="password"
+              value={ipsecForm.psk}
+              onChange={(e) => set({ psk: e.target.value })}
+              placeholder={editingIpsecId ? "(unchanged)" : "at least 16 characters"}
+              className={inputCls}
+            />
+          </div>
+        ) : (
+          <>
+            <div>
+              <label className={labelCls}>Certificate Source</label>
+              <select
+                value={ipsecForm.cert_source}
+                onChange={(e) => set({ cert_source: e.target.value as "acme" | "manual" })}
+                className={selectCls}
+              >
+                <option value="manual">Paste PEM</option>
+                <option value="acme">ACME store</option>
+              </select>
+            </div>
+            {ipsecForm.cert_source === "acme" && (
+              <div>
+                <label className={labelCls}>ACME Certificate</label>
+                <select
+                  value={ipsecForm.acme_cert_id}
+                  onChange={(e) => set({ acme_cert_id: e.target.value })}
+                  className={selectCls}
+                >
+                  <option value="">Select…</option>
+                  {acmeCerts.map((c) => (
+                    <option key={c.id} value={String(c.id)}>
+                      {c.common_name} ({c.status})
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Manual PEM material */}
+      {ipsecForm.auth_method === "cert" && ipsecForm.cert_source === "manual" && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <label className={labelCls}>Local Certificate (PEM)</label>
+            <textarea
+              value={ipsecForm.local_cert_pem}
+              onChange={(e) => set({ local_cert_pem: e.target.value })}
+              placeholder="-----BEGIN CERTIFICATE-----"
+              className={textareaCls}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Private Key (PEM)</label>
+            <textarea
+              value={ipsecForm.local_key_pem}
+              onChange={(e) => set({ local_key_pem: e.target.value })}
+              placeholder={editingIpsecId ? "(unchanged)" : "-----BEGIN PRIVATE KEY-----"}
+              className={textareaCls}
+            />
+          </div>
+        </div>
+      )}
+      {ipsecForm.auth_method === "cert" && (
+        <div>
+          <label className={labelCls}>Peer CA Certificate (PEM, optional)</label>
+          <textarea
+            value={ipsecForm.ca_cert_pem}
+            onChange={(e) => set({ ca_cert_pem: e.target.value })}
+            placeholder="-----BEGIN CERTIFICATE-----  (CA that signed the peer's certificate)"
+            className={textareaCls}
+          />
+        </div>
+      )}
+
+      {/* Advanced */}
+      <button
+        type="button"
+        onClick={() => setShowAdvanced((o) => !o)}
+        className="text-xs text-blue-400 hover:text-blue-300"
+      >
+        {showAdvanced ? "▾ Hide advanced options" : "▸ Advanced options"}
+      </button>
+      {showAdvanced && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <div>
+            <label className={labelCls}>Local Endpoint (optional)</label>
+            <input
+              type="text"
+              value={ipsecForm.local_addr}
+              onChange={(e) => set({ local_addr: e.target.value })}
+              placeholder="any local address"
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Local IKE ID (optional)</label>
+            <input
+              type="text"
+              value={ipsecForm.local_id}
+              onChange={(e) => set({ local_id: e.target.value })}
+              placeholder="defaults to endpoint"
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Remote IKE ID (optional)</label>
+            <input
+              type="text"
+              value={ipsecForm.remote_id}
+              onChange={(e) => set({ remote_id: e.target.value })}
+              placeholder="defaults to endpoint"
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Start Action</label>
+            <select
+              value={ipsecForm.start_action}
+              onChange={(e) => set({ start_action: e.target.value as "start" | "trap" | "none" })}
+              className={selectCls}
+            >
+              <option value="start">Start immediately</option>
+              <option value="trap">On demand (trap)</option>
+              <option value="none">Manual only</option>
+            </select>
+          </div>
+          <div>
+            <label className={labelCls}>IKE Proposal</label>
+            <input
+              type="text"
+              value={ipsecForm.ike_proposal}
+              onChange={(e) => set({ ike_proposal: e.target.value })}
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>ESP Proposal</label>
+            <input
+              type="text"
+              value={ipsecForm.esp_proposal}
+              onChange={(e) => set({ esp_proposal: e.target.value })}
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>IKE Rekey (secs)</label>
+            <input
+              type="number"
+              value={ipsecForm.ike_lifetime_secs}
+              onChange={(e) => set({ ike_lifetime_secs: e.target.value })}
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>ESP Rekey (secs)</label>
+            <input
+              type="number"
+              value={ipsecForm.esp_lifetime_secs}
+              onChange={(e) => set({ esp_lifetime_secs: e.target.value })}
+              className={inputCls}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>DPD Interval (secs, 0 = off)</label>
+            <input
+              type="number"
+              value={ipsecForm.dpd_delay_secs}
+              onChange={(e) => set({ dpd_delay_secs: e.target.value })}
+              className={inputCls}
+            />
+          </div>
+          <div className="flex items-end pb-1.5">
+            <label className="flex items-center gap-2 text-xs text-gray-300">
+              <input
+                type="checkbox"
+                checked={ipsecForm.enabled}
+                onChange={(e) => set({ enabled: e.target.checked })}
+                className="rounded border-gray-600 bg-gray-800"
+              />
+              Enabled
+            </label>
+          </div>
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        <button onClick={onSubmit} disabled={!canSubmit} className={btnPrimary}>
+          {ipsecSubmitting
+            ? "Saving..."
+            : editingIpsecId
+              ? "Save Tunnel"
+              : "Create Tunnel"}
         </button>
-        <button
-          onClick={onCancel}
-          className={btnCancel}
-        >
+        <button onClick={onCancel} className={btnCancel}>
           Cancel
         </button>
       </div>

--- a/aifw-ui/src/app/vpn/components/IpsecSection.tsx
+++ b/aifw-ui/src/app/vpn/components/IpsecSection.tsx
@@ -2,38 +2,81 @@
 
 import { useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
-import type { IpsecSa, IpsecFormState } from "@/lib/api/vpn";
+import type {
+  IpsecSa,
+  IpsecTunnel,
+  IpsecLiveStatus,
+  IpsecFormState,
+  AcmeCertOption,
+} from "@/lib/api/vpn";
+import { fmtBytes } from "@/lib/api/vpn";
 import { ChevronIcon } from "./ChevronIcon";
-import { StatusBadge } from "./StatusBadge";
 import { DeleteButton } from "./DeleteButton";
 import { IpsecForm } from "./IpsecForm";
 
 interface IpsecSectionProps {
+  ipsecTunnels: IpsecTunnel[];
+  ipsecStatuses: Record<string, IpsecLiveStatus>;
   ipsecSas: IpsecSa[];
   ipsecLoading: boolean;
   showIpsecForm: boolean;
   ipsecForm: IpsecFormState;
   setIpsecForm: Dispatch<SetStateAction<IpsecFormState>>;
+  editingIpsecId: string | null;
   ipsecSubmitting: boolean;
+  acmeCerts: AcmeCertOption[];
   onToggleForm: () => void;
   onSubmit: () => void;
   onCancel: () => void;
-  onDelete: (id: string) => void;
+  onEdit: (t: IpsecTunnel) => void;
+  onDeleteTunnel: (id: string) => void;
+  onStart: (id: string) => void;
+  onStop: (id: string) => void;
+  onDeleteLegacySa: (id: string) => void;
+}
+
+/// Colored badge for the live IKE state reported by charon.
+function IkeStateBadge({ state }: { state: string }) {
+  const cls =
+    state === "ESTABLISHED"
+      ? "bg-green-900/60 text-green-400"
+      : state === "CONNECTING" || state === "REKEYING"
+        ? "bg-yellow-900/60 text-yellow-400"
+        : "bg-gray-700 text-gray-400";
+  return (
+    <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${cls}`}>
+      {state.toLowerCase()}
+    </span>
+  );
+}
+
+function fmtUptime(secs: number | null): string {
+  if (secs == null) return "";
+  if (secs < 3600) return `${Math.floor(secs / 60)}m ${secs % 60}s`;
+  return `${Math.floor(secs / 3600)}h ${Math.floor((secs % 3600) / 60)}m`;
 }
 
 /* ═══════════════ IPsec Section ═══════════════ */
 
 export function IpsecSection({
+  ipsecTunnels,
+  ipsecStatuses,
   ipsecSas,
   ipsecLoading,
   showIpsecForm,
   ipsecForm,
   setIpsecForm,
+  editingIpsecId,
   ipsecSubmitting,
+  acmeCerts,
   onToggleForm,
   onSubmit,
   onCancel,
-  onDelete,
+  onEdit,
+  onDeleteTunnel,
+  onStart,
+  onStop,
+  onDeleteLegacySa,
 }: IpsecSectionProps) {
   const [ipsecOpen, setIpsecOpen] = useState(true);
 
@@ -45,15 +88,17 @@ export function IpsecSection({
         className="w-full flex items-center justify-between p-4 hover:bg-gray-750 transition-colors"
       >
         <div className="flex items-center gap-3">
-          <h2 className="text-lg font-semibold text-white">IPsec Security Associations</h2>
-          <span className="text-xs text-gray-500">{ipsecSas.length} SA(s)</span>
+          <h2 className="text-lg font-semibold text-white">IPsec Tunnels</h2>
+          <span className="text-xs text-gray-500">
+            {ipsecTunnels.length} tunnel(s) · IKEv2 site-to-site
+          </span>
         </div>
         <ChevronIcon open={ipsecOpen} />
       </button>
 
       {ipsecOpen && (
         <div className="border-t border-gray-700">
-          {/* Add IPsec SA button */}
+          {/* Add tunnel button */}
           <div className="px-4 py-3 flex justify-end border-b border-gray-700/50">
             <button
               onClick={onToggleForm}
@@ -62,76 +107,134 @@ export function IpsecSection({
               <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
               </svg>
-              Add IPsec SA
+              Add IPsec Tunnel
             </button>
           </div>
 
-          {/* IPsec form */}
+          {/* Tunnel form */}
           {showIpsecForm && (
             <IpsecForm
               ipsecForm={ipsecForm}
               setIpsecForm={setIpsecForm}
+              editingIpsecId={editingIpsecId}
               ipsecSubmitting={ipsecSubmitting}
+              acmeCerts={acmeCerts}
               onSubmit={onSubmit}
               onCancel={onCancel}
             />
           )}
 
-          {/* IPsec table */}
+          {/* Tunnel table */}
           {ipsecLoading ? (
-            <div className="text-center py-12 text-gray-500">Loading IPsec SAs...</div>
-          ) : ipsecSas.length === 0 ? (
-            <div className="text-center py-12 text-gray-500">No IPsec security associations configured</div>
+            <div className="text-center py-12 text-gray-500">Loading IPsec tunnels...</div>
+          ) : ipsecTunnels.length === 0 ? (
+            <div className="text-center py-12 text-gray-500">
+              No IPsec tunnels configured
+            </div>
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b border-gray-700">
-                    <th className="text-left py-3 px-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Name
-                    </th>
-                    <th className="text-left py-3 px-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Local
-                    </th>
-                    <th className="text-left py-3 px-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Remote
-                    </th>
-                    <th className="text-left py-3 px-3 text-xs font-medium text-gray-500 uppercase tracking-wider w-20">
-                      Protocol
-                    </th>
-                    <th className="text-left py-3 px-3 text-xs font-medium text-gray-500 uppercase tracking-wider w-24">
-                      Mode
-                    </th>
-                    <th className="text-left py-3 px-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      SPI In
-                    </th>
-                    <th className="text-left py-3 px-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      SPI Out
-                    </th>
-                    <th className="text-left py-3 px-3 text-xs font-medium text-gray-500 uppercase tracking-wider w-24">
-                      Status
-                    </th>
-                    <th className="w-12" />
+                    <th className="text-left py-3 px-3 text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                    <th className="text-left py-3 px-3 text-xs font-medium text-gray-500 uppercase tracking-wider">Remote</th>
+                    <th className="text-left py-3 px-3 text-xs font-medium text-gray-500 uppercase tracking-wider">Traffic Selectors</th>
+                    <th className="text-left py-3 px-3 text-xs font-medium text-gray-500 uppercase tracking-wider w-16">Auth</th>
+                    <th className="text-left py-3 px-3 text-xs font-medium text-gray-500 uppercase tracking-wider w-28">IKE State</th>
+                    <th className="text-left py-3 px-3 text-xs font-medium text-gray-500 uppercase tracking-wider">Live</th>
+                    <th className="w-36" />
                   </tr>
                 </thead>
                 <tbody>
+                  {ipsecTunnels.map((t) => {
+                    const live = ipsecStatuses[t.id];
+                    const child = live?.child_sas[0];
+                    const established = live?.ike_state === "ESTABLISHED";
+                    return (
+                      <tr key={t.id} className="border-b border-gray-700/50 hover:bg-gray-700/30 transition-colors">
+                        <td className="py-2.5 px-3 font-medium text-white">
+                          {t.name}
+                          {!t.enabled && (
+                            <span className="ml-2 text-xs text-gray-500">(disabled)</span>
+                          )}
+                        </td>
+                        <td className="py-2.5 px-3 font-mono text-xs text-gray-300">{t.remote_addr}</td>
+                        <td className="py-2.5 px-3 font-mono text-xs text-gray-400">
+                          {t.local_ts.join(",")} ⇄ {t.remote_ts.join(",")}
+                        </td>
+                        <td className="py-2.5 px-3 text-gray-400 uppercase text-xs">{t.auth_method}</td>
+                        <td className="py-2.5 px-3">
+                          <IkeStateBadge state={t.enabled ? (live?.ike_state ?? "DOWN") : "DISABLED"} />
+                        </td>
+                        <td className="py-2.5 px-3 text-xs text-gray-400">
+                          {established && child ? (
+                            <>
+                              ↓{fmtBytes(child.bytes_in)} ↑{fmtBytes(child.bytes_out)}
+                              {live.established_secs != null && (
+                                <span className="text-gray-500"> · up {fmtUptime(live.established_secs)}</span>
+                              )}
+                              {child.rekey_in_secs != null && (
+                                <span className="text-gray-500"> · rekey {fmtUptime(child.rekey_in_secs)}</span>
+                              )}
+                            </>
+                          ) : (
+                            <span className="text-gray-600">—</span>
+                          )}
+                        </td>
+                        <td className="py-2.5 px-2">
+                          <div className="flex items-center justify-end gap-1.5">
+                            {t.enabled && (established ? (
+                              <button
+                                onClick={() => onStop(t.id)}
+                                className="px-2 py-1 text-xs rounded bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors"
+                              >
+                                Stop
+                              </button>
+                            ) : (
+                              <button
+                                onClick={() => onStart(t.id)}
+                                className="px-2 py-1 text-xs rounded bg-green-700 hover:bg-green-600 text-white transition-colors"
+                              >
+                                Start
+                              </button>
+                            ))}
+                            <button
+                              onClick={() => onEdit(t)}
+                              className="px-2 py-1 text-xs rounded bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors"
+                            >
+                              Edit
+                            </button>
+                            <DeleteButton onClick={() => onDeleteTunnel(t.id)} title="Delete tunnel" />
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Legacy SA records — read-only leftovers from before the real
+              data plane; they never carried traffic. */}
+          {ipsecSas.length > 0 && (
+            <div className="border-t border-gray-700">
+              <div className="px-4 py-2 text-xs text-gray-500 bg-gray-900/40">
+                Legacy IPsec SA records (inactive — these predate real IPsec
+                support and never carried traffic; delete them or recreate as
+                tunnels above)
+              </div>
+              <table className="w-full text-sm">
+                <tbody>
                   {ipsecSas.map((sa) => (
-                    <tr
-                      key={sa.id}
-                      className="border-b border-gray-700/50 hover:bg-gray-700/30 transition-colors"
-                    >
-                      <td className="py-2.5 px-3 font-medium text-white">{sa.name}</td>
-                      <td className="py-2.5 px-3 font-mono text-xs text-gray-300">{sa.local_addr}</td>
-                      <td className="py-2.5 px-3 font-mono text-xs text-gray-300">{sa.remote_addr}</td>
-                      <td className="py-2.5 px-3 text-gray-400 uppercase text-xs">{sa.protocol}</td>
-                      <td className="py-2.5 px-3 text-gray-400 text-xs">{sa.mode}</td>
-                      <td className="py-2.5 px-3 font-mono text-xs text-gray-400">{sa.spi_in}</td>
-                      <td className="py-2.5 px-3 font-mono text-xs text-gray-400">{sa.spi_out}</td>
-                      <td className="py-2.5 px-3">
-                        <StatusBadge status={sa.status} />
+                    <tr key={sa.id} className="border-b border-gray-700/50">
+                      <td className="py-2 px-4 text-gray-400">{sa.name}</td>
+                      <td className="py-2 px-3 font-mono text-xs text-gray-500">
+                        {sa.local_addr} → {sa.remote_addr}
                       </td>
-                      <td className="py-2.5 px-2">
-                        <DeleteButton onClick={() => onDelete(sa.id)} title="Delete SA" />
+                      <td className="py-2 px-3 text-xs text-gray-500 uppercase">{sa.protocol}</td>
+                      <td className="py-2 px-2 w-12">
+                        <DeleteButton onClick={() => onDeleteLegacySa(sa.id)} title="Delete legacy record" />
                       </td>
                     </tr>
                   ))}

--- a/aifw-ui/src/app/vpn/page.tsx
+++ b/aifw-ui/src/app/vpn/page.tsx
@@ -55,15 +55,17 @@ export default function VpnPage() {
           value={Object.values(vpn.peersByTunnel).reduce((n, p) => n + p.length, 0)}
           color="blue"
         />
-        <SummaryCard label="IPsec SAs" value={vpn.ipsecSas.length} color="green" />
+        <SummaryCard label="IPsec Tunnels" value={vpn.ipsecTunnels.length} color="green" />
         <SummaryCard
           label="Active VPNs"
           value={
             vpn.tunnels.filter((t) => t.status === "up").length +
-            vpn.ipsecSas.filter((s) => s.status === "up" || s.status === "established").length
+            vpn.ipsecTunnels.filter(
+              (t) => vpn.ipsecStatuses[t.id]?.ike_state === "ESTABLISHED",
+            ).length
           }
           color="green"
-          subtitle={`of ${vpn.tunnels.length + vpn.ipsecSas.length} total`}
+          subtitle={`of ${vpn.tunnels.length + vpn.ipsecTunnels.length} total`}
         />
       </div>
 
@@ -105,16 +107,24 @@ export default function VpnPage() {
 
       {/* IPsec section */}
       <IpsecSection
+        ipsecTunnels={vpn.ipsecTunnels}
+        ipsecStatuses={vpn.ipsecStatuses}
         ipsecSas={vpn.ipsecSas}
         ipsecLoading={vpn.ipsecLoading}
         showIpsecForm={vpn.showIpsecForm}
         ipsecForm={vpn.ipsecForm}
         setIpsecForm={vpn.setIpsecForm}
+        editingIpsecId={vpn.editingIpsecId}
         ipsecSubmitting={vpn.ipsecSubmitting}
+        acmeCerts={vpn.acmeCerts}
         onToggleForm={vpn.handleToggleIpsecForm}
         onSubmit={vpn.handleIpsecSubmit}
         onCancel={vpn.handleCancelIpsecForm}
-        onDelete={vpn.handleDeleteIpsec}
+        onEdit={vpn.handleEditIpsec}
+        onDeleteTunnel={vpn.handleDeleteIpsecTunnel}
+        onStart={vpn.handleStartIpsec}
+        onStop={vpn.handleStopIpsec}
+        onDeleteLegacySa={vpn.handleDeleteIpsec}
       />
 
       {/* Peer client-config modal */}

--- a/aifw-ui/src/hooks/useVpn.ts
+++ b/aifw-ui/src/hooks/useVpn.ts
@@ -13,6 +13,10 @@ import type {
   WgTunnel,
   WgPeer,
   IpsecSa,
+  IpsecTunnel,
+  IpsecLiveStatus,
+  IpsecTunnelRequest,
+  AcmeCertOption,
   VpnInterface,
   WgLiveTunnelStatus,
   ConfigModalData,
@@ -35,8 +39,15 @@ import {
   getNextPeerIp,
   getWgPeerConfig,
   listIpsecSas,
-  createIpsecSa,
   deleteIpsecSa,
+  listIpsecTunnels,
+  createIpsecTunnel,
+  updateIpsecTunnel,
+  deleteIpsecTunnel,
+  startIpsecTunnel,
+  stopIpsecTunnel,
+  getIpsecStatus,
+  listAcmeCertOptions,
   listVpnInterfaces,
 } from "@/lib/api/vpn";
 
@@ -56,12 +67,16 @@ export function useVpn() {
   const [peerForm, setPeerForm] = useState(defaultPeerForm);
   const [peerSubmitting, setPeerSubmitting] = useState(false);
 
-  /* ── IPsec state ── */
+  /* ── IPsec state (#530: real tunnels + read-only legacy SA records) ── */
+  const [ipsecTunnels, setIpsecTunnels] = useState<IpsecTunnel[]>([]);
+  const [ipsecStatuses, setIpsecStatuses] = useState<Record<string, IpsecLiveStatus>>({});
   const [ipsecSas, setIpsecSas] = useState<IpsecSa[]>([]);
   const [ipsecLoading, setIpsecLoading] = useState(true);
   const [showIpsecForm, setShowIpsecForm] = useState(false);
   const [ipsecForm, setIpsecForm] = useState(defaultIpsecForm);
+  const [editingIpsecId, setEditingIpsecId] = useState<string | null>(null);
   const [ipsecSubmitting, setIpsecSubmitting] = useState(false);
+  const [acmeCerts, setAcmeCerts] = useState<AcmeCertOption[]>([]);
 
   /* ── Tunnel live status from WebSocket ── */
   const ws = useWs();
@@ -100,12 +115,22 @@ export function useVpn() {
 
   const fetchIpsec = useCallback(async () => {
     try {
-      const data = await listIpsecSas();
-      setIpsecSas(data);
+      const [tunnels, sas] = await Promise.all([listIpsecTunnels(), listIpsecSas()]);
+      setIpsecTunnels(tunnels);
+      setIpsecSas(sas);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load IPsec SAs");
+      setError(err instanceof Error ? err.message : "Failed to load IPsec tunnels");
     } finally {
       setIpsecLoading(false);
+    }
+  }, []);
+
+  const fetchIpsecStatus = useCallback(async () => {
+    try {
+      const statuses = await getIpsecStatus();
+      setIpsecStatuses(Object.fromEntries(statuses.map((s) => [s.tunnel_id, s])));
+    } catch {
+      // status is best-effort; the table just shows no live badge
     }
   }, []);
 
@@ -113,11 +138,20 @@ export function useVpn() {
     queueMicrotask(() => {
       fetchTunnels();
       fetchIpsec();
+      fetchIpsecStatus();
       listVpnInterfaces()
         .then((data) => setInterfaces(data))
         .catch(() => {});
+      listAcmeCertOptions().then(setAcmeCerts);
     });
-  }, [fetchTunnels, fetchIpsec]);
+  }, [fetchTunnels, fetchIpsec, fetchIpsecStatus]);
+
+  /* Poll live IPsec status every 10s while any tunnel exists. */
+  useEffect(() => {
+    if (ipsecTunnels.length === 0) return;
+    const timer = setInterval(fetchIpsecStatus, 10_000);
+    return () => clearInterval(timer);
+  }, [ipsecTunnels.length, fetchIpsecStatus]);
 
   /* ────────────────────────── WireGuard CRUD ────────────────────────── */
 
@@ -323,45 +357,141 @@ export function useVpn() {
     }
   };
 
-  /* ────────────────────────── IPsec CRUD ────────────────────────── */
+  /* ────────────────────────── IPsec tunnel CRUD ────────────────────────── */
 
-  /// Add IPsec SA button: toggles the create form, always resetting to
+  /// Add Tunnel button: toggles the create form, always resetting to
   /// defaults.
   const handleToggleIpsecForm = () => {
-    if (showIpsecForm) {
+    if (showIpsecForm && !editingIpsecId) {
       setShowIpsecForm(false);
       setIpsecForm(defaultIpsecForm);
     } else {
       setIpsecForm(defaultIpsecForm);
+      setEditingIpsecId(null);
       setShowIpsecForm(true);
     }
   };
 
   const handleCancelIpsecForm = () => {
     setShowIpsecForm(false);
+    setEditingIpsecId(null);
     setIpsecForm(defaultIpsecForm);
   };
 
+  const handleEditIpsec = (t: IpsecTunnel) => {
+    setIpsecForm({
+      name: t.name,
+      enabled: t.enabled,
+      local_addr: t.local_addr,
+      remote_addr: t.remote_addr,
+      local_id: t.local_id,
+      remote_id: t.remote_id,
+      auth_method: t.auth_method,
+      psk: "", // blank = keep stored secret
+      cert_source: t.cert_source ?? "manual",
+      acme_cert_id: t.acme_cert_id != null ? String(t.acme_cert_id) : "",
+      local_cert_pem: t.local_cert_pem === "REDACTED" ? "" : t.local_cert_pem,
+      local_key_pem: "", // blank = keep stored secret
+      ca_cert_pem: t.ca_cert_pem,
+      local_ts: t.local_ts.join(", "),
+      remote_ts: t.remote_ts.join(", "),
+      ike_proposal: t.ike_proposal,
+      esp_proposal: t.esp_proposal,
+      ike_lifetime_secs: String(t.ike_lifetime_secs),
+      esp_lifetime_secs: String(t.esp_lifetime_secs),
+      dpd_delay_secs: String(t.dpd_delay_secs),
+      start_action: t.start_action,
+    });
+    setEditingIpsecId(t.id);
+    setShowIpsecForm(true);
+  };
+
+  const splitTs = (s: string) =>
+    s
+      .split(",")
+      .map((p) => p.trim())
+      .filter(Boolean);
+
   const handleIpsecSubmit = async () => {
     if (ipsecSubmitting) return;
-    if (!ipsecForm.name.trim() || !ipsecForm.local_addr.trim() || !ipsecForm.remote_addr.trim()) return;
+    if (!ipsecForm.name.trim() || !ipsecForm.remote_addr.trim()) return;
+    if (!splitTs(ipsecForm.local_ts).length || !splitTs(ipsecForm.remote_ts).length) return;
     setIpsecSubmitting(true);
     setError(null);
     try {
-      await createIpsecSa({
+      const body: IpsecTunnelRequest = {
         name: ipsecForm.name.trim(),
-        local_addr: ipsecForm.local_addr.trim(),
         remote_addr: ipsecForm.remote_addr.trim(),
-        protocol: ipsecForm.protocol,
-        mode: ipsecForm.mode,
-      });
-      setIpsecForm(defaultIpsecForm);
-      setShowIpsecForm(false);
+        local_ts: splitTs(ipsecForm.local_ts),
+        remote_ts: splitTs(ipsecForm.remote_ts),
+        enabled: ipsecForm.enabled,
+        local_addr: ipsecForm.local_addr.trim(),
+        local_id: ipsecForm.local_id.trim(),
+        remote_id: ipsecForm.remote_id.trim(),
+        auth_method: ipsecForm.auth_method,
+        ike_proposal: ipsecForm.ike_proposal.trim(),
+        esp_proposal: ipsecForm.esp_proposal.trim(),
+        ike_lifetime_secs: parseInt(ipsecForm.ike_lifetime_secs, 10) || 14400,
+        esp_lifetime_secs: parseInt(ipsecForm.esp_lifetime_secs, 10) || 3600,
+        dpd_delay_secs: parseInt(ipsecForm.dpd_delay_secs, 10) || 0,
+        start_action: ipsecForm.start_action,
+      };
+      if (ipsecForm.auth_method === "psk") {
+        // Blank on edit means "keep the stored PSK" (send the marker).
+        body.psk = ipsecForm.psk.trim() || (editingIpsecId ? "REDACTED" : "");
+      } else {
+        body.cert_source = ipsecForm.cert_source;
+        if (ipsecForm.cert_source === "acme") {
+          body.acme_cert_id = parseInt(ipsecForm.acme_cert_id, 10);
+        } else {
+          if (ipsecForm.local_cert_pem.trim()) body.local_cert_pem = ipsecForm.local_cert_pem.trim();
+          body.local_key_pem = ipsecForm.local_key_pem.trim() || (editingIpsecId ? "REDACTED" : "");
+        }
+        if (ipsecForm.ca_cert_pem.trim()) body.ca_cert_pem = ipsecForm.ca_cert_pem.trim();
+      }
+
+      if (editingIpsecId) {
+        await updateIpsecTunnel(editingIpsecId, body);
+      } else {
+        await createIpsecTunnel(body);
+      }
+      handleCancelIpsecForm();
       await fetchIpsec();
+      await fetchIpsecStatus();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create IPsec SA");
+      setError(err instanceof Error ? err.message : "Failed to save IPsec tunnel");
     } finally {
       setIpsecSubmitting(false);
+    }
+  };
+
+  const handleDeleteIpsecTunnel = async (id: string) => {
+    setError(null);
+    try {
+      await deleteIpsecTunnel(id);
+      setIpsecTunnels((prev) => prev.filter((t) => t.id !== id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete IPsec tunnel");
+    }
+  };
+
+  const handleStartIpsec = async (id: string) => {
+    setError(null);
+    try {
+      await startIpsecTunnel(id);
+      await fetchIpsecStatus();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to initiate IPsec tunnel");
+    }
+  };
+
+  const handleStopIpsec = async (id: string) => {
+    setError(null);
+    try {
+      await stopIpsecTunnel(id);
+      await fetchIpsecStatus();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to terminate IPsec tunnel");
     }
   };
 
@@ -371,7 +501,7 @@ export function useVpn() {
       await deleteIpsecSa(id);
       setIpsecSas((prev) => prev.filter((sa) => sa.id !== id));
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to delete IPsec SA");
+      setError(err instanceof Error ? err.message : "Failed to delete legacy IPsec SA record");
     }
   };
 
@@ -408,16 +538,24 @@ export function useVpn() {
     // Config modal
     configModal,
     closeConfigModal,
-    // IPsec
+    // IPsec tunnels + legacy SA records
+    ipsecTunnels,
+    ipsecStatuses,
     ipsecSas,
     ipsecLoading,
     showIpsecForm,
     ipsecForm,
     setIpsecForm,
+    editingIpsecId,
     ipsecSubmitting,
+    acmeCerts,
     handleToggleIpsecForm,
     handleCancelIpsecForm,
+    handleEditIpsec,
     handleIpsecSubmit,
+    handleDeleteIpsecTunnel,
+    handleStartIpsec,
+    handleStopIpsec,
     handleDeleteIpsec,
     // Live status + interfaces + shared error
     vpnStatus,

--- a/aifw-ui/src/lib/api/vpn.ts
+++ b/aifw-ui/src/lib/api/vpn.ts
@@ -34,6 +34,9 @@ export interface WgPeer {
   created_at: string;
 }
 
+/// Legacy pre-#530 IPsec SA record. Configuration-only — never carried
+/// traffic; the API now flags every row `legacy: true` and refuses new
+/// creations (410).
 export interface IpsecSa {
   id: string;
   name: string;
@@ -45,6 +48,67 @@ export interface IpsecSa {
   spi_out: string;
   status: string;
   created_at: string;
+  legacy?: boolean;
+}
+
+/// A real IPsec IKEv2 site-to-site tunnel (#530). Secrets (`psk`,
+/// `local_key_pem`) always arrive as "REDACTED".
+export interface IpsecTunnel {
+  id: string;
+  name: string;
+  enabled: boolean;
+  local_addr: string;
+  remote_addr: string;
+  local_id: string;
+  remote_id: string;
+  auth_method: "psk" | "cert";
+  psk: string;
+  cert_source: "acme" | "manual" | null;
+  acme_cert_id: number | null;
+  local_cert_pem: string;
+  local_key_pem: string;
+  ca_cert_pem: string;
+  ike_proposal: string;
+  esp_proposal: string;
+  local_ts: string[];
+  remote_ts: string[];
+  ike_lifetime_secs: number;
+  esp_lifetime_secs: number;
+  dpd_delay_secs: number;
+  start_action: "start" | "trap" | "none";
+  created_at: string;
+  updated_at: string;
+}
+
+/// Live negotiated state of one child (ESP) SA.
+export interface ChildSaStatus {
+  name: string;
+  state: string;
+  local_ts: string[];
+  remote_ts: string[];
+  bytes_in: number;
+  bytes_out: number;
+  rekey_in_secs: number | null;
+  enc_alg: string | null;
+}
+
+/// Live negotiated tunnel state from charon (`swanctl --list-sas`).
+/// `ike_state` is "DOWN" when no SA exists.
+export interface IpsecLiveStatus {
+  tunnel_id: string;
+  conn_name: string;
+  ike_state: string;
+  established_secs: number | null;
+  remote_host: string | null;
+  ike_version: number | null;
+  child_sas: ChildSaStatus[];
+}
+
+/// ACME store certificate summary, for the cert-auth picker.
+export interface AcmeCertOption {
+  id: number;
+  common_name: string;
+  status: string;
 }
 
 /// Interface entry for the "Listen Interface" dropdown.
@@ -110,13 +174,31 @@ export interface WgPeerRequest {
   preshared_key?: string;
 }
 
-/// Create body for an IPsec SA.
-export interface IpsecSaRequest {
+/// Create/update body for an IPsec tunnel. Optional fields keep
+/// defaults on create / stored values on update; secrets set to
+/// "REDACTED" keep the stored secret.
+export interface IpsecTunnelRequest {
   name: string;
-  local_addr: string;
   remote_addr: string;
-  protocol: string;
-  mode: string;
+  local_ts: string[];
+  remote_ts: string[];
+  enabled?: boolean;
+  local_addr?: string;
+  local_id?: string;
+  remote_id?: string;
+  auth_method?: string;
+  psk?: string;
+  cert_source?: string;
+  acme_cert_id?: number;
+  local_cert_pem?: string;
+  local_key_pem?: string;
+  ca_cert_pem?: string;
+  ike_proposal?: string;
+  esp_proposal?: string;
+  ike_lifetime_secs?: number;
+  esp_lifetime_secs?: number;
+  dpd_delay_secs?: number;
+  start_action?: string;
 }
 
 /* ────────────────────────── Helpers ────────────────────────── */
@@ -179,18 +261,50 @@ export const defaultPeerForm: PeerFormState = {
 
 export interface IpsecFormState {
   name: string;
+  enabled: boolean;
   local_addr: string;
   remote_addr: string;
-  protocol: string;
-  mode: string;
+  local_id: string;
+  remote_id: string;
+  auth_method: "psk" | "cert";
+  psk: string;
+  cert_source: "acme" | "manual";
+  acme_cert_id: string;
+  local_cert_pem: string;
+  local_key_pem: string;
+  ca_cert_pem: string;
+  local_ts: string;
+  remote_ts: string;
+  ike_proposal: string;
+  esp_proposal: string;
+  ike_lifetime_secs: string;
+  esp_lifetime_secs: string;
+  dpd_delay_secs: string;
+  start_action: "start" | "trap" | "none";
 }
 
 export const defaultIpsecForm: IpsecFormState = {
   name: "",
+  enabled: true,
   local_addr: "",
   remote_addr: "",
-  protocol: "esp",
-  mode: "tunnel",
+  local_id: "",
+  remote_id: "",
+  auth_method: "psk",
+  psk: "",
+  cert_source: "manual",
+  acme_cert_id: "",
+  local_cert_pem: "",
+  local_key_pem: "",
+  ca_cert_pem: "",
+  local_ts: "",
+  remote_ts: "",
+  ike_proposal: "aes256gcm16-prfsha256-ecp256",
+  esp_proposal: "aes256gcm16-ecp256",
+  ike_lifetime_secs: "14400",
+  esp_lifetime_secs: "3600",
+  dpd_delay_secs: "30",
+  start_action: "start",
 };
 
 /* ────────────────────────── WireGuard tunnels ────────────────────────── */
@@ -247,17 +361,56 @@ export async function getWgPeerConfig(tunnelId: string, peerId: string): Promise
 
 /* ────────────────────────── IPsec ────────────────────────── */
 
+/// Legacy read-only SA records (creation is 410 Gone on the API).
 export async function listIpsecSas(): Promise<IpsecSa[]> {
   const res = await api.get<{ data: IpsecSa[] }>("/api/v1/vpn/ipsec");
   return res.data;
 }
 
-export async function createIpsecSa(body: IpsecSaRequest): Promise<void> {
-  await api.post("/api/v1/vpn/ipsec", body);
-}
-
 export async function deleteIpsecSa(id: string): Promise<void> {
   await api.delete(`/api/v1/vpn/ipsec/${id}`);
+}
+
+/* ────────────────────────── IPsec tunnels (#530) ────────────────────────── */
+
+export async function listIpsecTunnels(): Promise<IpsecTunnel[]> {
+  const res = await api.get<{ data: IpsecTunnel[] }>("/api/v1/vpn/ipsec/tunnels");
+  return res.data;
+}
+
+export async function createIpsecTunnel(body: IpsecTunnelRequest): Promise<void> {
+  await api.post("/api/v1/vpn/ipsec/tunnels", body);
+}
+
+export async function updateIpsecTunnel(id: string, body: IpsecTunnelRequest): Promise<void> {
+  await api.put(`/api/v1/vpn/ipsec/tunnels/${id}`, body);
+}
+
+export async function deleteIpsecTunnel(id: string): Promise<void> {
+  await api.delete(`/api/v1/vpn/ipsec/tunnels/${id}`);
+}
+
+export async function startIpsecTunnel(id: string): Promise<void> {
+  await api.post(`/api/v1/vpn/ipsec/tunnels/${id}/start`);
+}
+
+export async function stopIpsecTunnel(id: string): Promise<void> {
+  await api.post(`/api/v1/vpn/ipsec/tunnels/${id}/stop`);
+}
+
+/// Live negotiated status for all tunnels (fresh `swanctl --list-sas`).
+export async function getIpsecStatus(): Promise<IpsecLiveStatus[]> {
+  const res = await api.get<{ data: IpsecLiveStatus[] }>("/api/v1/vpn/ipsec/status");
+  return res.data;
+}
+
+/// ACME certs for the cert-auth picker (best-effort; empty on error).
+export async function listAcmeCertOptions(): Promise<AcmeCertOption[]> {
+  try {
+    return await api.get<AcmeCertOption[]>("/api/v1/acme/certs");
+  } catch {
+    return [];
+  }
 }
 
 /* ────────────────────────── Interfaces ────────────────────────── */

--- a/freebsd/build-iso.sh
+++ b/freebsd/build-iso.sh
@@ -113,7 +113,7 @@ cp /etc/resolv.conf "$STAGEDIR/etc/resolv.conf"
 # Bootstrap pkg and install required packages
 chroot "$STAGEDIR" /bin/sh -c '
     env ASSUME_ALWAYS_YES=yes pkg bootstrap -f
-    pkg install -y wireguard-tools sudo unbound curl
+    pkg install -y wireguard-tools sudo unbound curl strongswan
 '
 
 umount "$STAGEDIR/dev"

--- a/freebsd/deploy.sh
+++ b/freebsd/deploy.sh
@@ -37,7 +37,7 @@ if ! command -v cargo >/dev/null 2>&1; then
 fi
 
 # --- Ensure dependencies ---
-for pkg in sudo unbound curl; do
+for pkg in sudo unbound curl wireguard-tools strongswan; do
     if ! pkg info -q "$pkg" 2>/dev/null; then
         echo "Installing $pkg..."
         pkg install -y "$pkg"

--- a/freebsd/manifest.json
+++ b/freebsd/manifest.json
@@ -6,6 +6,9 @@
     "local": ["aifw", "aifw-daemon", "aifw-api", "aifw-ids", "aifw-tui", "aifw-setup"]
   },
 
+  "packages": ["curl", "strongswan", "sudo", "unbound", "wireguard-tools"],
+  "_packages_comment": "OS packages required at runtime. build-iso.sh installs them into the image; deploy.sh ensures them on the dev VM; the in-app updater installs any that are missing during upgrade. A workspace test (aifw-core packaging_tests) asserts the build scripts stay in sync with this list.",
+
   "external_repos": [
     {
       "_comment": "commit pins the exact revision built into appliance artifacts (#538). CI and build-local.sh check out and verify this SHA and fail if it is missing. To take a companion update: review the upstream diff, bump the SHA here, and land it through a PR.",
@@ -75,6 +78,10 @@
     "/usr/local/etc/rtime",
     "/var/run/rtime",
     "/var/log/rtime",
-    "/usr/local/lib/aifw/plugins"
+    "/usr/local/lib/aifw/plugins",
+    "/usr/local/etc/swanctl/conf.d",
+    "/usr/local/etc/swanctl/private",
+    "/usr/local/etc/swanctl/x509",
+    "/usr/local/etc/swanctl/x509ca"
   ]
 }

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-mkdir
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-mkdir
@@ -10,6 +10,7 @@
 #   /usr/local/etc/rdhcpd/*        — rDHCP config tree
 #   /usr/local/etc/rtime/*         — rTIME config tree
 #   /usr/local/etc/trafficcop/*    — TrafficCop config tree
+#   /usr/local/etc/swanctl/*       — strongSwan swanctl tree (#530 IPsec)
 #   /usr/local/etc/sudoers.d       — exact: directory for the sudoers file
 #   /usr/local/libexec             — exact: helper script dir (updater)
 #   /usr/local/lib/aifw/*          — plugin dir (manifest.json directories)
@@ -59,6 +60,7 @@ case "$TARGET" in
     /usr/local/etc/rdhcpd|/usr/local/etc/rdhcpd/*) ;;
     /usr/local/etc/rtime|/usr/local/etc/rtime/*) ;;
     /usr/local/etc/trafficcop|/usr/local/etc/trafficcop/*) ;;
+    /usr/local/etc/swanctl|/usr/local/etc/swanctl/*) ;;
     /usr/local/etc/sudoers.d) ;;
     /usr/local/libexec) ;;
     /usr/local/lib/aifw|/usr/local/lib/aifw/*) ;;

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-rm
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-rm
@@ -11,6 +11,7 @@
 #   /usr/local/share/aifw/backup/* — pre-upgrade snapshot (updater)
 #   /usr/local/etc/rdns/rpz/*      — rDNS RPZ zone files
 #   /usr/local/etc/rdns/blocklists/* — rDNS blocklist files
+#   /usr/local/etc/swanctl/{conf.d,private,x509,x509ca}/aifw-* — IPsec (#530)
 #   /tmp/aifw-*                    — temp staging files we own
 #   /tmp/aifw_*                    — temp staging files we own (other naming)
 
@@ -55,6 +56,10 @@ case "$TARGET" in
     /usr/local/share/aifw/backup|/usr/local/share/aifw/backup/*) ;;
     /usr/local/etc/rdns/rpz|/usr/local/etc/rdns/rpz/*) ;;
     /usr/local/etc/rdns/blocklists|/usr/local/etc/rdns/blocklists/*) ;;
+    /usr/local/etc/swanctl/conf.d/aifw-*.conf) ;;
+    /usr/local/etc/swanctl/private/aifw-*.pem) ;;
+    /usr/local/etc/swanctl/x509/aifw-*.pem) ;;
+    /usr/local/etc/swanctl/x509ca/aifw-*.pem) ;;
     /tmp/aifw-*|/tmp/aifw_*) ;;
     *)
         echo "aifw-sudo-rm: target not in allowlist: $TARGET" >&2

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-service
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-service
@@ -24,7 +24,7 @@ case "$SERVICE" in
         ;;
     rdhcpd|rdns|rtime|trafficcop)
         ;;
-    unbound|local_unbound|sshd)
+    unbound|local_unbound|sshd|strongswan)
         ;;
     *)
         echo "aifw-sudo-service: service not in allowlist: $SERVICE" >&2

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-swanctl
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-swanctl
@@ -1,0 +1,107 @@
+#!/bin/sh
+# /usr/local/libexec/aifw-sudo-swanctl <verb> [args...]
+#
+# Narrow-grant wrapper around /usr/local/sbin/swanctl (#530 IPsec data
+# plane). charon runs as root and its VICI control socket is
+# root-only, so the `aifw` user drives it through this wrapper instead
+# of a broad swanctl grant.
+#
+# Allowed forms:
+#   --load-all [--noprompt]                      — (re)load conns/creds from swanctl.conf
+#   --initiate  (--ike|--child <name>)... [--timeout <secs>]
+#   --terminate (--ike|--child <name>)... [--timeout <secs>] [--force]
+#   --list-sas   [--raw] [--ike <name>]
+#   --list-conns [--raw] [--ike <name>]
+#
+# Connection/child names are restricted to the aifw-<id> namespace so a
+# compromised aifw user can't tear down IPsec state configured outside
+# AiFw (e.g. by an operator directly in swanctl.conf).
+
+set -eu
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <--load-all|--initiate|--terminate|--list-sas|--list-conns> [args...]" >&2
+    exit 2
+fi
+
+VERB="$1"
+shift
+
+fail() {
+    echo "aifw-sudo-swanctl: $1" >&2
+    exit 1
+}
+
+# aifw-<id> namespace: alnum + hyphen after the prefix (engine uses
+# aifw-<uuid> for conns and aifw-<uuid>-<n> for children).
+valid_name() {
+    case "$1" in
+        aifw-*) ;;
+        *) return 1 ;;
+    esac
+    case "$1" in
+        *[!A-Za-z0-9-]*) return 1 ;;
+    esac
+    return 0
+}
+
+# Validation iterates over "$@" without consuming it, tracking what the
+# next word must be (EXPECT: '' = a flag, 'name' = conn/child name,
+# 'secs' = numeric timeout). The original argv is then passed through
+# verbatim to swanctl.
+EXPECT=""
+SAW_NAME=""
+
+case "$VERB" in
+    --load-all)
+        for a in "$@"; do
+            [ "$a" = "--noprompt" ] || fail "--load-all takes only optional --noprompt"
+        done
+        [ $# -le 1 ] || fail "--load-all takes only optional --noprompt"
+        ;;
+    --initiate|--terminate)
+        for a in "$@"; do
+            case "$EXPECT" in
+                name)
+                    valid_name "$a" || fail "name not in aifw-* namespace: $a"
+                    EXPECT="" ;;
+                secs)
+                    case "$a" in
+                        ""|*[!0-9]*) fail "--timeout must be numeric: $a" ;;
+                    esac
+                    EXPECT="" ;;
+                *)
+                    case "$a" in
+                        --ike|--child) EXPECT=name; SAW_NAME=1 ;;
+                        --timeout)     EXPECT=secs ;;
+                        --force)
+                            [ "$VERB" = "--terminate" ] || fail "--force only valid with --terminate" ;;
+                        *) fail "arg not allowed for $VERB: $a" ;;
+                    esac ;;
+            esac
+        done
+        [ -z "$EXPECT" ] || fail "missing value after last flag"
+        [ -n "$SAW_NAME" ] || fail "$VERB requires --ike or --child <name>"
+        ;;
+    --list-sas|--list-conns)
+        for a in "$@"; do
+            case "$EXPECT" in
+                name)
+                    valid_name "$a" || fail "name not in aifw-* namespace: $a"
+                    EXPECT="" ;;
+                *)
+                    case "$a" in
+                        --raw) ;;
+                        --ike) EXPECT=name ;;
+                        *) fail "arg not allowed for $VERB: $a" ;;
+                    esac ;;
+            esac
+        done
+        [ -z "$EXPECT" ] || fail "missing value after --ike"
+        ;;
+    *)
+        fail "unsupported verb: $VERB"
+        ;;
+esac
+
+exec /usr/local/sbin/swanctl "$VERB" "$@"

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-sysrc
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-sysrc
@@ -64,6 +64,9 @@ case "$KEY" in
     rdhcpd_enable|rdns_enable|rtime_enable|trafficcop_enable) ;;
     local_unbound_enable|unbound_enable) ;;
 
+    # strongSwan IKE daemon (#530 IPsec data plane)
+    strongswan_enable) ;;
+
     # rsync may be pulled in transitively but is never used by AiFw.
     # Allow setting rsyncd_enable=NO so we can silence the
     # `WARNING: $rsyncd_enable is not set properly` noise.

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-write
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-write
@@ -20,10 +20,21 @@ fi
 
 DEST="$1"
 
+# Wildcard-leaf entries below make '..'/'//' traversal a concern (sh
+# case '*' matches '/' too) — reject those forms outright.
+case "$DEST" in
+    *..*|*//*)
+        echo "aifw-sudo-write: '..' or '//' not allowed: $DEST" >&2
+        exit 1
+        ;;
+esac
+
 # Allowlisted destinations + per-path mode/owner. daemon.key is the
 # inter-service auth secret (read by aifw-daemon as the aifw user) and
 # stays root-owned at 640 so a compromise of any of the API/UI surface
-# can't overwrite or chmod the on-disk material.
+# can't overwrite or chmod the on-disk material. swanctl material
+# (#530) is root-owned: conn files + private keys 600 (PSKs/keys are
+# secrets, charon reads them as root), certs 644.
 case "$DEST" in
     /etc/pf.conf)
         FMODE=644; FOWNER=root:wheel ;;
@@ -31,6 +42,14 @@ case "$DEST" in
         FMODE=644; FOWNER=root:wheel ;;
     /usr/local/etc/aifw/daemon.key)
         FMODE=640; FOWNER=root:aifw ;;
+    /usr/local/etc/swanctl/conf.d/aifw-*.conf)
+        FMODE=600; FOWNER=root:wheel ;;
+    /usr/local/etc/swanctl/private/aifw-*.pem)
+        FMODE=600; FOWNER=root:wheel ;;
+    /usr/local/etc/swanctl/x509/aifw-*.pem)
+        FMODE=644; FOWNER=root:wheel ;;
+    /usr/local/etc/swanctl/x509ca/aifw-*.pem)
+        FMODE=644; FOWNER=root:wheel ;;
     *)
         echo "aifw-sudo-write: refusing write outside allowlist: $DEST" >&2
         exit 1

--- a/working-plan.md
+++ b/working-plan.md
@@ -133,25 +133,35 @@ established_secs, remote_host }` parsed from `swanctl --list-sas --raw`.
       conf.d/*.conf (ship an include line if not).
 - [x] 2e. Version bump to 5.106.0, commit.
 
-### Phase 3 — Apply lifecycle + rollback (→ minor bump)
+### Phase 3 — Apply lifecycle + rollback (→ 5.107.0) — DONE
 
-- [ ] 3a. `apply()`: write conf set atomically (tmp + rename), `--load-all`;
-      on error restore previous files, reload, surface the swanctl stderr.
-- [ ] 3b. `start/stop`: `--initiate`/`--terminate`; `delete` = terminate +
-      remove conf + reload; `update` = re-render + reload (+ re-initiate if
-      it was up and start_action='start').
-- [ ] 3c. Reboot recovery: conf files persist; rc start runs `--load-all`;
-      daemon startup calls `IpsecEngine::ensure_applied()` to re-render from
-      DB (DB is source of truth) — covers restore-from-backup too.
-- [ ] 3d. Cert auth material: from `acme_cert_id` (reuse acme store, re-export
-      on renewal via existing export hooks) or manual PEM; written to
-      swanctl/x509* dirs 0600.
-- [ ] 3e. pf rules from tunnel model (IKE 500/4500 to/from remote_addr, ESP,
-      enc0 pass) into the existing `aifw-vpn` anchor; remove `IpsecSa` rule
-      emission.
-- [ ] 3f. Tests: apply/rollback with a failing mock load; update/delete
-      lifecycle; ensure_applied idempotence.
-- [ ] 3g. Version bump, commit.
+- [x] 3a. `IpsecConfStore` trait (SystemConfStore via aifw-sudo-write/rm +
+      readdir listing; MemConfStore for tests). `apply_all()` regenerates
+      the full managed file set from DB, removes stale files, `--load-all`.
+      Rollback model: DB is source of truth — failed apply reverts the DB
+      mutation and re-applies the previous state (aifw user can't read
+      root-owned conf files back, so file snapshots were a non-starter).
+- [x] 3b. `create/update/delete_tunnel_applied` with rollback;
+      `start_tunnel` (initiate child, 30s timeout) / `stop_tunnel`
+      (terminate ike); delete terminates best-effort first.
+- [x] 3c. `ensure_applied()` — no-op on boxes that never used IPsec;
+      re-renders + reloads otherwise. `ensure_service()` (FreeBSD only):
+      sysrc strongswan_enable=YES + service start when not running.
+- [x] 3d. Cert material: manual PEM or ACME store (`acme::load_cert` by i64
+      id — acme_cert_id type corrected from Uuid; cert→x509, key→private,
+      chain→x509ca aifw-<id>-chain.pem, peer CA→aifw-<id>-ca.pem).
+      NOTE: ACME renewal re-export hook deferred to Phase 6 verification
+      (apply_all re-reads the store, so a renewal + apply picks up new
+      material; automatic re-apply-on-renewal still to wire).
+- [x] 3e. `endpoint_pf_rules` free fn + `IpsecTunnel::to_pf_rules`;
+      `collect_vpn_rules` now emits rules for enabled ipsec_tunnels and
+      NOTHING for legacy ipsec_sas (their pf holes were pure attack
+      surface); tolerates missing table pre-migration.
+- [x] 3f. Tests: apply writes+loads, disabled not rendered, create/update
+      rollback on failing load, delete removes files + terminates, cert
+      material files, missing ACME cert fails apply, start/stop,
+      ensure_applied no-op, stale file cleanup. Full suite 754 green.
+- [x] 3g. Version bump to 5.107.0, commit.
 
 ### Phase 4 — Live status + API/CLI (→ minor bump)
 

--- a/working-plan.md
+++ b/working-plan.md
@@ -188,16 +188,20 @@ established_secs, remote_host }` parsed from `swanctl --list-sas --raw`.
       message, 410, status list). Full suite 762 green.
 - [x] 4g. Version bump to 5.108.0, commit.
 
-### Phase 5 — UI (→ minor bump)
+### Phase 5 — UI (→ 5.109.0) — DONE
 
-- [ ] 5a. `src/lib/api/vpn.ts` + `useVpn.ts`: tunnel types, CRUD, start/stop,
-      live status polling.
-- [ ] 5b. Rework `IpsecSection`/`IpsecForm`: tunnel form (endpoints, IDs,
-      auth method toggle PSK/cert with ACME cert picker, subnets, proposals
-      with sane defaults collapsed under "Advanced"), live state badges
-      (IKE up / child SAs / bytes / rekey countdown), start/stop buttons.
-      Legacy SA rows shown read-only under a "legacy (inactive)" divider.
-- [ ] 5c. `npm run lint` + build; version bump, commit.
+- [x] 5a. `lib/api/vpn.ts`: IpsecTunnel/IpsecLiveStatus/ChildSaStatus/
+      AcmeCertOption types + tunnel CRUD/start/stop/status calls; legacy
+      SA create removed (API 410s it). `useVpn`: tunnel state, 10s live
+      status polling while tunnels exist, edit flow with blank-secret =
+      keep-stored semantics (sends REDACTED marker).
+- [x] 5b. `IpsecForm`: endpoints/subnets, PSK↔cert toggle, ACME cert
+      picker or PEM paste, peer CA, advanced collapse (IDs, proposals,
+      lifetimes, DPD, start action, enabled). `IpsecSection`: tunnels
+      table with IKE-state badge + live bytes/uptime/rekey, start/stop/
+      edit/delete; legacy SA records under an explicit "inactive" divider
+      with delete-only.
+- [x] 5c. ESLint clean, static export builds; bump to 5.109.0, commit.
 
 ### Phase 6 — Functional proof on FreeBSD (→ patch bumps as needed)
 

--- a/working-plan.md
+++ b/working-plan.md
@@ -1,318 +1,216 @@
-# AiFw Enterprise Multi-WAN — Working Plan
+# AiFw IPsec Data Plane (#530) — Working Plan
 
-Goal: add multi-WAN support that exceeds Cisco (IOS PBR + IP SLA + track objects) and Juniper (routing-instances, RPM, `then routing-instance`, rib-groups) in features, usability, correctness, and observability.
+Goal: replace the CRUD-only IPsec surface with a real data plane: strongSwan
+(charon) as the IKE daemon, driven via `swanctl`, establishing kernel
+SAs/SPs on FreeBSD, with live negotiated state reported through the API/UI.
 
-Track progress here per CLAUDE.md workflow: one sub-phase at a time, `cargo check`, commit after each, mark `[x]` when done.
+Decisions (triage + scoping):
+- **Backend**: strongSwan from FreeBSD pkg (`security/strongswan`), config via
+  `swanctl` conf files + CLI. Same architecture as pfSense/OPNsense.
+- **v1 scope**: IKEv2, site-to-site **tunnel mode only**, **PSK and X.509
+  cert** auth (certs can come from the ACME store or pasted PEM), NAT-T,
+  AES-256-GCM / SHA-256 / ECP-256+MODP-2048 defaults. No transport mode, no
+  AH, no IKEv1 in v1 — docs/UI must not claim them.
+- Old `ipsec_sas` rows are preserved as read-only legacy records (never shown
+  as active); new model is `ipsec_tunnels`.
+
+Track progress per CLAUDE.md workflow: one sub-phase at a time, `cargo check`,
+commit after each (bump Cargo.toml + package.json versions), mark `[x]`.
+Branch: `feat/530-ipsec-dataplane` off `main`.
 
 ## Design Principles
 
-1. `cargo check` zero warnings, all tests green, `npm run build` succeeds before every commit.
-2. Mock (Linux/WSL) compiles with full coverage for every FreeBSD-only code path.
-3. Each sub-phase is independently shippable; migrations forward-only.
-4. Default behavior for existing single-WAN users is identical before/after upgrade. Multi-WAN is opt-in.
-5. pf state is global on FreeBSD — every PBR rule emits paired `reply-to` and uses `(if-bound)` state policy.
+1. `cargo check` zero warnings, tests green, `npm run build` before every commit.
+2. Everything compiles and is testable on Linux/WSL: swanctl invocations go
+   through a small `IkeControl` trait (real = sudo swanctl, mock = in-memory)
+   mirroring the PfBackend pattern.
+3. Live state comes from `swanctl --list-sas` (kernel/IKE truth), never from a
+   DB `status` column. DB stores desired config only.
+4. Apply is transactional: render new conf → load → on failure restore the
+   previous conf set and reload (last working state survives).
+5. Secrets (PSKs, private keys) live in 0600 files under
+   `/usr/local/etc/swanctl/` owned by the service user; never logged, redacted
+   in API responses.
+6. Every new sudo command gets an `aifw-sudo-*` wrapper + narrow sudoers grant
+   + guard test (sudoers-drift lesson: grants must match call sites exactly).
 
-## Convergence Contract
+## Architecture
 
-- Probe interval default: 500 ms
-- Declare down after 3 consecutive failures (1.5 s)
-- pf re-apply within 200 ms of state change
-- End-to-end target: ≤3 s median, ≤5 s p99 (probe-fail → dataplane)
-- Failed WAN's `(if-bound)` states → killed via `pfctl -k` scoped to failed iface
+```
+UI / CLI ──► aifw-api (routes/vpn.rs: ipsec_tunnels CRUD, start/stop, live status)
+                 │
+                 ▼
+          IpsecEngine (aifw-core/src/ipsec.rs)
+            │ desired config: SQLite ipsec_tunnels
+            │ render: /usr/local/etc/swanctl/conf.d/aifw-<id>.conf (+ secrets)
+            │ control: IkeControl trait
+            │            ├── SwanctlControl (FreeBSD: sudo swanctl --load-all /
+            │            │                   --initiate / --terminate / --list-sas)
+            │            └── MockIkeControl (Linux/tests)
+            ▼
+        strongSwan charon ──PF_KEY──► FreeBSD kernel SAD/SPD ──► enc0 / ESP
+```
+
+pf side (existing anchors): IKE UDP 500/4500, ESP, and enc0 pass rules are
+emitted from the new tunnel model (replacing `IpsecSa::to_pf_rules`).
 
 ## Data Model
 
-```
-Interface ─(ifconfig fib N)─► RoutingInstance (fib_number unique)
-                                   │
-                                   ▼
-                              Gateway (monitor, state, RTT/loss/jitter/MOS)
-                                   │
-                                   ▼
-                              GatewayGroupMember (tier, weight)
-                                   │
-                                   ▼
-                              GatewayGroup (policy, preempt, sticky, hysteresis)
-
-PolicyRule (priority-ordered, evaluated before aifw anchor)
-  match: src/dst/port/proto/iface-in/schedule/dscp/geoip/user
-  action: SetInstance | SetGateway | SetGroup | MarkDscp | Shape | Mix
-
-RouteLeak (decoupled)
-  src_instance, dst_instance, prefix, proto, ports, direction
-
-GatewayEvent (100 per gw, append-only)
-SlaSample (1-min buckets, 30-day retention)
-```
-
-## Anchor Hierarchy
-
-Root ruleset ordering:
-`aifw-pbr` → `aifw-mwan-leak` → `aifw-mwan-reply` → `aifw-nat` → `aifw` → `aifw-vpn` → `aifw-geoip`
-
-Loader emitter lives in `aifw-setup/src/apply.rs`.
-
-## Kernel / Build Prereqs (one-time, Phase 1)
-
-- [ ] `aifw-setup/src/tuning.rs::generate_tuning()` — append `TuningItem { LoaderConf, "net.fibs", "16", "Multi-WAN" }` gated behind wizard step
-- [ ] `freebsd/overlay/usr/local/etc/rc.d/aifw_fibs` — pins iface→FIB at boot via `aifw-cli multiwan apply-boot`
-- [ ] `freebsd/manifest.json` — add `aifw_fibs` to `rc_scripts`
-- [ ] `docs/multi-wan.md` — document `net.fibs` loader tunable
-
----
-
-## Phase 1 — Foundations: FIB-aware PfBackend + RoutingInstance engine (→ v5.35.0)
-
-User value: declare named routing instances, assign interfaces to FIBs via UI/API. Feature-flagged "Multi-WAN preview."
-
-- [x] 1a. `aifw-common/src/multiwan.rs` — types: `RoutingInstance`, `InstanceStatus`, `InstanceMember`
-- [x] 1b. `PfBackend` additions — `set_interface_fib`, `get_interface_fib`, `list_fibs` (mock + ioctl)
-- [x] 1c. `aifw-core/src/multiwan/instance.rs::InstanceEngine` + migrate (tables + seed `default/fib 0/mgmt_reachable=1`)
-- [x] 1d. `aifw-common/src/permission.rs` — `MultiWanRead`, `MultiWanWrite`
-- [x] 1e. `aifw-api/src/multiwan.rs` — instances CRUD + members + `/fibs` endpoint; wire in `main.rs` AppState + build_router
-- [x] 1f. `aifw-ui/src/app/multi-wan/page.tsx` + nav entry
-- [x] 1g. Tests: unit CRUD, duplicate fib, cascade delete; API integration tests
-- [x] 1h. Version bump to 5.35.0, commit
-
-Tables:
 ```sql
-multiwan_instances (id PK, name UNIQUE, fib_number UNIQUE, description, mgmt_reachable, created_at, updated_at)
-multiwan_instance_members (instance_id FK, interface, PRIMARY KEY (instance_id, interface))
+ipsec_tunnels (
+  id TEXT PK, name TEXT UNIQUE, enabled INTEGER,
+  -- endpoints & identities
+  local_addr TEXT,            -- IP or interface address; '' = %any
+  remote_addr TEXT,           -- peer IP/FQDN
+  local_id TEXT, remote_id TEXT,          -- IKE identities (default = addrs)
+  -- auth
+  auth_method TEXT,           -- 'psk' | 'cert'
+  psk TEXT,                   -- redacted in API output
+  cert_source TEXT,           -- 'acme' | 'manual' (cert auth only)
+  acme_cert_id TEXT,          -- FK acme_cert when cert_source='acme'
+  local_cert_pem TEXT, local_key_pem TEXT, ca_cert_pem TEXT,  -- manual PEM
+  -- proposals
+  ike_proposal TEXT,          -- default 'aes256gcm16-prfsha256-ecp256'
+  esp_proposal TEXT,          -- default 'aes256gcm16-ecp256'
+  -- traffic selectors (tunnel mode)
+  local_ts TEXT,              -- CSV of local subnets
+  remote_ts TEXT,             -- CSV of remote subnets
+  -- behavior
+  ike_lifetime_secs INTEGER,  -- default 14400 (rekey)
+  esp_lifetime_secs INTEGER,  -- default 3600
+  dpd_delay_secs INTEGER,     -- default 30, 0 = off
+  start_action TEXT,          -- 'start' (initiate on load) | 'trap' (on-demand) | 'none'
+  created_at TEXT, updated_at TEXT
+)
+-- legacy ipsec_sas table kept as-is, read-only, flagged legacy in API list
 ```
 
-Risks:
-- `ifconfig fib` on live default iface can drop routes → require `?confirm_drops=true`, pre-flight check via `netstat -rnF 0`
-- Default seed must be idempotent → `INSERT OR IGNORE` with fixed UUID constant
+Live status (not stored): per-tunnel `{ ike_state, child_sas: [{ name, state,
+local_ts, remote_ts, bytes_in, bytes_out, rekey_in_secs, enc_alg }],
+established_secs, remote_host }` parsed from `swanctl --list-sas --raw`.
 
----
+## Phases
 
-## Phase 2 — Gateways + health monitoring
+### Phase 1 — Packaging + control plumbing (→ 5.105.0) — DONE
 
-User value: define gateways; live RTT/loss/jitter/MOS. No dataplane effect.
+- [x] 1a. `freebsd/manifest.json`: `packages` list (strongswan + existing
+      deps) — build-iso.sh/deploy.sh mirror it (guard test enforces sync);
+      updater installs missing packages on upgrade from the manifest list.
+      strongswan_enable via sysrc happens at engine apply time (Phase 3),
+      not install time — no reason to run charon on boxes with no tunnels.
+- [x] 1b. Overlay: `aifw-sudo-swanctl` wrapper (verbs `--load-all`,
+      `--initiate/--terminate --ike|--child <aifw-*>`, `--list-sas`,
+      `--list-conns`; names pinned to aifw-* namespace) + sudoers grant;
+      swanctl dirs in manifest `directories`; also extended allowlists:
+      aifw-sudo-write (swanctl conf/key/cert paths + `..` guard),
+      aifw-sudo-rm (same paths), aifw-sudo-mkdir (/usr/local/etc/swanctl),
+      aifw-sudo-service (strongswan), aifw-sudo-sysrc (strongswan_enable).
+- [x] 1c. `aifw-core/src/sudo.rs`: `swanctl()` (no broad-grant fallback —
+      none ever existed); embedded in EMBEDDED_SUDO_HELPERS for upgrade
+      self-heal; sudoers refresh reaches upgraded boxes via aifw-restart.sh.
+- [x] 1d. Guard tests: sudoers narrow_helpers_are_granted + new
+      test_manifest_packages_synced_with_build_scripts; wrapper validator
+      smoke-tested (17 arg-validation cases).
+- [x] 1e. Version bump to 5.105.0, commit.
 
-- [x] 2a. Probes module in `aifw-core/src/multiwan/probe.rs` (kept inline for minimal deps)
-- [x] 2b. `IcmpProbe` (sudo `/sbin/ping`)
-- [x] 2c. `TcpProbe` (tokio TcpStream + timeout)
-- [x] 2d. `HttpProbe` (curl shell-out with expect status)
-- [x] 2e. `DnsProbe` (`/usr/bin/host` shell-out)
-- [x] 2f. `GatewayEngine` with hysteresis, broadcast event channel, MOS scoring
-- [x] 2g. `aifw-daemon` starts all gateway monitors on boot + spawns SLA aggregation loop
-- [x] 2h. API CRUD + `/probe-now` + `/events` (SSE deferred)
-- [x] 2i. UI `multi-wan/gateways/page.tsx` with full form validation + live polling
-- [ ] 2j. Metrics emission (deferred — `aifw-metrics` integration is a separate effort)
-- [x] 2k. `GatewayEngine::inject_sample` test helper
-- [x] 2l. Tests: transitions emit events, CRUD, probe outcomes, evaluate_transition
+### Phase 2 — Types + engine core (→ minor bump)
 
-Tables:
-```sql
-multiwan_gateways (id, name UNIQUE, instance_id FK, interface, next_hop, ip_version,
-                   monitor_kind, monitor_target, monitor_port, monitor_expect,
-                   interval_ms=500, timeout_ms=1000,
-                   loss_pct_down=20.0, loss_pct_up=5.0, latency_ms_down, latency_ms_up,
-                   consec_fail_down=3, consec_ok_up=5,
-                   weight=1, dampening_secs=10, dscp_tag, enabled=1,
-                   state='unknown', last_rtt_ms, last_jitter_ms, last_loss_pct, last_mos,
-                   last_probe_ts, created_at, updated_at)
-multiwan_gateway_events (id AUTO, gateway_id FK, ts, from_state, to_state, reason,
-                         probe_snapshot_json)
-```
+- [ ] 2a. `aifw-common/src/ipsec.rs`: `IpsecTunnel`, `IpsecAuthMethod`,
+      `IpsecStartAction`, `IpsecLiveStatus`, `ChildSaStatus`; proposal
+      validation against strongSwan-accepted algorithm strings (curated
+      whitelist + unit tests). Mark old `IpsecSa`/`IpsecSp` `#[deprecated]`
+      internals-only (kept for legacy rows + migration).
+- [ ] 2b. `IkeControl` trait in `aifw-core/src/ipsec.rs` + `SwanctlControl`
+      (cfg FreeBSD path via sudo::swanctl) + `MockIkeControl` (records loads,
+      fabricates list-sas output for tests).
+- [ ] 2c. `IpsecEngine`: migrate() (ipsec_tunnels), CRUD with validation
+      (subnets, addrs, proposal strings, PSK strength ≥ 16 chars, cert
+      presence for cert auth).
+- [ ] 2d. Conf rendering: swanctl conn + secrets sections per tunnel; golden
+      tests for PSK and cert variants, NAT-T implicit (charon handles 4500).
+- [ ] 2e. Version bump, commit.
 
----
+### Phase 3 — Apply lifecycle + rollback (→ minor bump)
 
-## Phase 3 — Gateway groups
+- [ ] 3a. `apply()`: write conf set atomically (tmp + rename), `--load-all`;
+      on error restore previous files, reload, surface the swanctl stderr.
+- [ ] 3b. `start/stop`: `--initiate`/`--terminate`; `delete` = terminate +
+      remove conf + reload; `update` = re-render + reload (+ re-initiate if
+      it was up and start_action='start').
+- [ ] 3c. Reboot recovery: conf files persist; rc start runs `--load-all`;
+      daemon startup calls `IpsecEngine::ensure_applied()` to re-render from
+      DB (DB is source of truth) — covers restore-from-backup too.
+- [ ] 3d. Cert auth material: from `acme_cert_id` (reuse acme store, re-export
+      on renewal via existing export hooks) or manual PEM; written to
+      swanctl/x509* dirs 0600.
+- [ ] 3e. pf rules from tunnel model (IKE 500/4500 to/from remote_addr, ESP,
+      enc0 pass) into the existing `aifw-vpn` anchor; remove `IpsecSa` rule
+      emission.
+- [ ] 3f. Tests: apply/rollback with a failing mock load; update/delete
+      lifecycle; ensure_applied idempotence.
+- [ ] 3g. Version bump, commit.
 
-User value: compose gateways into ordered groups with policy.
+### Phase 4 — Live status + API/CLI (→ minor bump)
 
-- [x] 3a. `aifw-core/src/multiwan/group.rs` — pure selection logic for failover/weighted/adaptive/LB
-- [x] 3b. API CRUD + member mgmt + `/active` endpoint
-- [x] 3c. UI `multi-wan/groups/page.tsx` with full form validation, live active-member indicator
-- [ ] 3d. `proptest` dev-dep (chaos harness in `examples/multiwan_chaos.rs` covers similar ground)
-- [x] 3e. Scenario tests: failover lowest-tier, fallback on down, adaptive MOS scaling
+- [ ] 4a. `swanctl --list-sas` parser (`--raw` output) → `IpsecLiveStatus`;
+      unit tests against captured real output fixtures.
+- [ ] 4b. API: `GET/POST /vpn/ipsec/tunnels`, `GET/PUT/DELETE .../{id}`,
+      `POST .../{id}/start|stop`, `GET .../{id}/status`, `GET /vpn/ipsec/status`
+      (all tunnels, 1-min cached poll + on-demand refresh). PSK/keys redacted
+      in every response. Legacy `GET /vpn/ipsec` keeps returning old rows with
+      `legacy: true`; legacy `POST` returns 410 Gone with a pointer.
+- [ ] 4c. Permissions: reuse existing VPN read/write perms; audit-log all
+      mutations.
+- [ ] 4d. Backup/config-io: include `ipsec_tunnels` (secrets included in
+      encrypted backups, consistent with WG private keys).
+- [ ] 4e. CLI: `aifw vpn ipsec list|add|delete|start|stop|status`.
+- [ ] 4f. API integration tests (axum_test + mock control).
+- [ ] 4g. Version bump, commit.
 
-Tables:
-```sql
-multiwan_groups (id, name UNIQUE, policy (failover|weighted_lb|adaptive|load_balance),
-                 preempt=1, sticky (none|src|five_tuple), hysteresis_ms=2000,
-                 kill_states_on_failover=1, created_at, updated_at)
-multiwan_group_members (group_id FK, gateway_id FK, tier=1, weight=1,
-                        PRIMARY KEY (group_id, gateway_id))
-```
+### Phase 5 — UI (→ minor bump)
 
----
+- [ ] 5a. `src/lib/api/vpn.ts` + `useVpn.ts`: tunnel types, CRUD, start/stop,
+      live status polling.
+- [ ] 5b. Rework `IpsecSection`/`IpsecForm`: tunnel form (endpoints, IDs,
+      auth method toggle PSK/cert with ACME cert picker, subnets, proposals
+      with sane defaults collapsed under "Advanced"), live state badges
+      (IKE up / child SAs / bytes / rekey countdown), start/stop buttons.
+      Legacy SA rows shown read-only under a "legacy (inactive)" divider.
+- [ ] 5c. `npm run lint` + build; version bump, commit.
 
-## Phase 4 — Policy routing rules + pf emission
+### Phase 6 — Functional proof on FreeBSD (→ patch bumps as needed)
 
-User value: first dataplane phase. Rules like "LAN→Netflix via WAN2" work end-to-end.
+- [ ] 6a. Bring-up: deploy to test VM (172.29.50.220) and appliance
+      (172.29.69.1); establish an IKEv2 PSK tunnel between them; verify
+      `swanctl --list-sas`, kernel SAD/SPD (`setkey -D`, `setkey -DP`),
+      bidirectional ping/iperf across the tunnel subnets.
+- [ ] 6b. Cert-auth tunnel variant (manual CA-signed pair).
+- [ ] 6c. NAT-T case (initiator behind NAT) — verify UDP 4500 encapsulation.
+- [ ] 6d. Rekey observed (short lifetimes), DPD teardown, reboot recovery
+      (tunnel re-establishes without operator action).
+- [ ] 6e. Failure paths: bad PSK → clear error surfaced, previous config
+      restored on bad apply.
+- [ ] 6f. #533 boot-smoke harness: add IPsec check artifact (swanctl list-sas
+      + cross-tunnel ping output) to CI/functional test collection.
 
-- [x] 4a. `PfBackend` additions: `kill_states_on_iface`, `kill_states_for_label`
-- [x] 4b. `PolicyEngine` with CRUD + `apply()` composing instance/gateway/group into pf
-- [x] 4c. Emitters: `route-to`+`reply-to` for SetGateway; `rtable N` for SetInstance; weighted route-to with sticky-address for SetGroup
-- [x] 4d. Anchor wiring into `aifw-setup/src/apply.rs` — `aifw-pbr`, `aifw-mwan-leak`, `aifw-mwan-reply` emitted ahead of `aifw-nat`/`aifw` in root ruleset
-- [x] 4e. API CRUD + `/apply` under `/api/v1/multiwan/policies`
-- [x] 4f. UI `multi-wan/policies/page.tsx` with target-aware picker + blast-radius preview button
-- [x] 4g. Golden tests: set_instance emits rtable, set_gateway emits paired route-to/reply-to with if-bound, disabled skipped
+### Phase 7 — Docs + issue close-out
 
-Tables:
-```sql
-multiwan_policies (id, priority, name, status, ip_version, iface_in,
-                   src_addr='any', dst_addr='any', src_port, dst_port, protocol='any',
-                   dscp_in, geoip_country, schedule_id,
-                   action_kind, target_id, sticky='none', fallback_target_id,
-                   description, created_at, updated_at)
-```
-
-Emission examples:
-```
-pass out quick on em1 inet proto udp from 10.0.0.0/24 to any port 443 \
-  route-to (em1 203.0.113.1) keep state (if-bound) label "pbr:<id>"
-pass in quick on em0 inet proto udp from 10.0.0.0/24 to any port 443 \
-  reply-to (em1 203.0.113.1) keep state (if-bound) label "pbr:<id>:rep"
-
-pass in quick on em_lan from 10.0.0.0/24 to any \
-  rtable 1 keep state (if-bound) label "pbr:inst:<id>"
-
-pass out quick on em1 inet proto tcp from 10.0.0.0/24 to any \
-  route-to { (em1 203.0.113.1) weight 2, (em2 198.51.100.1) weight 1 } \
-  round-robin sticky-address keep state (if-bound) label "pbr:grp:<id>"
-```
-
-Risks: rule explosion → consolidate via pf tables (`<pbr_src_10_0_0_0_24>`), defer if small.
-
----
-
-## Phase 5 — Route leaking + mgmt escape hatches
-
-User value: cross-FIB traffic for DNS/NTP/API (Juniper rib-groups, declarative).
-
-- [x] 5a. `LeakEngine` + anchor `aifw-mwan-leak`
-- [x] 5b. `seed_mgmt_escapes` — idempotent seeding of src→mgmt leaks for each non-default instance
-- [x] 5c. API CRUD + `/seed-mgmt`
-- [x] 5d. UI `multi-wan/leaks/page.tsx` with validation + "auto-seed mgmt escapes" button
-- [x] 5e. Tests: bidirectional compile, disabled skip; API returns 409 on mgmt-escape deletion
-
-Tables:
-```sql
-multiwan_leaks (id, name, src_instance_id FK, dst_instance_id FK, prefix,
-                protocol='any', ports, direction (bidirectional|one_way), enabled=1,
-                created_at, updated_at)
-```
-
----
-
-## Phase 6 — Pre-flight / blast-radius / force-migrate
-
-User value: nobody in enterprise gear does this well. Dry-run config changes.
-
-- [x] 6a. `PreflightEngine` using `PfBackend::get_states` + policy compile diff
-- [x] 6b. `BlastRadiusReport` with affected_flows, would_strand_mgmt, new/removed_rules, findings
-- [x] 6c. `POST /api/v1/multiwan/preview`
-- [x] 6d. `POST /api/v1/multiwan/apply`
-- [x] 6e. `POST /api/v1/multiwan/flows/{label}/migrate`
-- [x] 6f. UI "Preview blast radius" button on policies page (modal via alert for now)
-- [x] 6g. Tests: mgmt-strand on src=any, specific subnet OK, disabled skipped, missing-mgmt warning
-
----
-
-## Phase 7 — SLA reporting + AI anomaly detection
-
-User value: long-term observability exceeding Cisco IP SLA.
-
-- [x] 7a. `SlaEngine` with `multiwan_sla_samples` table + prune helper
-- [x] 7b. Daemon SLA aggregation loop: 1-min bucket record for each gateway, daily 30-day prune
-- [ ] 7c. AI anomaly hook (requires `aifw-ai` analysis pipeline — tracked separately)
-- [x] 7d. API `/gateways/{id}/sla?window=24h|7d|30d`
-- [x] 7e. UI `multi-wan/sla/page.tsx` with uptime/RTT/loss/MOS stat cards + RTT sparkline
-
----
-
-## Phase 8 — Per-flow visibility + force-migrate UX
-
-User value: live per-flow WAN table with 1-click re-steer.
-
-- [x] 8a. `PfState` gains optional `iface`, `rtable`
-- [x] 8b. `GET /multiwan/flows` exposes flow summaries
-- [x] 8c. `POST /multiwan/flows/{label}/migrate` kills states by label
-- [x] 8d. UI `multi-wan/flows/page.tsx` with filter, auto-refresh, and force-migrate-by-label
-
----
-
-## Phase 9 — GitOps / BGP / discovery
-
-User value: the stuff Cisco/Juniper still make hard.
-
-- [x] 9a. `GET /multiwan/config.yaml` — full config as JSON/YAML-compatible struct
-- [x] 9b. `POST /multiwan/apply-yaml` — upsert all instances/gateways/groups/policies/leaks by id, then apply
-- [ ] 9c. `aifw-bgp` crate — needs separate issue; requires FRR integration
-- [ ] 9d. Auto-discovery — needs separate issue; traceroute + ASN DB
-- [x] 9e. IPv6 parity via `ip_version` field across Gateway/Policy/Instance
-- [ ] 9f. Plugin probe hook — needs plugin-system trait extension; separate issue
-
----
-
-## Phase 10 — Hardening + chaos + docs
-
-- [x] 10a. `cargo run --example multiwan_chaos` — seeded PRNG, invariant checks on oscillation + monotonic events
-- [ ] 10b. FreeBSD dual-WAN VM convergence test — requires VM infra; tracked separately
-- [x] 10c. `docs/multi-wan.md` architecture, quick-start, anchors, convergence, Cisco/Juniper comparison matrix
-
----
-
-## Observability Contract (cross-phase)
-
-Metrics (`aifw-metrics`):
-- `aifw_gateway_{rtt_ms,jitter_ms,loss_ratio,mos,state}{name,instance}` gauges
-- `aifw_gateway_transitions_total{name,from,to}` counter
-- `aifw_policy_flows_current{policy,gw}` gauge
-- `aifw_multiwan_pf_reloads_total{anchor}` counter
-- `aifw_multiwan_convergence_ms` histogram {gw}
-
-Log lines (structured `tracing`):
-- `target=multiwan.gateway event=transition gw=wan1 from=up to=down reason="loss=100%" consec_fail=3`
-- `target=multiwan.policy event=reload anchor=aifw-pbr rules=42 took_ms=87`
-- `target=multiwan.preflight event=block reason=would_strand_mgmt`
-
-Webhooks (`/api/v1/multiwan/webhooks`): `gateway.transition`, `anomaly.detected`, `group.active_changed`.
-
----
-
-## Migration Path
-
-On first run with Phase 1:
-1. Idempotent seed: `default` instance on FIB 0, `mgmt_reachable=1`
-2. All existing interfaces stay on FIB 0 (no `ifconfig fib` calls)
-3. UI shows Multi-WAN nav under "Advanced"
-4. pf anchors `aifw-pbr`/`aifw-mwan-leak`/`aifw-mwan-reply` not emitted when empty → pf output byte-identical to pre-upgrade
-5. Release notes link to `docs/multi-wan.md`
-
----
-
-## Critical File Touchpoints
-
-- `/home/mack/dev/AiFw/aifw-pf/src/backend.rs` — trait additions
-- `/home/mack/dev/AiFw/aifw-pf/src/{mock,ioctl}.rs` — impls
-- `/home/mack/dev/AiFw/aifw-core/src/lib.rs` — re-exports
-- `/home/mack/dev/AiFw/aifw-core/src/multiwan/*.rs` — new engines
-- `/home/mack/dev/AiFw/aifw-api/src/main.rs` — AppState + router
-- `/home/mack/dev/AiFw/aifw-api/src/multiwan.rs` — handlers
-- `/home/mack/dev/AiFw/aifw-common/src/{multiwan,permission}.rs` — types + perms
-- `/home/mack/dev/AiFw/aifw-common/src/rule.rs` — `to_pf_rule` (extend to emit route-to/rtable)
-- `/home/mack/dev/AiFw/aifw-setup/src/{tuning,apply,wizard}.rs` — kernel tuning + anchor wiring + wizard
-- `/home/mack/dev/AiFw/aifw-daemon/` — probe supervisor
-- `/home/mack/dev/AiFw/aifw-ui/src/app/multi-wan/` — new UI
-- `/home/mack/dev/AiFw/freebsd/overlay/usr/local/etc/rc.d/aifw_fibs` — boot pin
-- `/home/mack/dev/AiFw/freebsd/manifest.json` — rc_scripts entry
-
----
+- [ ] 7a. Flip #552 "in development" markers: claims become "IPsec IKEv2
+      site-to-site (tunnel mode, PSK/cert), powered by strongSwan"; remove
+      AH/transport claims everywhere (README, docs, comparison pages).
+- [ ] 7b. `docs/` IPsec guide: setup walkthrough, interop notes (tested:
+      strongSwan↔strongSwan; expected: any IKEv2 peer), troubleshooting.
+- [ ] 7c. Comment + close #530 (and verify #529/#552 consistency), Project
+      #12 → Done.
 
 ## Risk Summary
 
 | Risk | Mitigation |
 |---|---|
-| pf state global → FIB leakage | `(if-bound)` on every PBR rule; `kill_states_on_iface` on failover |
-| Asymmetric return traffic | `reply-to` auto-paired with every `route-to` |
-| Admin lock-out from PBR | Pre-flight validation; default mgmt escape leak seeded |
-| `ROUTETABLES` compile-time cap | `net.fibs` loader tunable; runtime check in `list_fibs` |
-| Daemon lacks raw socket | TCP probe default; sudo ICMP fallback |
-| Rule explosion | pf tables for src/dst sets; debounced reloads; anchor-scoped flushes |
-| Mock/ioctl divergence | Golden pf-output tests run identically against both backends |
-| Probe flapping | Hysteresis (consec_fail/ok), dampening_secs, group hysteresis_ms |
+| charon runs as root; aifw user must drive it | sudo wrapper with whitelisted swanctl subcommands only; guard test |
+| Secrets on disk | 0600 swanctl-owned files, redacted API, encrypted backups |
+| swanctl output format drift | parse `--raw` (machine format); fixture tests from the real pkg version; pin strongSwan pkg version in manifest |
+| Bad apply kills all tunnels | atomic conf-set swap + rollback reload |
+| ACME renewal rotates cert under a live tunnel | hook acme export → re-write x509 files + `--load-all` (reload-safe) |
+| Legacy `ipsec_sas` confusion | read-only, `legacy: true`, POST 410; migration doc note |
+| Mock/real divergence | golden conf-render tests + Phase 6 live matrix is the gate for claims |

--- a/working-plan.md
+++ b/working-plan.md
@@ -113,22 +113,25 @@ established_secs, remote_host }` parsed from `swanctl --list-sas --raw`.
       smoke-tested (17 arg-validation cases).
 - [x] 1e. Version bump to 5.105.0, commit.
 
-### Phase 2 — Types + engine core (→ minor bump)
+### Phase 2 — Types + engine core (→ 5.106.0) — DONE
 
-- [ ] 2a. `aifw-common/src/ipsec.rs`: `IpsecTunnel`, `IpsecAuthMethod`,
-      `IpsecStartAction`, `IpsecLiveStatus`, `ChildSaStatus`; proposal
-      validation against strongSwan-accepted algorithm strings (curated
-      whitelist + unit tests). Mark old `IpsecSa`/`IpsecSp` `#[deprecated]`
-      internals-only (kept for legacy rows + migration).
-- [ ] 2b. `IkeControl` trait in `aifw-core/src/ipsec.rs` + `SwanctlControl`
-      (cfg FreeBSD path via sudo::swanctl) + `MockIkeControl` (records loads,
-      fabricates list-sas output for tests).
-- [ ] 2c. `IpsecEngine`: migrate() (ipsec_tunnels), CRUD with validation
-      (subnets, addrs, proposal strings, PSK strength ≥ 16 chars, cert
-      presence for cert auth).
-- [ ] 2d. Conf rendering: swanctl conn + secrets sections per tunnel; golden
-      tests for PSK and cert variants, NAT-T implicit (charon handles 4500).
-- [ ] 2e. Version bump, commit.
+- [x] 2a. `aifw-common/src/ipsec.rs`: `IpsecTunnel`, `IpsecAuthMethod`,
+      `IpsecCertSource`, `IpsecStartAction`, `IpsecLiveStatus`,
+      `ChildSaStatus`; curated proposal-token whitelist; validate() doubles
+      as conf-injection guard (no quotes/newlines in rendered values);
+      `redacted()` blanks psk/private key. Old `IpsecSa`/`IpsecSp` kept
+      undeprecated (still compiled by legacy paths) with doc note.
+- [x] 2b. `IkeControl` trait + `SwanctlControl` (sudo::swanctl, stderr
+      surfaced) + `MockIkeControl` (records calls, canned list-sas output,
+      injectable load failure).
+- [x] 2c. `IpsecEngine`: migrate (ipsec_tunnels), add/list/get/update/delete
+      with validation-before-persist; explicit column list (no SELECT *).
+- [x] 2d. `render_swanctl_conf`: conn + children + PSK secrets sections
+      (secrets bound to peer ids); cert auth via x509/private dirs, key
+      never in conf. Golden tests: PSK, cert, multi-TS, trap action.
+      NOTE for Phase 3/6: confirm FreeBSD pkg swanctl.conf includes
+      conf.d/*.conf (ship an include line if not).
+- [x] 2e. Version bump to 5.106.0, commit.
 
 ### Phase 3 — Apply lifecycle + rollback (→ minor bump)
 

--- a/working-plan.md
+++ b/working-plan.md
@@ -203,12 +203,25 @@ established_secs, remote_host }` parsed from `swanctl --list-sas --raw`.
       with delete-only.
 - [x] 5c. ESLint clean, static export builds; bump to 5.109.0, commit.
 
-### Phase 6 — Functional proof on FreeBSD (→ patch bumps as needed)
+### Phase 6 — Functional proof on FreeBSD (→ 5.109.1 so far)
 
-- [ ] 6a. Bring-up: deploy to test VM (172.29.50.220) and appliance
-      (172.29.69.1); establish an IKEv2 PSK tunnel between them; verify
-      `swanctl --list-sas`, kernel SAD/SPD (`setkey -D`, `setkey -DP`),
-      bidirectional ping/iperf across the tunnel subnets.
+Single-box smoke on the dev VM (172.29.50.220, FreeBSD 15.0) — DONE:
+- [x] strongswan pkg installs; default swanctl.conf has `include
+      conf.d/*.conf` (line 587) — no extra config shipping needed.
+- [x] Full lifecycle through the narrow sudo path: CLI ipsec-add →
+      conf rendered root:wheel 0600 in conf.d → `--load-all` → conn
+      loaded (IKEv2, TUNNEL, correct TS/proposals/DPD) → initiate error
+      surfaced with charon diagnostic → live status → terminate →
+      delete removes conf + unloads conn.
+- [x] Caught + fixed: real `--list-sas --raw` is compact `key=value`
+      (no spaces) — tokenizer rewritten, verbatim FreeBSD fixture added
+      (5.109.1). Live CONNECTING state + remote host verified parsing.
+
+Remaining (needs a second endpoint — appliance gets builds via update
+tarball, Mack's call on when):
+- [ ] 6a. Two-endpoint IKEv2 PSK tunnel VM↔appliance: ESTABLISHED,
+      kernel SAD/SPD (`setkey -D` / `-DP`), bidirectional ping/iperf
+      across tunnel subnets.
 - [ ] 6b. Cert-auth tunnel variant (manual CA-signed pair).
 - [ ] 6c. NAT-T case (initiator behind NAT) — verify UDP 4500 encapsulation.
 - [ ] 6d. Rekey observed (short lifetimes), DPD teardown, reboot recovery

--- a/working-plan.md
+++ b/working-plan.md
@@ -163,22 +163,30 @@ established_secs, remote_host }` parsed from `swanctl --list-sas --raw`.
       ensure_applied no-op, stale file cleanup. Full suite 754 green.
 - [x] 3g. Version bump to 5.107.0, commit.
 
-### Phase 4 — Live status + API/CLI (→ minor bump)
+### Phase 4 — Live status + API/CLI (→ 5.108.0) — DONE
 
-- [ ] 4a. `swanctl --list-sas` parser (`--raw` output) → `IpsecLiveStatus`;
-      unit tests against captured real output fixtures.
-- [ ] 4b. API: `GET/POST /vpn/ipsec/tunnels`, `GET/PUT/DELETE .../{id}`,
-      `POST .../{id}/start|stop`, `GET .../{id}/status`, `GET /vpn/ipsec/status`
-      (all tunnels, 1-min cached poll + on-demand refresh). PSK/keys redacted
-      in every response. Legacy `GET /vpn/ipsec` keeps returning old rows with
-      `legacy: true`; legacy `POST` returns 410 Gone with a pointer.
-- [ ] 4c. Permissions: reuse existing VPN read/write perms; audit-log all
-      mutations.
-- [ ] 4d. Backup/config-io: include `ipsec_tunnels` (secrets included in
-      encrypted backups, consistent with WG private keys).
-- [ ] 4e. CLI: `aifw vpn ipsec list|add|delete|start|stop|status`.
-- [ ] 4f. API integration tests (axum_test + mock control).
-- [ ] 4g. Version bump, commit.
+- [x] 4a. `ipsec_status.rs`: tolerant tokenizer/tree parser for
+      `--list-sas --raw` (vici_dump shape; handles DN ids with embedded
+      `=`, bracketed TS lists, compact + indented forms); unit fixtures —
+      swap in a captured real-appliance fixture during Phase 6.
+      `IpsecEngine::live_status()`/`tunnel_status()` degrade to DOWN when
+      charon is unreachable.
+- [x] 4b. API: tunnels CRUD + start/stop + per-tunnel and all-tunnels
+      status; PSK/private key redacted everywhere; mutations return
+      status+message errors so charon/validation detail reaches clients.
+      Legacy `GET /vpn/ipsec` rows now carry `legacy: true`; POST → 410
+      pointing at the tunnels API; DELETE kept for cleanup. Polling left
+      to the UI (Phase 5) — status endpoint is a fresh list-sas each call.
+- [x] 4c. Permissions: VpnRead/VpnWrite groups (router.rs).
+- [x] 4d. Backup/config-io: VpnConfig.ipsec_tunnels (serde default),
+      table cleared+restored on import, one apply after restore; export
+      counts tunnels; startup ensure_applied in aifw-api main.
+- [x] 4e. CLI: `aifw vpn ipsec-add` now creates a real IKEv2 tunnel
+      (legacy SA creation removed); new ipsec-start/ipsec-stop/
+      ipsec-status; list shows tunnels + legacy records separately.
+- [x] 4f. 4 axum_test integration tests (CRUD+redaction, validation
+      message, 410, status list). Full suite 762 green.
+- [x] 4g. Version bump to 5.108.0, commit.
 
 ### Phase 5 — UI (→ minor bump)
 


### PR DESCRIPTION
Implements the real IPsec data plane decided in #530 (option 2): strongSwan (charon) as the IKE daemon, driven via swanctl, establishing kernel SAs/SPs on FreeBSD, with live negotiated state reported through the API/UI instead of a database status column.

## Scope (v1)

IKEv2 site-to-site, **tunnel mode only**, PSK and X.509 certificate auth (ACME store or pasted PEM), NAT-T, AES-256-GCM/SHA-256 defaults. AH, transport mode, and IKEv1 are deliberately not claimed or exposed.

## What's in here (one commit per phase)

1. **Packaging + control plumbing** — strongswan added to `manifest.json` `packages` (updater installs it on upgrade; build-iso/deploy mirror it with a sync guard test); new `aifw-sudo-swanctl` narrow wrapper (verbs whitelisted, conn names pinned to the `aifw-*` namespace) + sudoers grant + embedded self-heal; allowlist extensions for write/rm/mkdir/service/sysrc helpers.
2. **Types + engine core** — `IpsecTunnel` model with validation that doubles as swanctl-conf injection guard; `IkeControl` trait (SwanctlControl / MockIkeControl mirroring the PfBackend split); `IpsecEngine` CRUD; swanctl conn+secrets rendering with golden tests.
3. **Apply lifecycle** — `IpsecConfStore` (real via sudo helpers / in-memory mock); `apply_all` regenerates the managed file set from the DB and prunes stale files; failed apply rolls back the DB mutation and restores the previous working state; reboot/restore recovery via `ensure_applied()` at API startup; cert material resolution from the ACME store or stored PEM. Legacy `ipsec_sas` records no longer emit pf rules (they never had a data plane — those holes were pure attack surface).
4. **Live status + API/CLI** — tolerant parser for `swanctl --list-sas --raw`; REST tunnels CRUD + start/stop + live status with secrets redacted everywhere and charon diagnostics surfaced in error responses; legacy SA POST is now 410 Gone (rows flagged `legacy: true`, delete kept for cleanup); CLI `ipsec-add/-start/-stop/-status`; backup/restore includes `ipsec_tunnels`.
5. **UI** — full tunnel form (PSK/cert toggle, ACME picker, advanced collapse), live IKE-state badges with bytes/uptime/rekey countdown, start/stop, legacy records under an explicit inactive divider.

762 tests green, zero clippy warnings, UI static export builds.

## Not yet done (before the #530 acceptance list closes)

- **Phase 6 — functional proof on FreeBSD**: two-endpoint tunnel (PSK, cert, NAT-T), rekey/DPD/reboot recovery, failure paths, real `--list-sas --raw` fixture to replace the synthetic parser fixture, #533 smoke-harness artifact. Also verify the pkg's default `swanctl.conf` includes `conf.d/*.conf`.
- **Phase 7 — docs**: flip the #552 "in development" markers only after Phase 6 proves the tunnel; ACME renewal → automatic re-apply hook.

Closes nothing yet — #530 stays open until the functional criteria are demonstrated.