### PR TITLE
fix: aifw-console ssh passthrough/EOF + restart-driver package self-heal (#564, #565)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.109.2"
+version = "5.109.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -147,6 +147,14 @@ struct ExternalRepo {
     repo: String,
 }
 
+/// OS packages this build requires, from the embedded manifest. Exposed
+/// for `aifw-setup --print-packages`, which aifw-restart.sh queries to
+/// install dependencies a transitional upgrade missed (#565: the old
+/// updater binary's embedded manifest predates newly-added packages).
+pub fn manifest_packages() -> Vec<String> {
+    load_manifest().packages
+}
+
 fn load_manifest() -> Manifest {
     serde_json::from_str(MANIFEST_JSON).expect("freebsd/manifest.json is invalid")
 }
@@ -1468,6 +1476,45 @@ mod tests {
                 "{name} must invoke the refresh_sudoers routine"
             );
         }
+    }
+
+    // #565: the restart driver (new-tarball code, runs as root) must
+    // install packages the old updater binary's embedded manifest didn't
+    // know about — the only reliable hook on a transitional upgrade.
+    #[test]
+    fn test_restart_driver_ensures_packages() {
+        assert!(
+            EMBEDDED_RESTART_SH.contains("aifw-setup --print-packages"),
+            "aifw-restart.sh must query the new binary's package list"
+        );
+        assert!(
+            EMBEDDED_RESTART_SH.contains("pkg install"),
+            "aifw-restart.sh must install missing packages"
+        );
+        assert!(
+            EMBEDDED_RESTART_SH.contains("ensure_packages"),
+            "aifw-restart.sh must invoke the ensure_packages routine"
+        );
+    }
+
+    // #564: aifw-console is root's login shell; it must exec `-c`
+    // commands (ssh/scp/sftp) instead of rendering the menu, and must
+    // exit — not busy-loop — when stdin hits EOF.
+    #[test]
+    fn test_console_passthrough_and_eof_exit() {
+        let console = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../freebsd/overlay/usr/local/sbin/aifw-console"),
+        )
+        .expect("aifw-console exists in the overlay");
+        assert!(
+            console.contains(r#"exec /bin/sh -c "$@""#),
+            "aifw-console must pass -c commands through to a real shell"
+        );
+        assert!(
+            console.contains("read choice || exit"),
+            "aifw-console menu must exit on stdin EOF, not busy-loop"
+        );
     }
 
     #[test]

--- a/aifw-setup/src/main.rs
+++ b/aifw-setup/src/main.rs
@@ -37,6 +37,12 @@ struct Args {
     /// Edit the CHANGE-ME placeholders, then: aifw-setup --config seed.json
     #[arg(long)]
     print_seed_template: bool,
+
+    /// Print the OS packages this build requires (one per line, from the
+    /// embedded manifest) and exit. Used by aifw-restart.sh to install
+    /// dependencies a transitional upgrade missed (#565).
+    #[arg(long)]
+    print_packages: bool,
 }
 
 #[tokio::main]
@@ -50,6 +56,13 @@ async fn main() -> anyhow::Result<()> {
 
     if args.print_seed_template {
         print!("{}", config::SetupConfig::seed_template());
+        return Ok(());
+    }
+
+    if args.print_packages {
+        for pkg in aifw_core::updater::manifest_packages() {
+            println!("{pkg}");
+        }
         return Ok(());
     }
 

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.109.2",
+  "version": "5.109.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/freebsd/overlay/usr/local/libexec/aifw-restart.sh
+++ b/freebsd/overlay/usr/local/libexec/aifw-restart.sh
@@ -60,6 +60,26 @@ refresh_sudoers() {
 }
 refresh_sudoers
 
+# --- package self-heal (in-place upgrade gap #565) --------------------------
+# The updater's own ensure-packages loop reads the manifest embedded in the
+# RUNNING (old) binary, so the first upgrade to a release that adds an OS
+# package never installs it (strongswan, #530). This driver executes the NEW
+# tarball's code as root, so it asks the freshly-installed aifw-setup for the
+# authoritative package list and installs whatever is missing — before the
+# bounce, so restarted services find their dependencies present.
+ensure_packages() {
+    [ -x /usr/local/sbin/aifw-setup ] || return 0
+    for _pkg in $(/usr/local/sbin/aifw-setup --print-packages 2>/dev/null); do
+        if ! pkg info -q "$_pkg" 2>/dev/null; then
+            log "installing missing dependency: $_pkg"
+            if ! env ASSUME_ALWAYS_YES=yes pkg install "$_pkg" >> "$LOG" 2>&1; then
+                log "WARN pkg install $_pkg failed — dependent features may not start"
+            fi
+        fi
+    done
+}
+ensure_packages
+
 # Settle: let the API HTTP response leave the box and the caller's tokio
 # runtime tear down before we touch services. Matches the 2-second delay
 # used by the previous in-process implementation.

--- a/freebsd/overlay/usr/local/sbin/aifw-console
+++ b/freebsd/overlay/usr/local/sbin/aifw-console
@@ -6,6 +6,17 @@ AIFW_CONF="/usr/local/etc/aifw/aifw.conf"
 AIFW_VERSION_FILE="/usr/local/share/aifw/version"
 AIFW_VERSION=$(cat "$AIFW_VERSION_FILE" 2>/dev/null || echo "unknown")
 
+# Non-interactive passthrough (#564). aifw-console is root's login shell
+# (aifw-login-migrate.sh), so sshd invokes it as `aifw-console -c <cmd>`
+# for every `ssh root@host <cmd>`, scp, and sftp. The hardening's goal
+# was console autologin, not disabling remote administration — SSH is
+# already key-gated — so command invocations exec through a real shell
+# instead of rendering the menu.
+if [ "${1:-}" = "-c" ]; then
+    shift
+    exec /bin/sh -c "$@"
+fi
+
 show_banner()
 {
     clear
@@ -218,7 +229,10 @@ while true; do
     show_banner
     show_menu
     echo -n "Enter an option: "
-    read choice
+    # Exit on EOF (#564): without this, a non-tty invocation spins the
+    # menu loop forever printing "Invalid option" — a runaway process
+    # per stray ssh/script invocation.
+    read choice || exit 0
 
     case "$choice" in
         0)  exit 0 ;;


### PR DESCRIPTION
Fixes #564 and #565 — both found live during the appliance's 5.97.17 → 5.109.2 upgrade while running #530 Phase 6 verification.

**#564 aifw-console:** root's login shell (post `aifw-login-migrate.sh`) now execs `-c` commands through `/bin/sh`, restoring `ssh root@host <cmd>`/scp/sftp, and the menu loop exits on stdin EOF instead of spinning a runaway "Invalid option" loop (two of which were found running on the appliance).

**#565 transitional upgrade gap:** new `aifw-setup --print-packages` (mirrors `--print-sudoers`) emits the embedded manifest package list; `aifw-restart.sh` — the first new-tarball code to run as root after an install — installs any missing packages before bouncing services. This closes the gap where the *old* updater binary's embedded manifest doesn't know about newly-added packages (strongswan had to be installed manually this upgrade).

Guard tests added for the console passthrough/EOF behavior and the restart-driver ensure step. Full suite green.