### PR TITLE
feat(tests): T07 IPsec single-host functional gate (#533, #530)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.109.2"
+version = "5.109.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.109.2",
+  "version": "5.109.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/freebsd/tests/lib.sh
+++ b/freebsd/tests/lib.sh
@@ -65,6 +65,18 @@ api() { # $1 = method, $2 = path, $3 = json body (optional). Prints body; rc!=0 
     esac
 }
 
+api_status() { # $1 = method, $2 = path, $3 = json body (optional). Prints only the HTTP status code; always rc 0.
+    _m="$1"; _p="$2"; _b="${3:-}"
+    if [ -n "$_b" ]; then
+        curl -sS -m 15 -o /dev/null -w '%{http_code}' -X "$_m" "$API_BASE$_p" \
+            -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+            -d "$_b"
+    else
+        curl -sS -m 15 -o /dev/null -w '%{http_code}' -X "$_m" "$API_BASE$_p" \
+            -H "Authorization: Bearer $TOKEN"
+    fi
+}
+
 api_login() { # bootstraps the first user and stores TOKEN
     curl -sS -m 15 -X POST "$API_BASE/api/v1/auth/register" \
         -H 'Content-Type: application/json' \

--- a/freebsd/tests/run-all.sh
+++ b/freebsd/tests/run-all.sh
@@ -231,7 +231,7 @@ log "API up, authenticated"
 
 # ---------------------------------------------------------------- run tests
 
-TESTS="${TESTS:-t01-pfctl-acceptance t02-pass-block t03-schedule-gating t04-nat t05-restore-roundtrip t06-wireguard}"
+TESTS="${TESTS:-t01-pfctl-acceptance t02-pass-block t03-schedule-gating t04-nat t05-restore-roundtrip t06-wireguard t07-ipsec}"
 TOTAL=0
 FAILED_TESTS=""
 

--- a/freebsd/tests/t07-ipsec.sh
+++ b/freebsd/tests/t07-ipsec.sh
@@ -1,0 +1,68 @@
+# shellcheck shell=sh
+# T07 — IPsec (#530) on the real kernel: create an IKEv2 tunnel through the
+# API and verify the swanctl conf is rendered root-only, charon loads the
+# conn (IKEv2 / TUNNEL / correct traffic selectors), the live-status
+# endpoint reports real charon state, the IKE/ESP/enc0 pass rules land in
+# the aifw-vpn anchor, and delete unloads + removes everything. Skips
+# (rc 3) when strongSwan isn't installed. Peer handshake + encrypted
+# traffic needs a charon peer in a jail — covered by the manual two-box
+# matrix (#530 Phase 6); this test gates the single-host contract.
+
+if ! command -v swanctl >/dev/null 2>&1; then
+    echo "strongswan not installed; skipping"
+    exit 3
+fi
+service strongswan onestatus >/dev/null 2>&1 || service strongswan onestart >/dev/null 2>&1 || true
+swanctl --version >/dev/null 2>&1 || { echo "charon/vici unavailable; skipping"; exit 3; }
+
+CONF_DIR=/usr/local/etc/swanctl/conf.d
+
+TUN=$(api POST /api/v1/vpn/ipsec/tunnels '{
+  "name": "t07-tunnel",
+  "remote_addr": "203.0.113.77",
+  "local_ts": ["10.99.7.0/24"],
+  "remote_ts": ["10.98.7.0/24"],
+  "psk": "t07-functional-harness-psk",
+  "start_action": "none"
+}') || fail "create tunnel"
+TUN_ID=$(printf '%s' "$TUN" | jq -r '.data.id')
+[ -n "$TUN_ID" ] && [ "$TUN_ID" != null ] || fail "tunnel id missing from create response"
+
+# Secrets must never leave the API
+printf '%s' "$TUN" | jq -e '.data.psk == "REDACTED"' >/dev/null || fail "PSK not redacted in create response"
+
+# Rendered conf: present, root-owned, mode 600 (contains the PSK)
+CONF="$CONF_DIR/aifw-$TUN_ID.conf"
+[ -f "$CONF" ] || fail "swanctl conf not rendered at $CONF"
+PERMS=$(stat -f '%Lp %Su' "$CONF" 2>/dev/null)
+[ "$PERMS" = "600 root" ] || fail "conf perms/owner wrong: $PERMS (want 600 root)"
+
+# charon actually loaded the conn with the right shape
+swanctl --list-conns > "$RESULTS_DIR/t07-list-conns.txt" 2>&1 || fail "swanctl --list-conns"
+grep -q "aifw-$TUN_ID: IKEv2" "$RESULTS_DIR/t07-list-conns.txt" || fail "conn not loaded as IKEv2"
+grep -q "aifw-$TUN_ID-1: TUNNEL" "$RESULTS_DIR/t07-list-conns.txt" || fail "child not TUNNEL mode"
+grep -q "10.99.7.0/24" "$RESULTS_DIR/t07-list-conns.txt" || fail "local TS missing from loaded conn"
+
+# Live status comes from charon, not the DB — no SA yet means DOWN
+STATUS=$(api GET "/api/v1/vpn/ipsec/tunnels/$TUN_ID/status") || fail "status endpoint"
+printf '%s' "$STATUS" | jq -e '.data.ike_state == "DOWN"' >/dev/null || fail "expected DOWN, got: $STATUS"
+swanctl --list-sas --raw > "$RESULTS_DIR/t07-list-sas-raw.txt" 2>&1 || true
+
+# pf: IKE/ESP/enc0 pass rules in the aifw-vpn anchor
+api_reload || fail "reload"
+pfctl_anchor_rules aifw-vpn > "$RESULTS_DIR/t07-vpn-anchor.txt" 2>&1 || true
+grep -q "proto esp" "$RESULTS_DIR/t07-vpn-anchor.txt" || fail "ESP pass rule missing from aifw-vpn anchor"
+grep -q "500" "$RESULTS_DIR/t07-vpn-anchor.txt" || fail "IKE port rule missing from aifw-vpn anchor"
+grep -q "enc0" "$RESULTS_DIR/t07-vpn-anchor.txt" || fail "enc0 pass rule missing from aifw-vpn anchor"
+
+# Legacy surface: creating pre-#530 SA records is gone
+LEGACY_CODE=$(api_status POST /api/v1/vpn/ipsec '{"name":"t07-legacy","local_addr":"1.2.3.4","remote_addr":"5.6.7.8","protocol":"esp","mode":"tunnel"}')
+[ "$LEGACY_CODE" = "410" ] || fail "legacy SA POST should be 410 Gone, got $LEGACY_CODE"
+
+# Delete: conf removed, conn unloaded
+api DELETE "/api/v1/vpn/ipsec/tunnels/$TUN_ID" >/dev/null || fail "delete tunnel"
+[ ! -f "$CONF" ] || fail "conf file survived delete"
+swanctl --list-conns 2>/dev/null | grep -q "aifw-$TUN_ID" && fail "conn still loaded after delete"
+
+[ "$FAILURES" = 0 ] || exit 1
+exit 0

--- a/freebsd/tests/t07-ipsec.sh
+++ b/freebsd/tests/t07-ipsec.sh
@@ -52,7 +52,9 @@ swanctl --list-sas --raw > "$RESULTS_DIR/t07-list-sas-raw.txt" 2>&1 || true
 api_reload || fail "reload"
 pfctl_anchor_rules aifw-vpn > "$RESULTS_DIR/t07-vpn-anchor.txt" 2>&1 || true
 grep -q "proto esp" "$RESULTS_DIR/t07-vpn-anchor.txt" || fail "ESP pass rule missing from aifw-vpn anchor"
-grep -q "500" "$RESULTS_DIR/t07-vpn-anchor.txt" || fail "IKE port rule missing from aifw-vpn anchor"
+# pfctl renders `port { 500 4500 }` as the service names isakmp / ipsec-nat-t
+grep -q "isakmp" "$RESULTS_DIR/t07-vpn-anchor.txt" || fail "IKE (500/isakmp) rule missing from aifw-vpn anchor"
+grep -q "ipsec-nat-t" "$RESULTS_DIR/t07-vpn-anchor.txt" || fail "NAT-T (4500) rule missing from aifw-vpn anchor"
 grep -q "enc0" "$RESULTS_DIR/t07-vpn-anchor.txt" || fail "enc0 pass rule missing from aifw-vpn anchor"
 
 # Legacy surface: creating pre-#530 SA records is gone

--- a/working-plan.md
+++ b/working-plan.md
@@ -217,19 +217,30 @@ Single-box smoke on the dev VM (172.29.50.220, FreeBSD 15.0) — DONE:
       (no spaces) — tokenizer rewritten, verbatim FreeBSD fixture added
       (5.109.1). Live CONNECTING state + remote host verified parsing.
 
-Remaining (needs a second endpoint — appliance gets builds via update
-tarball, Mack's call on when):
-- [ ] 6a. Two-endpoint IKEv2 PSK tunnel VM↔appliance: ESTABLISHED,
-      kernel SAD/SPD (`setkey -D` / `-DP`), bidirectional ping/iperf
-      across tunnel subnets.
-- [ ] 6b. Cert-auth tunnel variant (manual CA-signed pair).
-- [ ] 6c. NAT-T case (initiator behind NAT) — verify UDP 4500 encapsulation.
-- [ ] 6d. Rekey observed (short lifetimes), DPD teardown, reboot recovery
-      (tunnel re-establishes without operator action).
-- [ ] 6e. Failure paths: bad PSK → clear error surfaced, previous config
-      restored on bad apply.
-- [ ] 6f. #533 boot-smoke harness: add IPsec check artifact (swanctl list-sas
-      + cross-tunnel ping output) to CI/functional test collection.
+Two-box matrix (appliance on 5.109.2 via pre-release update tarball ↔
+dev VM; full results on #530) — ALL DONE 2026-07-21:
+- [x] 6a. IKEv2 PSK tunnel VM↔appliance ESTABLISHED both sides; 4/4
+      pings each direction; kernel SAD/SPD verified (`setkey -D`/`-DP`);
+      tcpdump shows pure ESP with SPIs matching the SAD.
+- [x] 6b. Cert-auth (manual CA-signed EC P-256 pair, CN identities):
+      created via API (PEM validation → x509/private/x509ca dirs →
+      load), ESTABLISHED with pubkey auth confirmed by the peer.
+- [x] 6c. NAT-T: peer-forced `encap = yes` → UDP-encap ESP on 4500 both
+      directions, traffic flowing; encap survived appliance reboot.
+- [x] 6d. Rekey: 120s child lifetime → SPIs rotated with 150/150 pings
+      0% loss across the boundary, IKE SA continuous. DPD: peer charon
+      killed → DOWN in ~75s; peer restored → auto re-ESTABLISHED <48s.
+      Reboot: appliance cold boot → API up in ~78s, tunnel ESTABLISHED
+      unattended (strongswan_enable persisted; ensure_applied loaded).
+- [x] 6e. Wrong PSK → negotiation refused with surfaced charon error.
+- [x] 6f. `t07-ipsec.sh` in the #533 harness (PR #567): API-driven
+      single-host gate (conf 0600, charon load, live status, pf anchor
+      rules with isakmp/ipsec-nat-t, 410 legacy, delete cleanup);
+      artifacts include list-conns/list-sas-raw/anchor dumps. Full
+      harness t01–t07 green on the VM.
+
+Upgrade fallout fixed separately: #564 console ssh/EOF, #565
+transitional package/sudoers gap (PR #566).
 
 ### Phase 7 — Docs + issue close-out
 


### PR DESCRIPTION
Adds `t07-ipsec.sh` to the FreeBSD functional harness — the CI-facing gate for the #530 IPsec data plane's single-host contract:

- IKEv2 tunnel created through the real REST API on a real FreeBSD host
- swanctl conf rendered root-owned 0600; charon loads the conn (IKEv2, TUNNEL mode, correct traffic selectors)
- live-status endpoint reflects charon state (DOWN with no SA), PSK redacted in every response
- IKE (isakmp), NAT-T (ipsec-nat-t), ESP, and enc0 pass rules land in the `aifw-vpn` anchor
- legacy SA POST returns 410 Gone
- delete removes the conf and unloads the conn

Skips (rc 3) when strongSwan isn't installed. New `lib.sh` `api_status` helper for exact HTTP-status assertions. Peer handshake + encrypted traffic remains the manual two-box matrix — full results posted on #530 (ESTABLISHED, bidirectional traffic, NAT-T, rekey with 0% loss, DPD recovery, cold-boot recovery, wrong-PSK rejection, cert auth).

Full harness green on the FreeBSD test VM: t01–t07 all pass.