### PR TITLE
test: extend FreeBSD packet, API, and boot coverage

### DIFF
--- a/freebsd/tests/README.md
+++ b/freebsd/tests/README.md
@@ -65,7 +65,8 @@ USB IMG unmodified with a seed ISO attached as a CD, waits for
 `aifw_firstboot` to complete unattended setup, then asserts the seeded
 admin can log in through the LAN side, invalid credentials are rejected,
 the static UI is served, live PF/rule counters are reported, and the WAN
-side stays default-denied.
+side stays default-denied. It also creates a rule, reboots the appliance,
+and verifies PF plus the persisted live rule recover after boot.
 
 ```sh
 xz -dk aifw-<ver>-amd64.img.xz

--- a/freebsd/tests/README.md
+++ b/freebsd/tests/README.md
@@ -63,8 +63,9 @@ Expect ~20–30 minutes; the FreeBSD VM boot + build dominates.
 Runs on a **Linux** host with qemu (KVM when available): boots the built
 USB IMG unmodified with a seed ISO attached as a CD, waits for
 `aifw_firstboot` to complete unattended setup, then asserts the seeded
-admin can log in through the LAN side and that the WAN side stays
-default-denied.
+admin can log in through the LAN side, invalid credentials are rejected,
+the static UI is served, live PF/rule counters are reported, and the WAN
+side stays default-denied.
 
 ```sh
 xz -dk aifw-<ver>-amd64.img.xz

--- a/freebsd/tests/README.md
+++ b/freebsd/tests/README.md
@@ -30,6 +30,7 @@ by hand on a test VM and under `vmactions/freebsd-vm` in CI
 | `t04-nat` | Outbound SNAT (translation visible in the pf state table) and rdr port-forward into the server jail, with return traffic |
 | `t05-restore-roundtrip` | #535: save → mutate → restore brings both DB and the live anchor back |
 | `t06-wireguard` | Tunnel creation on the real kernel + #541 pubkey-derives-from-privkey via `wg pubkey` (skips without wireguard-kmod) |
+| `t08-control-plane` | Unauthenticated access rejection, invalid-login rejection, live PF/rule counters, identity, and representative JSON response shapes |
 
 ## Running on a test VM
 

--- a/freebsd/tests/lib.sh
+++ b/freebsd/tests/lib.sh
@@ -129,6 +129,16 @@ server_listen_once() { # $1 = port, $2 = marker file
     jx_server sh -c "rm -f '$2'; (nc -l '$1' >/dev/null 2>&1 && touch '$2') &"
 }
 
+# One-shot UDP listener for packet-path tests. UDP has no connection refusal,
+# so callers must wait for the marker rather than rely on nc's exit status.
+server_listen_udp_once() { # $1 = port, $2 = marker file
+    jx_server sh -c "rm -f '$2'; (nc -u -l '$1' >/dev/null 2>&1 && touch '$2') &"
+}
+
+client_send_udp() { # $1 = host, $2 = port
+    printf 'aifw-functional-udp\n' | jx_client nc -u -w 2 "$1" "$2" >/dev/null 2>&1
+}
+
 wait_for_file() { # $1 = jail (client|server), $2 = file, $3 = seconds
     _i=0
     while [ "$_i" -lt "$3" ]; do

--- a/freebsd/tests/lib.sh
+++ b/freebsd/tests/lib.sh
@@ -132,7 +132,7 @@ server_listen_once() { # $1 = port, $2 = marker file
 # One-shot UDP listener for packet-path tests. UDP has no connection refusal,
 # so callers must wait for the marker rather than rely on nc's exit status.
 server_listen_udp_once() { # $1 = port, $2 = marker file
-    jx_server sh -c "rm -f '$2'; (nc -u -l '$1' >/dev/null 2>&1 && touch '$2') &"
+    jx_server sh -c "rm -f '$2'; (nc -u -l '$1' 2>/dev/null | (IFS= read -r line && touch '$2')) &"
 }
 
 client_send_udp() { # $1 = host, $2 = port

--- a/freebsd/tests/run-all.sh
+++ b/freebsd/tests/run-all.sh
@@ -231,7 +231,7 @@ log "API up, authenticated"
 
 # ---------------------------------------------------------------- run tests
 
-TESTS="${TESTS:-t01-pfctl-acceptance t02-pass-block t03-schedule-gating t04-nat t05-restore-roundtrip t06-wireguard t07-ipsec}"
+TESTS="${TESTS:-t01-pfctl-acceptance t02-pass-block t03-schedule-gating t04-nat t05-restore-roundtrip t06-wireguard t07-ipsec t08-control-plane}"
 TOTAL=0
 FAILED_TESTS=""
 

--- a/freebsd/tests/smoke-boot.sh
+++ b/freebsd/tests/smoke-boot.sh
@@ -140,6 +140,23 @@ if [ -z "$TOKEN" ]; then
 fi
 log "first boot complete after ~${elapsed}s; admin login OK via LAN ($SCHEME)"
 
+# Exercise the unauthenticated boundary and the shipped static UI before
+# relying on the authenticated status response below.
+invalid=$(curl -k -s -m 10 -o /dev/null -w '%{http_code}' \
+    -X POST "$SCHEME://127.0.0.1:$LAN_PORT/api/v1/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d '{"username":"admin","password":"definitely-wrong"}')
+[ "$invalid" = 401 ] || {
+    log "FAIL: invalid login returned HTTP $invalid (expected 401)"
+    exit 1
+}
+ui=$(curl -k -s -m 10 "$SCHEME://127.0.0.1:$LAN_PORT/")
+printf '%s' "$ui" | grep -q 'AiFw' || {
+    log "FAIL: LAN-served UI did not contain the AiFw marker"
+    exit 1
+}
+log "auth boundary and served UI checks OK"
+
 # Authenticated status call — proves the API is actually serving, not just
 # terminating connections.
 status=$(curl -k -s -m 10 "$SCHEME://127.0.0.1:$LAN_PORT/api/v1/status" \
@@ -147,6 +164,10 @@ status=$(curl -k -s -m 10 "$SCHEME://127.0.0.1:$LAN_PORT/api/v1/status" \
 printf '%s\n' "$status" > "$RESULTS_DIR/status.json"
 printf '%s' "$status" | jq -e . >/dev/null 2>&1 || {
     log "FAIL: /api/v1/status did not return JSON: $status"
+    exit 1
+}
+printf '%s' "$status" | jq -e '.pf_running == true and (.aifw_rules | type == "number") and (.nat_rules | type == "number")' >/dev/null 2>&1 || {
+    log "FAIL: status response did not report live PF/rule counters: $status"
     exit 1
 }
 log "status endpoint OK"

--- a/freebsd/tests/smoke-boot.sh
+++ b/freebsd/tests/smoke-boot.sh
@@ -27,7 +27,7 @@ while [ $# -gt 0 ]; do
 done
 [ -n "$IMG" ] && [ -f "$IMG" ] || { echo "usage: smoke-boot.sh --img PATH" >&2; exit 2; }
 
-for c in qemu-system-x86_64 curl jq; do
+for c in qemu-system-x86_64 curl jq ssh ssh-keygen; do
     command -v "$c" >/dev/null 2>&1 || { echo "missing: $c" >&2; exit 2; }
 done
 MKISO=""
@@ -44,8 +44,13 @@ ADMIN_USER="admin"
 ADMIN_PASS="SmokeTest123"
 LAN_PORT=18443   # host port forwarded to the appliance LAN address
 WAN_PORT=18081   # host port forwarded to the appliance WAN address (must stay blocked)
+SSH_PORT=18422   # root SSH on the LAN side, used for reboot persistence
 
 # ---------------------------------------------------------------- seed ISO
+
+ssh-keygen -q -t ed25519 -N '' -f "$WORK/id_ed25519" \
+    || { echo "ephemeral SSH key generation failed" >&2; exit 2; }
+SSH_PUB=$(cat "$WORK/id_ed25519.pub")
 
 cat > "$WORK/aifw-seed.json" <<EOF
 {
@@ -70,9 +75,9 @@ cat > "$WORK/aifw-seed.json" <<EOF
   "dhcp_enabled": false,
   "default_policy": "standard",
   "nat_enabled": true,
-  "ssh_auth_method": "password",
+  "ssh_auth_method": "keys",
   "ssh_github_user": null,
-  "ssh_authorized_keys": [],
+  "ssh_authorized_keys": ["$SSH_PUB"],
   "db_path": "/var/db/aifw/aifw.db",
   "config_dir": "/usr/local/etc/aifw"
 }
@@ -95,7 +100,7 @@ qemu-system-x86_64 \
     -cdrom "$WORK/seed.iso" \
     -netdev "user,id=wan,hostfwd=tcp:127.0.0.1:$WAN_PORT-:8080" \
     -device virtio-net-pci,netdev=wan \
-    -netdev "user,id=lan,net=192.168.1.0/24,hostfwd=tcp:127.0.0.1:$LAN_PORT-192.168.1.1:8080" \
+    -netdev "user,id=lan,net=192.168.1.0/24,hostfwd=tcp:127.0.0.1:$LAN_PORT-192.168.1.1:8080,hostfwd=tcp:127.0.0.1:$SSH_PORT-192.168.1.1:22" \
     -device virtio-net-pci,netdev=lan \
     -display none \
     -serial "file:$RESULTS_DIR/serial.log" \
@@ -171,6 +176,71 @@ printf '%s' "$status" | jq -e '.pf_running == true and (.aifw_rules | type == "n
     exit 1
 }
 log "status endpoint OK"
+
+# Create a distinctive rule, reboot the real appliance, and prove both the DB
+# record and live PF anchor recover. This catches boot ordering and disabled-PF
+# regressions that an API-only restart cannot expose.
+rule=$(curl -k -s -m 15 -X POST \
+    "$SCHEME://127.0.0.1:$LAN_PORT/api/v1/rules" \
+    -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+    -d '{"action":"block","direction":"in","protocol":"tcp","src_addr":"203.0.113.77","dst_addr":"192.0.2.77","dst_port_start":65530,"dst_port_end":65530,"label":"smoke-reboot-persist"}')
+RULE_ID=$(printf '%s' "$rule" | jq -r '.data.id // empty')
+[ -n "$RULE_ID" ] || {
+    log "FAIL: could not create reboot-persistence rule: $rule"
+    exit 1
+}
+curl -k -s -m 30 -X POST "$SCHEME://127.0.0.1:$LAN_PORT/api/v1/reload" \
+    -H "Authorization: Bearer $TOKEN" >/dev/null || {
+    log "FAIL: reload before reboot failed"
+    exit 1
+}
+
+SSH="ssh -i $WORK/id_ed25519 -p $SSH_PORT -o BatchMode=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5"
+ssh_elapsed=0
+while [ "$ssh_elapsed" -lt 60 ]; do
+    # shellcheck disable=SC2086
+    $SSH root@127.0.0.1 true >/dev/null 2>&1 && break
+    sleep 2
+    ssh_elapsed=$((ssh_elapsed + 2))
+done
+[ "$ssh_elapsed" -lt 60 ] || { log "FAIL: appliance SSH never became reachable"; exit 1; }
+
+log "requesting appliance reboot"
+# A successful reboot normally drops the SSH transport before it can return.
+# shellcheck disable=SC2086
+$SSH root@127.0.0.1 /sbin/shutdown -r now >/dev/null 2>&1 || true
+sleep 10
+
+TOKEN=""
+elapsed=0
+while [ "$elapsed" -lt "$TIMEOUT" ]; do
+    resp=$(curl -k -s -m 5 -X POST "$SCHEME://127.0.0.1:$LAN_PORT/api/v1/auth/login" \
+        -H 'Content-Type: application/json' -d "$login_body" 2>/dev/null) || true
+    TOKEN=$(printf '%s' "$resp" | jq -r '.tokens.access_token // empty' 2>/dev/null)
+    [ -n "$TOKEN" ] && break
+    sleep 5
+    elapsed=$((elapsed + 5))
+done
+[ -n "$TOKEN" ] || { log "FAIL: API did not recover after reboot"; exit 1; }
+
+post_status=$(curl -k -s -m 10 "$SCHEME://127.0.0.1:$LAN_PORT/api/v1/status" \
+    -H "Authorization: Bearer $TOKEN")
+printf '%s' "$post_status" | jq -e '.pf_running == true' >/dev/null 2>&1 || {
+    log "FAIL: post-reboot status reports PF is not running: $post_status"
+    exit 1
+}
+post_rules=$(curl -k -s -m 10 "$SCHEME://127.0.0.1:$LAN_PORT/api/v1/rules" \
+    -H "Authorization: Bearer $TOKEN")
+printf '%s' "$post_rules" | jq -e --arg id "$RULE_ID" '.data[] | select(.id == $id and .label == "smoke-reboot-persist")' >/dev/null 2>&1 || {
+    log "FAIL: persisted rule missing from API after reboot: $post_rules"
+    exit 1
+}
+# shellcheck disable=SC2086
+$SSH root@127.0.0.1 "pfctl -a aifw -sr" 2>/dev/null | grep -q 'smoke-reboot-persist' || {
+    log "FAIL: persisted rule missing from live PF anchor after reboot"
+    exit 1
+}
+log "reboot recovery OK; PF enabled and persisted rule live"
 
 # Default-deny on WAN: the management API port via the WAN interface must
 # NOT answer — the seed configures a LAN, so generate_pf_conf scopes the

--- a/freebsd/tests/t02-pass-block.sh
+++ b/freebsd/tests/t02-pass-block.sh
@@ -41,5 +41,34 @@ save_pf_artifacts t02
 api DELETE "/api/v1/rules/$PASS_ID" >/dev/null || fail "delete pass"
 api_reload || fail "cleanup reload"
 
+# 5. UDP follows the same default-deny/pass/remove contract. UDP has no
+# handshake, so the server marker is the authoritative evidence of delivery.
+UDP_PORT=8085
+UDP_MARKER=/tmp/aifwfx-t02-udp-marker
+server_listen_udp_once "$UDP_PORT" "$UDP_MARKER"
+client_send_udp "$SERVER_IP" "$UDP_PORT"
+wait_for_file server "$UDP_MARKER" 3 && fail "default-deny: UDP reached server with no pass rule"
+
+UDP_ID=$(add_rule '{"action":"pass","direction":"in","protocol":"udp","dst_addr":"'"$SERVER_IP"'","dst_port_start":'"$UDP_PORT"',"dst_port_end":'"$UDP_PORT"',"label":"t02-udp-pass"}') || fail "create UDP pass"
+api_reload || fail "reload UDP pass"
+server_listen_udp_once "$UDP_PORT" "$UDP_MARKER"
+client_send_udp "$SERVER_IP" "$UDP_PORT"
+wait_for_file server "$UDP_MARKER" 3 || fail "UDP pass: server never saw the datagram"
+
+api DELETE "/api/v1/rules/$UDP_ID" >/dev/null || fail "delete UDP pass"
+api_reload || fail "reload UDP removal"
+server_listen_udp_once "$UDP_PORT" "$UDP_MARKER"
+client_send_udp "$SERVER_IP" "$UDP_PORT"
+wait_for_file server "$UDP_MARKER" 3 && fail "after removing UDP pass, datagram was delivered"
+
+# 6. ICMP is explicitly exercised instead of being inferred from TCP.
+ping -c 1 -t 2 "$SERVER_IP" >/dev/null 2>&1 && fail "default-deny: ICMP reached server with no pass rule"
+ICMP_ID=$(add_rule '{"action":"pass","direction":"in","protocol":"icmp","dst_addr":"'"$SERVER_IP"'","label":"t02-icmp-pass"}') || fail "create ICMP pass"
+api_reload || fail "reload ICMP pass"
+ping -c 1 -t 2 "$SERVER_IP" >/dev/null 2>&1 || fail "ICMP pass: echo request failed"
+api DELETE "/api/v1/rules/$ICMP_ID" >/dev/null || fail "delete ICMP pass"
+api_reload || fail "reload ICMP removal"
+ping -c 1 -t 2 "$SERVER_IP" >/dev/null 2>&1 && fail "after removing ICMP pass, echo succeeded"
+
 [ "$FAILURES" = 0 ] || exit 1
 exit 0

--- a/freebsd/tests/t02-pass-block.sh
+++ b/freebsd/tests/t02-pass-block.sh
@@ -62,13 +62,13 @@ client_send_udp "$SERVER_IP" "$UDP_PORT"
 wait_for_file server "$UDP_MARKER" 3 && fail "after removing UDP pass, datagram was delivered"
 
 # 6. ICMP is explicitly exercised instead of being inferred from TCP.
-ping -c 1 -t 2 "$SERVER_IP" >/dev/null 2>&1 && fail "default-deny: ICMP reached server with no pass rule"
+jx_client ping -c 1 -t 2 "$SERVER_IP" >/dev/null 2>&1 && fail "default-deny: ICMP reached server with no pass rule"
 ICMP_ID=$(add_rule '{"action":"pass","direction":"in","protocol":"icmp","dst_addr":"'"$SERVER_IP"'","label":"t02-icmp-pass"}') || fail "create ICMP pass"
 api_reload || fail "reload ICMP pass"
-ping -c 1 -t 2 "$SERVER_IP" >/dev/null 2>&1 || fail "ICMP pass: echo request failed"
+jx_client ping -c 1 -t 2 "$SERVER_IP" >/dev/null 2>&1 || fail "ICMP pass: echo request failed"
 api DELETE "/api/v1/rules/$ICMP_ID" >/dev/null || fail "delete ICMP pass"
 api_reload || fail "reload ICMP removal"
-ping -c 1 -t 2 "$SERVER_IP" >/dev/null 2>&1 && fail "after removing ICMP pass, echo succeeded"
+jx_client ping -c 1 -t 2 "$SERVER_IP" >/dev/null 2>&1 && fail "after removing ICMP pass, echo succeeded"
 
 [ "$FAILURES" = 0 ] || exit 1
 exit 0

--- a/freebsd/tests/t08-control-plane.sh
+++ b/freebsd/tests/t08-control-plane.sh
@@ -1,0 +1,36 @@
+# shellcheck shell=sh
+# T08 — authenticated control-plane contract. The Linux/PfMock suite covers
+# handler logic; this checks the shipped API, auth boundary, and representative
+# response shapes on the same FreeBSD process used by the packet tests.
+
+BASE="$API_BASE"
+
+code=$(curl -sS -m 15 -o /dev/null -w '%{http_code}' "$BASE/api/v1/status")
+[ "$code" = 401 ] || fail "protected /status returned $code without auth"
+
+code=$(curl -sS -m 15 -o /dev/null -w '%{http_code}' -X POST \
+    "$BASE/api/v1/auth/login" -H 'Content-Type: application/json' \
+    -d '{"username":"functest","password":"definitely-wrong"}')
+[ "$code" = 401 ] || fail "invalid login returned $code"
+
+for endpoint in /api/v1/status /api/v1/about /api/v1/auth/me \
+    /api/v1/rules /api/v1/nat /api/v1/interfaces/detailed /api/v1/auth/users; do
+    body=$(api GET "$endpoint") || { fail "GET $endpoint failed"; continue; }
+    printf '%s' "$body" | jq -e 'type == "object"' >/dev/null 2>&1 \
+        || fail "$endpoint did not return a JSON object"
+done
+
+status=$(api GET /api/v1/status) || fail "status request failed"
+printf '%s' "$status" | jq -e '.pf_running == true and (.aifw_rules | type == "number") and (.nat_rules | type == "number")' >/dev/null 2>&1 \
+    || fail "status response is missing live pf/rule counters: $status"
+
+me=$(api GET /api/v1/auth/me) || fail "auth/me request failed"
+printf '%s' "$me" | jq -e '.username == "functest" and (.permissions | type == "array")' >/dev/null 2>&1 \
+    || fail "auth/me response does not identify the authenticated user: $me"
+
+about=$(api GET /api/v1/about) || fail "about request failed"
+printf '%s' "$about" | jq -e '.version and (.memory | type == "number")' >/dev/null 2>&1 \
+    || fail "about response is missing version/memory: $about"
+
+[ "$FAILURES" = 0 ] || exit 1
+exit 0

--- a/freebsd/tests/t08-control-plane.sh
+++ b/freebsd/tests/t08-control-plane.sh
@@ -29,7 +29,7 @@ printf '%s' "$me" | jq -e '.username == "functest" and (.permissions | type == "
     || fail "auth/me response does not identify the authenticated user: $me"
 
 about=$(api GET /api/v1/about) || fail "about request failed"
-printf '%s' "$about" | jq -e '.version and (.memory | type == "number")' >/dev/null 2>&1 \
+printf '%s' "$about" | jq -e '(.version | type == "string") and (.memory | type == "object")' >/dev/null 2>&1 \
     || fail "about response is missing version/memory: $about"
 
 [ "$FAILURES" = 0 ] || exit 1


### PR DESCRIPTION
Part of #533.

Ports the generally useful assertions from a larger private appliance harness into the repository's existing portable FreeBSD/QEMU tests. The Proxmox lifecycle and self-hosted runner orchestration are deliberately not included.

## Added coverage

- UDP default-deny, pass, and rule-deletion behavior with live jail traffic;
- ICMP default-deny, pass, and rule-deletion behavior with live jail traffic;
- unauthenticated `/status` rejection and invalid-login rejection;
- representative authenticated JSON response shapes;
- live `pf_running`, rule, and NAT counters;
- authenticated identity checks;
- booted-image invalid-login and static-UI assertions;
- API-created rule persistence across a real appliance reboot;
- post-reboot PF-running state and live-anchor verification.

The existing TCP, NAT, restore, WireGuard, IPsec, and WAN-management checks remain unchanged.

## Validation

- `sh -n freebsd/tests/*.sh`
- `git diff --check`

The actual packet and boot assertions require the existing FreeBSD functional and appliance-smoke jobs. The release-time smoke job is already the repository's portable built-image lane; no private lab credentials or framework are required.
