### PR TITLE
fix: allow isolated static WAN seeds without a gateway

### DIFF
--- a/aifw-setup/src/config.rs
+++ b/aifw-setup/src/config.rs
@@ -108,10 +108,8 @@ impl SetupConfig {
         if self.wan_interface.trim().is_empty() {
             return Err("wan_interface must not be empty".to_string());
         }
-        if matches!(self.wan_mode, WanMode::Static)
-            && (self.wan_ip.is_none() || self.wan_gateway.is_none())
-        {
-            return Err("static wan_mode requires wan_ip and wan_gateway".to_string());
+        if matches!(self.wan_mode, WanMode::Static) && self.wan_ip.is_none() {
+            return Err("static wan_mode requires wan_ip".to_string());
         }
         if self.lan_ip.is_some() && self.lan_interface.is_none() {
             return Err("lan_ip requires lan_interface".to_string());

--- a/aifw-setup/src/tests.rs
+++ b/aifw-setup/src/tests.rs
@@ -527,7 +527,13 @@ mod let_underscore_tests {
         };
         let mut c = mk();
         c.wan_mode = crate::config::WanMode::Static;
-        assert!(c.validate_seed().is_err(), "static without ip/gateway");
+        assert!(c.validate_seed().is_err(), "static without ip");
+
+        c.wan_ip = Some("198.18.0.1/24".to_string());
+        assert!(
+            c.validate_seed().is_ok(),
+            "static WAN without a default gateway is valid"
+        );
 
         let mut c = mk();
         c.lan_ip = Some("192.168.1.1/24".to_string());


### PR DESCRIPTION
## Problem

Unattended setup currently requires both `wan_ip` and `wan_gateway` whenever `wan_mode` is `static`. A static interface does not always need a default route: isolated labs, transit-less segments, and explicitly routed appliances are valid configurations.

The apply path already treats `wan_gateway` as optional; only seed validation rejects the configuration.

## Fix

Require a static WAN address, but allow the default gateway to be omitted. Extend the coherence test to cover the valid isolated-static case.

## Validation

- `cargo fmt --all --check`
- `cargo test -p aifw-setup` — 42 passed
