### PR TITLE
WireGuard: dual-stack IPv6 inside the tunnel (#471)

### DIFF
--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -661,6 +661,7 @@ pub(crate) async fn build_current_config(state: &AppState) -> Result<FirewallCon
             private_key: t.private_key.clone(),
             public_key: t.public_key.clone(),
             address: t.address.to_string(),
+            address6: t.address6.as_ref().map(|a| a.to_string()),
             dns: t.dns.clone(),
             mtu: t.mtu,
             peers: peers
@@ -1952,6 +1953,7 @@ pub(crate) async fn apply_firewall_config(
             public_key: wg.public_key.clone(),
             listen_port: wg.listen_port,
             address,
+            address6: wg.address6.as_deref().and_then(|s| Address::parse(s).ok()),
             dns: wg.dns.clone(),
             mtu: wg.mtu,
             listen_interface: None,

--- a/aifw-api/src/routes/vpn.rs
+++ b/aifw-api/src/routes/vpn.rs
@@ -7,6 +7,9 @@ pub struct CreateWgTunnelRequest {
     pub name: String,
     pub listen_port: u16,
     pub address: String,
+    /// Optional IPv6 tunnel address for dual-stack tunnels (#471),
+    /// e.g. `fd00:a1f0::1/64`. Empty/omitted means IPv4-only.
+    pub address6: Option<String>,
     pub private_key: Option<String>,
     pub dns: Option<String>,
     pub mtu: Option<u16>,
@@ -14,6 +17,14 @@ pub struct CreateWgTunnelRequest {
     /// Comma-separated CIDRs to advertise as split-tunnel AllowedIPs.
     /// When empty/omitted, falls back to the tunnel's network CIDR.
     pub split_routes: Option<String>,
+}
+
+/// Parse the optional IPv6 tunnel address; empty/whitespace means None.
+fn parse_address6(raw: Option<&str>) -> Result<Option<Address>, StatusCode> {
+    match raw.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(s) => Address::parse(s).map(Some).map_err(|_| bad_request()),
+        None => Ok(None),
+    }
 }
 
 pub async fn list_wg_tunnels(
@@ -32,6 +43,7 @@ pub async fn create_wg_tunnel(
     Json(req): Json<CreateWgTunnelRequest>,
 ) -> Result<(StatusCode, Json<ApiResponse<WgTunnel>>), StatusCode> {
     let address = Address::parse(&req.address).map_err(|_| bad_request())?;
+    let address6 = parse_address6(req.address6.as_deref())?;
     // FreeBSD requires short interface names: wg0, wg1, etc. (not wg51820)
     let existing = state.vpn_engine.list_wg_tunnels().await.unwrap_or_default();
     let used_indices: std::collections::HashSet<u32> = existing
@@ -52,6 +64,7 @@ pub async fn create_wg_tunnel(
         tunnel.public_key = aifw_common::vpn::derive_wg_pubkey(pk).map_err(|_| bad_request())?;
         tunnel.private_key = pk.clone();
     }
+    tunnel.address6 = address6;
     tunnel.dns = req.dns;
     tunnel.mtu = req.mtu;
     tunnel.listen_interface = req.listen_interface;
@@ -83,6 +96,7 @@ pub async fn update_wg_tunnel(
     tunnel.name = req.name;
     tunnel.listen_port = req.listen_port;
     tunnel.address = Address::parse(&req.address).map_err(|_| bad_request())?;
+    tunnel.address6 = parse_address6(req.address6.as_deref())?;
     tunnel.dns = req.dns;
     tunnel.mtu = req.mtu;
     tunnel.listen_interface = req.listen_interface;

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -2673,6 +2673,7 @@ mod tests {
                     interface: "wg0".to_string(),
                     listen_port: 51820,
                     address: "10.9.0.1/24".to_string(),
+                    address6: None,
                     private_key: "k".into(),
                     public_key: "K".into(),
                     dns: None,

--- a/aifw-common/src/vpn.rs
+++ b/aifw-common/src/vpn.rs
@@ -24,6 +24,10 @@ pub struct WgTunnel {
     pub listen_port: u16,
     /// Server's tunnel address with prefix (e.g. 10.10.0.1/24); defines the tunnel subnet
     pub address: Address,
+    /// Server's IPv6 tunnel address with prefix (e.g. fd00:a1f0::1/64) for
+    /// dual-stack tunnels (#471); None means the tunnel carries no inner IPv6
+    #[serde(default)]
+    pub address6: Option<Address>,
     /// DNS server(s) pushed to clients in generated configs; None omits the DNS line
     pub dns: Option<String>,
     /// Interface MTU; None uses the system default
@@ -63,6 +67,7 @@ impl WgTunnel {
             public_key,
             listen_port,
             address,
+            address6: None,
             dns: None,
             mtu: None,
             listen_interface: None,
@@ -73,16 +78,46 @@ impl WgTunnel {
         })
     }
 
-    /// Generate ifconfig commands to create the WireGuard interface
+    /// Generate ifconfig commands to create the WireGuard interface.
+    /// Uses the address-family-correct keyword (`inet`/`inet6`) — configuring
+    /// an IPv6 address with `inet` silently fails on FreeBSD (#471).
     pub fn to_ifconfig_cmds(&self) -> Vec<String> {
+        let family = if address_is_v6(&self.address) {
+            "inet6"
+        } else {
+            "inet"
+        };
         let mut cmds = vec![
             format!("ifconfig {} create", self.interface),
-            format!("ifconfig {} inet {} up", self.interface, self.address),
+            format!("ifconfig {} {} {} up", self.interface, family, self.address),
         ];
+        if let Some(ref addr6) = self.address6 {
+            cmds.push(format!("ifconfig {} inet6 {}", self.interface, addr6));
+        }
         if let Some(mtu) = self.mtu {
             cmds.push(format!("ifconfig {} mtu {mtu}", self.interface));
         }
         cmds
+    }
+
+    /// Validate the address/address6 pairing: `address6` must be IPv6, and
+    /// when it is set `address` must be IPv4 (dual-stack means one of each —
+    /// two v6 addresses belong in a differently shaped config).
+    pub fn validate_addresses(&self) -> crate::Result<()> {
+        if let Some(ref a6) = self.address6 {
+            if !address_is_v6(a6) {
+                return Err(crate::AifwError::Validation(
+                    "IPv6 tunnel address must be an IPv6 address (e.g. fd00:a1f0::1/64)"
+                        .to_string(),
+                ));
+            }
+            if address_is_v6(&self.address) {
+                return Err(crate::AifwError::Validation(
+                    "with an IPv6 tunnel address set, the primary address must be IPv4".to_string(),
+                ));
+            }
+        }
+        Ok(())
     }
 
     /// Generate pf rules to allow WireGuard traffic
@@ -112,6 +147,13 @@ impl WgTunnel {
         address_network_cidr(&self.address)
     }
 
+    /// Network CIDR of the IPv6 tunnel subnet, masked to the network boundary
+    /// (e.g. address6 fd00:a1f0::1/64 → "fd00:a1f0::/64"); None when the
+    /// tunnel has no inner IPv6.
+    pub fn network_cidr6(&self) -> Option<String> {
+        self.address6.as_ref().map(address_network_cidr)
+    }
+
     /// Outbound NAT rule so tunnel clients reach the internet through the
     /// WAN (#469). Only IPv4 tunnel subnets are NAT'd — returns None for
     /// IPv6 / alias / any addresses so we never masquerade 0.0.0.0/0.
@@ -125,6 +167,15 @@ impl WgTunnel {
             _ => None,
         }
     }
+}
+
+/// Whether an Address is IPv6 (Single or Network variant).
+fn address_is_v6(addr: &Address) -> bool {
+    use std::net::IpAddr;
+    matches!(
+        addr,
+        Address::Single(IpAddr::V6(_)) | Address::Network(IpAddr::V6(_), _)
+    )
 }
 
 /// AllowedIPs for a full-tunnel client config, scoped to the address
@@ -787,6 +838,7 @@ mod split_tunnel_tests {
             public_key: "y".into(),
             listen_port: 51820,
             address: Address::Network("172.29.240.1".parse().unwrap(), 24),
+            address6: None,
             dns: None,
             mtu: None,
             listen_interface: None,
@@ -822,6 +874,7 @@ mod split_tunnel_tests {
             public_key: "y".into(),
             listen_port: 51820,
             address: Address::Network("172.29.240.1".parse().unwrap(), 24),
+            address6: None,
             dns: None,
             mtu: None,
             listen_interface: None,
@@ -857,6 +910,7 @@ mod split_tunnel_tests {
             public_key: "y".into(),
             listen_port: 51820,
             address,
+            address6: None,
             dns: None,
             mtu: None,
             listen_interface: None,
@@ -897,6 +951,39 @@ mod split_tunnel_tests {
         let cfg = test_peer(tunnel.id).to_client_config(&tunnel, "vpn.example.com", false);
         assert!(cfg.contains("AllowedIPs = ::/0\n"));
         assert!(!cfg.contains("0.0.0.0/0"));
+    }
+
+    #[test]
+    fn ifconfig_cmds_dual_stack_configures_both_families() {
+        let mut tunnel = test_tunnel(Address::Network("10.10.0.1".parse().unwrap(), 24));
+        tunnel.address6 = Some(Address::Network("fd00:a1f0::1".parse().unwrap(), 64));
+        let cmds = tunnel.to_ifconfig_cmds();
+        assert_eq!(cmds[1], "ifconfig wg0 inet 10.10.0.1/24 up");
+        assert_eq!(cmds[2], "ifconfig wg0 inet6 fd00:a1f0::1/64");
+    }
+
+    #[test]
+    fn ifconfig_cmds_v6_primary_uses_inet6() {
+        let tunnel = test_tunnel(Address::Network("fd00:a1f0::1".parse().unwrap(), 64));
+        assert!(tunnel.to_ifconfig_cmds()[1].starts_with("ifconfig wg0 inet6 "));
+    }
+
+    #[test]
+    fn validate_addresses_rejects_bad_pairings() {
+        // v4 in the address6 slot
+        let mut t = test_tunnel(Address::Network("10.10.0.1".parse().unwrap(), 24));
+        t.address6 = Some(Address::Network("192.168.1.1".parse().unwrap(), 24));
+        assert!(t.validate_addresses().is_err());
+
+        // two v6 addresses
+        let mut t = test_tunnel(Address::Network("fd00:1::1".parse().unwrap(), 64));
+        t.address6 = Some(Address::Network("fd00:2::1".parse().unwrap(), 64));
+        assert!(t.validate_addresses().is_err());
+
+        // proper dual-stack is fine
+        let mut t = test_tunnel(Address::Network("10.10.0.1".parse().unwrap(), 24));
+        t.address6 = Some(Address::Network("fd00:a1f0::1".parse().unwrap(), 64));
+        assert!(t.validate_addresses().is_ok());
     }
 
     #[test]

--- a/aifw-common/src/vpn.rs
+++ b/aifw-common/src/vpn.rs
@@ -154,18 +154,36 @@ impl WgTunnel {
         self.address6.as_ref().map(address_network_cidr)
     }
 
-    /// Outbound NAT rule so tunnel clients reach the internet through the
-    /// WAN (#469). Only IPv4 tunnel subnets are NAT'd — returns None for
-    /// IPv6 / alias / any addresses so we never masquerade 0.0.0.0/0.
-    pub fn to_nat_rule(&self, wan_if: &str) -> Option<String> {
+    /// Outbound NAT rules so tunnel clients reach the internet through the
+    /// WAN: the #469 IPv4 masquerade plus, for tunnels carrying inner IPv6,
+    /// an NPTv6-style NAT66 masquerade (#471) — same shape pf uses for
+    /// NAT64 (`nat on <if> inet6`). Only Single/Network tunnel subnets are
+    /// NAT'd — alias/any addresses emit nothing so we never masquerade a
+    /// whole address family.
+    pub fn to_nat_rules(&self, wan_if: &str) -> Vec<String> {
         use std::net::IpAddr;
+        let mut rules = Vec::new();
         match &self.address {
-            Address::Single(IpAddr::V4(_)) | Address::Network(IpAddr::V4(_), _) => Some(format!(
-                "nat on {wan_if} from {} to any -> ({wan_if})",
-                self.network_cidr()
-            )),
-            _ => None,
+            Address::Single(IpAddr::V4(_)) | Address::Network(IpAddr::V4(_), _) => {
+                rules.push(format!(
+                    "nat on {wan_if} from {} to any -> ({wan_if})",
+                    self.network_cidr()
+                ));
+            }
+            Address::Single(IpAddr::V6(_)) | Address::Network(IpAddr::V6(_), _) => {
+                rules.push(format!(
+                    "nat on {wan_if} inet6 from {} to any -> ({wan_if})",
+                    self.network_cidr()
+                ));
+            }
+            _ => {}
         }
+        if let Some(net6) = self.network_cidr6() {
+            rules.push(format!(
+                "nat on {wan_if} inet6 from {net6} to any -> ({wan_if})"
+            ));
+        }
+        rules
     }
 }
 
@@ -990,16 +1008,36 @@ mod split_tunnel_tests {
     fn nat_rule_masks_to_network_boundary() {
         let tunnel = test_tunnel(Address::Network("10.10.0.1".parse().unwrap(), 24));
         assert_eq!(
-            tunnel.to_nat_rule("em0").as_deref(),
-            Some("nat on em0 from 10.10.0.0/24 to any -> (em0)")
+            tunnel.to_nat_rules("em0"),
+            vec!["nat on em0 from 10.10.0.0/24 to any -> (em0)"]
         );
     }
 
     #[test]
-    fn nat_rule_skipped_for_non_v4_addresses() {
+    fn nat_rules_dual_stack_adds_nat66() {
+        let mut tunnel = test_tunnel(Address::Network("10.10.0.1".parse().unwrap(), 24));
+        tunnel.address6 = Some(Address::Network("fd00:a1f0::1".parse().unwrap(), 64));
+        assert_eq!(
+            tunnel.to_nat_rules("em0"),
+            vec![
+                "nat on em0 from 10.10.0.0/24 to any -> (em0)",
+                "nat on em0 inet6 from fd00:a1f0::/64 to any -> (em0)",
+            ]
+        );
+    }
+
+    #[test]
+    fn nat_rules_v6_only_tunnel_gets_nat66() {
         let v6 = test_tunnel(Address::Network("fd00:a1f0::1".parse().unwrap(), 64));
-        assert_eq!(v6.to_nat_rule("em0"), None);
+        assert_eq!(
+            v6.to_nat_rules("em0"),
+            vec!["nat on em0 inet6 from fd00:a1f0::/64 to any -> (em0)"]
+        );
+    }
+
+    #[test]
+    fn nat_rules_skipped_for_alias_and_any_addresses() {
         let any = test_tunnel(Address::Any);
-        assert_eq!(any.to_nat_rule("em0"), None);
+        assert!(any.to_nat_rules("em0").is_empty());
     }
 }

--- a/aifw-common/src/vpn.rs
+++ b/aifw-common/src/vpn.rs
@@ -197,12 +197,19 @@ fn address_is_v6(addr: &Address) -> bool {
 }
 
 /// AllowedIPs for a full-tunnel client config, scoped to the address
-/// families the tunnel's inner network can carry.
-fn full_tunnel_allowed_ips(addr: &Address) -> &'static str {
+/// families the tunnel's inner network can carry. A dual-stack tunnel
+/// (v4 primary + address6) routes both families (#471); emitting `::/0`
+/// for a v4-only tunnel blackholes client IPv6 (#469).
+fn full_tunnel_allowed_ips(tunnel: &WgTunnel) -> &'static str {
     use std::net::IpAddr;
-    match addr {
-        Address::Single(IpAddr::V4(_)) | Address::Network(IpAddr::V4(_), _) => "0.0.0.0/0",
-        Address::Single(IpAddr::V6(_)) | Address::Network(IpAddr::V6(_), _) => "::/0",
+    let has_v6 = tunnel.address6.is_some() || address_is_v6(&tunnel.address);
+    let has_v4 = matches!(
+        &tunnel.address,
+        Address::Single(IpAddr::V4(_)) | Address::Network(IpAddr::V4(_), _)
+    );
+    match (has_v4, has_v6) {
+        (true, false) => "0.0.0.0/0",
+        (false, true) => "::/0",
         _ => "0.0.0.0/0, ::/0",
     }
 }
@@ -282,9 +289,11 @@ impl WgPeer {
         } else {
             conf.push_str("PrivateKey = <paste-your-private-key-here>\n");
         }
-        // Use the first allowed_ip as the client's address
-        if let Some(addr) = self.allowed_ips.first() {
-            conf.push_str(&format!("Address = {addr}\n"));
+        // The allowed_ips double as the client's addresses — emit them all
+        // so a dual-stack peer (v4/32 + v6/128) gets both families (#471).
+        if !self.allowed_ips.is_empty() {
+            let addrs: Vec<String> = self.allowed_ips.iter().map(|a| a.to_string()).collect();
+            conf.push_str(&format!("Address = {}\n", addrs.join(", ")));
         }
         if let Some(ref dns) = tunnel.dns
             && !dns.is_empty()
@@ -304,16 +313,20 @@ impl WgPeer {
         ));
         if split_tunnel {
             // Prefer admin-configured split routes; otherwise derive the
-            // network CIDR from the tunnel address (so 172.29.240.1/24 yields
-            // 172.29.240.0/24 instead of a host/prefix that confuses some
-            // clients).
+            // network CIDR(s) from the tunnel addresses (so 172.29.240.1/24
+            // yields 172.29.240.0/24 instead of a host/prefix that confuses
+            // some clients; dual-stack tunnels include the v6 subnet too).
             let routes = tunnel
                 .split_routes
                 .as_deref()
                 .map(|s| s.trim())
                 .filter(|s| !s.is_empty())
                 .map(|s| s.to_string())
-                .unwrap_or_else(|| address_network_cidr(&tunnel.address));
+                .unwrap_or_else(|| {
+                    let mut nets = vec![address_network_cidr(&tunnel.address)];
+                    nets.extend(tunnel.network_cidr6());
+                    nets.join(", ")
+                });
             conf.push_str(&format!("AllowedIPs = {routes}\n"));
         } else {
             // Route all traffic through the VPN — but only the address
@@ -322,7 +335,7 @@ impl WgPeer {
             // dual-stack clients (#469).
             conf.push_str(&format!(
                 "AllowedIPs = {}\n",
-                full_tunnel_allowed_ips(&tunnel.address)
+                full_tunnel_allowed_ips(tunnel)
             ));
         }
         if let Some(ka) = self.persistent_keepalive {
@@ -969,6 +982,28 @@ mod split_tunnel_tests {
         let cfg = test_peer(tunnel.id).to_client_config(&tunnel, "vpn.example.com", false);
         assert!(cfg.contains("AllowedIPs = ::/0\n"));
         assert!(!cfg.contains("0.0.0.0/0"));
+    }
+
+    #[test]
+    fn full_tunnel_dual_stack_routes_both_families() {
+        let mut tunnel = test_tunnel(Address::Network("10.10.0.1".parse().unwrap(), 24));
+        tunnel.address6 = Some(Address::Network("fd00:a1f0::1".parse().unwrap(), 64));
+        let mut peer = test_peer(tunnel.id);
+        peer.allowed_ips = vec![
+            Address::Network("10.10.0.2".parse().unwrap(), 32),
+            Address::Network("fd00:a1f0::2".parse().unwrap(), 128),
+        ];
+        let cfg = peer.to_client_config(&tunnel, "vpn.example.com", false);
+        assert!(cfg.contains("Address = 10.10.0.2/32, fd00:a1f0::2/128\n"));
+        assert!(cfg.contains("AllowedIPs = 0.0.0.0/0, ::/0\n"));
+    }
+
+    #[test]
+    fn split_tunnel_fallback_includes_v6_subnet() {
+        let mut tunnel = test_tunnel(Address::Network("10.10.0.1".parse().unwrap(), 24));
+        tunnel.address6 = Some(Address::Network("fd00:a1f0::1".parse().unwrap(), 64));
+        let cfg = test_peer(tunnel.id).to_client_config(&tunnel, "vpn.example.com", true);
+        assert!(cfg.contains("AllowedIPs = 10.10.0.0/24, fd00:a1f0::/64\n"));
     }
 
     #[test]

--- a/aifw-core/src/config.rs
+++ b/aifw-core/src/config.rs
@@ -558,6 +558,9 @@ pub struct WireguardTunnelConfig {
     pub listen_port: u16,
     /// Tunnel interface address (IP/prefix)
     pub address: String,
+    /// Optional IPv6 tunnel address for dual-stack tunnels (#471)
+    #[serde(default)]
+    pub address6: Option<String>,
     /// Local WireGuard private key (base64; sensitive)
     pub private_key: String,
     /// Local WireGuard public key (base64)

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -827,6 +827,7 @@ mod tests {
         .unwrap();
         tunnel.dns = Some("1.1.1.1".to_string());
         tunnel.mtu = Some(1420);
+        tunnel.address6 = Some(Address::Network("fd00:a1f0::1".parse().unwrap(), 64));
         let id = tunnel.id;
         engine.add_wg_tunnel(tunnel).await.unwrap();
 
@@ -835,8 +836,39 @@ mod tests {
         assert_eq!(fetched.interface.0, "wg1");
         assert_eq!(fetched.dns, Some("1.1.1.1".to_string()));
         assert_eq!(fetched.mtu, Some(1420));
+        assert_eq!(
+            fetched.address6,
+            Some(Address::Network("fd00:a1f0::1".parse().unwrap(), 64))
+        );
         assert!(!fetched.private_key.is_empty());
         assert!(!fetched.public_key.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_wg_tunnel_address6_validation() {
+        let engine = create_vpn_engine().await;
+
+        // address6 must actually be IPv6
+        let mut t = WgTunnel::new(
+            "bad6".to_string(),
+            Interface("wg0".to_string()),
+            51830,
+            Address::Network("10.9.0.1".parse().unwrap(), 24),
+        )
+        .unwrap();
+        t.address6 = Some(Address::Network("192.168.1.1".parse().unwrap(), 24));
+        assert!(engine.add_wg_tunnel(t).await.is_err());
+
+        // with address6 set, the primary address must be IPv4
+        let mut t = WgTunnel::new(
+            "doublev6".to_string(),
+            Interface("wg0".to_string()),
+            51831,
+            Address::Network("fd00:1::1".parse().unwrap(), 64),
+        )
+        .unwrap();
+        t.address6 = Some(Address::Network("fd00:2::1".parse().unwrap(), 64));
+        assert!(engine.add_wg_tunnel(t).await.is_err());
     }
 
     #[tokio::test]

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -845,6 +845,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_next_peer_ip_v4_skips_used() {
+        let engine = create_vpn_engine().await;
+        let tunnel = WgTunnel::new(
+            "wg0".to_string(),
+            Interface("wg0".to_string()),
+            51820,
+            Address::Network("10.0.0.1".parse().unwrap(), 24),
+        )
+        .unwrap();
+        let tid = tunnel.id;
+        engine.add_wg_tunnel(tunnel).await.unwrap();
+
+        assert_eq!(engine.next_peer_ip(tid).await.unwrap(), "10.0.0.2/32");
+
+        let mut peer = WgPeer::new(tid, "p1".to_string(), "pk1".to_string());
+        peer.allowed_ips = vec![Address::Network("10.0.0.2".parse().unwrap(), 32)];
+        engine.add_wg_peer(peer).await.unwrap();
+
+        assert_eq!(engine.next_peer_ip(tid).await.unwrap(), "10.0.0.3/32");
+    }
+
+    #[tokio::test]
+    async fn test_next_peer_ip_dual_stack() {
+        let engine = create_vpn_engine().await;
+        let mut tunnel = WgTunnel::new(
+            "wg0".to_string(),
+            Interface("wg0".to_string()),
+            51820,
+            Address::Network("10.0.0.1".parse().unwrap(), 24),
+        )
+        .unwrap();
+        tunnel.address6 = Some(Address::Network("fd00:a1f0::1".parse().unwrap(), 64));
+        let tid = tunnel.id;
+        engine.add_wg_tunnel(tunnel).await.unwrap();
+
+        assert_eq!(
+            engine.next_peer_ip(tid).await.unwrap(),
+            "10.0.0.2/32, fd00:a1f0::2/128"
+        );
+
+        let mut peer = WgPeer::new(tid, "p1".to_string(), "pk1".to_string());
+        peer.allowed_ips = vec![
+            Address::Network("10.0.0.2".parse().unwrap(), 32),
+            Address::Network("fd00:a1f0::2".parse().unwrap(), 128),
+        ];
+        engine.add_wg_peer(peer).await.unwrap();
+
+        assert_eq!(
+            engine.next_peer_ip(tid).await.unwrap(),
+            "10.0.0.3/32, fd00:a1f0::3/128"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_next_peer_ip_v6_only_tunnel() {
+        let engine = create_vpn_engine().await;
+        let tunnel = WgTunnel::new(
+            "wg6".to_string(),
+            Interface("wg0".to_string()),
+            51820,
+            Address::Network("fd00:b::1".parse().unwrap(), 64),
+        )
+        .unwrap();
+        let tid = tunnel.id;
+        engine.add_wg_tunnel(tunnel).await.unwrap();
+
+        assert_eq!(engine.next_peer_ip(tid).await.unwrap(), "fd00:b::2/128");
+    }
+
+    #[tokio::test]
     async fn test_wg_tunnel_address6_validation() {
         let engine = create_vpn_engine().await;
 

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -907,7 +907,8 @@ impl VpnEngine {
     }
 
     /// Collect outbound NAT rules for up WireGuard tunnels so clients reach
-    /// the internet through the WAN (#469). These load into the `aifw-vpn`
+    /// the internet through the WAN — IPv4 masquerade (#469) plus NAT66 for
+    /// tunnels carrying inner IPv6 (#471). These load into the `aifw-vpn`
     /// nat-anchor declared in pf.conf — do NOT mix them into the filter-rule
     /// extras, pfctl requires translation rules before filter rules.
     pub async fn collect_vpn_nat_rules(&self) -> Result<Vec<String>> {
@@ -925,7 +926,7 @@ impl VpnEngine {
             );
             return Ok(Vec::new());
         };
-        Ok(up.iter().filter_map(|t| t.to_nat_rule(&wan)).collect())
+        Ok(up.iter().flat_map(|t| t.to_nat_rules(&wan)).collect())
     }
 
     /// Resolve the WAN interface from the interface_roles table (seeded by

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -827,40 +827,43 @@ impl VpnEngine {
         Ok(started)
     }
 
-    /// Compute the next available IP in a tunnel's subnet for auto-assigning to a new peer.
+    /// Compute the next available IP(s) in a tunnel's subnet for
+    /// auto-assigning to a new peer. IPv4 tunnels yield `a.b.c.d/32`;
+    /// dual-stack tunnels (#471) yield `a.b.c.d/32, x::y/128` so the new
+    /// peer gets an address in every family the tunnel carries. Errors when
+    /// any carried family has no free addresses left — a dual-stack peer
+    /// with only half its addresses would silently lose one family.
     pub async fn next_peer_ip(&self, tunnel_id: Uuid) -> Result<String> {
-        let tunnel = self.get_wg_tunnel(tunnel_id).await?;
-        let addr_str = tunnel.address.to_string();
-        // Parse "10.10.0.1/24" → base "10.10.0", server_last = 1
-        let parts: Vec<&str> = addr_str.split('/').collect();
-        let ip_str = parts[0];
-        let octets: Vec<u8> = ip_str.split('.').filter_map(|o| o.parse().ok()).collect();
-        if octets.len() != 4 {
-            return Err(AifwError::Validation("Invalid tunnel address".to_string()));
-        }
+        use std::net::IpAddr;
 
-        // Collect existing peer IPs
+        let tunnel = self.get_wg_tunnel(tunnel_id).await?;
         let peers = self.list_wg_peers(tunnel_id).await?;
-        let used: std::collections::HashSet<String> = peers
+        let used: std::collections::HashSet<IpAddr> = peers
             .iter()
-            .flat_map(|p| {
-                p.allowed_ips
-                    .iter()
-                    .map(|a| a.to_string().split('/').next().unwrap_or("").to_string())
+            .flat_map(|p| p.allowed_ips.iter())
+            .filter_map(|a| match a {
+                Address::Single(ip) => Some(*ip),
+                Address::Network(ip, _) => Some(*ip),
+                _ => None,
             })
             .collect();
 
-        // Find next free IP in the /24 (or smaller) range
-        let base = [octets[0], octets[1], octets[2]];
-        for last in 2u8..=254 {
-            let candidate = format!("{}.{}.{}.{}", base[0], base[1], base[2], last);
-            if candidate != ip_str && !used.contains(&candidate) {
-                return Ok(format!("{candidate}/32"));
-            }
+        let mut parts: Vec<String> = Vec::new();
+        // A Single (prefix-less) tunnel address falls back to the
+        // conventional subnet size for its family.
+        match &tunnel.address {
+            Address::Single(IpAddr::V4(ip)) => parts.push(next_free_v4(*ip, 24, &used)?),
+            Address::Network(IpAddr::V4(ip), p) => parts.push(next_free_v4(*ip, *p, &used)?),
+            Address::Single(IpAddr::V6(ip)) => parts.push(next_free_v6(*ip, 64, &used)?),
+            Address::Network(IpAddr::V6(ip), p) => parts.push(next_free_v6(*ip, *p, &used)?),
+            _ => return Err(AifwError::Validation("Invalid tunnel address".to_string())),
         }
-        Err(AifwError::Validation(
-            "No free IPs in tunnel subnet".to_string(),
-        ))
+        match &tunnel.address6 {
+            Some(Address::Single(IpAddr::V6(ip))) => parts.push(next_free_v6(*ip, 64, &used)?),
+            Some(Address::Network(IpAddr::V6(ip), p)) => parts.push(next_free_v6(*ip, *p, &used)?),
+            _ => {}
+        }
+        Ok(parts.join(", "))
     }
 
     // ============================================================
@@ -958,6 +961,73 @@ impl VpnEngine {
 
         Ok(())
     }
+}
+
+/// Scanning more candidates than this per family means the subnet is
+/// effectively full for auto-assignment purposes (a /64 has 2^64 hosts —
+/// exhaustive iteration is not an option).
+const MAX_AUTO_IP_SCAN: u32 = 65536;
+
+/// Next free IPv4 host in `server`'s subnet as a `/32` peer address:
+/// skips the network address, the broadcast address, the server itself,
+/// and every already-assigned peer IP.
+fn next_free_v4(
+    server: std::net::Ipv4Addr,
+    prefix: u8,
+    used: &std::collections::HashSet<std::net::IpAddr>,
+) -> Result<String> {
+    let p = prefix.min(32);
+    let server_bits = u32::from(server);
+    let mask: u32 = if p == 0 { 0 } else { u32::MAX << (32 - p) };
+    let net = server_bits & mask;
+    let bcast = net | !mask;
+
+    let mut candidate = net.saturating_add(1);
+    let mut tries = 0u32;
+    while candidate < bcast && tries < MAX_AUTO_IP_SCAN {
+        if candidate != server_bits {
+            let ip = std::net::Ipv4Addr::from(candidate);
+            if !used.contains(&std::net::IpAddr::V4(ip)) {
+                return Ok(format!("{ip}/32"));
+            }
+        }
+        candidate += 1;
+        tries += 1;
+    }
+    Err(AifwError::Validation(
+        "No free IPv4 addresses in tunnel subnet".to_string(),
+    ))
+}
+
+/// Next free IPv6 host in `server`'s subnet as a `/128` peer address:
+/// skips the subnet-router anycast address (all-zero host part), the
+/// server itself, and every already-assigned peer IP.
+fn next_free_v6(
+    server: std::net::Ipv6Addr,
+    prefix: u8,
+    used: &std::collections::HashSet<std::net::IpAddr>,
+) -> Result<String> {
+    let p = prefix.min(128);
+    let server_bits = u128::from(server);
+    let mask: u128 = if p == 0 { 0 } else { u128::MAX << (128 - p) };
+    let net = server_bits & mask;
+    let last = net | !mask;
+
+    let mut candidate = net.saturating_add(1);
+    let mut tries = 0u32;
+    while candidate <= last && tries < MAX_AUTO_IP_SCAN {
+        if candidate != server_bits {
+            let ip = std::net::Ipv6Addr::from(candidate);
+            if !used.contains(&std::net::IpAddr::V6(ip)) {
+                return Ok(format!("{ip}/128"));
+            }
+        }
+        candidate += 1;
+        tries += 1;
+    }
+    Err(AifwError::Validation(
+        "No free IPv6 addresses in tunnel subnet".to_string(),
+    ))
 }
 
 // ============================================================

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -90,6 +90,12 @@ impl VpnEngine {
             .execute(&self.pool)
             .await;
 
+        // Add address6 column: the server's IPv6 tunnel address for
+        // dual-stack tunnels (#471). NULL means no inner IPv6.
+        let _ = sqlx::query("ALTER TABLE wg_tunnels ADD COLUMN address6 TEXT")
+            .execute(&self.pool)
+            .await;
+
         // Shared with aifw-setup / aifw-api (QUAL-C5) — wan_interface() below
         // reads it to build the WireGuard outbound NAT rule.
         sqlx::query(aifw_common::schemas::INTERFACE_ROLES_CREATE)
@@ -182,11 +188,13 @@ impl VpnEngine {
         if tunnel.listen_port == 0 {
             return Err(AifwError::Validation("listen port required".to_string()));
         }
+        tunnel.validate_addresses()?;
         sqlx::query(
             r#"
             INSERT INTO wg_tunnels (id, name, interface, private_key, public_key, listen_port,
-                address, dns, mtu, listen_interface, split_routes, status, created_at, updated_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+                address, address6, dns, mtu, listen_interface, split_routes, status,
+                created_at, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
             "#,
         )
         .bind(tunnel.id.to_string())
@@ -196,6 +204,7 @@ impl VpnEngine {
         .bind(&tunnel.public_key)
         .bind(tunnel.listen_port as i64)
         .bind(tunnel.address.to_string())
+        .bind(tunnel.address6.as_ref().map(|a| a.to_string()))
         .bind(tunnel.dns.as_deref())
         .bind(tunnel.mtu.map(|m| m as i64))
         .bind(tunnel.listen_interface.as_deref())
@@ -257,18 +266,21 @@ impl VpnEngine {
             )));
         }
 
+        tunnel.validate_addresses()?;
+
         let result = sqlx::query(
             r#"
             UPDATE wg_tunnels
-               SET name = ?1, listen_port = ?2, address = ?3, dns = ?4, mtu = ?5,
-                   listen_interface = ?6, split_routes = ?7,
-                   private_key = ?8, public_key = ?9, updated_at = ?10
-             WHERE id = ?11
+               SET name = ?1, listen_port = ?2, address = ?3, address6 = ?4, dns = ?5,
+                   mtu = ?6, listen_interface = ?7, split_routes = ?8,
+                   private_key = ?9, public_key = ?10, updated_at = ?11
+             WHERE id = ?12
             "#,
         )
         .bind(&tunnel.name)
         .bind(tunnel.listen_port as i64)
         .bind(tunnel.address.to_string())
+        .bind(tunnel.address6.as_ref().map(|a| a.to_string()))
         .bind(tunnel.dns.as_deref())
         .bind(tunnel.mtu.map(|m| m as i64))
         .bind(tunnel.listen_interface.as_deref())
@@ -573,9 +585,24 @@ impl VpnEngine {
             )));
         }
 
-        // Set address and bring up
+        // Set addresses and bring up. The keyword must match the address
+        // family — FreeBSD's `ifconfig <if> inet <v6-addr>` fails, which is
+        // how IPv6 tunnel addresses used to silently not configure (#471).
         let addr = tunnel.address.to_string();
-        let _ = crate::sudo::ifconfig(iface, "inet", &[&addr, "up"]).await;
+        let v6_primary = matches!(
+            &tunnel.address,
+            Address::Single(std::net::IpAddr::V6(_)) | Address::Network(std::net::IpAddr::V6(_), _)
+        );
+        if v6_primary {
+            Self::ifconfig_logged(iface, "inet6", &[&addr]).await;
+            Self::ifconfig_logged(iface, "up", &[]).await;
+        } else {
+            Self::ifconfig_logged(iface, "inet", &[&addr, "up"]).await;
+        }
+        if let Some(ref a6) = tunnel.address6 {
+            let a6 = a6.to_string();
+            Self::ifconfig_logged(iface, "inet6", &[&a6]).await;
+        }
 
         // Set MTU if specified
         if let Some(mtu) = tunnel.mtu {
@@ -633,6 +660,25 @@ impl VpnEngine {
 
         tracing::info!(%id, iface, "WireGuard tunnel started");
         Ok(())
+    }
+
+    /// Run an ifconfig action, logging (not failing) on error. Address
+    /// configuration problems shouldn't abort tunnel startup, but they must
+    /// be visible — a swallowed error here is how IPv6 addresses silently
+    /// failed to configure before #471.
+    async fn ifconfig_logged(iface: &str, action: &str, args: &[&str]) {
+        match crate::sudo::ifconfig(iface, action, args).await {
+            Ok(out) if !out.status.success() => {
+                tracing::warn!(
+                    iface,
+                    action,
+                    stderr = %String::from_utf8_lossy(&out.stderr),
+                    "ifconfig failed"
+                );
+            }
+            Err(e) => tracing::warn!(iface, action, error = %e, "ifconfig failed"),
+            _ => {}
+        }
     }
 
     /// Stop a WireGuard tunnel: destroy the interface.
@@ -925,7 +971,7 @@ impl VpnEngine {
 /// CREATE TABLE (base columns then ALTER-added columns).
 const WG_TUNNEL_COLUMNS: &str = "id, name, interface, private_key, public_key, \
     listen_port, address, dns, mtu, status, created_at, updated_at, \
-    listen_interface, split_routes";
+    listen_interface, split_routes, address6";
 
 #[derive(sqlx::FromRow)]
 struct WgTunnelRow {
@@ -941,6 +987,8 @@ struct WgTunnelRow {
     listen_interface: Option<String>,
     #[sqlx(default)]
     split_routes: Option<String>,
+    #[sqlx(default)]
+    address6: Option<String>,
     status: String,
     created_at: String,
     updated_at: String,
@@ -956,6 +1004,7 @@ impl WgTunnelRow {
             public_key: self.public_key,
             listen_port: self.listen_port as u16,
             address: Address::parse(&self.address)?,
+            address6: self.address6.as_deref().map(Address::parse).transpose()?,
             dns: self.dns,
             mtu: self.mtu.map(|m| m as u16),
             listen_interface: self.listen_interface,

--- a/aifw-ui/src/app/nat/flows/page.tsx
+++ b/aifw-ui/src/app/nat/flows/page.tsx
@@ -83,7 +83,7 @@ function ifaceForIp(table: Route[], ip: string): string | null {
 }
 
 type WgTunnelLite = { id: string; interface: string; address: string | null; split_routes: string | null };
-type WgPeerLite = { allowed_ips: string };
+type WgPeerLite = { allowed_ips: string[] };
 
 /* ────────────────────────── Pipe geometry helpers ──────────────────────────
  *
@@ -239,7 +239,7 @@ export default function NatFlowsPage() {
         try {
           const pRes = await fetchApi<{ data: WgPeerLite[] }>(`/api/v1/vpn/wg/${t.id}/peers`);
           for (const p of pRes.data || [])
-            for (const a of (p.allowed_ips || "").split(/[,\s]+/)) if (a) add(a);
+            for (const a of p.allowed_ips || []) if (a) add(a);
         } catch { /* peers are optional — address/split_routes already cover the interface */ }
       }
       setWgRoutes(routes);

--- a/aifw-ui/src/app/vpn/components/ConfigModal.tsx
+++ b/aifw-ui/src/app/vpn/components/ConfigModal.tsx
@@ -79,7 +79,7 @@ export function ConfigModal({ config, onClose }: ConfigModalProps) {
           </div>
           <p className="text-xs text-gray-400 mb-3">
             {configTab === "full"
-              ? "Everything goes through the VPN: the device reaches the internet via the firewall\u2019s WAN address. Use this on untrusted networks (public Wi-Fi) or to apply the firewall\u2019s filtering everywhere. IPv6 traffic stays on the device\u2019s normal connection \u2014 the tunnel carries IPv4 only for now."
+              ? "Everything goes through the VPN: the device reaches the internet via the firewall\u2019s WAN address. Use this on untrusted networks (public Wi-Fi) or to apply the firewall\u2019s filtering everywhere. IPv6 goes through the VPN too when the tunnel has an IPv6 address; otherwise it stays on the device\u2019s normal connection."
               : "Only the VPN subnet (plus any split-tunnel routes configured on the tunnel) goes through the VPN \u2014 use this to reach home/office devices while everything else uses the device\u2019s normal connection. Faster, but internet traffic is not protected by the VPN."}
           </p>
           <pre className="bg-gray-900 border border-gray-700 rounded-lg p-4 text-sm font-mono text-green-400 whitespace-pre-wrap select-all overflow-x-auto">

--- a/aifw-ui/src/app/vpn/components/WgPeerForm.tsx
+++ b/aifw-ui/src/app/vpn/components/WgPeerForm.tsx
@@ -43,9 +43,12 @@ export function WgPeerForm({
             <Help title="Client IP" size="xs">
               This device&apos;s address inside the
               tunnel, e.g. <code>10.10.0.2/32</code>.
+              On a dual-stack tunnel give both,
+              comma-separated:{" "}
+              <code>10.10.0.2/32, fd00:a1f0::2/128</code>.
               Every peer needs its own — <b>Auto</b>{" "}
-              picks the next free IP in the tunnel
-              subnet.
+              picks the next free IP in every subnet
+              the tunnel carries.
             </Help>
           </label>
           <div className="flex gap-1">

--- a/aifw-ui/src/app/vpn/components/WgPeerTable.tsx
+++ b/aifw-ui/src/app/vpn/components/WgPeerTable.tsx
@@ -54,7 +54,7 @@ export function WgPeerTable({ tunnelId, peers, vpnStatus, onShowConfig, onDelete
                 {peer.public_key.slice(0, 16)}...
               </td>
               <td className="py-2 px-2 font-mono text-gray-300">
-                {peer.allowed_ips}
+                {peer.allowed_ips.join(", ")}
               </td>
               <td className="py-2 px-2 font-mono text-gray-400">
                 {peer.endpoint || "-"}

--- a/aifw-ui/src/app/vpn/components/WgTunnelForm.tsx
+++ b/aifw-ui/src/app/vpn/components/WgTunnelForm.tsx
@@ -62,13 +62,13 @@ export function WgTunnelForm({
         </div>
         <div>
           <label className={labelCls}>
-            Address (CIDR){" "}
+            IPv4 Address (CIDR){" "}
             <Help title="Tunnel address" size="xs">
               The firewall&apos;s IP <i>inside</i> the VPN, plus the
               tunnel subnet size — e.g. <code>10.10.0.1/24</code>.
               Peers get other IPs from this subnet. Use a private
               range that doesn&apos;t overlap your LAN or any
-              network you connect from. IPv4 only for now.
+              network you connect from.
             </Help>
           </label>
           <input
@@ -79,6 +79,29 @@ export function WgTunnelForm({
             className={inputCls}
           />
         </div>
+        <div>
+          <label className={labelCls}>
+            IPv6 Address (optional){" "}
+            <Help title="IPv6 tunnel address" size="xs">
+              Add this to make the tunnel dual-stack: peers get an
+              IPv6 address too, and full-tunnel configs route IPv6
+              through the VPN. Use a unique-local subnet like{" "}
+              <code>fd00:a1f0::1/64</code>. IPv6 egress is NAT&apos;d
+              through the WAN automatically (the WAN needs a working
+              IPv6 address for peers to reach the v6 internet).
+              Leave empty for an IPv4-only tunnel.
+            </Help>
+          </label>
+          <input
+            type="text"
+            value={wgForm.address6}
+            onChange={(e) => setWgForm((f) => ({ ...f, address6: e.target.value }))}
+            placeholder="fd00:a1f0::1/64"
+            className={inputCls}
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-3">
         <div>
           <label className={labelCls}>
             Listen Interface{" "}
@@ -101,8 +124,6 @@ export function WgTunnelForm({
             ))}
           </select>
         </div>
-      </div>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-3">
         <div>
           <label className={labelCls}>
             DNS Servers{" "}
@@ -173,8 +194,9 @@ export function WgTunnelForm({
         />
         <p className="text-xs text-gray-500 mt-1">
           When a client uses split-tunnel mode, only these networks are
-          routed through the VPN. Empty = just the tunnel&apos;s own
-          subnet. Use this to reach your whole LAN over the VPN.
+          routed through the VPN. IPv6 CIDRs work too. Empty = just the
+          tunnel&apos;s own subnet(s). Use this to reach your whole LAN
+          over the VPN.
         </p>
       </div>
       <div className="flex gap-2 mt-3">

--- a/aifw-ui/src/app/vpn/components/WgTunnelRow.tsx
+++ b/aifw-ui/src/app/vpn/components/WgTunnelRow.tsx
@@ -105,7 +105,10 @@ export function WgTunnelRow({
           </div>
           <div>
             <span className="text-gray-500">Address:</span>{" "}
-            <span className="text-gray-300 font-mono">{tunnel.address}</span>
+            <span className="text-gray-300 font-mono">
+              {tunnel.address}
+              {tunnel.address6 ? `, ${tunnel.address6}` : ""}
+            </span>
           </div>
           <div className="md:col-span-2">
             <span className="text-gray-500">Public Key:</span>{" "}

--- a/aifw-ui/src/app/vpn/page.tsx
+++ b/aifw-ui/src/app/vpn/page.tsx
@@ -41,9 +41,12 @@ export default function VpnPage() {
           another router, forward the listen port (UDP) to it there.
         </p>
         <p>
-          Peers can <i>connect</i> to the firewall over IPv4 or IPv6, but
-          traffic <i>inside</i> the tunnel is IPv4-only for now — client
-          configs are generated accordingly.
+          Peers can <i>connect</i> to the firewall over IPv4 or IPv6. Give
+          a tunnel an IPv6 address too (e.g. <code>fd00:a1f0::1/64</code>)
+          and it carries both families <i>inside</i>: peers get dual-stack
+          addresses and full-tunnel configs route IPv6 through the VPN.
+          Tunnels without one stay IPv4-only and client configs are
+          generated accordingly.
         </p>
       </HelpBanner>
 

--- a/aifw-ui/src/hooks/useVpn.ts
+++ b/aifw-ui/src/hooks/useVpn.ts
@@ -177,6 +177,9 @@ export function useVpn() {
         listen_port: parseInt(wgForm.listen_port, 10),
         address: wgForm.address.trim(),
       };
+      if (wgForm.address6.trim()) {
+        body.address6 = wgForm.address6.trim();
+      }
       if (wgForm.private_key.trim()) {
         body.private_key = wgForm.private_key.trim();
       }
@@ -210,6 +213,7 @@ export function useVpn() {
       name: tunnel.name,
       listen_port: String(tunnel.listen_port),
       address: tunnel.address,
+      address6: tunnel.address6 || "",
       private_key: "",
       dns: tunnel.dns || "",
       mtu: tunnel.mtu ? String(tunnel.mtu) : "",

--- a/aifw-ui/src/lib/api/vpn.ts
+++ b/aifw-ui/src/lib/api/vpn.ts
@@ -11,6 +11,8 @@ export interface WgTunnel {
   interface: string;
   listen_port: number;
   address: string;
+  /** IPv6 tunnel address for dual-stack tunnels (#471); null = IPv4-only */
+  address6: string | null;
   private_key: string;
   public_key: string;
   dns: string | null;
@@ -29,7 +31,9 @@ export interface WgPeer {
   preshared_key: string | null;
   client_private_key: string | null;
   endpoint: string | null;
-  allowed_ips: string;
+  /** Serialized by the API as an array of CIDR strings (one per family
+   *  on dual-stack tunnels, e.g. ["10.10.0.2/32", "fd00:a1f0::2/128"]) */
+  allowed_ips: string[];
   persistent_keepalive: number | null;
   created_at: string;
 }
@@ -156,6 +160,7 @@ export interface WgTunnelRequest {
   name: string;
   listen_port: number;
   address: string;
+  address6?: string;
   private_key?: string;
   dns?: string;
   mtu?: number;
@@ -221,6 +226,7 @@ export interface WgFormState {
   name: string;
   listen_port: string;
   address: string;
+  address6: string;
   private_key: string;
   dns: string;
   mtu: string;
@@ -232,6 +238,7 @@ export const defaultWgForm: WgFormState = {
   name: "",
   listen_port: "",
   address: "",
+  address6: "",
   private_key: "",
   dns: "",
   mtu: "",


### PR DESCRIPTION
Closes #471. Follow-up to #469/#470 — IPv6 previously worked only as WireGuard *transport*; this makes traffic *inside* the tunnel dual-stack, one commit per phase:

1. **Dual-stack tunnel addresses** — optional `address6` on `wg_tunnels` (idempotent `ALTER TABLE`), model/API/backup-restore support, and address-family-aware interface bring-up (`ifconfig inet6`; a v6 address configured via `inet` used to silently fail — those failures are now logged).
2. **v6-aware peer auto-assign** — `next_peer_ip` now does per-family integer math over the real prefix; dual-stack tunnels yield `v4/32, v6/128`, v6-only tunnels work.
3. **NAT66 egress** — `to_nat_rules` adds `nat on <wan> inet6 from <tunnel-v6-net> -> (<wan>)` alongside the #469 IPv4 masquerade so clients get a v6 path out.
4. **Client configs** — `Address =` emits every peer address (both families), full-tunnel routes `0.0.0.0/0, ::/0` only when the tunnel actually carries v6, split-tunnel fallback includes the v6 subnet.
5. **UI** — IPv6 address field with help text on the tunnel form, dual-stack shown on tunnel cards / peer table, updated peer-IP help, page banner and config-modal copy no longer claim IPv4-only. Also fixes `WgPeer.allowed_ips` typing (API sends a string array): dual-stack peers rendered glued together, and the NAT flows page's `.split()` on an array threw, so WG peer routes never loaded there.

Acceptance per the issue:
- A dual-stack tunnel hands a peer both a v4 and v6 inner address; full-tunnel config routes both families, with NAT66 egress through the WAN.
- Existing v4-only tunnels are untouched: nullable column, same rules/configs as before.

Tests: 13 new (address6 roundtrip + validation, per-family auto-IP, NAT66 rules, dual-stack ifconfig/client configs); full workspace suite passes, `npm run build`/lint clean.