### PR TITLE
fix(backup): round-trip rDNS resolver config in snapshots (#589)

### DIFF
--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -857,6 +857,7 @@ pub(crate) async fn build_current_config(state: &AppState) -> Result<FirewallCon
         dhcp: build_dhcp_section(&state.pool).await,
         aliases: build_aliases_section(state).await,
         static_routes: build_static_routes_section(&state.pool).await,
+        dns_resolver: Some(crate::dns_resolver::load_config(&state.pool).await),
     };
 
     Ok(config)
@@ -2128,6 +2129,15 @@ pub(crate) async fn apply_firewall_config(
     // rDHCP service regen runs after commit)
     apply_dhcp_section_db(&mut tx, &config.dhcp).await?;
 
+    // DNS resolver settings (#589). `None` = backup predates the section;
+    // leave the box's resolver config untouched instead of resetting it to
+    // defaults. Service regen runs after commit.
+    if let Some(resolver) = &config.dns_resolver {
+        crate::dns_resolver::save_config_on(&mut tx, resolver)
+            .await
+            .map_err(|e| apply_fail("dns resolver config restore", e))?;
+    }
+
     // One audit row for the whole restore, committed atomically with it.
     // (Pre-#158 each engine `add` wrote a per-row audit entry; a restore is
     // one operator action, not N rule additions.)
@@ -2259,6 +2269,22 @@ pub(crate) async fn apply_firewall_config(
     // effect. Best-effort: the companion service may be absent (dev hosts);
     // the DB rows are authoritative and reapplied at boot.
     crate::dhcp::auto_apply(state).await;
+
+    // Regenerate resolver config + restart the DNS backend so the restored
+    // settings take effect (#589). Best-effort like rDHCP above: the backend
+    // service may be absent (dev hosts); the DB rows are authoritative and
+    // switch_backend probes + auto-rolls-back on a failed start.
+    if let Some(resolver) = &config.dns_resolver {
+        let report = crate::dns_resolver::switch_backend(state, &resolver.backend, resolver).await;
+        if report.rolled_back || (resolver.enabled && !report.probe_udp) {
+            tracing::warn!(
+                backend = %resolver.backend,
+                rolled_back = report.rolled_back,
+                message = %report.message,
+                "import: DNS resolver apply did not come up healthy — settings are restored in the DB, re-apply via /dns/resolver/apply"
+            );
+        }
+    }
 
     // Final data-plane applies — a failure here means the kernel does NOT
     // match the restored DB, so it must not report success (#535).

--- a/aifw-api/src/dns_resolver.rs
+++ b/aifw-api/src/dns_resolver.rs
@@ -205,127 +205,10 @@ fn sanitize_zone_filename(name: &str) -> String {
 // Types
 // ============================================================
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ResolverConfig {
-    pub backend: String, // "unbound" or "rdns"
-    pub enabled: bool,
-    pub listen_interfaces: Vec<String>,
-    pub port: u16,
-    pub dnssec: bool,
-    pub dns64: bool,
-    pub register_dhcp: bool,
-    pub dhcp_domain: String, // domain for DHCP lease DNS registration (e.g. "local")
-    pub local_zone_type: String, // transparent, static, redirect, etc.
-    pub outgoing_interface: Option<String>,
-    // Advanced
-    pub num_threads: u32,
-    pub msg_cache_size: String,
-    pub rrset_cache_size: String,
-    pub cache_max_ttl: u32,
-    pub cache_min_ttl: u32,
-    pub prefetch: bool,
-    pub prefetch_key: bool,
-    pub infra_host_ttl: u32,
-    pub unwanted_reply_threshold: u32,
-    pub log_queries: bool,
-    pub log_replies: bool,
-    pub log_verbosity: u32,
-    /// Ceiling on a single query's resolution (ms). 0 = rDNS built-in
-    /// per-transport defaults (UDP 3000, TCP/DoT 30000).
-    #[serde(default)]
-    pub query_timeout_ms: u32,
-    pub hide_identity: bool,
-    pub hide_version: bool,
-    pub rebind_protection: bool,
-    pub private_addresses: Vec<String>,
-    // Forwarding
-    pub forwarding_enabled: bool,
-    pub forwarding_servers: Vec<String>, // plain upstream DNS IPs (e.g. "8.8.8.8", "1.1.1.1")
-    pub use_system_nameservers: bool,    // also forward to /etc/resolv.conf nameservers
-    // DoT
-    pub dot_enabled: bool,
-    pub dot_upstream: Vec<String>, // "1.1.1.1@853#cloudflare-dns.com"
-    // Blocklists
-    pub blocklists_enabled: bool,
-    pub blocklist_urls: Vec<String>,
-    pub whitelist: Vec<String>,
-    pub blocklist_action: String, // "nxdomain" | "redirect"
-    pub blocklist_redirect_ip: Option<String>,
-    // Custom
-    pub custom_options: String,
-    // Safety
-    /// Probe :53 after a resolver switch and auto-rollback on failure.
-    /// Default: true. Disable to restore the old fire-and-forget behavior
-    /// (e.g. for debugging, or on boxes where the probe misfires).
-    #[serde(default = "default_true")]
-    pub probe_enabled: bool,
-}
-
-fn default_true() -> bool {
-    true
-}
-
-impl Default for ResolverConfig {
-    fn default() -> Self {
-        Self {
-            backend: "rdns".to_string(),
-            enabled: false,
-            listen_interfaces: vec!["0.0.0.0".to_string()],
-            port: 53,
-            dnssec: true,
-            dns64: false,
-            register_dhcp: true,
-            dhcp_domain: "local".to_string(),
-            local_zone_type: "transparent".to_string(),
-            outgoing_interface: None,
-            num_threads: 2,
-            msg_cache_size: "8m".to_string(),
-            rrset_cache_size: "16m".to_string(),
-            cache_max_ttl: 86400,
-            cache_min_ttl: 0,
-            prefetch: true,
-            prefetch_key: true,
-            infra_host_ttl: 900,
-            unwanted_reply_threshold: 10000,
-            log_queries: false,
-            log_replies: false,
-            log_verbosity: 1,
-            query_timeout_ms: 0,
-            hide_identity: true,
-            hide_version: true,
-            rebind_protection: true,
-            private_addresses: vec![
-                "10.0.0.0/8".into(),
-                "172.16.0.0/12".into(),
-                "192.168.0.0/16".into(),
-                "169.254.0.0/16".into(),
-                "fd00::/8".into(),
-                "fe80::/10".into(),
-            ],
-            // Default ON. Iterative recursion in rDNS 1.12.8 returns referrals
-            // instead of following them to completion, leaving clients with
-            // 0-answer responses for anything not already cached. Forwarding
-            // to public resolvers is the battle-tested fallback and keeps DNS
-            // working out of the box. Operators who want pure recursion can
-            // flip this off in the UI.
-            forwarding_enabled: true,
-            forwarding_servers: vec!["1.1.1.1".into(), "8.8.8.8".into()],
-            use_system_nameservers: false,
-            dot_enabled: false,
-            dot_upstream: vec![
-                "1.1.1.1@853#cloudflare-dns.com".into(),
-                "1.0.0.1@853#cloudflare-dns.com".into(),
-            ],
-            blocklists_enabled: false,
-            blocklist_urls: vec![],
-            whitelist: vec![],
-            blocklist_action: "nxdomain".to_string(),
-            blocklist_redirect_ip: None,
-            custom_options: String::new(),
-            probe_enabled: true,
-        }
-    }
-}
+/// The resolver settings struct lives in aifw-core so config snapshots can
+/// round-trip it as `FirewallConfig::dns_resolver` (#589). Same JSON shape
+/// the `/api/v1/dns/resolver/config` endpoint has always spoken.
+pub use aifw_core::config::DnsResolverSection as ResolverConfig;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct HostOverride {
@@ -516,7 +399,7 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
 // Config helpers
 // ============================================================
 
-async fn load_config(pool: &SqlitePool) -> ResolverConfig {
+pub(crate) async fn load_config(pool: &SqlitePool) -> ResolverConfig {
     let rows = sqlx::query_as::<_, (String, String)>("SELECT key, value FROM dns_resolver_config")
         .fetch_all(pool)
         .await
@@ -1514,70 +1397,94 @@ pub async fn update_config_handler(
     State(state): State<AppState>,
     Json(c): Json<ResolverConfig>,
 ) -> Result<Json<MessageResponse>, StatusCode> {
-    let pool = &state.pool;
-    save_key(pool, "backend", &c.backend).await;
-    save_key(pool, "enabled", bool_str(c.enabled)).await;
-    save_key(pool, "dhcp_domain", &c.dhcp_domain).await;
-    save_key(pool, "listen_interfaces", &c.listen_interfaces.join(",")).await;
-    save_key(pool, "port", &c.port.to_string()).await;
-    save_key(pool, "dnssec", bool_str(c.dnssec)).await;
-    save_key(pool, "dns64", bool_str(c.dns64)).await;
-    save_key(pool, "register_dhcp", bool_str(c.register_dhcp)).await;
-    save_key(pool, "local_zone_type", &c.local_zone_type).await;
-    save_key(
-        pool,
-        "outgoing_interface",
-        c.outgoing_interface.as_deref().unwrap_or(""),
-    )
-    .await;
-    save_key(pool, "num_threads", &c.num_threads.to_string()).await;
-    save_key(pool, "msg_cache_size", &c.msg_cache_size).await;
-    save_key(pool, "rrset_cache_size", &c.rrset_cache_size).await;
-    save_key(pool, "cache_max_ttl", &c.cache_max_ttl.to_string()).await;
-    save_key(pool, "cache_min_ttl", &c.cache_min_ttl.to_string()).await;
-    save_key(pool, "prefetch", bool_str(c.prefetch)).await;
-    save_key(pool, "prefetch_key", bool_str(c.prefetch_key)).await;
-    save_key(pool, "infra_host_ttl", &c.infra_host_ttl.to_string()).await;
-    save_key(
-        pool,
-        "unwanted_reply_threshold",
-        &c.unwanted_reply_threshold.to_string(),
-    )
-    .await;
-    save_key(pool, "log_queries", bool_str(c.log_queries)).await;
-    save_key(pool, "log_replies", bool_str(c.log_replies)).await;
-    save_key(pool, "log_verbosity", &c.log_verbosity.to_string()).await;
-    save_key(pool, "query_timeout_ms", &c.query_timeout_ms.to_string()).await;
-    save_key(pool, "hide_identity", bool_str(c.hide_identity)).await;
-    save_key(pool, "hide_version", bool_str(c.hide_version)).await;
-    save_key(pool, "rebind_protection", bool_str(c.rebind_protection)).await;
-    save_key(pool, "private_addresses", &c.private_addresses.join(",")).await;
-    save_key(pool, "forwarding_enabled", bool_str(c.forwarding_enabled)).await;
-    save_key(pool, "forwarding_servers", &c.forwarding_servers.join(",")).await;
-    save_key(
-        pool,
-        "use_system_nameservers",
-        bool_str(c.use_system_nameservers),
-    )
-    .await;
-    save_key(pool, "dot_enabled", bool_str(c.dot_enabled)).await;
-    save_key(pool, "dot_upstream", &c.dot_upstream.join(",")).await;
-    save_key(pool, "blocklists_enabled", bool_str(c.blocklists_enabled)).await;
-    save_key(pool, "blocklist_urls", &c.blocklist_urls.join("\n")).await;
-    save_key(pool, "whitelist", &c.whitelist.join("\n")).await;
-    save_key(pool, "blocklist_action", &c.blocklist_action).await;
-    save_key(
-        pool,
-        "blocklist_redirect_ip",
-        c.blocklist_redirect_ip.as_deref().unwrap_or(""),
-    )
-    .await;
-    save_key(pool, "custom_options", &c.custom_options).await;
-    save_key(pool, "probe_enabled", bool_str(c.probe_enabled)).await;
+    let mut conn = state.pool.acquire().await.map_err(|_| internal())?;
+    save_config_on(&mut conn, &c).await.map_err(|e| {
+        tracing::error!(error = %e, "resolver config save failed");
+        internal()
+    })?;
     state.set_pending(|p| p.dns = true).await;
     Ok(Json(MessageResponse {
         message: "DNS resolver config saved".to_string(),
     }))
+}
+
+/// Persist every `ResolverConfig` field into `dns_resolver_config`. Shared
+/// by the `PUT /dns/resolver/config` handler and the backup restore path
+/// (#589) — the latter runs it on the restore transaction, so this takes a
+/// connection rather than the pool.
+pub(crate) async fn save_config_on(
+    conn: &mut sqlx::SqliteConnection,
+    c: &ResolverConfig,
+) -> Result<(), sqlx::Error> {
+    for (k, v) in [
+        ("backend", c.backend.clone()),
+        ("enabled", bool_str(c.enabled).to_string()),
+        ("dhcp_domain", c.dhcp_domain.clone()),
+        ("listen_interfaces", c.listen_interfaces.join(",")),
+        ("port", c.port.to_string()),
+        ("dnssec", bool_str(c.dnssec).to_string()),
+        ("dns64", bool_str(c.dns64).to_string()),
+        ("register_dhcp", bool_str(c.register_dhcp).to_string()),
+        ("local_zone_type", c.local_zone_type.clone()),
+        (
+            "outgoing_interface",
+            c.outgoing_interface.clone().unwrap_or_default(),
+        ),
+        ("num_threads", c.num_threads.to_string()),
+        ("msg_cache_size", c.msg_cache_size.clone()),
+        ("rrset_cache_size", c.rrset_cache_size.clone()),
+        ("cache_max_ttl", c.cache_max_ttl.to_string()),
+        ("cache_min_ttl", c.cache_min_ttl.to_string()),
+        ("prefetch", bool_str(c.prefetch).to_string()),
+        ("prefetch_key", bool_str(c.prefetch_key).to_string()),
+        ("infra_host_ttl", c.infra_host_ttl.to_string()),
+        (
+            "unwanted_reply_threshold",
+            c.unwanted_reply_threshold.to_string(),
+        ),
+        ("log_queries", bool_str(c.log_queries).to_string()),
+        ("log_replies", bool_str(c.log_replies).to_string()),
+        ("log_verbosity", c.log_verbosity.to_string()),
+        ("query_timeout_ms", c.query_timeout_ms.to_string()),
+        ("hide_identity", bool_str(c.hide_identity).to_string()),
+        ("hide_version", bool_str(c.hide_version).to_string()),
+        (
+            "rebind_protection",
+            bool_str(c.rebind_protection).to_string(),
+        ),
+        ("private_addresses", c.private_addresses.join(",")),
+        (
+            "forwarding_enabled",
+            bool_str(c.forwarding_enabled).to_string(),
+        ),
+        ("forwarding_servers", c.forwarding_servers.join(",")),
+        (
+            "use_system_nameservers",
+            bool_str(c.use_system_nameservers).to_string(),
+        ),
+        ("dot_enabled", bool_str(c.dot_enabled).to_string()),
+        ("dot_upstream", c.dot_upstream.join(",")),
+        (
+            "blocklists_enabled",
+            bool_str(c.blocklists_enabled).to_string(),
+        ),
+        ("blocklist_urls", c.blocklist_urls.join("\n")),
+        ("whitelist", c.whitelist.join("\n")),
+        ("blocklist_action", c.blocklist_action.clone()),
+        (
+            "blocklist_redirect_ip",
+            c.blocklist_redirect_ip.clone().unwrap_or_default(),
+        ),
+        ("custom_options", c.custom_options.clone()),
+        ("probe_enabled", bool_str(c.probe_enabled).to_string()),
+    ] {
+        sqlx::query("INSERT OR REPLACE INTO dns_resolver_config (key, value) VALUES (?1, ?2)")
+            .bind(k)
+            .bind(v)
+            .execute(&mut *conn)
+            .await?;
+    }
+    Ok(())
 }
 
 // ============================================================

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -2280,6 +2280,89 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_restore_round_trips_dns_resolver_config() {
+        // #589: resolver settings live in dns_resolver_config, not
+        // /etc/resolv.conf — a backup/restore must carry them.
+        let state = crate::create_app_state_in_memory(plain_auth_settings())
+            .await
+            .unwrap();
+
+        let resolver = crate::dns_resolver::ResolverConfig {
+            forwarding_servers: vec!["9.9.9.9".to_string()],
+            blocklists_enabled: true,
+            ..Default::default()
+        };
+        let mut conn = state.pool.acquire().await.unwrap();
+        crate::dns_resolver::save_config_on(&mut conn, &resolver)
+            .await
+            .unwrap();
+        drop(conn);
+
+        let config = crate::backup::build_current_config(&state).await.unwrap();
+        let exported = config
+            .dns_resolver
+            .as_ref()
+            .expect("export must include resolver");
+        assert_eq!(exported.forwarding_servers, vec!["9.9.9.9".to_string()]);
+        assert!(exported.blocklists_enabled);
+
+        // Simulate drift after the backup was taken.
+        sqlx::query(
+            "INSERT OR REPLACE INTO dns_resolver_config (key, value) VALUES ('forwarding_servers', '8.8.4.4')",
+        )
+        .execute(&state.pool)
+        .await
+        .unwrap();
+
+        crate::backup::apply_firewall_config(&state, &config, &Default::default())
+            .await
+            .expect("restore must succeed");
+
+        let (servers,): (String,) = sqlx::query_as(
+            "SELECT value FROM dns_resolver_config WHERE key = 'forwarding_servers'",
+        )
+        .fetch_one(&state.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            servers, "9.9.9.9",
+            "restore must reinstate the backed-up forwarders"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_restore_without_resolver_section_leaves_config_untouched() {
+        // A pre-#589 backup has no dns_resolver section — restoring it must
+        // not reset the box's resolver config to defaults.
+        let state = crate::create_app_state_in_memory(plain_auth_settings())
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT OR REPLACE INTO dns_resolver_config (key, value) VALUES ('forwarding_servers', '9.9.9.9')",
+        )
+        .execute(&state.pool)
+        .await
+        .unwrap();
+
+        let mut config = crate::backup::build_current_config(&state).await.unwrap();
+        config.dns_resolver = None;
+        crate::backup::apply_firewall_config(&state, &config, &Default::default())
+            .await
+            .expect("restore must succeed");
+
+        let (servers,): (String,) = sqlx::query_as(
+            "SELECT value FROM dns_resolver_config WHERE key = 'forwarding_servers'",
+        )
+        .fetch_one(&state.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            servers, "9.9.9.9",
+            "legacy restore must not clobber resolver config"
+        );
+    }
+
+    #[tokio::test]
     async fn test_restore_fails_instead_of_partial_apply() {
         // A required step failing (here: clearing a table that no longer
         // exists) must abort the restore with an error, never return Ok after

--- a/aifw-core/src/config.rs
+++ b/aifw-core/src/config.rs
@@ -68,6 +68,12 @@ pub struct FirewallConfig {
     /// snapshot/restore silently drops every route the user defined.
     #[serde(default)]
     pub static_routes: Vec<StaticRouteConfig>,
+    /// rDNS/unbound resolver settings (the `dns_resolver_config` table).
+    /// `None` means the backup predates this section (#589) — restore
+    /// leaves the box's resolver config untouched rather than resetting
+    /// it to defaults.
+    #[serde(default)]
+    pub dns_resolver: Option<DnsResolverSection>,
 }
 
 impl Default for FirewallConfig {
@@ -88,6 +94,7 @@ impl Default for FirewallConfig {
             dhcp: DhcpSection::default(),
             aliases: Vec::new(),
             static_routes: Vec::new(),
+            dns_resolver: None,
         }
     }
 }
@@ -221,6 +228,24 @@ impl FirewallConfig {
         }
         if self.system.api_port == 0 {
             return Err("system.api_port cannot be 0".to_string());
+        }
+        if let Some(r) = &self.dns_resolver {
+            for s in &r.forwarding_servers {
+                if s.parse::<std::net::IpAddr>().is_err() {
+                    return Err(format!(
+                        "dns_resolver.forwarding_servers entry {s} is not a valid IP"
+                    ));
+                }
+            }
+            if r.blocklist_urls.len() > 10_000
+                || r.whitelist.len() > 100_000
+                || r.forwarding_servers.len() > 100
+                || r.dot_upstream.len() > 100
+                || r.listen_interfaces.len() > 100
+                || r.private_addresses.len() > 1_000
+            {
+                return Err("dns_resolver list length exceeds cap".to_string());
+            }
         }
         Ok(())
     }
@@ -976,6 +1001,170 @@ pub struct DhcpHaSection {
     pub tls_key: Option<String>,
     /// TLS CA certificate path for peer verification
     pub tls_ca: Option<String>,
+}
+
+// ============================================================
+// DNS resolver (rDNS / unbound)
+// ============================================================
+
+/// rDNS/unbound resolver settings — the `dns_resolver_config` key/value
+/// table materialized as a struct. This is the same type the
+/// `/api/v1/dns/resolver/config` endpoint speaks (aifw-api re-exports it
+/// as `ResolverConfig`); it lives here so config snapshots can round-trip
+/// it (#589).
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DnsResolverSection {
+    /// Resolver backend: `rdns` or `unbound`
+    pub backend: String,
+    /// Whether the resolver service runs
+    pub enabled: bool,
+    /// Listen addresses (e.g. `0.0.0.0`)
+    pub listen_interfaces: Vec<String>,
+    /// DNS listen port (default 53)
+    pub port: u16,
+    /// DNSSEC validation
+    pub dnssec: bool,
+    /// DNS64 synthesis
+    pub dns64: bool,
+    /// Register DHCP leases in DNS
+    pub register_dhcp: bool,
+    /// Domain for DHCP lease DNS registration (e.g. `local`)
+    pub dhcp_domain: String,
+    /// Local zone type — transparent, static, redirect, etc.
+    pub local_zone_type: String,
+    /// Interface for outgoing queries; None = any
+    pub outgoing_interface: Option<String>,
+    // Advanced
+    /// Worker thread count
+    pub num_threads: u32,
+    /// Message cache size (e.g. `8m`)
+    pub msg_cache_size: String,
+    /// RRset cache size (e.g. `16m`)
+    pub rrset_cache_size: String,
+    /// Maximum cache TTL in seconds
+    pub cache_max_ttl: u32,
+    /// Minimum cache TTL in seconds
+    pub cache_min_ttl: u32,
+    /// Prefetch popular records before expiry
+    pub prefetch: bool,
+    /// Prefetch DNSKEY records
+    pub prefetch_key: bool,
+    /// Host infrastructure cache TTL in seconds
+    pub infra_host_ttl: u32,
+    /// Unwanted-reply threshold before cache flush
+    pub unwanted_reply_threshold: u32,
+    /// Log client queries
+    pub log_queries: bool,
+    /// Log replies
+    pub log_replies: bool,
+    /// Log verbosity level
+    pub log_verbosity: u32,
+    /// Ceiling on a single query's resolution (ms). 0 = rDNS built-in
+    /// per-transport defaults (UDP 3000, TCP/DoT 30000).
+    #[serde(default)]
+    pub query_timeout_ms: u32,
+    /// Refuse id.server/hostname.bind queries
+    pub hide_identity: bool,
+    /// Refuse version.server/version.bind queries
+    pub hide_version: bool,
+    /// DNS-rebind protection
+    pub rebind_protection: bool,
+    /// Private address ranges for rebind protection
+    pub private_addresses: Vec<String>,
+    // Forwarding
+    /// Forward to upstream servers instead of full recursion
+    pub forwarding_enabled: bool,
+    /// Plain upstream DNS IPs (e.g. `8.8.8.8`, `1.1.1.1`)
+    pub forwarding_servers: Vec<String>,
+    /// Also forward to /etc/resolv.conf nameservers
+    pub use_system_nameservers: bool,
+    // DoT
+    /// DNS-over-TLS forwarding
+    pub dot_enabled: bool,
+    /// DoT upstreams (`1.1.1.1@853#cloudflare-dns.com`)
+    pub dot_upstream: Vec<String>,
+    // Blocklists
+    /// Enable domain blocklists
+    pub blocklists_enabled: bool,
+    /// Blocklist source URLs
+    pub blocklist_urls: Vec<String>,
+    /// Domains exempted from blocklists
+    pub whitelist: Vec<String>,
+    /// `nxdomain` or `redirect`
+    pub blocklist_action: String,
+    /// Redirect target when blocklist_action is `redirect`
+    pub blocklist_redirect_ip: Option<String>,
+    // Custom
+    /// Free-form extra config lines appended to the generated config
+    pub custom_options: String,
+    // Safety
+    /// Probe :53 after a resolver switch and auto-rollback on failure.
+    /// Default: true. Disable to restore the old fire-and-forget behavior
+    /// (e.g. for debugging, or on boxes where the probe misfires).
+    #[serde(default = "default_true")]
+    pub probe_enabled: bool,
+}
+
+impl Default for DnsResolverSection {
+    fn default() -> Self {
+        Self {
+            backend: "rdns".to_string(),
+            enabled: false,
+            listen_interfaces: vec!["0.0.0.0".to_string()],
+            port: 53,
+            dnssec: true,
+            dns64: false,
+            register_dhcp: true,
+            dhcp_domain: "local".to_string(),
+            local_zone_type: "transparent".to_string(),
+            outgoing_interface: None,
+            num_threads: 2,
+            msg_cache_size: "8m".to_string(),
+            rrset_cache_size: "16m".to_string(),
+            cache_max_ttl: 86400,
+            cache_min_ttl: 0,
+            prefetch: true,
+            prefetch_key: true,
+            infra_host_ttl: 900,
+            unwanted_reply_threshold: 10000,
+            log_queries: false,
+            log_replies: false,
+            log_verbosity: 1,
+            query_timeout_ms: 0,
+            hide_identity: true,
+            hide_version: true,
+            rebind_protection: true,
+            private_addresses: vec![
+                "10.0.0.0/8".into(),
+                "172.16.0.0/12".into(),
+                "192.168.0.0/16".into(),
+                "169.254.0.0/16".into(),
+                "fd00::/8".into(),
+                "fe80::/10".into(),
+            ],
+            // Default ON. Iterative recursion in rDNS 1.12.8 returns referrals
+            // instead of following them to completion, leaving clients with
+            // 0-answer responses for anything not already cached. Forwarding
+            // to public resolvers is the battle-tested fallback and keeps DNS
+            // working out of the box. Operators who want pure recursion can
+            // flip this off in the UI.
+            forwarding_enabled: true,
+            forwarding_servers: vec!["1.1.1.1".into(), "8.8.8.8".into()],
+            use_system_nameservers: false,
+            dot_enabled: false,
+            dot_upstream: vec![
+                "1.1.1.1@853#cloudflare-dns.com".into(),
+                "1.0.0.1@853#cloudflare-dns.com".into(),
+            ],
+            blocklists_enabled: false,
+            blocklist_urls: vec![],
+            whitelist: vec![],
+            blocklist_action: "nxdomain".to_string(),
+            blocklist_redirect_ip: None,
+            custom_options: String::new(),
+            probe_enabled: true,
+        }
+    }
 }
 
 // ============================================================

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -1865,5 +1865,43 @@ mod tests {
         assert_eq!(c.system.domain, ""); // default
         assert_eq!(c.system.timezone, "UTC"); // default
         assert_eq!(c.system.ssh.port, 22); // default
+        assert!(
+            c.dns_resolver.is_none(),
+            "pre-#589 backups must restore with the resolver section absent, not defaulted"
+        );
+    }
+
+    #[test]
+    fn dns_resolver_section_round_trips() {
+        let c = crate::FirewallConfig {
+            dns_resolver: Some(crate::config::DnsResolverSection {
+                forwarding_servers: vec!["9.9.9.9".into()],
+                enabled: true,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        c.validate().expect("valid resolver section must pass");
+
+        let json = c.to_json();
+        let back = crate::FirewallConfig::from_json(&json).expect("round trip");
+        let r = back.dns_resolver.expect("section must survive round trip");
+        assert_eq!(r.forwarding_servers, vec!["9.9.9.9".to_string()]);
+        assert!(r.enabled);
+    }
+
+    #[test]
+    fn dns_resolver_section_validates_forwarder_ips() {
+        let c = crate::FirewallConfig {
+            dns_resolver: Some(crate::config::DnsResolverSection {
+                forwarding_servers: vec!["not-an-ip; rm -rf /".into()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(
+            c.validate().is_err(),
+            "non-IP forwarding_servers entries must fail validation"
+        );
     }
 }


### PR DESCRIPTION
Fixes #589.

Backups exported DNS by parsing `/etc/resolv.conf`, but the resolver clients actually use is rDNS, whose settings live in the `dns_resolver_config` table — which the backup never captured. Restoring onto a fresh box came up with default resolver config: upstream forwarders, forwarding mode, blocklists, and everything else were lost.

**Changes**

- `ResolverConfig` moves to aifw-core as `config::DnsResolverSection` (aifw-api re-exports it under the old name — identical JSON shape, so the `/api/v1/dns/resolver/config` API and UI are unaffected).
- `FirewallConfig` gains `dns_resolver: Option<DnsResolverSection>`. `None` means the backup predates the section — restore leaves the box's resolver config untouched instead of resetting it to defaults.
- Export captures the full table via the existing `load_config`; restore writes it back **inside the restore transaction** through the new `save_config_on` (also now used by the PUT config handler, which previously swallowed DB errors), then re-applies the backend post-commit via `switch_backend`'s probe/auto-rollback path — warn-only, matching the rDHCP regen convention.
- `FirewallConfig::validate()` rejects non-IP `forwarding_servers` entries and absurd list lengths from tampered backups.
- Cluster HA snapshots embed `FirewallConfig`, so standby peers now receive resolver config too.

**Tests**: serde round-trip + legacy-JSON (section absent → `None`) + validation tests in aifw-core; full export→drift→restore round-trip and legacy-backup-leaves-config-untouched integration tests in aifw-api. Full `cargo test`: 796 passed. clippy/fmt clean.