### PR TITLE
fix(ui): make AppShell content margin react to viewport breakpoint

### DIFF
--- a/aifw-ui/src/components/AppShell.tsx
+++ b/aifw-ui/src/components/AppShell.tsx
@@ -114,7 +114,10 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
             </div>
 
             {/* Main content */}
-            <main className="flex-1 min-h-screen" style={{ marginLeft: typeof window !== "undefined" && window.innerWidth >= 1024 ? sidebarWidth : 0 }}>
+            <main
+              className="flex-1 min-h-screen ml-0 lg:ml-[var(--sidebar-width)]"
+              style={{ "--sidebar-width": `${sidebarWidth}px` } as React.CSSProperties}
+            >
               {/* Mobile header bar */}
               <div className="lg:hidden sticky top-0 z-20 bg-[var(--bg-secondary)] border-b border-[var(--border)] px-4 py-3 flex items-center gap-3">
                 <button onClick={() => setSidebarOpen(true)} className="text-[var(--text-primary)] hover:text-[var(--accent)] transition-colors">


### PR DESCRIPTION
Fixes #585.

`AppShell` derived the desktop `marginLeft` from `window.innerWidth` at render time with no resize listener, so crossing the 1024px breakpoint updated the sidebar via CSS (`lg:translate-x-0`) but left the content margin stale until an unrelated re-render — a dead gutter when shrinking, sidebar overlapping content when widening.

The margin is now pure CSS: the sidebar width is exposed as a `--sidebar-width` CSS variable on `<main>` and applied with `lg:ml-[var(--sidebar-width)]`, so it tracks the media query instantly. Reading `window` during render is gone, which also removes the SSR/client hydration mismatch on that style.

Verified: `npm run lint` and `npm run build` (static export) pass.