### PR TITLE
fix(security): move UI auth to HttpOnly session cookies (SEC-M7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,10 @@ Central type: `Database` struct in `aifw-core/src/db.rs` wrapping `SqlitePool`.
 - `Authorization: ApiKey <key>` header
 - `?ticket=<id>` query param (WebSocket/SSE) — single-use, 30-second
   ticket issued by `POST /auth/ws-ticket` (see `auth::ws_ticket`).
+- `aifw_at` HttpOnly session cookie (browser UI; SEC-M7 #304, see
+  `auth::cookies`) — fallback when no header/ticket is present. Cookie-authed
+  non-GET requests must also send the `X-AiFw-Csrf` header; the UI never
+  stores the JWT in `localStorage`.
 
 **AppState** holds all engines as `Arc<T>`, shared `Arc<dyn PfBackend>`, and `SqlitePool`. Passed to handlers via Axum's `State` extractor.
 

--- a/aifw-api/src/auth/cookies.rs
+++ b/aifw-api/src/auth/cookies.rs
@@ -1,0 +1,173 @@
+//! Session cookies for the browser UI (SEC-M7 #304).
+//!
+//! The web UI authenticates with `HttpOnly` cookies instead of storing the
+//! JWT in `localStorage`, so an XSS bug can no longer exfiltrate the token.
+//! Non-browser clients (CLI, API keys, scripts) keep using `Authorization`
+//! headers — cookies are an additional credential source, not a replacement.
+//!
+//! Two cookies are issued at login and rotated on refresh:
+//! - [`ACCESS_COOKIE`]: the access JWT, sent on every request (`Path=/`).
+//! - [`REFRESH_COOKIE`]: the refresh token, scoped to `Path=/api/v1/auth` so
+//!   it only travels to the refresh/logout endpoints.
+//!
+//! Both are `HttpOnly; SameSite=Strict`, plus `Secure` when the API serves
+//! TLS. Cross-site request forgery is blocked twice over: `SameSite=Strict`
+//! keeps browsers from attaching the cookies cross-site at all, and the auth
+//! middleware additionally requires the custom [`CSRF_HEADER`] on unsafe
+//! methods when the credential came from a cookie (a cross-site page cannot
+//! set custom headers without a CORS preflight, and credentialed cross-origin
+//! requests are never approved — the CORS layer does not allow credentials).
+
+use axum::http::{HeaderMap, HeaderValue};
+
+use super::config::AuthSettings;
+use super::tokens::TokenPair;
+
+/// Access-token cookie: the JWT, attached to every same-site request.
+pub const ACCESS_COOKIE: &str = "aifw_at";
+/// Refresh-token cookie, scoped to the auth endpoints only.
+pub const REFRESH_COOKIE: &str = "aifw_rt";
+/// Path scope for [`REFRESH_COOKIE`].
+const REFRESH_PATH: &str = "/api/v1/auth";
+/// Header the UI sends on every request; required by the auth middleware for
+/// unsafe methods when authenticating via cookie (CSRF defense in depth).
+pub const CSRF_HEADER: &str = "x-aifw-csrf";
+
+/// Read a cookie's value from the request headers. Handles multiple `Cookie`
+/// headers and the standard `name=value; name2=value2` form.
+pub fn cookie_value(headers: &HeaderMap, name: &str) -> Option<String> {
+    for header in headers.get_all(axum::http::header::COOKIE) {
+        let Ok(s) = header.to_str() else { continue };
+        for pair in s.split(';') {
+            let mut it = pair.trim().splitn(2, '=');
+            if it.next() == Some(name) {
+                return Some(it.next().unwrap_or("").to_string());
+            }
+        }
+    }
+    None
+}
+
+fn build_cookie(name: &str, value: &str, path: &str, max_age_secs: i64, secure: bool) -> String {
+    let secure = if secure { "; Secure" } else { "" };
+    format!(
+        "{name}={value}; Path={path}; Max-Age={max_age_secs}; HttpOnly; SameSite=Strict{secure}"
+    )
+}
+
+/// `Set-Cookie` values installing a freshly issued token pair.
+pub fn session_cookies(
+    tokens: &TokenPair,
+    settings: &AuthSettings,
+    secure: bool,
+) -> Vec<HeaderValue> {
+    let access = build_cookie(
+        ACCESS_COOKIE,
+        &tokens.access_token,
+        "/",
+        settings.access_token_expiry_mins.max(0) * 60,
+        secure,
+    );
+    let refresh = build_cookie(
+        REFRESH_COOKIE,
+        &tokens.refresh_token,
+        REFRESH_PATH,
+        settings.refresh_token_expiry_days.max(0) * 86_400,
+        secure,
+    );
+    // The values are ASCII we produced ourselves (JWT / rfx_ hex + fixed
+    // attributes), so HeaderValue conversion cannot fail.
+    [access, refresh]
+        .into_iter()
+        .filter_map(|c| HeaderValue::from_str(&c).ok())
+        .collect()
+}
+
+/// `Set-Cookie` values expiring both session cookies (logout).
+pub fn clear_cookies(secure: bool) -> Vec<HeaderValue> {
+    [
+        build_cookie(ACCESS_COOKIE, "", "/", 0, secure),
+        build_cookie(REFRESH_COOKIE, "", REFRESH_PATH, 0, secure),
+    ]
+    .into_iter()
+    .filter_map(|c| HeaderValue::from_str(&c).ok())
+    .collect()
+}
+
+/// Append `Set-Cookie` headers onto a response's header map.
+pub fn append_set_cookies(headers: &mut HeaderMap, cookies: Vec<HeaderValue>) {
+    for c in cookies {
+        headers.append(axum::http::header::SET_COOKIE, c);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings() -> AuthSettings {
+        AuthSettings {
+            jwt_secret: "s".into(),
+            access_token_expiry_mins: 60,
+            refresh_token_expiry_days: 7,
+            ..AuthSettings::default()
+        }
+    }
+
+    fn pair() -> TokenPair {
+        TokenPair {
+            access_token: "jwt-value".into(),
+            refresh_token: "rfx_abc".into(),
+            access_expires_at: String::new(),
+            refresh_expires_at: String::new(),
+            token_type: "Bearer".into(),
+        }
+    }
+
+    #[test]
+    fn parses_cookie_header() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            axum::http::header::COOKIE,
+            HeaderValue::from_static("foo=1; aifw_at=tok.en; bar=2"),
+        );
+        assert_eq!(cookie_value(&h, ACCESS_COOKIE).as_deref(), Some("tok.en"));
+        assert_eq!(cookie_value(&h, REFRESH_COOKIE), None);
+    }
+
+    #[test]
+    fn session_cookies_are_httponly_samesite_strict() {
+        for c in session_cookies(&pair(), &settings(), false) {
+            let s = c.to_str().unwrap();
+            assert!(s.contains("HttpOnly"), "{s}");
+            assert!(s.contains("SameSite=Strict"), "{s}");
+            assert!(!s.contains("Secure"), "{s}");
+        }
+    }
+
+    #[test]
+    fn secure_flag_follows_tls() {
+        for c in session_cookies(&pair(), &settings(), true) {
+            assert!(c.to_str().unwrap().contains("; Secure"));
+        }
+    }
+
+    #[test]
+    fn refresh_cookie_is_path_scoped() {
+        let cookies = session_cookies(&pair(), &settings(), false);
+        let refresh = cookies[1].to_str().unwrap();
+        assert!(
+            refresh.starts_with("aifw_rt=rfx_abc; Path=/api/v1/auth;"),
+            "{refresh}"
+        );
+        let access = cookies[0].to_str().unwrap();
+        assert!(access.starts_with("aifw_at=jwt-value; Path=/;"), "{access}");
+    }
+
+    #[test]
+    fn clear_cookies_expire_immediately() {
+        for c in clear_cookies(false) {
+            assert!(c.to_str().unwrap().contains("Max-Age=0"));
+        }
+    }
+}

--- a/aifw-api/src/auth/middleware.rs
+++ b/aifw-api/src/auth/middleware.rs
@@ -50,74 +50,98 @@ pub async fn auth_middleware(
     use std::time::Instant;
 
     // Credentials: Authorization: Bearer <jwt>, Authorization: ApiKey <key>,
-    // or ?ticket=<id> (short-lived, single-use; see auth::ws_ticket).
+    // ?ticket=<id> (short-lived, single-use; see auth::ws_ticket), or the
+    // HttpOnly session cookie set at login (SEC-M7 #304 — browser UI).
     let auth_header = headers.get("authorization").and_then(|v| v.to_str().ok());
 
+    // The cookie is a fallback only: an Authorization header or ticket wins,
+    // so non-browser clients and the WS/SSE ticket flow are unaffected.
+    let cookie_token = if auth_header.is_none() && query_ticket(request.uri().query()).is_none() {
+        super::cookies::cookie_value(&headers, super::cookies::ACCESS_COOKIE)
+    } else {
+        None
+    };
+
+    // CSRF defense in depth (on top of SameSite=Strict): a cookie is attached
+    // by the browser, not the page, so state-changing requests must also carry
+    // the custom header only same-origin script can set.
+    if cookie_token.is_some()
+        && !matches!(
+            *request.method(),
+            axum::http::Method::GET | axum::http::Method::HEAD | axum::http::Method::OPTIONS
+        )
+        && !headers.contains_key(super::cookies::CSRF_HEADER)
+    {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
     // Resolve (user_id, perm_from_token, role_from_token, api_key_name) from the credential
-    let (user_id, jwt_perm, jwt_role, api_key_name) =
-        if let Some(token) = auth_header.and_then(|h| h.strip_prefix("Bearer ")) {
-            // PERF-H21: reuse a previously decoded token. The entry deadline
-            // is capped at the token's `exp` on insert, so a live cache hit
-            // is always still within the token's validity window.
-            let now = Instant::now();
-            let claims = if let Some(entry) = state.auth_token_cache.get(token)
-                && entry.value().1 > now
-            {
-                entry.value().0.clone()
-            } else {
-                let claims = verify_access_token(token, &state.auth_settings)
-                    .map_err(|_| StatusCode::UNAUTHORIZED)?
-                    .claims;
-                // Cap TTL at the token's remaining lifetime (never negative),
-                // and at AUTH_TOKEN_CACHE_TTL so a rotated jwt_secret can't
-                // keep validating an old token for longer than that window.
-                let ttl = std::time::Duration::from_secs(token_cache_ttl_secs(
-                    claims.exp,
-                    chrono::Utc::now().timestamp(),
-                ));
-                // Bound memory: sweep expired entries when the map grows large
-                // (these caches are otherwise evicted only lazily).
-                if state.auth_token_cache.len() >= AUTH_TOKEN_CACHE_MAX {
-                    state
-                        .auth_token_cache
-                        .retain(|_, (_, deadline)| *deadline > now);
-                }
+    let (user_id, jwt_perm, jwt_role, api_key_name) = if let Some(token) = auth_header
+        .and_then(|h| h.strip_prefix("Bearer "))
+        .or(cookie_token.as_deref())
+    {
+        // PERF-H21: reuse a previously decoded token. The entry deadline
+        // is capped at the token's `exp` on insert, so a live cache hit
+        // is always still within the token's validity window.
+        let now = Instant::now();
+        let claims = if let Some(entry) = state.auth_token_cache.get(token)
+            && entry.value().1 > now
+        {
+            entry.value().0.clone()
+        } else {
+            let claims = verify_access_token(token, &state.auth_settings)
+                .map_err(|_| StatusCode::UNAUTHORIZED)?
+                .claims;
+            // Cap TTL at the token's remaining lifetime (never negative),
+            // and at AUTH_TOKEN_CACHE_TTL so a rotated jwt_secret can't
+            // keep validating an old token for longer than that window.
+            let ttl = std::time::Duration::from_secs(token_cache_ttl_secs(
+                claims.exp,
+                chrono::Utc::now().timestamp(),
+            ));
+            // Bound memory: sweep expired entries when the map grows large
+            // (these caches are otherwise evicted only lazily).
+            if state.auth_token_cache.len() >= AUTH_TOKEN_CACHE_MAX {
                 state
                     .auth_token_cache
-                    .insert(token.to_string(), (claims.clone(), now + ttl));
-                claims
-            };
-            let jti = &claims.jti;
-            // JTI revocation: positive cache to skip the DB lookup. Cached
-            // entry value=true means revoked, value=false means not revoked.
-            let revoked = if let Some(entry) = state.auth_jti_cache.get(jti)
-                && entry.value().1 > now
-            {
-                entry.value().0
-            } else {
-                let r = is_token_revoked(&state.pool, jti).await;
-                state
-                    .auth_jti_cache
-                    .insert(jti.clone(), (r, now + AUTH_JTI_CACHE_TTL));
-                r
-            };
-            if revoked {
-                return Err(StatusCode::UNAUTHORIZED);
+                    .retain(|_, (_, deadline)| *deadline > now);
             }
-            (claims.sub, claims.perm, claims.role, None)
-        } else if let Some(key) = auth_header.and_then(|h| h.strip_prefix("ApiKey ")) {
-            let (uid, key_name) = verify_api_key(&state.pool, key).await?;
-            (uid, None, None, Some(key_name)) // API keys don't carry JWT claims — will do DB lookup
-        } else if let Some(ticket_id) = query_ticket(request.uri().query()) {
-            let uid = state
-                .ws_tickets
-                .consume(&ticket_id)
-                .await
-                .ok_or(StatusCode::UNAUTHORIZED)?;
-            (uid, None, None, None) // tickets inherit permissions from the DB row
-        } else {
-            return Err(StatusCode::UNAUTHORIZED);
+            state
+                .auth_token_cache
+                .insert(token.to_string(), (claims.clone(), now + ttl));
+            claims
         };
+        let jti = &claims.jti;
+        // JTI revocation: positive cache to skip the DB lookup. Cached
+        // entry value=true means revoked, value=false means not revoked.
+        let revoked = if let Some(entry) = state.auth_jti_cache.get(jti)
+            && entry.value().1 > now
+        {
+            entry.value().0
+        } else {
+            let r = is_token_revoked(&state.pool, jti).await;
+            state
+                .auth_jti_cache
+                .insert(jti.clone(), (r, now + AUTH_JTI_CACHE_TTL));
+            r
+        };
+        if revoked {
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+        (claims.sub, claims.perm, claims.role, None)
+    } else if let Some(key) = auth_header.and_then(|h| h.strip_prefix("ApiKey ")) {
+        let (uid, key_name) = verify_api_key(&state.pool, key).await?;
+        (uid, None, None, Some(key_name)) // API keys don't carry JWT claims — will do DB lookup
+    } else if let Some(ticket_id) = query_ticket(request.uri().query()) {
+        let uid = state
+            .ws_tickets
+            .consume(&ticket_id)
+            .await
+            .ok_or(StatusCode::UNAUTHORIZED)?;
+        (uid, None, None, None) // tickets inherit permissions from the DB row
+    } else {
+        return Err(StatusCode::UNAUTHORIZED);
+    };
 
     // User-by-id with TTL cache. Disabled-user lockout has up to
     // AUTH_USER_CACHE_TTL latency — acceptable trade for skipping a DB hit

--- a/aifw-api/src/auth/mod.rs
+++ b/aifw-api/src/auth/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod api_keys;
 pub mod config;
+pub mod cookies;
 pub mod jwt_key;
 pub mod middleware;
 pub mod migrate;

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -179,6 +179,10 @@ pub struct AppState {
     /// Never changes without a config write, so a one-shot read is correct.
     pub cluster_enabled: Arc<std::sync::atomic::AtomicBool>,
     pub cluster_events: aifw_common::ClusterEventBus,
+    /// Whether the API is serving TLS — controls the `Secure` attribute on
+    /// the session cookies (SEC-M7 #304). Set from `!args.no_tls` in `main`;
+    /// defaults to `false` in tests.
+    pub tls_enabled: bool,
     /// Ring buffer of deflate-compressed `WsHistoryEntry` JSON frames
     /// (PERF-M5). ~2-3 KB of repetitive JSON per tick compresses 4-8x, so a
     /// 1800-entry ring costs ~1 MB instead of ~5 MB. Compress/decompress
@@ -1039,6 +1043,7 @@ async fn create_state_from_db(
         tls_engine,
         cluster_enabled,
         cluster_events,
+        tls_enabled: false,
         metrics_history: Arc::new(RwLock::new(VecDeque::with_capacity(history_max.min(86400)))),
         metrics_history_max: Arc::new(std::sync::atomic::AtomicUsize::new(history_max)),
         redis: None,
@@ -1765,6 +1770,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let tls_enabled = !args.no_tls;
+    state.tls_enabled = tls_enabled;
     let app = build_router(
         state,
         args.ui_dir.as_deref(),

--- a/aifw-api/src/routes/auth.rs
+++ b/aifw-api/src/routes/auth.rs
@@ -8,11 +8,23 @@
 use super::*;
 use crate::auth;
 
+/// Build the `Set-Cookie` response headers installing a token pair as the
+/// browser session (SEC-M7 #304). Non-browser clients keep using the tokens
+/// from the JSON body; the cookies are additive.
+fn session_cookie_headers(state: &AppState, tokens: &auth::TokenPair) -> HeaderMap {
+    let mut h = HeaderMap::new();
+    auth::cookies::append_set_cookies(
+        &mut h,
+        auth::cookies::session_cookies(tokens, &state.auth_settings, state.tls_enabled),
+    );
+    h
+}
+
 pub async fn login(
     State(state): State<AppState>,
     headers: HeaderMap,
     Json(req): Json<auth::LoginRequest>,
-) -> Result<Json<auth::LoginResponse>, StatusCode> {
+) -> Result<(HeaderMap, Json<auth::LoginResponse>), StatusCode> {
     // Rate-limit on two axes: the X-Forwarded-For-ish client IP (best
     // effort — spoofable without a trusted-proxies allow-list, tracked
     // as a follow-up) AND the username. The username axis guarantees a
@@ -74,18 +86,24 @@ pub async fn login(
 
     // Check if TOTP is required
     if user.totp_enabled {
-        return Ok(Json(auth::LoginResponse {
-            tokens: None,
-            totp_required: true,
-        }));
+        return Ok((
+            HeaderMap::new(),
+            Json(auth::LoginResponse {
+                tokens: None,
+                totp_required: true,
+            }),
+        ));
     }
 
     // Check if TOTP enforcement is on but user hasn't set it up
     if state.auth_settings.require_totp && !user.totp_enabled {
-        return Ok(Json(auth::LoginResponse {
-            tokens: None,
-            totp_required: true,
-        }));
+        return Ok((
+            HeaderMap::new(),
+            Json(auth::LoginResponse {
+                tokens: None,
+                totp_required: true,
+            }),
+        ));
     }
 
     // Resolve permissions for the JWT
@@ -114,16 +132,20 @@ pub async fn login(
     )
     .await;
 
-    Ok(Json(auth::LoginResponse {
-        tokens: Some(tokens),
-        totp_required: false,
-    }))
+    let cookies = session_cookie_headers(&state, &tokens);
+    Ok((
+        cookies,
+        Json(auth::LoginResponse {
+            tokens: Some(tokens),
+            totp_required: false,
+        }),
+    ))
 }
 
 pub async fn totp_login(
     State(state): State<AppState>,
     Json(req): Json<auth::totp::TotpLoginRequest>,
-) -> Result<Json<auth::TokenPair>, StatusCode> {
+) -> Result<(HeaderMap, Json<auth::TokenPair>), StatusCode> {
     let user = auth::get_user_by_username(&state.pool, &req.username)
         .await?
         .ok_or(StatusCode::UNAUTHORIZED)?;
@@ -171,20 +193,27 @@ pub async fn totp_login(
     .await
     .map_err(|_| internal())?;
 
-    Ok(Json(tokens))
+    let cookies = session_cookie_headers(&state, &tokens);
+    Ok((cookies, Json(tokens)))
 }
 
 pub async fn refresh_token(
     State(state): State<AppState>,
     headers: HeaderMap,
-    Json(req): Json<auth::tokens::RefreshRequest>,
-) -> Result<Json<auth::TokenPair>, StatusCode> {
+    body: Option<Json<auth::tokens::RefreshRequest>>,
+) -> Result<(HeaderMap, Json<auth::TokenPair>), StatusCode> {
+    // Token comes from the JSON body (header-auth clients) or, for the
+    // browser UI, from the HttpOnly refresh cookie (SEC-M7 #304).
+    let refresh_token = body
+        .map(|Json(r)| r.refresh_token)
+        .or_else(|| auth::cookies::cookie_value(&headers, auth::cookies::REFRESH_COOKIE))
+        .ok_or(bad_request())?;
     // SEC-H8: rate-limit refresh like login. Key on the client IP (best
     // effort, spoofable without a trusted-proxy allow-list) and on the
     // token prefix so a spray of forged tokens from one source is capped.
     // Falling back to the prefix as the IP key when there's no XFF avoids a
     // single shared global bucket that would block unrelated clients.
-    let token_prefix = auth::tokens::refresh_prefix(&req.refresh_token).to_string();
+    let token_prefix = auth::tokens::refresh_prefix(&refresh_token).to_string();
     let client_ip = headers
         .get("x-forwarded-for")
         .and_then(|v| v.to_str().ok())
@@ -200,40 +229,56 @@ pub async fn refresh_token(
         return Err(StatusCode::TOO_MANY_REQUESTS);
     }
 
-    let tokens = match auth::tokens::rotate_refresh_token(
-        &state.pool,
-        &req.refresh_token,
-        &state.auth_settings,
-    )
-    .await
-    {
-        Ok(t) => t,
-        Err(_) => {
-            state
-                .login_limiter
-                .record_failure(&client_ip, &token_prefix)
-                .await;
-            return Err(StatusCode::UNAUTHORIZED);
-        }
-    };
+    let tokens =
+        match auth::tokens::rotate_refresh_token(&state.pool, &refresh_token, &state.auth_settings)
+            .await
+        {
+            Ok(t) => t,
+            Err(_) => {
+                state
+                    .login_limiter
+                    .record_failure(&client_ip, &token_prefix)
+                    .await;
+                return Err(StatusCode::UNAUTHORIZED);
+            }
+        };
 
     state.login_limiter.clear(&client_ip, &token_prefix).await;
-    Ok(Json(tokens))
+    let cookies = session_cookie_headers(&state, &tokens);
+    Ok((cookies, Json(tokens)))
 }
 
 pub async fn logout(
     State(state): State<AppState>,
     headers: HeaderMap,
-    Json(req): Json<auth::tokens::LogoutRequest>,
-) -> Result<Json<MessageResponse>, StatusCode> {
-    // Revoke the refresh token
-    auth::tokens::revoke_refresh_token(&state.pool, &req.refresh_token)
-        .await
-        .map_err(|_| bad_request())?;
-    // Also revoke the current access token if present
-    if let Some(auth_header) = headers.get("authorization").and_then(|v| v.to_str().ok())
-        && let Some(token) = auth_header.strip_prefix("Bearer ")
-        && let Ok(data) = auth::verify_access_token(token, &state.auth_settings)
+    body: Option<Json<auth::tokens::LogoutRequest>>,
+) -> Result<(HeaderMap, Json<MessageResponse>), StatusCode> {
+    // Revoke the refresh token. Body token (header-auth clients) keeps the
+    // strict 400-on-unknown contract; the cookie fallback is best-effort so
+    // a stale cookie can't wedge the browser in a can't-log-out state.
+    match body {
+        Some(Json(req)) => {
+            auth::tokens::revoke_refresh_token(&state.pool, &req.refresh_token)
+                .await
+                .map_err(|_| bad_request())?;
+        }
+        None => {
+            if let Some(rt) = auth::cookies::cookie_value(&headers, auth::cookies::REFRESH_COOKIE)
+                && let Err(e) = auth::tokens::revoke_refresh_token(&state.pool, &rt).await
+            {
+                tracing::warn!(error = %e, "logout: refresh cookie revocation failed");
+            }
+        }
+    }
+    // Also revoke the current access token if present (header or cookie)
+    let access_token = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "))
+        .map(str::to_string)
+        .or_else(|| auth::cookies::cookie_value(&headers, auth::cookies::ACCESS_COOKIE));
+    if let Some(token) = access_token
+        && let Ok(data) = auth::verify_access_token(&token, &state.auth_settings)
     {
         let exp = chrono::DateTime::from_timestamp(data.claims.exp, 0)
             .map(|d| d.to_rfc3339())
@@ -243,9 +288,18 @@ pub async fn logout(
         // can't ride the positive-cache TTL.
         state.auth_jti_cache.remove(&data.claims.jti);
     }
-    Ok(Json(MessageResponse {
-        message: "Logged out".to_string(),
-    }))
+    // Expire the session cookies regardless of revocation outcome.
+    let mut cookies = HeaderMap::new();
+    auth::cookies::append_set_cookies(
+        &mut cookies,
+        auth::cookies::clear_cookies(state.tls_enabled),
+    );
+    Ok((
+        cookies,
+        Json(MessageResponse {
+            message: "Logged out".to_string(),
+        }),
+    ))
 }
 
 pub async fn totp_setup(
@@ -564,19 +618,19 @@ pub async fn create_api_key(
     Ok((StatusCode::CREATED, Json(response)))
 }
 
-/// Pull the authenticated user's id out of a `Bearer` token. Shared with
-/// `routes::users`, which needs the actor id for audit entries.
+/// Pull the authenticated user's id out of a `Bearer` token or the session
+/// cookie (SEC-M7 #304). Shared with `routes::users`, which needs the actor
+/// id for audit entries.
 pub(super) fn extract_user_id(headers: &HeaderMap, state: &AppState) -> Result<String, StatusCode> {
-    let auth_header = headers
+    let token = headers
         .get("authorization")
         .and_then(|v| v.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "))
+        .map(str::to_string)
+        .or_else(|| auth::cookies::cookie_value(headers, auth::cookies::ACCESS_COOKIE))
         .ok_or(StatusCode::UNAUTHORIZED)?;
 
-    if let Some(token) = auth_header.strip_prefix("Bearer ") {
-        let data = auth::verify_access_token(token, &state.auth_settings)
-            .map_err(|_| StatusCode::UNAUTHORIZED)?;
-        Ok(data.claims.sub)
-    } else {
-        Err(StatusCode::UNAUTHORIZED)
-    }
+    let data = auth::verify_access_token(&token, &state.auth_settings)
+        .map_err(|_| StatusCode::UNAUTHORIZED)?;
+    Ok(data.claims.sub)
 }

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -2919,4 +2919,206 @@ mod tests {
                 .starts_with("aifw-")
         );
     }
+
+    // ============ Session-cookie auth (SEC-M7 #304) ============
+
+    /// Collect the `Set-Cookie` header values from a response.
+    fn set_cookies(resp: &axum_test::TestResponse) -> Vec<String> {
+        resp.headers()
+            .get_all(axum::http::header::SET_COOKIE)
+            .iter()
+            .filter_map(|v| v.to_str().ok().map(str::to_string))
+            .collect()
+    }
+
+    /// Extract `<name>=<value>` (value only) from a `Set-Cookie` list.
+    fn cookie_from(cookies: &[String], name: &str) -> String {
+        cookies
+            .iter()
+            .find(|c| c.starts_with(&format!("{name}=")))
+            .and_then(|c| c.split(';').next())
+            .and_then(|kv| kv.split('=').nth(1))
+            .unwrap_or_else(|| panic!("cookie {name} not found in {cookies:?}"))
+            .to_string()
+    }
+
+    /// Register the first user and log in, returning the raw `Set-Cookie`
+    /// values from the login response.
+    async fn login_cookies(server: &TestServer) -> Vec<String> {
+        server
+            .post("/api/v1/auth/register")
+            .json(&json!({"username": "admin", "password": "TestPass123"}))
+            .await;
+        let resp = server
+            .post("/api/v1/auth/login")
+            .json(&json!({"username": "admin", "password": "TestPass123"}))
+            .await;
+        resp.assert_status_ok();
+        set_cookies(&resp)
+    }
+
+    #[tokio::test]
+    async fn test_login_sets_httponly_session_cookies() {
+        let (server, _) = test_app().await;
+        let cookies = login_cookies(&server).await;
+
+        assert_eq!(cookies.len(), 2, "expected access + refresh cookies");
+        for c in &cookies {
+            assert!(c.contains("HttpOnly"), "{c}");
+            assert!(c.contains("SameSite=Strict"), "{c}");
+        }
+        let access = cookies.iter().find(|c| c.starts_with("aifw_at=")).unwrap();
+        assert!(access.contains("Path=/;"), "{access}");
+        let refresh = cookies.iter().find(|c| c.starts_with("aifw_rt=")).unwrap();
+        assert!(refresh.contains("Path=/api/v1/auth;"), "{refresh}");
+    }
+
+    #[tokio::test]
+    async fn test_cookie_authenticates_requests() {
+        let (server, _) = test_app().await;
+        let cookies = login_cookies(&server).await;
+        let access = cookie_from(&cookies, "aifw_at");
+
+        // No Authorization header — the cookie alone must authenticate.
+        let resp = server
+            .get("/api/v1/auth/me")
+            .add_header("cookie", format!("aifw_at={access}"))
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["username"], "admin");
+    }
+
+    #[tokio::test]
+    async fn test_cookie_write_requires_csrf_header() {
+        let (server, _) = test_app().await;
+        let cookies = login_cookies(&server).await;
+        let access = cookie_from(&cookies, "aifw_at");
+
+        // Unsafe method with cookie auth but no CSRF header → 403.
+        let resp = server
+            .post("/api/v1/auth/ws-ticket")
+            .add_header("cookie", format!("aifw_at={access}"))
+            .await;
+        resp.assert_status(StatusCode::FORBIDDEN);
+
+        // Same request with the custom header succeeds.
+        let resp = server
+            .post("/api/v1/auth/ws-ticket")
+            .add_header("cookie", format!("aifw_at={access}"))
+            .add_header("x-aifw-csrf", "1")
+            .await;
+        resp.assert_status_ok();
+    }
+
+    #[tokio::test]
+    async fn test_bearer_writes_do_not_need_csrf_header() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        // Header-auth clients are CSRF-immune; no custom header required.
+        let resp = server
+            .post("/api/v1/auth/ws-ticket")
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+    }
+
+    #[tokio::test]
+    async fn test_refresh_via_cookie_rotates_session() {
+        let (server, _) = test_app().await;
+        let cookies = login_cookies(&server).await;
+        let refresh = cookie_from(&cookies, "aifw_rt");
+
+        // No JSON body — the refresh token rides the cookie.
+        let resp = server
+            .post("/api/v1/auth/refresh")
+            .add_header("cookie", format!("aifw_rt={refresh}"))
+            .await;
+        resp.assert_status_ok();
+
+        let rotated = set_cookies(&resp);
+        let new_access = cookie_from(&rotated, "aifw_at");
+        let new_refresh = cookie_from(&rotated, "aifw_rt");
+        assert_ne!(new_refresh, refresh, "refresh token must rotate");
+
+        // The rotated access cookie authenticates.
+        server
+            .get("/api/v1/auth/me")
+            .add_header("cookie", format!("aifw_at={new_access}"))
+            .await
+            .assert_status_ok();
+
+        // The old refresh token was revoked by the rotation.
+        let resp = server
+            .post("/api/v1/auth/refresh")
+            .add_header("cookie", format!("aifw_rt={refresh}"))
+            .await;
+        resp.assert_status(StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_logout_via_cookies_clears_and_revokes() {
+        let (server, _) = test_app().await;
+        let cookies = login_cookies(&server).await;
+        let access = cookie_from(&cookies, "aifw_at");
+        let refresh = cookie_from(&cookies, "aifw_rt");
+
+        // Cookie-only logout: no body, no Authorization header.
+        let resp = server
+            .post("/api/v1/auth/logout")
+            .add_header("cookie", format!("aifw_at={access}; aifw_rt={refresh}"))
+            .add_header("x-aifw-csrf", "1")
+            .await;
+        resp.assert_status_ok();
+        for c in set_cookies(&resp) {
+            assert!(c.contains("Max-Age=0"), "logout must expire cookies: {c}");
+        }
+
+        // Access token was revoked (JTI) — cookie no longer authenticates.
+        let resp = server
+            .get("/api/v1/auth/me")
+            .add_header("cookie", format!("aifw_at={access}"))
+            .await;
+        resp.assert_status(StatusCode::UNAUTHORIZED);
+
+        // Refresh token was revoked too.
+        let resp = server
+            .post("/api/v1/auth/refresh")
+            .add_header("cookie", format!("aifw_rt={refresh}"))
+            .await;
+        resp.assert_status(StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_totp_required_login_sets_no_cookies() {
+        let (server, _) = test_app().await;
+        // First login normally to create the user, then enable TOTP.
+        let token = create_user_and_login(&server).await;
+        let resp = server
+            .post("/api/v1/auth/totp/setup")
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        let secret = body["secret"].as_str().unwrap().to_string();
+        let code = crate::auth::totp::generate_current(&secret).unwrap();
+        server
+            .post("/api/v1/auth/totp/verify")
+            .authorization_bearer(&token)
+            .json(&json!({"code": code}))
+            .await
+            .assert_status_ok();
+
+        // Password-only login now returns totp_required and must NOT install
+        // session cookies.
+        let resp = server
+            .post("/api/v1/auth/login")
+            .json(&json!({"username": "admin", "password": "TestPass123"}))
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["totp_required"], true);
+        assert!(set_cookies(&resp).is_empty(), "no cookies before 2FA");
+    }
 }

--- a/aifw-ui/src/app/login/page.tsx
+++ b/aifw-ui/src/app/login/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import { api } from "@/lib/api";
+import { api, setAuthed } from "@/lib/api";
 
 export default function LoginPage() {
   const [username, setUsername] = useState("");
@@ -21,14 +21,15 @@ export default function LoginPage() {
     try {
       // noAuthRedirect: a 401 here means bad credentials, not an expired
       // session — redirecting to /login would just loop.
+      // On success the server installs the session as HttpOnly cookies
+      // (SEC-M7 #304); the page only records the logged-in marker.
       const data = await api.post<{ tokens?: { access_token?: string }; totp_required?: boolean }>(
         "/api/v1/auth/login",
         { username, password },
         { noAuthRedirect: true },
       );
-      const token = data.tokens?.access_token;
-      if (token) {
-        localStorage.setItem("aifw_token", token);
+      if (data.tokens?.access_token) {
+        setAuthed(true);
         window.location.href = "/";
       } else if (data.totp_required) {
         setTotpRequired(true);
@@ -50,9 +51,8 @@ export default function LoginPage() {
         { username, password, totp_code: totpCode },
         { noAuthRedirect: true },
       );
-      const token = data.access_token;
-      if (token) {
-        localStorage.setItem("aifw_token", token);
+      if (data.access_token) {
+        setAuthed(true);
         window.location.href = "/";
       }
     } catch {

--- a/aifw-ui/src/app/page.tsx
+++ b/aifw-ui/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useRef, useMemo, useCallback } from "react";
 import { useWs } from "@/context/WsContext";
-import { api } from "@/lib/api";
+import { api, isAuthed } from "@/lib/api";
 import { usePolling } from "@/lib/usePolling";
 
 interface StatusData {
@@ -332,8 +332,7 @@ export default function Dashboard() {
 
   // Fetch DNS/DHCP/Time status on mount + every 30s (paused while hidden)
   const fetchSvc = useCallback(async () => {
-    const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
-    if (!token) return;
+    if (!isAuthed()) return;
     const [dnsRes, dhcpRes, timeRes] = await Promise.allSettled([
       api.get<{ running: boolean; version: string; total_hosts: number; total_domains: number; total_acls: number; queries_total: number; cache_hits: number; cache_misses: number }>("/api/v1/dns/resolver/status"),
       api.get<{ running: boolean; version: string; total_subnets: number; active_leases: number; total_reservations: number }>("/api/v1/dhcp/status"),
@@ -350,8 +349,7 @@ export default function Dashboard() {
 
   // Fetch HA status once on mount — only show card when HA is configured
   useEffect(() => {
-    const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
-    if (!token) return;
+    if (!isAuthed()) return;
     api.get<{ role?: string; peer_reachable?: boolean }>("/api/v1/cluster/status")
       .then((s) => {
         if (s && s.role && s.role !== "standalone") {

--- a/aifw-ui/src/app/profile/page.tsx
+++ b/aifw-ui/src/app/profile/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
+import { useAuth } from "@/context/AuthContext";
 
 interface UserProfile {
   id: string;
@@ -43,24 +44,19 @@ export default function ProfilePage() {
     setTimeout(() => setFeedback(null), 5000);
   };
 
-  // Get current user ID from JWT
-  const getUserId = (): string | null => {
-    const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
-    if (!token) return null;
-    try {
-      const payload = JSON.parse(atob(token.split(".")[1]));
-      return payload.sub;
-    } catch { return null; }
-  };
+  // Current user ID comes from AuthContext (/auth/me) — the session is an
+  // HttpOnly cookie, so there is no JWT to decode client-side (SEC-M7 #304).
+  const { userId, isLoading: authLoading } = useAuth();
 
   useEffect(() => {
-    const userId = getUserId();
-    if (!userId) return;
+    // No userId with auth settled means the guard is about to redirect to
+    // /login — leave the spinner up rather than flash an empty profile.
+    if (authLoading || !userId) return;
     api.get<{ data: UserProfile }>(`/api/v1/auth/users/${userId}`)
       .then((d) => setUser(d.data))
       .catch(() => showFeedback("error", "Failed to load profile"))
       .finally(() => setLoading(false));
-  }, []);
+  }, [userId, authLoading]);
 
   const handleChangePassword = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -83,7 +79,6 @@ export default function ProfilePage() {
         return;
       }
 
-      const userId = getUserId();
       await api.put(`/api/v1/auth/users/${userId}`, { password: newPassword });
       showFeedback("success", "Password changed successfully");
       setCurrentPassword("");

--- a/aifw-ui/src/app/users/page.tsx
+++ b/aifw-ui/src/app/users/page.tsx
@@ -40,18 +40,6 @@ interface Feedback {
   message: string;
 }
 
-function getCurrentUserId(): string | null {
-  const token = localStorage.getItem("aifw_token");
-  if (!token) return null;
-  try {
-    let b64 = token.split(".")[1];
-    b64 = b64.replace(/-/g, "+").replace(/_/g, "/");
-    while (b64.length % 4) b64 += "=";
-    const payload = JSON.parse(atob(b64));
-    return payload.sub || null;
-  } catch { return null; }
-}
-
 const roleColors: Record<string, { badge: string; accent: string }> = {
   admin: { badge: "bg-red-500/20 text-red-400 border-red-500/30", accent: "border-red-500/40" },
   operator: { badge: "bg-blue-500/20 text-blue-400 border-blue-500/30", accent: "border-blue-500/40" },
@@ -214,9 +202,8 @@ export default function UsersPage() {
   const [editRoleDesc, setEditRoleDesc] = useState("");
   const [deletingRoleId, setDeletingRoleId] = useState<string | null>(null);
 
-  const { permissions: myPerms } = useAuth();
+  const { permissions: myPerms, userId: currentUserId } = useAuth();
   const canWriteUsers = myPerms.has("users:write");
-  const currentUserId = getCurrentUserId();
 
   // User count per role
   const userCountByRole = useMemo(() => {

--- a/aifw-ui/src/components/AuthGuard.tsx
+++ b/aifw-ui/src/components/AuthGuard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
+import { isAuthed } from "@/lib/api";
 
 const PUBLIC_PATHS = ["/login", "/login/"];
 
@@ -9,51 +10,36 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
   const [checked, setChecked] = useState(false);
-  const [authed, setAuthed] = useState(false);
+  const [authed, setAuthedState] = useState(false);
 
   useEffect(() => {
     queueMicrotask(() => {
-      const token = localStorage.getItem("aifw_token");
+      // The session itself is an HttpOnly cookie the page can't inspect
+      // (SEC-M7 #304); this flag is the client-side marker set at login.
+      // Expiry is handled by the API: a 401 triggers a silent refresh and,
+      // failing that, the centralized redirect to /login (see lib/api.ts).
+      const loggedIn = isAuthed();
 
       if (PUBLIC_PATHS.includes(pathname)) {
         // On login page — if already authed, redirect to dashboard
-        if (token) {
+        if (loggedIn) {
           router.replace("/");
         }
         setChecked(true);
-        setAuthed(!!token);
+        setAuthedState(loggedIn);
         return;
       }
 
-      // Protected page — redirect to login if no token
-      if (!token) {
+      // Protected page — redirect to login if not logged in
+      if (!loggedIn) {
         router.replace("/login");
         setChecked(true);
-        setAuthed(false);
+        setAuthedState(false);
         return;
-      }
-
-      // Validate token isn't expired (decode JWT payload)
-      try {
-        // Handle URL-safe base64 and missing padding
-        let b64 = token.split(".")[1];
-        b64 = b64.replace(/-/g, "+").replace(/_/g, "/");
-        while (b64.length % 4) b64 += "=";
-        const payload = JSON.parse(atob(b64));
-        if (payload.exp && payload.exp * 1000 < Date.now()) {
-          localStorage.removeItem("aifw_token");
-          router.replace("/login");
-          setChecked(true);
-          setAuthed(false);
-          return;
-        }
-      } catch {
-        // If decode fails, don't log out — just trust the token exists
-        // The API will return 401 if it's actually invalid
       }
 
       setChecked(true);
-      setAuthed(true);
+      setAuthedState(true);
     });
   }, [pathname, router]);
 

--- a/aifw-ui/src/components/PendingBanner.tsx
+++ b/aifw-ui/src/components/PendingBanner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { api, getWsTicket } from "@/lib/api";
+import { api, getWsTicket, isAuthed } from "@/lib/api";
 
 interface PendingState {
   firewall: boolean;
@@ -19,8 +19,7 @@ export default function PendingBanner() {
 
   // One-shot fetch for initial state or fallback
   const fetchPending = useCallback(async () => {
-    const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
-    if (!token) return;
+    if (!isAuthed()) return;
     try {
       setPending(await api.get<PendingState>("/api/v1/pending"));
     } catch { /* silent */ }
@@ -28,8 +27,7 @@ export default function PendingBanner() {
 
   // SSE connection
   useEffect(() => {
-    const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
-    if (!token) return;
+    if (!isAuthed()) return;
 
     const connect = async () => {
       // EventSource can't set Authorization, so auth rides via a single-use

--- a/aifw-ui/src/components/Sidebar.tsx
+++ b/aifw-ui/src/components/Sidebar.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useState, useEffect } from "react";
 import { useAuth } from "@/context/AuthContext";
-import { api } from "@/lib/api";
+import { api, isAuthed, setAuthed } from "@/lib/api";
 
 interface NavChild { href: string; label: string; permission?: string; }
 interface NavItem {
@@ -187,8 +187,7 @@ export default function Sidebar({ onClose, width }: { onClose?: () => void; widt
   const [interfaces, setInterfaces] = useState<{ name: string; role?: string }[]>([]);
 
   useEffect(() => {
-    const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
-    if (!token) return;
+    if (!isAuthed()) return;
     api
       .get<{ data?: { name: string; role?: string }[] }>("/api/v1/interfaces")
       .then((d) => {
@@ -361,7 +360,13 @@ export default function Sidebar({ onClose, width }: { onClose?: () => void; widt
           My Profile
         </Link>
         <button
-          onClick={() => { localStorage.removeItem("aifw_token"); window.location.href = "/login"; }}
+          onClick={async () => {
+            // Revoke the session server-side and clear the HttpOnly cookies;
+            // best-effort — always fall through to the login page.
+            try { await api.post("/api/v1/auth/logout", undefined, { noAuthRedirect: true }); } catch { /* ignore */ }
+            setAuthed(false);
+            window.location.href = "/login";
+          }}
           className="flex items-center gap-2 px-2 py-1.5 rounded-md text-xs text-red-400 hover:bg-red-500/10 hover:text-red-300 transition-colors w-full">
           <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />

--- a/aifw-ui/src/context/AuthContext.tsx
+++ b/aifw-ui/src/context/AuthContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from "react";
-import { decodePermissions } from "@/lib/permissions";
+import { api, isAuthed } from "@/lib/api";
 
 interface AuthState {
   userId: string | null;
@@ -21,44 +21,36 @@ const defaultState: AuthState = {
 
 const AuthContext = createContext<AuthState>(defaultState);
 
-function decodeJwt(token: string): AuthState {
-  try {
-    let b64 = token.split(".")[1];
-    b64 = b64.replace(/-/g, "+").replace(/_/g, "/");
-    while (b64.length % 4) b64 += "=";
-    const payload = JSON.parse(atob(b64));
-
-    // Check expiry
-    if (payload.exp && payload.exp * 1000 < Date.now()) {
-      return { ...defaultState, isLoading: false };
-    }
-
-    const permissions = payload.perm != null
-      ? decodePermissions(payload.perm)
-      : new Set<string>(); // Legacy token — no permissions in JWT
-
-    return {
-      userId: payload.sub || null,
-      username: payload.username || null,
-      role: payload.role || null,
-      permissions,
-      isLoading: false,
-    };
-  } catch {
-    return { ...defaultState, isLoading: false };
-  }
+/// Shape of GET /api/v1/auth/me (see aifw-api routes::rbac::get_current_user).
+interface MeResponse {
+  id: string;
+  username: string;
+  role: string;
+  permissions?: string[];
 }
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<AuthState>(defaultState);
 
+  // The session lives in an HttpOnly cookie (SEC-M7 #304), so identity and
+  // permissions come from /auth/me rather than decoding a stored JWT.
   const refresh = useCallback(() => {
-    const token = localStorage.getItem("aifw_token");
-    if (!token) {
+    if (!isAuthed()) {
       setState({ ...defaultState, isLoading: false });
       return;
     }
-    setState(decodeJwt(token));
+    api
+      .get<MeResponse>("/api/v1/auth/me")
+      .then((me) =>
+        setState({
+          userId: me.id || null,
+          username: me.username || null,
+          role: me.role || null,
+          permissions: new Set(me.permissions ?? []),
+          isLoading: false,
+        }),
+      )
+      .catch(() => setState({ ...defaultState, isLoading: false }));
   }, []);
 
   useEffect(() => {

--- a/aifw-ui/src/context/WsContext.tsx
+++ b/aifw-ui/src/context/WsContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useContext, useEffect, useRef, useState, useCallback, ReactNode } from "react";
-import { getWsTicket } from "@/lib/api";
+import { getWsTicket, isAuthed } from "@/lib/api";
 
 interface WsData {
   status: Record<string, unknown> | null;
@@ -47,8 +47,7 @@ export function WsProvider({ children }: { children: ReactNode }) {
   const connectRef = useRef<() => void>(() => {});
 
   const connect = useCallback(async () => {
-    const token = typeof window !== "undefined" ? localStorage.getItem("aifw_token") : null;
-    if (!token) return;
+    if (!isAuthed()) return;
     if (wsRef.current && wsRef.current.readyState <= 1) return;
 
     let ticket: string;

--- a/aifw-ui/src/lib/api.ts
+++ b/aifw-ui/src/lib/api.ts
@@ -1,5 +1,21 @@
 const API_BASE = "";
-const TOKEN_KEY = "aifw_token";
+/// Non-sensitive "logged in" marker (SEC-M7 #304). The real credential is an
+/// HttpOnly session cookie the page can't read; this flag only gates eager
+/// fetches and drives cross-tab login/logout sync via the storage event.
+const AUTH_FLAG_KEY = "aifw_authed";
+/// Custom header the API requires on cookie-authenticated state-changing
+/// requests (CSRF defense in depth) — a cross-site page can't set it.
+const CSRF_HEADER = "X-AiFw-Csrf";
+
+export function isAuthed(): boolean {
+  return typeof window !== "undefined" && localStorage.getItem(AUTH_FLAG_KEY) === "1";
+}
+
+export function setAuthed(value: boolean): void {
+  if (typeof window === "undefined") return;
+  if (value) localStorage.setItem(AUTH_FLAG_KEY, "1");
+  else localStorage.removeItem(AUTH_FLAG_KEY);
+}
 
 /// Error thrown for any non-2xx response. `message` carries the
 /// server-provided error/message body field when one exists, so call
@@ -23,8 +39,25 @@ export interface RequestOptions {
   signal?: AbortSignal;
 }
 
-function authToken(): string | null {
-  return typeof window !== "undefined" ? localStorage.getItem(TOKEN_KEY) : null;
+/// In-flight session refresh, shared so parallel 401s trigger exactly one
+/// rotation — a second concurrent rotate of the same refresh token would
+/// trip the server's reuse detection and revoke the whole token family.
+let refreshPromise: Promise<boolean> | null = null;
+
+/// Rotate the session via the HttpOnly refresh cookie. Resolves true when a
+/// new access cookie was installed.
+function refreshSession(): Promise<boolean> {
+  refreshPromise ??= fetch(`${API_BASE}/api/v1/auth/refresh`, {
+    method: "POST",
+    headers: { [CSRF_HEADER]: "1" },
+    credentials: "same-origin",
+  })
+    .then((r) => r.ok)
+    .catch(() => false)
+    .finally(() => {
+      refreshPromise = null;
+    });
+  return refreshPromise;
 }
 
 /// Pull a human-readable message out of an error response. The API mostly
@@ -48,17 +81,17 @@ async function errorMessage(res: Response): Promise<string> {
   return `API ${res.status}: ${res.statusText || "request failed"}`;
 }
 
-/// Core request: attaches the Bearer token, JSON-encodes plain bodies
-/// (FormData passes through untouched so the browser sets the multipart
-/// boundary), centralizes the 401 → /login redirect, and throws ApiError
-/// with the server's error message on any non-2xx status.
+/// Core request: rides the HttpOnly session cookie (with the CSRF header the
+/// API requires on writes), JSON-encodes plain bodies (FormData passes
+/// through untouched so the browser sets the multipart boundary), silently
+/// refreshes an expired session once, centralizes the 401 → /login redirect,
+/// and throws ApiError with the server's error message on any non-2xx status.
 async function request(
   method: string,
   path: string,
   body?: unknown,
   opts: RequestOptions = {},
 ): Promise<Response> {
-  const token = authToken();
   const isForm = typeof FormData !== "undefined" && body instanceof FormData;
   // Strings are passed through as-is (already-serialized JSON from legacy
   // fetchApi callers); FormData passes through so the browser sets the
@@ -72,22 +105,34 @@ async function request(
         : undefined;
   const headers: Record<string, string> = {
     ...(body !== undefined && !isForm ? { "Content-Type": "application/json" } : {}),
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    [CSRF_HEADER]: "1",
     ...(opts.headers ?? {}),
   };
 
-  const res = await fetch(`${API_BASE}${path}`, {
-    method,
-    headers,
-    body: rawBody,
-    signal: opts.signal,
-  });
+  const doFetch = () =>
+    fetch(`${API_BASE}${path}`, {
+      method,
+      headers,
+      body: rawBody,
+      signal: opts.signal,
+      credentials: "same-origin",
+    });
 
-  if (!res.ok) {
-    if (res.status === 401 && !opts.noAuthRedirect && typeof window !== "undefined") {
-      localStorage.removeItem(TOKEN_KEY);
+  let res = await doFetch();
+
+  if (res.status === 401 && !opts.noAuthRedirect && typeof window !== "undefined") {
+    // Access cookie may just have expired — rotate via the refresh cookie
+    // and retry once before treating the session as dead.
+    if (await refreshSession()) {
+      res = await doFetch();
+    }
+    if (res.status === 401) {
+      setAuthed(false);
       window.location.href = "/login";
     }
+  }
+
+  if (!res.ok) {
     throw new ApiError(res.status, await errorMessage(res));
   }
   return res;

--- a/aifw-ui/src/lib/api/updates.ts
+++ b/aifw-ui/src/lib/api/updates.ts
@@ -183,7 +183,6 @@ export function installLocalPackage(
   onProgress: (percent: number) => void,
 ): Promise<LocalInstallResult> {
   return new Promise((resolve) => {
-    const token = localStorage.getItem("aifw_token") ?? "";
     const xhr = new XMLHttpRequest();
     xhr.upload.addEventListener("progress", (e) => {
       if (e.lengthComputable) {
@@ -204,7 +203,9 @@ export function installLocalPackage(
       resolve({ ok, message });
     });
     xhr.open("POST", "/api/v1/updates/aifw/install-local");
-    xhr.setRequestHeader("Authorization", `Bearer ${token}`);
+    // Auth rides the HttpOnly session cookie (same-origin XHR sends it
+    // automatically); the custom header satisfies the API's CSRF check.
+    xhr.setRequestHeader("X-AiFw-Csrf", "1");
     xhr.send(form);
   });
 }


### PR DESCRIPTION
Fixes #304.

The web UI kept the access JWT in localStorage (`aifw_token`), so any XSS sink anywhere in the UI could exfiltrate a token with an 8-hour default lifetime. The browser session now rides HttpOnly cookies the page can never read.

## Server (aifw-api)

- New `auth::cookies` module. Login and TOTP login additionally install two cookies: `aifw_at` (access JWT, `Path=/`) and `aifw_rt` (refresh token, scoped to `Path=/api/v1/auth`). Both are `HttpOnly; SameSite=Strict`, plus `Secure` when serving TLS. The JSON body is unchanged, so header-based clients keep working.
- The auth middleware accepts the access cookie as a fallback credential — an `Authorization` header or WS ticket always wins. Cookie-authenticated non-GET requests must also send an `X-AiFw-Csrf` header (defense in depth on top of SameSite=Strict; a cross-site page can't set custom headers and the CORS layer never allows credentials).
- `/auth/refresh` and `/auth/logout` fall back to the cookie when no JSON body is sent; both responses rotate/clear the cookies, and logout still revokes the refresh token and access JTI.

## UI (aifw-ui)

- All 16 `localStorage.getItem("aifw_token")` call sites are gone. The only thing left in localStorage is a non-sensitive `aifw_authed` marker used to gate eager fetches and sync login/logout across tabs.
- Identity and permissions come from `GET /auth/me` (AuthContext) instead of decoding the JWT client-side.
- `lib/api.ts` sends `credentials: same-origin` + the CSRF header, and on a 401 silently rotates the session once via the refresh cookie before redirecting to /login. Parallel 401s share a single refresh promise so concurrent rotation can't trip the server's refresh-token reuse detection.
- Logout now actually revokes the session server-side before redirecting.

## Testing

- 7 new integration tests: cookie flags/paths, cookie-only auth, CSRF 403/allow, Bearer exemption, cookie refresh rotation + old-token revocation, cookie logout revoking both tokens, and no cookies issued on the totp_required response. `cargo test` passes (194 aifw-api tests), `cargo check` zero warnings, `npm run lint` + `npm run build` clean.
- Verified end-to-end in Chrome against a local build: UI login sets HttpOnly cookies (invisible to `document.cookie`), dashboard + WebSocket load normally, localStorage holds no JWT, logout clears cookies and a subsequent `/auth/me` returns 401.