### PR TITLE
fix(ui): retry WebSocket ticket fetch in global provider

### DIFF
--- a/aifw-ui/src/context/WsContext.tsx
+++ b/aifw-ui/src/context/WsContext.tsx
@@ -54,6 +54,10 @@ export function WsProvider({ children }: { children: ReactNode }) {
     try {
       ticket = await getWsTicket();
     } catch {
+      // Transient ticket failure (API restart, network blip): retry like the
+      // post-close path does, otherwise all shared live data stays dead
+      // until a full page reload (#584).
+      reconRef.current = setTimeout(() => connectRef.current(), 3000);
       return;
     }
 


### PR DESCRIPTION
Fixes #584.

`WsProvider.connect()` bailed out with no retry when `getWsTicket()` threw, so a transient API/network failure during the initial ticket fetch left every shared live data consumer (status, connections, interfaces, blocked traffic, services, IDS) disconnected until the page was reloaded. The provider only recovered after an *established* socket closed.

The ticket-failure path now schedules the same 3-second reconnect via `connectRef` that the `onclose` path uses — the pattern the cluster and DNS dashboard streams already follow. The `isAuthed()` early return is unchanged, so the retry loop only runs for logged-in sessions.

`npm run lint` and `npm run build` (static export) both pass.