### PR TITLE
fix(release): pre-release gate applies before any asset is public

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -391,7 +391,12 @@ jobs:
         with:
           name: "AiFw v${{ steps.version.outputs.version }}"
           draft: false
-          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
+          # ALWAYS pre-release: field appliances auto-pull /releases/latest,
+          # which skips pre-releases. A plain v* tag used to publish stable
+          # instantly — an untested build every appliance would grab the
+          # moment CI finished. Promote after testing with:
+          #   gh release edit <tag> --prerelease=false --latest
+          prerelease: true
           generate_release_notes: true
           files: |
             release-assets/*

--- a/freebsd/release.sh
+++ b/freebsd/release.sh
@@ -272,8 +272,18 @@ fi
 # Create release (or update if exists)
 if gh release view "$TAG" >/dev/null 2>&1; then
     echo "Release ${TAG} exists, uploading assets..."
+    # Pre-release gate FIRST, upload after: field appliances poll
+    # /releases/latest, so fresh assets must never sit on a stable release
+    # even for the duration of the upload. Strict (no || true) — if the
+    # flag can't be applied, abort before any asset lands. The stable flip
+    # for AIFW_RELEASE_FINAL stays AFTER the upload for the same reason,
+    # in the publish edit below.
+    if [ -z "${AIFW_RELEASE_FINAL:-}" ]; then
+        gh release edit "$TAG" --prerelease=true
+    fi
     gh release upload "$TAG" $ASSETS --clobber
-    # Ensure it's not stuck as a draft, and apply the chosen pre-release state.
+    # Publish last: un-draft, retitle, and (for FINAL) flip to stable only
+    # once the asset set is complete.
     gh release edit "$TAG" --draft=false $EDIT_PRE --title "AiFw v${VERSION}" --notes "$BODY" 2>/dev/null || true
 else
     gh release create "$TAG" \


### PR DESCRIPTION
Closes the two windows where untested bits could reach the stable channel that field appliances auto-pull from (`/releases/latest`):

1. **build-iso CI**: a plain `v*` tag published a STABLE release the moment CI finished — only `-rc`/`-beta`/`-alpha` tags got the pre-release flag. Every CI release is now a pre-release; promoting to stable is a deliberate manual step (`gh release edit <tag> --prerelease=false --latest`).
2. **release.sh (release-exists path)**: assets uploaded first, pre-release flag applied after — fresh assets briefly sat on a stable release. The flag now applies strictly (abort on failure) *before* any asset lands; the stable flip for `AIFW_RELEASE_FINAL` stays *after* the upload so a half-uploaded asset set is never marked stable.

The create path was already atomic (`gh release create --prerelease`). Companion PR for rDNS's release.sh: ZerosAndOnesLLC/rDNS#88.