### PR TITLE
chore: bump rDNS pin to 04d5975 (DNS64)

### DIFF
--- a/freebsd/manifest.json
+++ b/freebsd/manifest.json
@@ -26,7 +26,7 @@
     {
       "name": "rDNS",
       "repo": "ZerosAndOnesLLC/rDNS",
-      "commit": "7bd12e293536ec3adae09e340b572b87e0fe942b",
+      "commit": "04d5975f2386f883db9b357424ca550a1bf72bce",
       "binaries": ["rdns", "rdns-control"]
     },
     {


### PR DESCRIPTION
Per the #538 pinning flow. Pulls in:

- **rDNS#87** — DNS64 synthesis (RFC 6147), incl. the CNAME-chain chasing fix and the `RDNS_LOCK_PATH` override
- **rDNS#88** — release.sh pre-release gate

Upstream range `7bd12e2..04d5975` reviewed: exclusively the #531-batch commits from this cycle. With this, appliance builds ship a DNS64-capable rdns and the NAT64 + DNS64 workflow (#531, PR #597) is complete end-to-end; the `dns64`/`dns64_prefix` directives AiFw already emits become live on the appliance.