### PR TITLE
fix: appliance post-upgrade sweep findings

### DIFF
--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -1247,6 +1247,12 @@ async fn ensure_rdr_anchor() {
     // pass rules, so an install predating `anchor "aifw-nat"` would load
     // them but never evaluate them (#531).
     let has_nat_filter = lines.iter().any(|l| l.trim() == "anchor \"aifw-nat\"");
+    // ICMPv6 neighbor discovery: aifw-setup only emits this into NEWLY
+    // generated pf.conf files, so upgraded appliances keep dropping ND and
+    // all IPv6 (incl. NAT64) stays broken until healed here (#601).
+    const ND_RULE: &str =
+        "pass quick inet6 proto icmp6 icmp6-type { routersol, routeradv, neighbrsol, neighbradv }";
+    let has_nd = lines.iter().any(|l| l.trim() == ND_RULE);
     let mwan_anchors = ["aifw-pbr", "aifw-mwan-leak", "aifw-mwan-reply"];
     let has_mwan: Vec<bool> = mwan_anchors
         .iter()
@@ -1257,6 +1263,7 @@ async fn ensure_rdr_anchor() {
         .collect();
 
     let mut mwan_inserted = false;
+    let mut nd_inserted = false;
 
     for line in lines.iter() {
         let t = line.trim();
@@ -1273,6 +1280,20 @@ async fn ensure_rdr_anchor() {
 
         // 2. Before the filter-section `anchor "aifw"` (trimmed EXACTLY — won't
         //    match nat-anchor or rdr-anchor), inject any missing mwan anchors.
+        // ND pass must precede the FIRST filter anchor — anchors hold
+        // `block quick` rules that would otherwise eat neighbor
+        // solicitations (#601). Checked against every filter-anchor form so
+        // it lands before aifw-pbr when the mwan anchors already exist.
+        if !has_nd
+            && !nd_inserted
+            && (t == "anchor \"aifw\""
+                || mwan_anchors.iter().any(|a| t == format!("anchor \"{a}\"")))
+        {
+            out.push(ND_RULE.to_string());
+            nd_inserted = true;
+            changed = true;
+        }
+
         if !mwan_inserted && t == "anchor \"aifw\"" {
             for (i, a) in mwan_anchors.iter().enumerate() {
                 if !has_mwan[i] {
@@ -1700,6 +1721,12 @@ async fn main() -> anyhow::Result<()> {
         let mem_state = state.clone();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+            // 24h alert count cache (#601): the COUNT rides an index but
+            // still costs >1s on multi-million-row tables — too expensive
+            // for a per-minute heartbeat. Refresh every 10th tick; the
+            // heartbeat is a health signal, not a live stat.
+            let mut alerts_24h_cache: i64 = 0;
+            let mut heartbeat_ticks: u32 = 0;
             loop {
                 interval.tick().await;
                 let hist_entries = mem_state.metrics_history.read().await.len();
@@ -1743,13 +1770,19 @@ async fn main() -> anyhow::Result<()> {
                 // rides idx_ids_alerts_ts instead of full-scanning a
                 // multi-million-row table every tick (and contending with
                 // ingestion). This is a health signal — recent persistence,
-                // not lifetime total — hence the _24h field name.
-                let (ids_alerts_db_24h,): (i64,) = sqlx::query_as(
-                    "SELECT COUNT(*) FROM ids_alerts WHERE timestamp >= datetime('now', '-1 day')",
-                )
-                .fetch_one(&mem_state.pool)
-                .await
-                .unwrap_or((0,));
+                // not lifetime total — hence the _24h field name. Refreshed
+                // every 10 minutes, cached between (#601).
+                if heartbeat_ticks.is_multiple_of(10) {
+                    let (count,): (i64,) = sqlx::query_as(
+                        "SELECT COUNT(*) FROM ids_alerts WHERE timestamp >= datetime('now', '-1 day')",
+                    )
+                    .fetch_one(&mem_state.pool)
+                    .await
+                    .unwrap_or((0,));
+                    alerts_24h_cache = count;
+                }
+                heartbeat_ticks = heartbeat_ticks.wrapping_add(1);
+                let ids_alerts_db_24h = alerts_24h_cache;
                 // PERF-H12: native RSS syscall, not a `ps` fork (finishes the
                 // main.rs shell-out #356 also cited).
                 let rss_mb =

--- a/aifw-core/src/sudo.rs
+++ b/aifw-core/src/sudo.rs
@@ -399,3 +399,30 @@ pub async fn tcpdump(args: &[&str]) -> std::io::Result<std::process::Output> {
     fallback.extend_from_slice(args);
     sudo_with_fallback(&narrow, &fallback).await
 }
+
+#[cfg(test)]
+mod allowlist_tests {
+    /// Guard (#601): every path the code writes through `aifw-sudo-write`
+    /// must appear in the helper's allowlist. `pf.conf.aifw` was missing,
+    /// so pf-tuning's boot apply failed silently on every appliance —
+    /// the same drift family as the sudoers guard in aifw-setup.
+    #[test]
+    fn sudo_write_allowlist_covers_call_sites() {
+        let helper = include_str!("../../freebsd/overlay/usr/local/libexec/aifw-sudo-write");
+        for path in [
+            "/etc/pf.conf",
+            "/usr/local/etc/aifw/pf.conf.aifw",
+            "/usr/local/etc/trafficcop/config.yaml",
+            "/usr/local/etc/aifw/daemon.key",
+            "/usr/local/etc/swanctl/conf.d/aifw-*.conf",
+            "/usr/local/etc/swanctl/private/aifw-*.pem",
+            "/usr/local/etc/swanctl/x509/aifw-*.pem",
+            "/usr/local/etc/swanctl/x509ca/aifw-*.pem",
+        ] {
+            assert!(
+                helper.contains(path),
+                "aifw-sudo-write allowlist is missing {path} — runtime writes to it are refused"
+            );
+        }
+    }
+}

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -1580,8 +1580,15 @@ mod tests {
                 script.contains("aifw-setup --print-sudoers"),
                 "{name} must regenerate sudoers from aifw-setup"
             );
+            // Absolute path required (#601): a bare `visudo` isn't found
+            // under the daemon(8) default PATH, silently disabling the
+            // refresh on every boot.
             assert!(
-                script.contains("visudo -cf"),
+                script.contains("VISUDO=/usr/local/sbin/visudo"),
+                "{name} must resolve visudo by absolute path (not in daemon PATH)"
+            );
+            assert!(
+                script.contains("\"$VISUDO\" -cf"),
                 "{name} must validate sudoers with visudo before installing"
             );
             assert!(

--- a/aifw-ids-bin/src/main.rs
+++ b/aifw-ids-bin/src/main.rs
@@ -99,6 +99,12 @@ async fn main() -> anyhow::Result<()> {
             .map_err(|e| anyhow::anyhow!("init engine: {e}"))?,
     );
 
+    // Alert retention runs regardless of engine mode (#601): pruning and
+    // the clock-skew scrub are hygiene for rows already in the DB, and
+    // gating them behind the mode check left disabled-IDS appliances with
+    // multi-million-row ids_alerts tables that never shrink.
+    engine.spawn_retention_worker();
+
     // Compile and start if mode != Disabled.
     if let Ok(cfg) = engine.load_config().await
         && cfg.mode != aifw_common::ids::IdsMode::Disabled

--- a/aifw-ids/src/lib.rs
+++ b/aifw-ids/src/lib.rs
@@ -472,13 +472,24 @@ impl IdsEngine {
             info!(interface = %iface_name, "capture worker started");
         }
 
-        // Retention worker — periodically prunes alerts past
-        // `alert_retention_days` and scrubs rows with implausible timestamps
-        // left by past clock-skew events. Without this, `ids_alerts` grows
-        // unbounded (the test VM hit 2.97M rows / 2.9GB before this landed).
+        info!("IDS engine started");
+        Ok(())
+    }
+
+    /// Spawn the alert-retention worker: an initial scrub + purge at boot,
+    /// then an hourly prune of alerts past `alert_retention_days` plus a
+    /// scrub of rows with implausible timestamps left by past clock-skew
+    /// events (year-9920 rows defeat age-based pruning forever).
+    ///
+    /// Called by the binary UNCONDITIONALLY — not from `start()` — because
+    /// data hygiene must not depend on the engine mode (#601): an appliance
+    /// with IDS disabled previously never pruned, leaving a 2.97M-row
+    /// `ids_alerts` table that slowed every dashboard query. The worker
+    /// deliberately ignores the engine `running` flag: it owns no capture
+    /// resources and dies with the process.
+    pub fn spawn_retention_worker(&self) {
         let retention_pool = self.pool.clone();
         let retention_config = self.config.clone();
-        let retention_running = self.running.clone();
         tokio::spawn(async move {
             let output = crate::output::sqlite::SqliteOutput::new(retention_pool);
 
@@ -505,11 +516,8 @@ impl IdsEngine {
 
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(3600));
             interval.tick().await; // burn the first immediate tick
-            while retention_running.load(Ordering::Relaxed) {
+            loop {
                 interval.tick().await;
-                if !retention_running.load(Ordering::Relaxed) {
-                    break;
-                }
                 let days = retention_config.config().alert_retention_days;
                 match output.purge_old(days).await {
                     Ok(0) => {}
@@ -520,11 +528,7 @@ impl IdsEngine {
                     error!("ids retention: invalid-timestamp scrub failed: {e}");
                 }
             }
-            info!("ids retention worker stopped");
         });
-
-        info!("IDS engine started");
-        Ok(())
     }
 
     /// Stop the IDS engine gracefully.

--- a/aifw-ui/src/app/traffic/page.tsx
+++ b/aifw-ui/src/app/traffic/page.tsx
@@ -104,7 +104,13 @@ export default function TrafficPage() {
   const prevIface = useRef<Record<string, { bytes_in: number; bytes_out: number }>>({});
   const prevTime = useRef(0);
 
-  const ifaceNames = (ws.interfaces as IfaceData[]);
+  // Stable name order (#601): the WS payload's interface order shifts with
+  // traffic, which made the graph cards (and their colors, keyed by index)
+  // jump around on every tick.
+  const ifaceNames = useMemo(
+    () => [...(ws.interfaces as IfaceData[])].sort((a, b) => a.name.localeCompare(b.name)),
+    [ws.interfaces],
+  );
   const allSelected = selectedNics.size === 0 || selectedNics.size === ifaceNames.length;
 
   const toggleNic = (name: string) => {
@@ -226,7 +232,7 @@ export default function TrafficPage() {
     connections.reduce<{ ip: string; bytes: number; conns: number }[]>((a, c) => {
       const e = a.find(t => t.ip === c.src_addr), tot = (c.bytes_in || 0) + (c.bytes_out || 0);
       if (e) { e.bytes += tot; e.conns++; } else a.push({ ip: c.src_addr, bytes: tot, conns: 1 }); return a;
-    }, []).sort((a, b) => b.bytes - a.bytes).slice(0, 10),
+    }, []).sort((a, b) => b.bytes - a.bytes || a.ip.localeCompare(b.ip)).slice(0, 10),
   [connections]);
   const maxTB = topTalkers[0]?.bytes || 1;
 
@@ -234,7 +240,7 @@ export default function TrafficPage() {
     connections.reduce<{ port: number; proto: string; conns: number }[]>((a, c) => {
       const key = `${c.dst_port}-${c.protocol}`, e = a.find(p => `${p.port}-${p.proto}` === key);
       if (e) e.conns++; else a.push({ port: c.dst_port, proto: c.protocol, conns: 1 }); return a;
-    }, []).sort((a, b) => b.conns - a.conns).slice(0, 15),
+    }, []).sort((a, b) => b.conns - a.conns || a.port - b.port).slice(0, 15),
   [connections]);
   const maxPC = topPorts[0]?.conns || 1;
 

--- a/freebsd/overlay/usr/local/libexec/aifw-restart.sh
+++ b/freebsd/overlay/usr/local/libexec/aifw-restart.sh
@@ -40,11 +40,19 @@ log "starting (pid $$)"
 # service bounce so the restarted services come up with correct grants.
 refresh_sudoers() {
     [ -x /usr/local/sbin/aifw-setup ] || return 0
+    # Absolute path (#601): visudo lives in /usr/local/sbin, which daemon(8)
+    # contexts don't have in PATH — a bare name fails command-not-found and
+    # reads as a validation failure.
+    VISUDO=/usr/local/sbin/visudo
+    [ -x "$VISUDO" ] || VISUDO=$(command -v visudo) || {
+        log "WARN visudo not found; sudoers refresh skipped"
+        return 0
+    }
     _tmp=$(mktemp /tmp/aifw-sudoers.XXXXXX) || return 0
     if /usr/local/sbin/aifw-setup --print-sudoers > "$_tmp" 2>/dev/null && [ -s "$_tmp" ]; then
         # Validate before installing — a malformed sudoers file would void
         # every NOPASSWD grant the appliance depends on.
-        if visudo -cf "$_tmp" >/dev/null 2>&1; then
+        if "$VISUDO" -cf "$_tmp" >/dev/null 2>&1; then
             if ! cmp -s "$_tmp" /usr/local/etc/sudoers.d/aifw 2>/dev/null; then
                 if install -m 440 -o root -g wheel "$_tmp" /usr/local/etc/sudoers.d/aifw; then
                     log "refreshed /usr/local/etc/sudoers.d/aifw from aifw-setup"

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-write
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-write
@@ -38,6 +38,10 @@ esac
 case "$DEST" in
     /etc/pf.conf)
         FMODE=644; FOWNER=root:wheel ;;
+    /usr/local/etc/aifw/pf.conf.aifw)
+        # pf_tuning + the API's anchor self-heal commit their patched
+        # pf.conf here; missing entry broke every boot-time tuning apply (#601).
+        FMODE=644; FOWNER=root:wheel ;;
     /usr/local/etc/trafficcop/config.yaml)
         FMODE=644; FOWNER=root:wheel ;;
     /usr/local/etc/aifw/daemon.key)

--- a/freebsd/overlay/usr/local/libexec/aifw-watchdog.sh
+++ b/freebsd/overlay/usr/local/libexec/aifw-watchdog.sh
@@ -54,9 +54,18 @@ log "starting (pid $$, interval ${INTERVAL}s)"
 # validated; a no-op once the file already matches.
 refresh_sudoers() {
     [ -x /usr/local/sbin/aifw-setup ] || return 0
+    # Absolute path (#601): visudo lives in /usr/local/sbin, which is NOT in
+    # the daemon(8) default PATH the watchdog runs under — the bare name
+    # made this check fail command-not-found on every boot, so the refresh
+    # never ran and the failure was misreported as a validation error.
+    VISUDO=/usr/local/sbin/visudo
+    [ -x "$VISUDO" ] || VISUDO=$(command -v visudo) || {
+        log "WARN visudo not found; sudoers refresh skipped"
+        return 0
+    }
     _tmp=$(mktemp /tmp/aifw-sudoers.XXXXXX) || return 0
     if /usr/local/sbin/aifw-setup --print-sudoers > "$_tmp" 2>/dev/null && [ -s "$_tmp" ]; then
-        if visudo -cf "$_tmp" >/dev/null 2>&1; then
+        if "$VISUDO" -cf "$_tmp" >/dev/null 2>&1; then
             if ! cmp -s "$_tmp" /usr/local/etc/sudoers.d/aifw 2>/dev/null; then
                 if install -m 440 -o root -g wheel "$_tmp" /usr/local/etc/sudoers.d/aifw; then
                     log "refreshed /usr/local/etc/sudoers.d/aifw from aifw-setup"


### PR DESCRIPTION
Fixes #601 — everything found in the post-5.110.0 log sweep on the live appliance:

1. **IDS retention never ran on disabled-IDS boxes**: the retention worker lived inside `engine.start()`, which the binary skips when mode=Disabled. That's how the appliance reached 2.97M `ids_alerts` rows including year-9920 clock-skew rows (which age-based pruning can never remove — only the scrub can, and it never ran). The binary now spawns the worker unconditionally; it owns no capture resources and ignores the engine running flag.
2. **`aifw-sudo-write` allowlist was missing `pf.conf.aifw`** — pf-tuning's boot apply failed on every appliance since the allowlist helper landed. Added, plus a guard test asserting every code write-target is allowlisted (same discipline as the sudoers guard).
3. **Watchdog sudoers refresh never worked**: bare `visudo` isn't in the daemon(8) PATH (`/usr/local/sbin`), so the check failed command-not-found on every boot and was misreported as a validation failure. Absolute path + distinct warning when visudo is genuinely absent.
4. **Upgraded appliances get the ICMPv6 ND rule self-healed** into pf.conf.aifw (before the first filter anchor) — previously only newly generated configs had it, leaving IPv6/NAT64 ND-blocked after upgrade.
5. **Heartbeat cost**: the per-minute 24h `ids_alerts` COUNT (>1.3s on the appliance) is now refreshed every 10th tick and cached between.
6. **Traffic page jumping**: interface graph cards (and their colors, keyed by index) reordered with each WS payload — now stably sorted by name; top-talkers/ports lists get deterministic tie-breaks.

All verified: 820+ tests incl. new allowlist guard, UI lint + static export clean.