### PR TITLE
release: v5.110.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "5.110.0"
+version = "5.110.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.110.0",
+  "version": "5.110.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.110.0",
+      "version": "5.110.1",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aifw-ui",
 
-  "version": "5.110.0",
+  "version": "5.110.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Version bump 5.110.0 → 5.110.1 (patch). Contents: the #601 appliance-sweep fixes from PR #602 — details there.

Notable for fielded appliances: first boot after taking this update scrubs the bloated `ids_alerts` table (retention now runs even with IDS disabled), fixes pf-tuning's boot apply, revives the sudoers-refresh safety net, and self-heals the ICMPv6 ND rule into upgraded pf.conf files.

**After merging**, on the build machine:

```
cd ~/AiFw && git pull
sh freebsd/build-update.sh
sh freebsd/release.sh        # publishes v5.110.1 as PRE-RELEASE
```

Validate on the test appliance (watch for the 'ids retention: scrubbed alerts' log line and a shrunken ids_alerts table), then promote:
`gh release edit v5.110.1 --prerelease=false --latest`