### PR TITLE
fix(release): root-owned build artifacts no longer break signing

### DIFF
--- a/freebsd/build-local.sh
+++ b/freebsd/build-local.sh
@@ -353,6 +353,15 @@ for d in stage dist iso efi-stage; do
 done
 echo "  Removed staged binaries, UI export, and build intermediates"
 
+# Hand the artifacts to the user who invoked the build: this script runs as
+# root, but release.sh runs unprivileged (it needs the operator's gh auth
+# and minisign key) and must be able to write .minisig files next to the
+# checksums. Without this, every release run died on "Permission denied".
+if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    chown -R "$SUDO_USER" "$OUTPUTDIR"
+    echo "  Output ownership -> $SUDO_USER (for unprivileged release.sh)"
+fi
+
 # --- Done ---
 echo ""
 echo "=== Complete ==="

--- a/freebsd/build-update.sh
+++ b/freebsd/build-update.sh
@@ -264,6 +264,11 @@ if [ -z "${AIFW_STAGE_OUT:-}" ]; then
     mv "${STAGE_OUT}/aifw-update-${VERSION}-amd64.tar.xz.sha256" "$OUTPUTDIR/"
     rmdir "$STAGE_OUT" 2>/dev/null || true
     STAGE_OUT="$OUTPUTDIR"
+    # release.sh runs unprivileged and signs next to these files — hand
+    # them to the invoking user when this build ran under sudo.
+    if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+        chown -R "$SUDO_USER" "$OUTPUTDIR" 2>/dev/null || true
+    fi
 fi
 
 echo ""

--- a/freebsd/release.sh
+++ b/freebsd/release.sh
@@ -123,6 +123,24 @@ if [ -z "$ISO_UPLOAD" ] && [ -z "$IMG_UPLOAD" ] && [ -z "$UPDATE_TARBALL" ]; the
     die "No artifacts to release. Run build-local.sh first."
 fi
 
+# --- Guard: signing writes .minisig files next to the checksums, so the
+# output dir must be writable by this (unprivileged) user. Builds run as
+# root and used to leave root-owned artifacts, killing every release run
+# with "Permission denied" mid-signing. The build scripts now chown their
+# output, but self-heal here too for artifacts from older builds — sudo -n
+# only, so this never hangs on a password prompt.
+UNWRITABLE=0
+[ -w "$OUTPUTDIR" ] || UNWRITABLE=1
+for f in "$OUTPUTDIR"/*; do
+    [ -e "$f" ] || continue
+    [ -w "$f" ] || { UNWRITABLE=1; break; }
+done
+if [ "$UNWRITABLE" = 1 ]; then
+    echo "Output dir has files this user can't write (root-owned build artifacts); fixing ownership..."
+    sudo -n chown -R "$(id -un)" "$OUTPUTDIR" 2>/dev/null \
+        || die "Cannot write to ${OUTPUTDIR} — run: sudo chown -R $(id -un) ${OUTPUTDIR}"
+fi
+
 # --- Sign checksums (publisher authenticity) ---
 # The in-app updater fails closed: a release without a valid .minisig for
 # its update tarball checksum cannot be installed by any appliance. Signing


### PR DESCRIPTION
Every release run has died at the signing step with `Permission denied`: builds run as root and leave root-owned artifacts in `/usr/obj/aifw-iso/output`, while release.sh runs unprivileged (it needs the operator's gh auth and minisign key) and must write `.minisig` files next to the checksums.

Fixed at both ends:
- `build-local.sh` / `build-update.sh` chown their output to `$SUDO_USER` when the build ran under sudo — artifacts land already owned by the operator.
- `release.sh` preflights output-dir writability before doing anything, self-heals artifacts from older builds via `sudo -n chown` (non-interactive — never hangs on a password prompt), and otherwise dies up front with the exact chown command instead of failing mid-signing.

Preflight logic functionally verified on the FreeBSD build VM (note: `find -writable` is GNU-only, hence the portable `test -w` loop).