### PR TITLE
fix: FreeBSD-target warnings + Updates-page restart hangs

### DIFF
--- a/aifw-core/src/system_apply/freebsd_impl.rs
+++ b/aifw-core/src/system_apply/freebsd_impl.rs
@@ -5,6 +5,8 @@ use super::freebsd_helpers::{rewrite_hosts_loopback, rewrite_resolv_conf_search}
 use super::{ApplyReport, BannerInput, ConsoleInput, GeneralInput, SshInput, SystemInfo};
 use crate::system_apply_helpers::replace_managed_block;
 
+/// Apply general system settings (hostname, domain, DNS search) via
+/// sysrc for persistence plus the live equivalents.
 pub async fn apply_general(i: &GeneralInput) -> ApplyReport {
     let mut warnings: Vec<String> = Vec::new();
 
@@ -58,6 +60,7 @@ pub async fn apply_general(i: &GeneralInput) -> ApplyReport {
     }
 }
 
+/// Install the login banner (/etc/issue) and MOTD content.
 pub async fn apply_banner(i: &BannerInput) -> ApplyReport {
     let mut warnings: Vec<String> = Vec::new();
 
@@ -84,12 +87,16 @@ pub async fn apply_banner(i: &BannerInput) -> ApplyReport {
     }
 }
 
+/// Whether the operator has hand-edited the MOTD (marker file set) —
+/// when true, apply paths must not overwrite it.
 pub async fn motd_user_edited_marker_set() -> bool {
     tokio::fs::try_exists("/var/db/aifw/motd.user-edited")
         .await
         .unwrap_or(false)
 }
 
+/// Apply SSH daemon settings (enable flag via sysrc + sshd_config
+/// managed block) and restart sshd when changed.
 pub async fn apply_ssh(i: &SshInput) -> ApplyReport {
     let mut warnings: Vec<String> = Vec::new();
 
@@ -141,6 +148,7 @@ pub async fn apply_ssh(i: &SshInput) -> ApplyReport {
     r
 }
 
+/// Apply the console kind (serial/video/dual) to /boot/loader.conf.
 pub async fn apply_console(i: &ConsoleInput) -> ApplyReport {
     let console_val = match i.kind {
         crate::config::ConsoleKind::Serial => "comconsole",
@@ -164,6 +172,8 @@ pub async fn apply_console(i: &ConsoleInput) -> ApplyReport {
     r
 }
 
+/// Collect live system facts (hostname, OS release, uptime, etc.) for
+/// the system-info API.
 pub async fn collect_info() -> SystemInfo {
     let hostname = read_sysctl_str("kern.hostname").unwrap_or_default();
     let os_release = run_stdout("/usr/bin/uname", &["-sr"])

--- a/aifw-ids/src/capture/mod.rs
+++ b/aifw-ids/src/capture/mod.rs
@@ -8,8 +8,10 @@ pub mod factory;
 pub mod pcap;
 pub mod types;
 
+/// BPF-based packet capture (FreeBSD /dev/bpf).
 #[cfg(target_os = "freebsd")]
 pub mod bpf;
+/// netmap-based high-rate capture (FreeBSD, experimental — #484).
 #[cfg(target_os = "freebsd")]
 pub mod netmap;
 

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -273,7 +273,6 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
     // 8. Configure network interfaces in rc.conf
     #[cfg(target_os = "freebsd")]
     {
-        use std::process::Command;
         console::info("Configuring network interfaces...");
 
         // WAN interface
@@ -319,7 +318,6 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
     // 9. Start services
     #[cfg(target_os = "freebsd")]
     {
-        use std::process::Command;
         console::info("Starting services...");
 
         // Anchor population is handled at runtime by aifw-daemon reading from
@@ -443,7 +441,6 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
 fn create_service_user() -> Result<(), String> {
     #[cfg(target_os = "freebsd")]
     {
-        use std::process::Command;
         // Check if user already exists
         let status = Command::new("pw").args(["usershow", "aifw"]).output();
         if let Ok(out) = status {
@@ -486,8 +483,6 @@ fn create_service_user() -> Result<(), String> {
 fn configure_devfs() -> Result<(), String> {
     #[cfg(target_os = "freebsd")]
     {
-        use std::process::Command;
-
         // Write rules directly to /etc/devfs.rules (the canonical location)
         let devfs_rules_path = "/etc/devfs.rules";
         let existing = std::fs::read_to_string(devfs_rules_path).unwrap_or_default();

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -442,7 +442,9 @@ fn create_service_user() -> Result<(), String> {
     #[cfg(target_os = "freebsd")]
     {
         // Check if user already exists
-        let status = Command::new("pw").args(["usershow", "aifw"]).output();
+        let status = std::process::Command::new("pw")
+            .args(["usershow", "aifw"])
+            .output();
         if let Ok(out) = status {
             if out.status.success() {
                 return Ok(()); // user exists
@@ -451,7 +453,7 @@ fn create_service_user() -> Result<(), String> {
         // Create group
         run_best_effort("pw", &["groupadd", "aifw", "-g", "470"]);
         // Create user: no login shell, no home, system account
-        let out = Command::new("pw")
+        let out = std::process::Command::new("pw")
             .args([
                 "useradd",
                 "aifw",
@@ -650,7 +652,6 @@ fn create_dirs(config: &SetupConfig) -> Result<(), String> {
     // Set ownership: config dir readable by aifw, db/log owned by aifw
     #[cfg(target_os = "freebsd")]
     {
-        use std::process::Command;
         // Config dir: root owns, aifw group can read
         run_best_effort("chown", &["root:aifw", &config.config_dir]);
         run_best_effort("chmod", &["750", &config.config_dir]);

--- a/aifw-ui/src/hooks/useUpdates.ts
+++ b/aifw-ui/src/hooks/useUpdates.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { ApiError } from "@/lib/api";
 import { usePolling } from "@/lib/usePolling";
 import { useFeedback } from "@/hooks/useFeedback";
 import {
@@ -320,13 +321,21 @@ export function useUpdates() {
   // Operator-confirmed restart. Posts to the dedicated restart endpoint
   // and switches to the bounce overlay.
   const handleConfirmRestart = async () => {
+    setRestartPrompt(null);
     try {
       await restartAifwServices();
-      setRestartPrompt(null);
-      watchRestart();
     } catch (err) {
-      showFeedback("error", err instanceof Error ? err.message : "Failed to restart services");
+      // A real API error (4xx/5xx) means the restart was refused — report
+      // it. A network failure means the API bounced before the response
+      // flushed (#601 follow-up: seen live — the restart driver SIGKILLs a
+      // slow-stopping API), so the restart IS running: fall through to the
+      // overlay, whose polling handles recovery either way.
+      if (err instanceof ApiError) {
+        showFeedback("error", err.message);
+        return;
+      }
     }
+    watchRestart();
   };
 
   // Operator-confirmed full system reboot. shutdown(8) defers actual
@@ -365,9 +374,28 @@ export function useUpdates() {
         setLocalInstalling(false);
         setInstallLocalResult(result);
         if (result.ok) {
+          if (installRestart) {
+            // Services bounce right after install — show the overlay and
+            // poll for the API to come back instead of leaving the page up.
+            watchRestart();
+            return;
+          }
           fetchHistory();
           fetchAifwStatus();
         }
+      })
+      .catch((err) => {
+        setUploadProgress(null);
+        setLocalInstalling(false);
+        // Network failure on a restart-install means the API bounced before
+        // the response flushed — the install itself succeeded and services
+        // are restarting. Watch the bounce instead of hanging the spinner
+        // forever (the exact symptom this replaced, #601 follow-up).
+        if (installRestart && !(err instanceof ApiError)) {
+          watchRestart();
+          return;
+        }
+        showFeedback("error", err instanceof Error ? err.message : "Install failed");
       });
   };
 


### PR DESCRIPTION
Two things from the v5.110.1 build/deploy cycle:

**FreeBSD-only cargo warnings** — the build machine showed 12 warnings that Linux dev boxes and CI never see, because they live behind `cfg(target_os = "freebsd")`: missing docs on the `system_apply` freebsd_impl functions and the bpf/netmap capture modules, plus four dead `use std::process::Command` imports in aifw-setup (every usage is fully qualified). All fixed; `cargo check` is warning-free on both targets now.

**Updates-page restart hangs** (hit live while installing v5.110.1): the local-tarball install flow had no `.catch` and never showed the restart overlay. With 'restart after install' set, the API can die before the install POST's response flushes (the restart driver SIGKILLs a slow-stopping API — visible in restart.log), so the fetch never settles and the spinner hangs forever even though the appliance restarted fine. Both the local-install and confirm-restart paths now hand off to `watchRestart`'s overlay + poll-for-recovery, and distinguish a refused restart (real ApiError, reported) from a lost response (restart in progress, watch it).

UI lint + build clean; 822 tests pass.