### PR TITLE
feat(ids): manual alert purge, auto space reclaim, 7-day retention default

### DIFF
--- a/aifw-api/src/ids.rs
+++ b/aifw-api/src/ids.rs
@@ -243,8 +243,38 @@ pub async fn purge_alerts(
         .execute(&state.pool)
         .await
         .map_err(|_| internal())?;
+
+    // Reclaim the space: a bare DELETE only moves pages to the freelist —
+    // seen live as a 2.9GB DB file with 34 rows (#601). VACUUM rewrites the
+    // file; the TRUNCATE checkpoint then shrinks the WAL that the rewrite
+    // itself produced (the rewrite streams through the WAL, so without this
+    // the reclaimed gigabytes just move into aifw.db-wal). Failures are
+    // non-fatal — the rows are gone either way.
+    let mut reclaimed = " and space reclaimed";
+    if let Err(e) = sqlx::query("VACUUM").execute(&state.pool).await {
+        tracing::warn!(error = %e, "ids purge: vacuum failed; space not reclaimed");
+        reclaimed = " (space reclaim deferred: vacuum busy)";
+    } else if let Err(e) = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+        .fetch_all(&state.pool)
+        .await
+    {
+        tracing::warn!(error = %e, "ids purge: wal checkpoint failed");
+    }
+
+    if let Err(e) = aifw_core::audit::AuditLog::new(state.pool.clone())
+        .log(
+            aifw_core::audit::AuditAction::ConfigChanged,
+            None,
+            &format!("ids: purged all alerts ({} rows)", res.rows_affected()),
+            "ids_api",
+        )
+        .await
+    {
+        tracing::warn!(error = %e, "ids purge: audit log write failed");
+    }
+
     Ok(Json(MessageResponse {
-        message: format!("{} alerts purged", res.rows_affected()),
+        message: format!("{} alerts purged{reclaimed}", res.rows_affected()),
     }))
 }
 

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -3424,3 +3424,102 @@ pub async fn cluster_verify(as_json: bool) -> anyhow::Result<()> {
         std::process::exit(1);
     }
 }
+
+/// Delete every stored IDS alert and reclaim the disk space. A bare DELETE
+/// only frees pages to SQLite's freelist (#601: a 2.9GB file holding 34
+/// rows), so this follows up with VACUUM + a TRUNCATE WAL checkpoint.
+/// "no such table" means the IDS subsystem has never initialized this DB —
+/// for read/purge paths that's simply "nothing stored", not an error.
+fn ids_table_missing(e: &sqlx::Error) -> bool {
+    e.to_string().contains("no such table")
+}
+
+pub async fn ids_purge_alerts(db_path: &Path, yes: bool) -> anyhow::Result<()> {
+    let db = Database::new(db_path).await?;
+    let pool = db.pool();
+    let (count,): (i64,) = match sqlx::query_as("SELECT COUNT(*) FROM ids_alerts")
+        .fetch_one(pool)
+        .await
+    {
+        Ok(row) => row,
+        Err(e) if ids_table_missing(&e) => {
+            println!("No IDS alerts stored.");
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+    if count == 0 {
+        println!("No IDS alerts stored.");
+        return Ok(());
+    }
+    if !yes {
+        use std::io::Write;
+        print!("Delete ALL {count} IDS alerts? This cannot be undone. [y/N] ");
+        std::io::stdout().flush()?;
+        let mut line = String::new();
+        std::io::stdin().read_line(&mut line)?;
+        if !matches!(line.trim(), "y" | "Y" | "yes") {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+    sqlx::query("DELETE FROM ids_alerts").execute(pool).await?;
+    println!("Deleted {count} alerts; reclaiming disk space (may take a moment)...");
+    sqlx::query("VACUUM").execute(pool).await?;
+    sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+        .fetch_all(pool)
+        .await?;
+    println!("Done.");
+    Ok(())
+}
+
+/// Show or set the alert retention window (days). The hourly retention
+/// sweep in aifw-ids prunes past it and reclaims space after big purges.
+pub async fn ids_retention(db_path: &Path, days: Option<u32>) -> anyhow::Result<()> {
+    let db = Database::new(db_path).await?;
+    let pool = db.pool();
+    match days {
+        None => {
+            let cur: Option<(String,)> = match sqlx::query_as(
+                "SELECT value FROM ids_config WHERE key = 'alert_retention_days'",
+            )
+            .fetch_optional(pool)
+            .await
+            {
+                Ok(row) => row,
+                Err(e) if ids_table_missing(&e) => None,
+                Err(e) => return Err(e.into()),
+            };
+            match cur {
+                Some((v,)) => println!("Alert retention: {v} days"),
+                None => println!("Alert retention: 7 days (default)"),
+            }
+        }
+        Some(d) => {
+            anyhow::ensure!(
+                (1..=365).contains(&d),
+                "retention must be between 1 and 365 days"
+            );
+            if let Err(e) = sqlx::query(
+                "INSERT INTO ids_config (key, value, updated_at) VALUES ('alert_retention_days', ?1, datetime('now')) \
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')",
+            )
+            .bind(d.to_string())
+            .execute(pool)
+            .await
+            {
+                if ids_table_missing(&e) {
+                    anyhow::bail!(
+                        "IDS database not initialized yet — start aifw-api/aifw-ids once, then retry"
+                    );
+                }
+                return Err(e.into());
+            }
+            println!("Alert retention set to {d} day(s).");
+            println!(
+                "  The running aifw-ids applies it after an IDS reload (UI) or 'service aifw_ids restart'."
+            );
+        }
+    }
+    Ok(())
+}

--- a/aifw-cli/src/main.rs
+++ b/aifw-cli/src/main.rs
@@ -36,6 +36,11 @@ enum Commands {
         #[command(subcommand)]
         action: NatAction,
     },
+    /// Manage the IDS engine (alerts, retention)
+    Ids {
+        #[command(subcommand)]
+        action: IdsAction,
+    },
     /// Manage traffic queues
     Queue {
         #[command(subcommand)]
@@ -748,6 +753,30 @@ enum DhcpAction {
 // add allocator overhead for a CLI command type that lives briefly on the stack.
 #[allow(clippy::large_enum_variant)]
 #[derive(Subcommand)]
+enum IdsAction {
+    /// Delete ALL stored IDS alerts and reclaim the disk space
+    #[command(after_help = "\
+EXAMPLES:
+    aifw ids purge-alerts            # asks for confirmation first
+    aifw ids purge-alerts --yes      # non-interactive (scripts/cron)")]
+    PurgeAlerts {
+        /// Skip the confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
+    /// Show or set how long alerts are kept (pruned hourly by aifw-ids)
+    #[command(after_help = "\
+EXAMPLES:
+    aifw ids retention               # show the current setting
+    aifw ids retention 7             # keep one week (the default)
+    aifw ids retention 30            # keep one month")]
+    Retention {
+        /// Days to keep alerts (1-365). Omit to show the current value.
+        days: Option<u32>,
+    },
+}
+
+#[derive(Subcommand)]
 enum NatAction {
     /// Add a NAT rule
     #[command(after_help = "\
@@ -946,6 +975,14 @@ async fn main() -> anyhow::Result<()> {
             }
             RulesAction::List { json } => {
                 commands::rules_list(&cli.db, json).await?;
+            }
+        },
+        Commands::Ids { action } => match action {
+            IdsAction::PurgeAlerts { yes } => {
+                commands::ids_purge_alerts(&cli.db, yes).await?;
+            }
+            IdsAction::Retention { days } => {
+                commands::ids_retention(&cli.db, days).await?;
             }
         },
         Commands::Nat { action } => match action {

--- a/aifw-common/src/ids.rs
+++ b/aifw-common/src/ids.rs
@@ -394,7 +394,7 @@ impl Default for IdsConfig {
             ],
             external_net: vec!["!$HOME_NET".into()],
             interfaces: Vec::new(),
-            alert_retention_days: 30,
+            alert_retention_days: 7,
             eve_log_enabled: false,
             eve_log_path: None,
             syslog_target: None,

--- a/aifw-ids/src/config.rs
+++ b/aifw-ids/src/config.rs
@@ -142,7 +142,7 @@ impl RuntimeConfig {
                     cfg.interfaces = serde_json::from_str(&value).unwrap_or_default();
                 }
                 "alert_retention_days" => {
-                    cfg.alert_retention_days = value.parse().unwrap_or(30);
+                    cfg.alert_retention_days = value.parse().unwrap_or(7);
                 }
                 "eve_log_enabled" => {
                     cfg.eve_log_enabled = value == "true" || value == "1";
@@ -314,12 +314,14 @@ mod tests {
 
         let mut cfg = (*config.config()).clone();
         cfg.mode = IdsMode::Ids;
-        cfg.alert_retention_days = 7;
+        // Non-default value (default is 7) so the round-trip proves the
+        // saved value is read back, not the default.
+        cfg.alert_retention_days = 3;
         config.save_to_db(&pool, &cfg).await.unwrap();
 
         let loaded = config.load_from_db(&pool).await.unwrap();
         assert_eq!(loaded.mode, IdsMode::Ids);
-        assert_eq!(loaded.alert_retention_days, 7);
+        assert_eq!(loaded.alert_retention_days, 3);
     }
 
     #[tokio::test]

--- a/aifw-ids/src/lib.rs
+++ b/aifw-ids/src/lib.rs
@@ -488,31 +488,46 @@ impl IdsEngine {
     /// deliberately ignores the engine `running` flag: it owns no capture
     /// resources and dies with the process.
     pub fn spawn_retention_worker(&self) {
+        // Auto-vacuum threshold: once this many rows have been purged since
+        // the last space reclaim, run VACUUM + WAL truncate. Deleted rows
+        // only hit SQLite's freelist otherwise, and the file never shrinks
+        // (#601: 2.9GB file, 34 live rows).
+        const VACUUM_AFTER_PURGED_ROWS: u64 = 100_000;
+
         let retention_pool = self.pool.clone();
         let retention_config = self.config.clone();
         tokio::spawn(async move {
             let output = crate::output::sqlite::SqliteOutput::new(retention_pool);
+            let mut purged_since_vacuum: u64 = 0;
 
             // Initial scrub on startup so a stale appliance cleans itself up
             // without waiting an hour.
             match output.purge_invalid_timestamps().await {
                 Ok(0) => {}
-                Ok(n) => warn!(
-                    rows = n,
-                    "ids retention: scrubbed alerts with implausible timestamps"
-                ),
+                Ok(n) => {
+                    purged_since_vacuum += n;
+                    warn!(
+                        rows = n,
+                        "ids retention: scrubbed alerts with implausible timestamps"
+                    )
+                }
                 Err(e) => error!("ids retention: invalid-timestamp scrub failed: {e}"),
             }
             let initial_days = retention_config.config().alert_retention_days;
             match output.purge_old(initial_days).await {
                 Ok(0) => {}
-                Ok(n) => info!(
-                    rows = n,
-                    days = initial_days,
-                    "ids retention: initial purge complete"
-                ),
+                Ok(n) => {
+                    purged_since_vacuum += n;
+                    info!(
+                        rows = n,
+                        days = initial_days,
+                        "ids retention: initial purge complete"
+                    )
+                }
                 Err(e) => error!("ids retention: initial purge failed: {e}"),
             }
+            purged_since_vacuum =
+                maybe_reclaim(&output, purged_since_vacuum, VACUUM_AFTER_PURGED_ROWS).await;
 
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(3600));
             interval.tick().await; // burn the first immediate tick
@@ -521,12 +536,18 @@ impl IdsEngine {
                 let days = retention_config.config().alert_retention_days;
                 match output.purge_old(days).await {
                     Ok(0) => {}
-                    Ok(n) => info!(rows = n, days, "ids retention: purged old alerts"),
+                    Ok(n) => {
+                        purged_since_vacuum += n;
+                        info!(rows = n, days, "ids retention: purged old alerts")
+                    }
                     Err(e) => error!("ids retention: purge failed: {e}"),
                 }
-                if let Err(e) = output.purge_invalid_timestamps().await {
-                    error!("ids retention: invalid-timestamp scrub failed: {e}");
+                match output.purge_invalid_timestamps().await {
+                    Ok(n) => purged_since_vacuum += n,
+                    Err(e) => error!("ids retention: invalid-timestamp scrub failed: {e}"),
                 }
+                purged_since_vacuum =
+                    maybe_reclaim(&output, purged_since_vacuum, VACUUM_AFTER_PURGED_ROWS).await;
             }
         });
     }
@@ -756,6 +777,29 @@ async fn detect_network_interfaces() -> Vec<String> {
 
 /// Capture worker — uses BPF on FreeBSD, pcap mock on Linux.
 /// Reads raw packets directly from the kernel with zero shell overhead.
+/// Run the space reclaim (VACUUM + WAL truncate) once `purged` crosses
+/// `threshold`; returns the new purged-since-vacuum counter. On reclaim
+/// failure the counter is kept so the next sweep retries.
+async fn maybe_reclaim(
+    output: &crate::output::sqlite::SqliteOutput,
+    purged: u64,
+    threshold: u64,
+) -> u64 {
+    if purged < threshold {
+        return purged;
+    }
+    match output.reclaim_space().await {
+        Ok(()) => {
+            info!(purged_rows = purged, "ids retention: reclaimed disk space");
+            0
+        }
+        Err(e) => {
+            warn!("ids retention: space reclaim failed (will retry next sweep): {e}");
+            purged
+        }
+    }
+}
+
 fn capture_interface_worker(
     iface: &str,
     detection: &std::sync::Arc<detect::DetectionEngine>,

--- a/aifw-ids/src/output/sqlite.rs
+++ b/aifw-ids/src/output/sqlite.rs
@@ -259,6 +259,20 @@ impl SqliteOutput {
         Ok(result.rows_affected())
     }
 
+    /// Reclaim disk space after mass deletions. A bare DELETE only frees
+    /// pages to SQLite's freelist — an appliance in the field sat at a
+    /// 2.9GB DB file holding 34 alert rows (#601). VACUUM rewrites the
+    /// file; the TRUNCATE checkpoint shrinks the WAL that the rewrite
+    /// itself streams through (without it the gigabytes just move into
+    /// aifw.db-wal).
+    pub async fn reclaim_space(&self) -> Result<()> {
+        sqlx::query("VACUUM").execute(&self.pool).await?;
+        sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     /// Scrub rows whose `timestamp` column is implausible — system-clock skew
     /// at insert time has left rows dated year 9920 or 2012 on appliances in
     /// the field. The companion guard at insert time (`sanitize_alert_timestamp`)

--- a/aifw-ui/src/app/ids/alerts/page.tsx
+++ b/aifw-ui/src/app/ids/alerts/page.tsx
@@ -82,6 +82,8 @@ export default function IdsAlertsPage() {
 
   // Acknowledging
   const [ackingId, setAckingId] = useState<string | null>(null);
+  const [purgeConfirm, setPurgeConfirm] = useState(false);
+  const [purging, setPurging] = useState(false);
 
   const clearFeedback = useCallback(() => {
     setTimeout(() => setFeedback(null), 4000);
@@ -133,6 +135,27 @@ export default function IdsAlertsPage() {
       clearFeedback();
     } finally {
       setAckingId(null);
+    }
+  }
+
+  async function handlePurgeAll() {
+    setPurging(true);
+    setFeedback(null);
+    try {
+      // Deletes every stored alert and reclaims the disk space (VACUUM) —
+      // millions of stale alerts have bloated appliances to multi-GB DBs.
+      const res = await api.delete<{ message?: string }>("/api/v1/ids/alerts");
+      setFeedback({ type: "success", message: res.message || "All alerts purged" });
+      clearFeedback();
+      setPage(0);
+      await fetchAlerts();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Failed to purge alerts";
+      setFeedback({ type: "error", message: msg });
+      clearFeedback();
+    } finally {
+      setPurging(false);
+      setPurgeConfirm(false);
     }
   }
 
@@ -199,8 +222,40 @@ export default function IdsAlertsPage() {
           >
             Filter
           </button>
+          <button
+            onClick={() => setPurgeConfirm(true)}
+            disabled={purging || total === 0}
+            className="ml-auto px-4 py-2 bg-red-600/80 hover:bg-red-600 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium rounded-md transition-colors"
+            title="Delete every stored alert and reclaim disk space"
+          >
+            {purging ? "Clearing..." : "Clear All Alerts"}
+          </button>
         </div>
       </div>
+
+      {/* Clear-all confirmation */}
+      {purgeConfirm && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50" onClick={() => setPurgeConfirm(false)}>
+          <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-6 max-w-md w-full mx-4 space-y-3" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-lg font-semibold text-[var(--text-primary)]">Clear all IDS alerts?</h3>
+            <p className="text-sm text-[var(--text-muted)]">
+              This permanently deletes all {total.toLocaleString()} stored alerts and reclaims the
+              disk space. It cannot be undone. Retention normally prunes alerts automatically
+              (IDS &rarr; Settings &rarr; Alert Retention) — use this for one-off cleanup.
+            </p>
+            <div className="flex gap-2 justify-end pt-1">
+              <button onClick={() => setPurgeConfirm(false)}
+                className="px-4 py-1.5 text-sm rounded-md border border-[var(--border)] text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors">
+                Cancel
+              </button>
+              <button onClick={handlePurgeAll} disabled={purging}
+                className="px-4 py-1.5 text-sm font-medium rounded-md bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white transition-colors">
+                {purging ? "Clearing..." : "Delete All"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Alerts Table */}
       <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg overflow-hidden">

--- a/aifw-ui/src/app/ids/settings/page.tsx
+++ b/aifw-ui/src/app/ids/settings/page.tsx
@@ -50,7 +50,7 @@ export default function IdsSettingsPage() {
     home_net: ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"],
     external_net: ["!$HOME_NET"],
     interfaces: [],
-    alert_retention_days: 30,
+    alert_retention_days: 7,
     eve_log_enabled: false,
     eve_log_path: "/var/log/aifw/eve.json",
     syslog_target: "",
@@ -83,7 +83,7 @@ export default function IdsSettingsPage() {
         home_net: d.home_net || ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"],
         external_net: d.external_net || ["!$HOME_NET"],
         interfaces: d.interfaces || [],
-        alert_retention_days: d.alert_retention_days ?? 30,
+        alert_retention_days: d.alert_retention_days ?? 7,
         eve_log_enabled: d.eve_log_enabled ?? false,
         eve_log_path: d.eve_log_path || "/var/log/aifw/eve.json",
         syslog_target: d.syslog_target || "",
@@ -335,21 +335,27 @@ export default function IdsSettingsPage() {
           {/* Alert Retention */}
           <div>
             <label className="block text-xs text-[var(--text-muted)] mb-1">
-              Alert Retention (days)
+              Alert Retention
             </label>
-            <input
-              type="number"
+            <select
               value={config.alert_retention_days}
               onChange={(e) =>
                 setConfig({
                   ...config,
-                  alert_retention_days: parseInt(e.target.value) || 30,
+                  alert_retention_days: parseInt(e.target.value) || 7,
                 })
               }
-              min={1}
-              max={365}
               className="w-full bg-[var(--bg-primary)] border border-[var(--border)] rounded-md px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)] transition-colors"
-            />
+            >
+              <option value={1}>1 day</option>
+              <option value={7}>7 days (default)</option>
+              <option value={30}>1 month</option>
+              <option value={90}>3 months</option>
+              <option value={365}>1 year</option>
+            </select>
+            <p className="mt-1 text-[11px] text-[var(--text-muted)]">
+              Older alerts are pruned hourly; disk space is reclaimed automatically after large purges.
+            </p>
           </div>
 
           {/* Syslog Target */}


### PR DESCRIPTION
Follow-up to #601, from operating the appliance: millions of stale alerts were causing real issues, and clearing them revealed that deletion alone doesn't return the space — the appliance sat at a **2.9GB DB file holding 34 rows** (DELETE freelists pages; the VACUUM rewrite streams through the WAL, so without a TRUNCATE checkpoint the gigabytes just migrate into `aifw.db-wal`).

- **Manual purge**: the Alerts page gets a *Clear All Alerts* button (confirm modal, shows the count); new CLI `aifw ids purge-alerts [--yes]`. Both delete everything, reclaim the space, and the API path audit-logs it.
- **Auto space reclaim**: the hourly retention sweep now runs VACUUM + WAL truncate once 100k purged rows accumulate (carries the counter over on busy/failure and retries next sweep).
- **Retention timeframe**: default drops 30 → 7 days; the IDS settings field becomes a preset select (1 day / 7 days / 1 month / 3 months / 1 year). Pruning continues to run as the hourly scheduled job (which since #602 runs regardless of IDS mode).
- CLI additionally gets `aifw ids retention [days]` to show/set the window, with graceful behavior on DBs the IDS subsystem never initialized.

822 tests pass; UI lint + static export clean; CLI flows smoke-tested including confirm prompt, --yes, bounds, and uninitialized-DB paths.