### PR TITLE
release: v5.111.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "5.110.1"
+version = "5.111.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.110.1",
+  "version": "5.111.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.110.1",
+      "version": "5.111.0",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aifw-ui",
 
-  "version": "5.110.1",
+  "version": "5.111.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Version bump 5.110.1 → 5.111.0 (minor — #606 adds features).

**Merge order matters**: land #605 (FreeBSD-target warnings + Updates-page restart hangs) and #606 (IDS alert purge / auto space reclaim / 7-day retention default) *before* this, then merge this bump last so the built tarball contains everything it claims.

Release contents once all three are in:
- IDS: *Clear All Alerts* in the UI, `aifw ids purge-alerts` / `aifw ids retention` in the CLI, automatic VACUUM + WAL truncate after mass deletions, retention preset select defaulting to **7 days**
- Updates page: local-install and confirm-restart flows can no longer hang forever when the API bounces mid-request
- Zero cargo warnings on the FreeBSD target (cfg-gated code Linux CI never sees)

**After merging**, on the build machine:
```
cd ~/AiFw && git pull
sh freebsd/build-update.sh
sh freebsd/release.sh        # pre-release by default; artifacts now self-chown (#604)
```
Validate on the test appliance, then promote:
`gh release edit v5.111.0 --prerelease=false --latest`