### PR TITLE
Move builds to FreeBSD 15.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ''
 e.g. 5.8.0
 
 **FreeBSD Version**
-e.g. FreeBSD 15.0-RELEASE
+e.g. FreeBSD 15.1-RELEASE
 
 **Component**
 Which part of AiFw is affected?

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -16,7 +16,7 @@ permissions:
   attestations: write
 
 env:
-  FREEBSD_VERSION: "15.0"
+  FREEBSD_VERSION: "15.1"
 
 jobs:
   build-ui:

--- a/.github/workflows/freebsd-functional.yml
+++ b/.github/workflows/freebsd-functional.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run harness in FreeBSD VM
         uses: vmactions/freebsd-vm@77ed28d336d03fe19a3f4f7266c1d2c4714dd79d # v1.5.2
         with:
-          release: "15.0"
+          release: "15.1"
           usesh: true
           copyback: true
           prepare: |

--- a/freebsd/build-iso.sh
+++ b/freebsd/build-iso.sh
@@ -12,8 +12,8 @@ ARCH="${2:-amd64}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-FREEBSD_VERSION="15.0"
-FREEBSD_RELEASE="15.0-RELEASE"
+FREEBSD_VERSION="15.1"
+FREEBSD_RELEASE="15.1-RELEASE"
 FREEBSD_MIRROR="https://download.freebsd.org/releases/${ARCH}/${FREEBSD_RELEASE}"
 
 WORKDIR="/usr/obj/aifw-iso"

--- a/freebsd/release.sh
+++ b/freebsd/release.sh
@@ -230,7 +230,7 @@ fi
 
 BODY="## AiFw v${VERSION}
 
-AI-Powered Firewall for FreeBSD 15.0
+AI-Powered Firewall for FreeBSD 15.1
 ${TARBALL_ONLY_NOTE}
 
 ### Downloads


### PR DESCRIPTION
Bumps every FreeBSD version pin from 15.0 to 15.1-RELEASE (shipped June 16, supported to March 2027):

- `freebsd/build-iso.sh` — ISO base/kernel fetch
- `.github/workflows/build-iso.yml` — CI build VM + release notes text
- `.github/workflows/freebsd-functional.yml` — functional-test VM
- `freebsd/release.sh` — release notes text
- `.github/ISSUE_TEMPLATE/bug_report.md` — example string

The pinned `vmactions/freebsd-vm` commit (v1.5.2) already includes `conf/15.1.conf`, and `base.txz`/`kernel.txz` for 15.1-RELEASE are confirmed live on download.freebsd.org, so no other changes are needed.

Closes #609