### PR TITLE
OS dependency gate + guided FreeBSD release upgrades

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -6,6 +6,13 @@ on:
       version:
         description: 'Version (e.g. 5.32.7)'
         required: true
+      freebsd_version:
+        description: >-
+          FreeBSD release to build on (default 15.1). Set to an older
+          release to cut a transitional build installable on appliances
+          that have not upgraded their OS yet (#612).
+        required: false
+        default: '15.1'
   push:
     tags:
       - 'v*'
@@ -16,7 +23,7 @@ permissions:
   attestations: write
 
 env:
-  FREEBSD_VERSION: "15.1"
+  FREEBSD_VERSION: ${{ inputs.freebsd_version || '15.1' }}
 
 jobs:
   build-ui:
@@ -172,6 +179,9 @@ jobs:
             cp -a freebsd/overlay/usr/local/libexec/* "$TARBALL_DIR/libexec/"
             chmod 755 "$TARBALL_DIR"/rc.d/* "$TARBALL_DIR"/sbin/* "$TARBALL_DIR"/libexec/*
             echo "$VERSION" > "$TARBALL_DIR/version"
+            # OS floor stamp (#612): the updater refuses this tarball on a
+            # FreeBSD older than the VM it was built in.
+            freebsd-version -u | sed 's/-.*//' > "$TARBALL_DIR/required-os"
             cp /tmp/aifw-components.json "$TARBALL_DIR/components.json"
             tar -C /tmp -cJf "/usr/obj/aifw-iso/output/aifw-update-${VERSION}-amd64.tar.xz" "aifw-update-${VERSION}-amd64"
             cd /usr/obj/aifw-iso/output
@@ -404,6 +414,8 @@ jobs:
             ## AiFw v${{ steps.version.outputs.version }}
 
             AI-Powered Firewall for FreeBSD ${{ env.FREEBSD_VERSION }}
+
+            Requires-OS: FreeBSD ${{ env.FREEBSD_VERSION }}
 
             ### Downloads
 

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -1579,6 +1579,11 @@ async fn main() -> anyhow::Result<()> {
     // full reasoning.
     ensure_rc_services_enabled().await;
 
+    // Continue an OS release upgrade across the mid-flow reboot (#613):
+    // after booting the new kernel this runs the remaining
+    // freebsd-update install passes in the background.
+    updates::resume_os_upgrade(state.pool.clone()).await;
+
     // Collect VPN pass rules and inject into rule engine so they appear
     // before the default block in the aifw anchor
     match state.vpn_engine.collect_vpn_rules().await {

--- a/aifw-api/src/router.rs
+++ b/aifw-api/src/router.rs
@@ -640,6 +640,10 @@ pub(crate) fn updates_read() -> Router<AppState> {
             "/api/v1/updates/aifw/check",
             post(updates::aifw_check_update),
         )
+        .route(
+            "/api/v1/updates/os/upgrade",
+            get(updates::os_upgrade_status),
+        )
         .layer(middleware::from_fn(perm_check!(Permission::UpdatesRead)))
 }
 
@@ -663,6 +667,10 @@ pub(crate) fn updates_install() -> Router<AppState> {
         .route(
             "/api/v1/updates/aifw/prerelease",
             post(updates::set_prerelease_channel),
+        )
+        .route(
+            "/api/v1/updates/os/upgrade",
+            post(updates::start_os_upgrade),
         )
         .layer(middleware::from_fn(perm_check!(Permission::UpdatesInstall)))
 }

--- a/aifw-api/src/updates.rs
+++ b/aifw-api/src/updates.rs
@@ -383,6 +383,339 @@ pub async fn install_updates(
     Ok(Json(MessageResponse { message: msg }))
 }
 
+// ============================================================
+// OS release upgrade (#613)
+// ============================================================
+
+/// Persistent state of an OS release upgrade, stored in `update_config`
+/// so it survives the reboot in the middle of the flow.
+///
+/// Phases: `fetching` (freebsd-update -r X upgrade) → `installing`
+/// (kernel install) → `reboot_required` → `finalizing` (post-reboot
+/// userland install passes, driven by `resume_os_upgrade`) → `done`,
+/// or `failed` with the reason in `detail`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OsUpgradeState {
+    pub target: String,
+    pub phase: String,
+    pub detail: String,
+    pub started_at: String,
+    pub updated_at: String,
+}
+
+const OS_UPGRADE_KEY: &str = "os_upgrade_state";
+
+async fn load_os_upgrade(pool: &SqlitePool) -> Option<OsUpgradeState> {
+    let row = sqlx::query_as::<_, (String,)>("SELECT value FROM update_config WHERE key = ?1")
+        .bind(OS_UPGRADE_KEY)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten()?;
+    serde_json::from_str(&row.0).ok()
+}
+
+async fn store_os_upgrade(pool: &SqlitePool, state: &OsUpgradeState) {
+    if let Ok(json) = serde_json::to_string(state) {
+        save_config(pool, OS_UPGRADE_KEY, &json).await;
+    }
+}
+
+async fn set_os_upgrade_phase(
+    pool: &SqlitePool,
+    state: &mut OsUpgradeState,
+    phase: &str,
+    detail: String,
+) {
+    state.phase = phase.to_string();
+    state.detail = detail;
+    state.updated_at = Utc::now().to_rfc3339();
+    store_os_upgrade(pool, state).await;
+}
+
+/// Last chunk of a command's output, for progress/error surfacing.
+fn output_tail(out: &std::process::Output) -> String {
+    let text = if out.stderr.is_empty() {
+        String::from_utf8_lossy(&out.stdout)
+    } else {
+        String::from_utf8_lossy(&out.stderr)
+    };
+    let trimmed = text.trim();
+    match trimmed.char_indices().nth_back(499) {
+        Some((idx, _)) => trimmed[idx..].to_string(),
+        None => trimmed.to_string(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OsUpgradeRequest {
+    /// Bare target release, e.g. "15.1"
+    pub target: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OsUpgradeStatus {
+    /// FreeBSD userland release currently running, if detectable
+    pub current_os: Option<String>,
+    pub state: Option<OsUpgradeState>,
+}
+
+pub async fn os_upgrade_status(
+    State(state): State<AppState>,
+) -> Result<Json<OsUpgradeStatus>, StatusCode> {
+    Ok(Json(OsUpgradeStatus {
+        current_os: updater::current_os_release().await,
+        state: load_os_upgrade(&state.pool).await,
+    }))
+}
+
+pub async fn start_os_upgrade(
+    State(state): State<AppState>,
+    Json(req): Json<OsUpgradeRequest>,
+) -> Result<Json<MessageResponse>, (StatusCode, String)> {
+    let target = req.target.trim().to_string();
+    // Same format the sudo helper enforces; reject early with a clear 400.
+    let valid = {
+        let mut parts = target.split('.');
+        let maj = parts.next().and_then(|p| p.parse::<u32>().ok());
+        let min = parts.next().and_then(|p| p.parse::<u32>().ok());
+        maj.is_some() && min.is_some() && parts.next().is_none()
+    };
+    if !valid {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("target must be a bare release like \"15.1\", got \"{target}\""),
+        ));
+    }
+    let current = updater::current_os_release().await.ok_or((
+        StatusCode::BAD_REQUEST,
+        "cannot determine the running FreeBSD release".to_string(),
+    ))?;
+    if updater::os_satisfies(&current, &target) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("already on {current}; {target} is not newer"),
+        ));
+    }
+    if let Some(existing) = load_os_upgrade(&state.pool).await
+        && matches!(
+            existing.phase.as_str(),
+            "fetching" | "installing" | "finalizing"
+        )
+    {
+        return Err((
+            StatusCode::CONFLICT,
+            format!(
+                "an OS upgrade to {} is already {} — wait for it to finish",
+                existing.target, existing.phase
+            ),
+        ));
+    }
+
+    let now = Utc::now().to_rfc3339();
+    let mut job = OsUpgradeState {
+        target: target.clone(),
+        phase: "fetching".to_string(),
+        detail: format!("downloading FreeBSD {target} from {current}"),
+        started_at: now.clone(),
+        updated_at: now,
+    };
+    store_os_upgrade(&state.pool, &job).await;
+    log_update(
+        &state.pool,
+        "os_upgrade",
+        &format!("started: {current} → {target}"),
+        "running",
+    )
+    .await;
+
+    let pool = state.pool.clone();
+    tokio::spawn(async move {
+        // Phase 1: fetch + stage the release (the long part, minutes).
+        match aifw_core::sudo::freebsd_update_upgrade(&job.target).await {
+            Ok(o) if o.status.success() => {
+                set_os_upgrade_phase(
+                    &pool,
+                    &mut job,
+                    "installing",
+                    "installing the new kernel".into(),
+                )
+                .await;
+            }
+            Ok(o) => {
+                let tail = output_tail(&o);
+                set_os_upgrade_phase(&pool, &mut job, "failed", format!("fetch failed: {tail}"))
+                    .await;
+                log_update(
+                    &pool,
+                    "os_upgrade",
+                    &format!("fetch failed: {tail}"),
+                    "failed",
+                )
+                .await;
+                return;
+            }
+            Err(e) => {
+                set_os_upgrade_phase(&pool, &mut job, "failed", format!("fetch failed: {e}")).await;
+                log_update(&pool, "os_upgrade", &format!("fetch failed: {e}"), "failed").await;
+                return;
+            }
+        }
+        // Phase 2: first `install` pass writes the new kernel; the rest
+        // waits for a reboot.
+        match aifw_core::sudo::freebsd_update("install", &[]).await {
+            Ok(o) if o.status.success() => {
+                let detail = format!(
+                    "kernel for {} installed — reboot to continue; the remaining install runs automatically after boot",
+                    job.target
+                );
+                set_os_upgrade_phase(&pool, &mut job, "reboot_required", detail).await;
+                log_update(
+                    &pool,
+                    "os_upgrade",
+                    "kernel installed, reboot required",
+                    "running",
+                )
+                .await;
+            }
+            Ok(o) => {
+                let tail = output_tail(&o);
+                set_os_upgrade_phase(
+                    &pool,
+                    &mut job,
+                    "failed",
+                    format!("kernel install failed: {tail}"),
+                )
+                .await;
+                log_update(
+                    &pool,
+                    "os_upgrade",
+                    &format!("kernel install failed: {tail}"),
+                    "failed",
+                )
+                .await;
+            }
+            Err(e) => {
+                set_os_upgrade_phase(
+                    &pool,
+                    &mut job,
+                    "failed",
+                    format!("kernel install failed: {e}"),
+                )
+                .await;
+                log_update(
+                    &pool,
+                    "os_upgrade",
+                    &format!("kernel install failed: {e}"),
+                    "failed",
+                )
+                .await;
+            }
+        }
+    });
+
+    Ok(Json(MessageResponse {
+        message: format!("OS upgrade to {target} started"),
+    }))
+}
+
+/// Pick up an OS upgrade across restarts. Called once at aifw-api startup.
+///
+/// - After the mid-upgrade reboot (phase `reboot_required`, now running the
+///   target release): run the remaining `freebsd-update install` passes and
+///   mark the upgrade done.
+/// - A phase of `fetching`/`installing` at startup means the process died
+///   mid-run (crash, power loss): mark failed so the operator can retry.
+pub async fn resume_os_upgrade(pool: SqlitePool) {
+    let Some(mut job) = load_os_upgrade(&pool).await else {
+        return;
+    };
+    match job.phase.as_str() {
+        "reboot_required" => {
+            let Some(current) = updater::current_os_release().await else {
+                return;
+            };
+            if !updater::os_satisfies(&current, &job.target) {
+                // Not rebooted into the new kernel yet — nothing to do.
+                return;
+            }
+            set_os_upgrade_phase(
+                &pool,
+                &mut job,
+                "finalizing",
+                "installing the new userland".into(),
+            )
+            .await;
+            tokio::spawn(async move {
+                // freebsd-update needs up to three install passes after the
+                // reboot (world, then old-library cleanup). It exits
+                // non-zero with "No updates are available" once done.
+                for pass in 1..=3u32 {
+                    match aifw_core::sudo::freebsd_update("install", &[]).await {
+                        Ok(o) if o.status.success() => {
+                            tracing::info!(pass, "os upgrade: install pass complete");
+                        }
+                        Ok(o) => {
+                            let tail = output_tail(&o);
+                            if tail.contains("No updates are available") {
+                                break;
+                            }
+                            set_os_upgrade_phase(
+                                &pool,
+                                &mut job,
+                                "failed",
+                                format!("post-reboot install failed: {tail}"),
+                            )
+                            .await;
+                            log_update(
+                                &pool,
+                                "os_upgrade",
+                                &format!("post-reboot install failed: {tail}"),
+                                "failed",
+                            )
+                            .await;
+                            return;
+                        }
+                        Err(e) => {
+                            set_os_upgrade_phase(
+                                &pool,
+                                &mut job,
+                                "failed",
+                                format!("post-reboot install failed: {e}"),
+                            )
+                            .await;
+                            log_update(
+                                &pool,
+                                "os_upgrade",
+                                &format!("post-reboot install failed: {e}"),
+                                "failed",
+                            )
+                            .await;
+                            return;
+                        }
+                    }
+                }
+                let done_detail = format!(
+                    "running FreeBSD {} — AiFw updates are unblocked",
+                    job.target
+                );
+                let done_log = format!("completed: now on {}", job.target);
+                set_os_upgrade_phase(&pool, &mut job, "done", done_detail).await;
+                log_update(&pool, "os_upgrade", &done_log, "completed").await;
+            });
+        }
+        "fetching" | "installing" | "finalizing" => {
+            let detail = format!(
+                "interrupted during {} (service restarted mid-upgrade) — start the upgrade again to retry",
+                job.phase
+            );
+            set_os_upgrade_phase(&pool, &mut job, "failed", detail.clone()).await;
+            log_update(&pool, "os_upgrade", &detail, "failed").await;
+        }
+        _ => {}
+    }
+}
+
 pub async fn reboot_system() -> Result<Json<MessageResponse>, StatusCode> {
     // Schedule reboot in 10 seconds
     let _ = Command::new("/usr/local/bin/sudo")
@@ -576,6 +909,8 @@ pub async fn aifw_update_status(
         reboot_recommended: false,
         reboot_reason: None,
         include_prereleases: prereleases_enabled(&state.pool).await,
+        required_os: None,
+        os_upgrade_required: false,
     }))
 }
 
@@ -638,6 +973,24 @@ pub async fn aifw_install_update(
             reboot_recommended: false,
             reboot_reason: None,
         }));
+    }
+
+    // OS dependency gate (#612): fail before downloading when the release
+    // says it needs a newer FreeBSD. The tarball-level gate in the updater
+    // still backstops releases without the notes stamp.
+    if info.os_upgrade_required {
+        let required = info.required_os.clone().unwrap_or_default();
+        let current = updater::current_os_release()
+            .await
+            .unwrap_or_else(|| "unknown".to_string());
+        return Err((
+            StatusCode::PRECONDITION_FAILED,
+            format!(
+                "AiFw v{} requires FreeBSD {required} but this system runs {current}. \
+                 Upgrade the OS first (System → Updates → Operating system), then install the AiFw update.",
+                info.latest_version
+            ),
+        ));
     }
 
     let msg = updater::download_and_install(&info).await.map_err(|e| {

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -1864,7 +1864,16 @@ pub async fn update_check(pre: bool) -> anyhow::Result<()> {
     println!("  Latest version:  v{}", info.latest_version);
     if info.update_available {
         println!("  Update available!");
-        if info.tarball_url.is_some() {
+        if info.os_upgrade_required {
+            println!(
+                "  ⚠ Requires FreeBSD {} — upgrade the OS first:",
+                info.required_os.as_deref().unwrap_or("newer")
+            );
+            println!(
+                "    aifw update os-upgrade {}",
+                info.required_os.as_deref().unwrap_or("<version>")
+            );
+        } else if info.tarball_url.is_some() {
             println!("  Run 'aifw update install' to update.");
         } else {
             println!("  No update tarball found in the release.");
@@ -1896,6 +1905,20 @@ pub async fn update_install(auto_restart: bool, pre: bool) -> anyhow::Result<()>
             info.current_version
         );
         return Ok(());
+    }
+
+    // OS dependency gate (#612): don't download a release this OS can't
+    // run. The tarball-level gate in the updater backstops this.
+    if info.os_upgrade_required {
+        let required = info.required_os.as_deref().unwrap_or("newer");
+        anyhow::bail!(
+            "AiFw v{} requires FreeBSD {required} but this system runs {}.\n\
+             Upgrade the OS first: aifw update os-upgrade {required}",
+            info.latest_version,
+            updater::current_os_release()
+                .await
+                .unwrap_or_else(|| "unknown".to_string()),
+        );
     }
 
     println!(
@@ -2170,6 +2193,67 @@ pub async fn update_os_install() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// FreeBSD release upgrade (#613): fetch + stage the target release,
+/// install the new kernel, then hand back to the operator for the reboot.
+/// The remaining install passes run automatically when aifw-api starts on
+/// the new kernel (or manually via 'aifw update os-install').
+pub async fn update_os_upgrade(target: &str, yes: bool) -> anyhow::Result<()> {
+    use aifw_core::updater;
+
+    let current = updater::current_os_release()
+        .await
+        .ok_or_else(|| anyhow::anyhow!("cannot determine the running FreeBSD release"))?;
+    if updater::os_satisfies(&current, target) {
+        println!("Already on FreeBSD {current}; {target} is not newer. Nothing to do.");
+        return Ok(());
+    }
+
+    println!("FreeBSD release upgrade: {current} → {target}-RELEASE");
+    println!("  1. Download and stage the release (can take a while)");
+    println!("  2. Install the new kernel");
+    println!("  3. Reboot — the remaining install finishes after boot");
+    if !yes && !prompt_yes("Proceed with the OS upgrade?")? {
+        println!("Aborted.");
+        return Ok(());
+    }
+
+    println!("Downloading FreeBSD {target}-RELEASE (this is the long part)...");
+    let fetch = aifw_core::sudo::freebsd_update_upgrade(target).await?;
+    if !fetch.status.success() {
+        anyhow::bail!(
+            "release fetch failed: {}",
+            String::from_utf8_lossy(&fetch.stderr).trim()
+        );
+    }
+    println!("Release staged. Installing the new kernel...");
+    let install = aifw_core::sudo::freebsd_update("install", &[]).await?;
+    if !install.status.success() {
+        anyhow::bail!(
+            "kernel install failed: {}",
+            String::from_utf8_lossy(&install.stderr).trim()
+        );
+    }
+
+    println!();
+    println!("Kernel for {target}-RELEASE installed.");
+    println!("Reboot now with 'aifw update reboot'. After boot, the remaining");
+    println!("userland install runs automatically; check progress on the");
+    println!("Updates page or with 'aifw update os-check'.");
+    Ok(())
+}
+
+fn prompt_yes(question: &str) -> anyhow::Result<bool> {
+    use std::io::{BufRead, Write};
+
+    print!("{question} [y/N] ");
+    // best-effort prompt flush; a broken stdout pipe is unactionable here
+    std::io::stdout().flush().ok();
+    let mut line = String::new();
+    std::io::stdin().lock().read_line(&mut line)?;
+    let answer = line.trim().to_ascii_lowercase();
+    Ok(answer == "y" || answer == "yes")
 }
 
 // ============================================================

--- a/aifw-cli/src/main.rs
+++ b/aifw-cli/src/main.rs
@@ -331,6 +331,17 @@ enum UpdateAction {
     OsCheck,
     /// Install OS and package updates
     OsInstall,
+    /// Upgrade FreeBSD to a newer release (e.g. 15.1). Downloads and
+    /// stages the release, installs the new kernel, then asks for a
+    /// reboot; the remaining install finishes automatically after boot.
+    /// Required before installing an AiFw release built on a newer OS.
+    OsUpgrade {
+        /// Target release, e.g. "15.1"
+        target: String,
+        /// Skip the confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1353,6 +1364,9 @@ async fn main() -> anyhow::Result<()> {
             UpdateAction::Reboot => commands::update_reboot().await?,
             UpdateAction::OsCheck => commands::update_os_check().await?,
             UpdateAction::OsInstall => commands::update_os_install().await?,
+            UpdateAction::OsUpgrade { target, yes } => {
+                commands::update_os_upgrade(&target, yes).await?
+            }
         },
         Commands::Interfaces => {
             commands::interfaces_list().await?;

--- a/aifw-core/src/sudo.rs
+++ b/aifw-core/src/sudo.rs
@@ -188,6 +188,21 @@ pub async fn freebsd_update(
     sudo_with_fallback(&narrow, &fallback).await
 }
 
+/// Start a FreeBSD *release* upgrade (`freebsd-update -r X.Y-RELEASE
+/// upgrade`) through the helper, which validates the target format,
+/// refuses downgrades, and runs the merge prompts non-interactively
+/// (#613). `release` must be the bare version, e.g. "15.1".
+///
+/// No direct-freebsd-update fallback here on purpose: without the
+/// helper's yes-pipe the interactive merge prompt would hang forever.
+pub async fn freebsd_update_upgrade(release: &str) -> std::io::Result<std::process::Output> {
+    let target = format!("{release}-RELEASE");
+    Command::new(SUDO)
+        .args([HELPER_FREEBSD_UPDATE, "upgrade", "-r", &target])
+        .output()
+        .await
+}
+
 /// Run `pkg <action> [args...]` as root via the `aifw-sudo-pkg` helper.
 ///
 /// The helper restricts `action` to `update` / `install` / `upgrade`

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -251,6 +251,17 @@ pub enum UpdaterError {
     /// The release has no update tarball asset to install
     #[error("No update tarball found in release")]
     NoTarball,
+    /// The release's binaries need a newer FreeBSD than the running one.
+    /// Raised before any file is swapped, so the current install is intact.
+    #[error(
+        "this release requires FreeBSD {required} but this system runs {current} — upgrade the OS first (System → Updates), then install the AiFw update"
+    )]
+    OsUpgradeRequired {
+        /// Minimum FreeBSD release the update's binaries link against
+        required: String,
+        /// FreeBSD release currently running
+        current: String,
+    },
 }
 
 /// Update status reported to the UI/API by the GitHub release check
@@ -305,6 +316,16 @@ pub struct AifwUpdateInfo {
     /// only ever pull stable releases.
     #[serde(default)]
     pub include_prereleases: bool,
+    /// Minimum FreeBSD release the update's binaries need, parsed from the
+    /// `Requires-OS:` line in the release notes (e.g. "15.1"). None for
+    /// releases published before OS stamping.
+    #[serde(default)]
+    pub required_os: Option<String>,
+    /// True when `required_os` is newer than the running FreeBSD release.
+    /// The UI/CLI must steer the operator to the OS upgrade flow instead of
+    /// the AiFw install; the installer refuses anyway (#612).
+    #[serde(default)]
+    pub os_upgrade_required: bool,
 }
 
 /// Read the current installed AiFw version.
@@ -370,6 +391,11 @@ pub async fn check_for_update(include_prereleases: bool) -> Result<AifwUpdateInf
     let (has_backup, backup_version) = get_backup_info().await;
     let restart_pending = restart_pending().await;
     let (reboot_recommended, reboot_reason) = parse_reboot_hint(&notes);
+    let required_os = parse_required_os(&notes);
+    let os_upgrade_required = match (&required_os, current_os_release().await) {
+        (Some(req), Some(cur)) => !os_satisfies(&cur, req),
+        _ => false,
+    };
 
     Ok(AifwUpdateInfo {
         update_available: version_newer(&current, latest),
@@ -387,6 +413,8 @@ pub async fn check_for_update(include_prereleases: bool) -> Result<AifwUpdateInf
         reboot_recommended,
         reboot_reason,
         include_prereleases,
+        required_os,
+        os_upgrade_required,
     })
 }
 
@@ -410,6 +438,68 @@ fn parse_reboot_hint(notes: &str) -> (bool, Option<String>) {
         }
     }
     (false, None)
+}
+
+/// Look for a `Requires-OS:` line in release notes and extract the FreeBSD
+/// release it names (e.g. `Requires-OS: FreeBSD 15.1` → "15.1"). Written
+/// into release bodies by CI and release.sh from the version the binaries
+/// were built on; absent on older releases.
+fn parse_required_os(notes: &str) -> Option<String> {
+    const MARKER: &str = "Requires-OS:";
+    for line in notes.lines() {
+        if let Some(idx) = line.find(MARKER) {
+            let tail = &line[idx + MARKER.len()..];
+            if let Some(ver) = extract_os_version(tail) {
+                return Some(ver);
+            }
+        }
+    }
+    None
+}
+
+/// Pull the first `major.minor` token out of a string like
+/// "FreeBSD 15.1" or "15.0-RELEASE-p11".
+fn extract_os_version(s: &str) -> Option<String> {
+    for token in s.split(|c: char| !(c.is_ascii_digit() || c == '.')) {
+        if parse_os_release(token).is_some() {
+            return Some(token.to_string());
+        }
+    }
+    None
+}
+
+/// Parse "15.1" (optionally with a "-RELEASE..." suffix) into (major, minor).
+fn parse_os_release(s: &str) -> Option<(u32, u32)> {
+    let base = s.split('-').next().unwrap_or(s);
+    let mut parts = base.split('.');
+    let major = parts.next()?.parse::<u32>().ok()?;
+    let minor = parts.next()?.parse::<u32>().ok()?;
+    Some((major, minor))
+}
+
+/// Running FreeBSD userland release ("15.0-RELEASE-p11"), or None when
+/// `freebsd-version` isn't available (dev hosts, tests).
+pub async fn current_os_release() -> Option<String> {
+    let out = Command::new("freebsd-version")
+        .arg("-u")
+        .output()
+        .await
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let v = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!v.is_empty()).then_some(v)
+}
+
+/// True when the running release `current` satisfies `required`
+/// (major.minor compare; unparseable inputs are treated as satisfied so a
+/// malformed stamp can never brick updates).
+pub fn os_satisfies(current: &str, required: &str) -> bool {
+    match (parse_os_release(current), parse_os_release(required)) {
+        (Some(cur), Some(req)) => cur >= req,
+        _ => true,
+    }
 }
 
 /// Install an AiFw update from a local tarball path.
@@ -528,6 +618,21 @@ pub async fn install_from_path(
             "extracted dir '{}' not found (corrupt tarball?)",
             top_name
         )));
+    }
+
+    // OS dependency gate (#612): a tarball built on a newer FreeBSD ships
+    // binaries the running libc can't load (e.g. FBSD_1.9 on a 15.0 box) —
+    // installing them takes the whole management plane down in a
+    // crash-loop. Refuse before any file is swapped. Tarballs without the
+    // stamp predate this scheme and install as before.
+    if let Ok(required) = tokio::fs::read_to_string(update_dir.join("required-os")).await {
+        let required = required.trim().to_string();
+        if !required.is_empty()
+            && let Some(current) = current_os_release().await
+            && !os_satisfies(&current, &required)
+        {
+            return Err(UpdaterError::OsUpgradeRequired { required, current });
+        }
     }
 
     // Install binaries from the tarball's bin/ directory.
@@ -1549,6 +1654,72 @@ mod tests {
     fn tar_listing_accepts_normal_release() {
         let ok = "aifw-5.97.9/\naifw-5.97.9/bin/\naifw-5.97.9/bin/aifw-api\n./aifw-5.97.9/ui/index.html\n";
         assert!(validate_tar_listing(ok).is_ok());
+    }
+
+    // #612: the OS floor stamp in release notes must parse from the shapes
+    // CI and release.sh actually write.
+    #[test]
+    fn required_os_parses_from_release_notes() {
+        assert_eq!(
+            parse_required_os("## AiFw v5.113.0\n\nRequires-OS: FreeBSD 15.1\n"),
+            Some("15.1".to_string())
+        );
+        assert_eq!(
+            parse_required_os("Requires-OS: 15.1"),
+            Some("15.1".to_string())
+        );
+        assert_eq!(
+            parse_required_os("body without a marker\nFreeBSD 15.1 mentioned casually"),
+            None
+        );
+        assert_eq!(parse_required_os("Requires-OS: soon"), None);
+    }
+
+    #[test]
+    fn os_release_parsing_handles_patch_suffixes() {
+        assert_eq!(parse_os_release("15.1"), Some((15, 1)));
+        assert_eq!(parse_os_release("15.0-RELEASE-p11"), Some((15, 0)));
+        assert_eq!(parse_os_release("16.10-RELEASE"), Some((16, 10)));
+        assert_eq!(parse_os_release("garbage"), None);
+        assert_eq!(parse_os_release("15"), None);
+    }
+
+    // #612: version compare drives both the install gate and the UI hint.
+    // Minor 10 must beat minor 9 (numeric, not lexicographic), and
+    // unparseable stamps must never block an update.
+    #[test]
+    fn os_satisfies_compares_numerically_and_fails_open() {
+        assert!(os_satisfies("15.1-RELEASE-p1", "15.1"));
+        assert!(os_satisfies("15.10-RELEASE", "15.9"));
+        assert!(os_satisfies("16.0-RELEASE", "15.1"));
+        assert!(!os_satisfies("15.0-RELEASE-p11", "15.1"));
+        assert!(!os_satisfies("14.3-RELEASE", "15.0"));
+        assert!(os_satisfies("unknowable", "15.1"));
+        assert!(os_satisfies("15.1-RELEASE", "not-a-version"));
+    }
+
+    // #612/#613: the embedded self-healing copy of the freebsd-update
+    // helper must keep the validated `upgrade` action — losing it silently
+    // breaks the OS upgrade flow on appliances (sudoers drift, #204).
+    #[test]
+    fn embedded_freebsd_update_helper_supports_upgrade() {
+        let helper = EMBEDDED_SUDO_HELPERS
+            .iter()
+            .find(|(name, _)| *name == "aifw-sudo-freebsd-update")
+            .map(|(_, body)| *body)
+            .expect("aifw-sudo-freebsd-update must be embedded for self-healing");
+        assert!(
+            helper.contains("upgrade)"),
+            "helper lost its upgrade action"
+        );
+        assert!(
+            helper.contains("-RELEASE"),
+            "helper must validate the X.Y-RELEASE target format"
+        );
+        assert!(
+            helper.contains("yes |"),
+            "upgrade must run non-interactively or merge prompts hang the daemon"
+        );
     }
 
     // SEC-H11 (#296): the install allowlist is derived from the embedded

--- a/aifw-ui/src/app/updates/components/FirmwareCard.tsx
+++ b/aifw-ui/src/app/updates/components/FirmwareCard.tsx
@@ -90,7 +90,15 @@ export function FirmwareCard({
             {checking ? "Checking..." : "Check for Update"}
           </button>
 
+          {info?.update_available && info?.os_upgrade_required && (
+            <p className="max-w-56 text-xs text-yellow-400">
+              v{info.latest_version} requires FreeBSD {info.required_os}.
+              Upgrade the operating system first (card above), then install.
+            </p>
+          )}
+
           {info?.update_available &&
+            !info?.os_upgrade_required &&
             info?.tarball_url &&
             info?.checksum_url &&
             info?.checksum_signature_url && (

--- a/aifw-ui/src/app/updates/components/OsUpgradeCard.tsx
+++ b/aifw-ui/src/app/updates/components/OsUpgradeCard.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState } from "react";
+import { AifwUpdateInfo, OsUpgradeStatus } from "@/lib/api/updates";
+
+interface OsUpgradeCardProps {
+  osUpgrade: OsUpgradeStatus | null;
+  aifwInfo: AifwUpdateInfo | null;
+  starting: boolean;
+  rebooting: boolean;
+  onStart: (target: string) => void;
+  onReboot: () => void;
+}
+
+const PHASE_LABEL: Record<string, string> = {
+  fetching: "Downloading release",
+  installing: "Installing kernel",
+  reboot_required: "Reboot required",
+  finalizing: "Finishing install",
+  done: "Complete",
+  failed: "Failed",
+};
+
+/**
+ * FreeBSD release upgrade flow (#613). Shown when the latest AiFw release
+ * needs a newer OS than this box runs, or while/after an upgrade job is
+ * in flight. The upgrade runs server-side (freebsd-update), needs one
+ * reboot in the middle, and finishes itself after boot.
+ */
+export function OsUpgradeCard({
+  osUpgrade,
+  aifwInfo,
+  starting,
+  rebooting,
+  onStart,
+  onReboot,
+}: OsUpgradeCardProps) {
+  const [confirming, setConfirming] = useState(false);
+  const [rebootConfirming, setRebootConfirming] = useState(false);
+
+  const state = osUpgrade?.state ?? null;
+  const currentOs = osUpgrade?.current_os ?? null;
+  // Target preference: what the newest AiFw release demands; fall back to
+  // the target of the job already on record (retry-after-failure case).
+  const neededTarget =
+    (aifwInfo?.os_upgrade_required && aifwInfo?.required_os) || null;
+  const retryTarget = state?.phase === "failed" ? state.target : null;
+  const startTarget = neededTarget ?? retryTarget;
+
+  const active = ["fetching", "installing", "finalizing"].includes(
+    state?.phase ?? "",
+  );
+
+  // Nothing to say: no upgrade needed, none running, none recorded.
+  if (!state && !neededTarget) return null;
+
+  return (
+    <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-6">
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+        <div className="space-y-2">
+          <div>
+            <span className="text-xs text-[var(--text-muted)] uppercase tracking-wider">
+              Operating System Upgrade
+            </span>
+            <p className="text-xl font-semibold text-[var(--text-primary)]">
+              {currentOs ?? "Unknown"}
+              {startTarget && !active && state?.phase !== "done" && (
+                <span className="text-[var(--text-muted)]"> → {startTarget}-RELEASE</span>
+              )}
+              {state && (active || state.phase === "reboot_required") && (
+                <span className="text-[var(--text-muted)]"> → {state.target}-RELEASE</span>
+              )}
+            </p>
+          </div>
+
+          {neededTarget && !state && (
+            <p className="text-sm text-[var(--text-secondary)] max-w-xl">
+              AiFw v{aifwInfo?.latest_version} requires FreeBSD {neededTarget}.
+              Upgrade the operating system first; the AiFw update unlocks
+              afterwards.
+            </p>
+          )}
+
+          {state && (
+            <div className="flex flex-wrap items-center gap-2 pt-1">
+              <span
+                className={`inline-flex items-center gap-2 px-2.5 py-0.5 rounded-full text-xs font-medium border ${
+                  state.phase === "failed"
+                    ? "bg-red-500/15 text-red-400 border-red-500/30"
+                    : state.phase === "done"
+                      ? "bg-green-500/15 text-green-400 border-green-500/30"
+                      : state.phase === "reboot_required"
+                        ? "bg-yellow-500/15 text-yellow-400 border-yellow-500/30"
+                        : "bg-blue-500/15 text-blue-400 border-blue-500/30"
+                }`}
+              >
+                {active && (
+                  <div className="w-3 h-3 border-2 border-blue-400/30 border-t-blue-400 rounded-full animate-spin" />
+                )}
+                {PHASE_LABEL[state.phase] ?? state.phase}
+              </span>
+              <span className="text-xs text-[var(--text-muted)]">
+                {state.detail}
+              </span>
+            </div>
+          )}
+
+          {active && (
+            <p className="text-xs text-[var(--text-muted)]">
+              This can take a while — the full release is downloaded and
+              staged. The firewall keeps filtering throughout.
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-2 sm:flex-col sm:items-end">
+          {startTarget && !active && state?.phase !== "reboot_required" && !confirming && (
+            <button
+              onClick={() => setConfirming(true)}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded-md transition-colors"
+            >
+              {state?.phase === "failed" ? "Retry Upgrade" : `Upgrade to ${startTarget}`}
+            </button>
+          )}
+
+          {confirming && startTarget && (
+            <div className="flex flex-col items-end gap-2">
+              <p className="max-w-56 text-xs text-[var(--text-secondary)] text-right">
+                Downloads and installs FreeBSD {startTarget}. A reboot is
+                required partway through; the rest completes automatically
+                after boot.
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => {
+                    setConfirming(false);
+                    onStart(startTarget);
+                  }}
+                  disabled={starting}
+                  className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded-md disabled:opacity-50 flex items-center gap-2 transition-colors"
+                >
+                  {starting && (
+                    <div className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                  )}
+                  {starting ? "Starting..." : "Start Upgrade"}
+                </button>
+                <button
+                  onClick={() => setConfirming(false)}
+                  className="px-3 py-2 text-sm text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+
+          {state?.phase === "reboot_required" && !rebootConfirming && (
+            <button
+              onClick={() => setRebootConfirming(true)}
+              className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-sm rounded-md transition-colors"
+            >
+              Reboot to Continue
+            </button>
+          )}
+
+          {rebootConfirming && (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => {
+                  setRebootConfirming(false);
+                  onReboot();
+                }}
+                disabled={rebooting}
+                className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-sm rounded-md disabled:opacity-50 transition-colors"
+              >
+                {rebooting ? "Rebooting..." : "Confirm Reboot"}
+              </button>
+              <button
+                onClick={() => setRebootConfirming(false)}
+                className="px-3 py-2 text-sm text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/aifw-ui/src/app/updates/page.tsx
+++ b/aifw-ui/src/app/updates/page.tsx
@@ -6,6 +6,7 @@ import { FirmwareCard } from "./components/FirmwareCard";
 import { LocalInstallCard } from "./components/LocalInstallCard";
 import { MaintenanceWindowCard } from "./components/MaintenanceWindowCard";
 import { OsStatusCard } from "./components/OsStatusCard";
+import { OsUpgradeCard } from "./components/OsUpgradeCard";
 import { PendingPackagesCard } from "./components/PendingPackagesCard";
 import { RebootOverlay } from "./components/RebootOverlay";
 import { RestartConfirmModal } from "./components/RestartConfirmModal";
@@ -57,6 +58,18 @@ export default function UpdatesPage() {
       {updates.aifwInfo?.restart_pending && !updates.restartPrompt && (
         <RestartPendingBanner info={updates.aifwInfo} onRestart={updates.handleConfirmRestart} />
       )}
+
+      {/* OS release upgrade (#613) — shown when the newest AiFw release
+          needs a newer FreeBSD, or while an upgrade job is running. Sits
+          above the firmware card because it must happen first. */}
+      <OsUpgradeCard
+        osUpgrade={updates.osUpgrade}
+        aifwInfo={updates.aifwInfo}
+        starting={updates.osUpgradeStarting}
+        rebooting={updates.aifwRebooting}
+        onStart={updates.handleOsUpgrade}
+        onReboot={updates.handleConfirmReboot}
+      />
 
       {/* AiFw Firmware Card */}
       <FirmwareCard

--- a/aifw-ui/src/hooks/useUpdates.ts
+++ b/aifw-ui/src/hooks/useUpdates.ts
@@ -7,6 +7,7 @@ import { useFeedback } from "@/hooks/useFeedback";
 import {
   AifwUpdateInfo,
   MaintenanceWindow,
+  OsUpgradeStatus,
   UpdateHistoryEntry,
   UpdateStatus,
   LocalInstallResult,
@@ -14,6 +15,7 @@ import {
   checkAifwUpdate,
   checkForUpdates,
   getAifwUpdateStatus,
+  getOsUpgrade,
   getUpdateHistory,
   getUpdateSchedule,
   getUpdateStatus,
@@ -28,6 +30,7 @@ import {
   saveUpdateSchedule,
   scheduleReboot,
   setPrereleaseChannel,
+  startOsUpgrade,
 } from "@/lib/api/updates";
 
 // Restart-confirm modal state — shown after install/rollback succeeds.
@@ -71,6 +74,10 @@ export function useUpdates() {
   const [uploadProgress, setUploadProgress] = useState<number | null>(null);
   const [installLocalResult, setInstallLocalResult] = useState<LocalInstallResult | null>(null);
   const [localInstalling, setLocalInstalling] = useState(false);
+
+  // OS release upgrade state (#613)
+  const [osUpgrade, setOsUpgrade] = useState<OsUpgradeStatus | null>(null);
+  const [osUpgradeStarting, setOsUpgradeStarting] = useState(false);
 
   // AiFw firmware update state
   const [aifwInfo, setAifwInfo] = useState<AifwUpdateInfo | null>(null);
@@ -125,17 +132,34 @@ export function useUpdates() {
     }
   }, []);
 
+  const fetchOsUpgrade = useCallback(async () => {
+    try {
+      setOsUpgrade(await getOsUpgrade());
+    } catch {
+      // silent on poll
+    }
+  }, []);
+
   useEffect(() => {
     queueMicrotask(() => {
       // Load fast endpoints first, then slow ones in background
       Promise.all([fetchSchedule(), fetchHistory()]).finally(() => setLoading(false));
       fetchStatus();
       fetchAifwStatus();
+      fetchOsUpgrade();
     });
-  }, [fetchStatus, fetchSchedule, fetchHistory, fetchAifwStatus]);
+  }, [fetchStatus, fetchSchedule, fetchHistory, fetchAifwStatus, fetchOsUpgrade]);
 
   // Poll status while checking or installing
   usePolling(fetchStatus, 3000, checking || installing);
+
+  // Poll the OS release upgrade while a phase is running. `fetching` can
+  // take many minutes (freebsd-update downloads a whole release), so this
+  // is the only progress channel the operator has.
+  const osUpgradeActive = ["fetching", "installing", "finalizing"].includes(
+    osUpgrade?.state?.phase ?? "",
+  );
+  usePolling(fetchOsUpgrade, 5000, osUpgradeActive);
 
   const handleCheck = async () => {
     setChecking(true);
@@ -175,6 +199,20 @@ export function useUpdates() {
       showFeedback("error", err instanceof Error ? err.message : "Failed to schedule reboot");
     } finally {
       setRebooting(false);
+    }
+  };
+
+  const handleOsUpgrade = async (target: string) => {
+    setOsUpgradeStarting(true);
+    try {
+      const data = await startOsUpgrade(target);
+      showFeedback("success", data.message || `OS upgrade to ${target} started`);
+      fetchOsUpgrade();
+      fetchHistory();
+    } catch (err) {
+      showFeedback("error", err instanceof Error ? err.message : "Failed to start OS upgrade");
+    } finally {
+      setOsUpgradeStarting(false);
     }
   };
 
@@ -412,6 +450,10 @@ export function useUpdates() {
     handleCheck,
     handleInstall,
     handleReboot,
+    // OS release upgrade
+    osUpgrade,
+    osUpgradeStarting,
+    handleOsUpgrade,
     // Maintenance window
     schedule,
     setSchedule,

--- a/aifw-ui/src/lib/api/updates.ts
+++ b/aifw-ui/src/lib/api/updates.ts
@@ -54,6 +54,28 @@ export interface AifwUpdateInfo {
   // Operator opted this box into the pre-release update channel. When on,
   // checks/installs consider GitHub pre-releases, not just stable releases.
   include_prereleases?: boolean;
+  // Minimum FreeBSD release the update needs (parsed from `Requires-OS:`
+  // in the release notes). Null on releases published before OS stamping.
+  required_os?: string | null;
+  // The release needs a newer FreeBSD than this box runs — the OS upgrade
+  // flow must happen first; the installer refuses otherwise (#612).
+  os_upgrade_required?: boolean;
+}
+
+// ---- OS release upgrade (#613) ----
+
+export interface OsUpgradeState {
+  target: string;
+  // fetching | installing | reboot_required | finalizing | done | failed
+  phase: string;
+  detail: string;
+  started_at: string;
+  updated_at: string;
+}
+
+export interface OsUpgradeStatus {
+  current_os: string | null;
+  state: OsUpgradeState | null;
 }
 
 export interface UpdateInstallResponse {
@@ -98,6 +120,14 @@ export function installUpdates(): Promise<{ message?: string }> {
 
 export function scheduleReboot(): Promise<{ message?: string }> {
   return api.post<{ message?: string }>("/api/v1/updates/reboot");
+}
+
+export function getOsUpgrade(): Promise<OsUpgradeStatus> {
+  return api.get<OsUpgradeStatus>("/api/v1/updates/os/upgrade");
+}
+
+export function startOsUpgrade(target: string): Promise<{ message?: string }> {
+  return api.post<{ message?: string }>("/api/v1/updates/os/upgrade", { target });
 }
 
 // ---- AiFw firmware updates ----

--- a/freebsd/build-local.sh
+++ b/freebsd/build-local.sh
@@ -287,6 +287,9 @@ fi
 chmod 755 "$TARBALL_DIR"/rc.d/* "$TARBALL_DIR"/sbin/* "$TARBALL_DIR"/libexec/* 2>/dev/null || true
 
 echo "$VERSION" > "$TARBALL_DIR/version"
+# OS floor stamp (#612): the updater refuses this tarball on a FreeBSD
+# older than the build host — its binaries wouldn't link.
+freebsd-version -u | sed 's/-.*//' > "$TARBALL_DIR/required-os"
 
 # Write a manifest of what made it into the tarball — commit SHAs for every
 # component plus a quick sanity check on rDNS features. Makes stale companion

--- a/freebsd/build-update.sh
+++ b/freebsd/build-update.sh
@@ -251,6 +251,12 @@ chmod 755 "$TARBALL_DIR"/rc.d/* "$TARBALL_DIR"/sbin/* "$TARBALL_DIR"/libexec/* 2
 
 echo "$VERSION" > "$TARBALL_DIR/version"
 
+# Stamp the FreeBSD release these binaries link against (#612). The
+# updater refuses to install the tarball on an older OS — binaries built
+# on 15.1 need libc symbols a 15.0 box doesn't have and would crash-loop
+# every service. The build host's userland IS the compatibility floor.
+freebsd-version -u | sed 's/-.*//' > "$TARBALL_DIR/required-os"
+
 # Write a BUILD_MANIFEST so stale companion repos are visible at build time.
 {
     echo "AiFw             $(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-freebsd-update
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-freebsd-update
@@ -7,16 +7,22 @@
 #   - updatesready             — exit code reflects whether updates pending
 #   - fetch [--not-running-from-cron]
 #   - install                  — apply downloaded updates
+#   - upgrade -r X.Y-RELEASE   — release upgrade to a NEWER official
+#                                release only (#613); runs non-interactive
+#                                (yes-piped, PAGER=cat) so config-merge
+#                                prompts can't hang the daemon
 #
-# Other subcommands (cron, IDS, rollback, upgrade) are denied so a
-# compromised daemon can't, for example, `freebsd-update rollback` to
-# uninstall security patches or `freebsd-update IDS` to spam the system
-# with checksumming load.
+# Other subcommands (cron, IDS, rollback) are denied so a compromised
+# daemon can't, for example, `freebsd-update rollback` to uninstall
+# security patches or `freebsd-update IDS` to spam the system with
+# checksumming load. `upgrade` only ever moves forward to a
+# FreeBSD-signed release, so it grants no downgrade or arbitrary-code
+# primitive.
 
 set -eu
 
 if [ $# -lt 1 ]; then
-    echo "usage: $0 <updatesready|fetch|install>" >&2
+    echo "usage: $0 <updatesready|fetch|install|upgrade>" >&2
     exit 2
 fi
 
@@ -55,6 +61,36 @@ case "$ACTION" in
             exit 1
         fi
         exec /usr/sbin/freebsd-update install
+        ;;
+    upgrade)
+        if [ $# -ne 2 ] || [ "$1" != "-r" ]; then
+            echo "aifw-sudo-freebsd-update: usage: upgrade -r <X.Y-RELEASE>" >&2
+            exit 1
+        fi
+        REL="$2"
+        case "$REL" in
+            [0-9].[0-9]-RELEASE|[0-9].[0-9][0-9]-RELEASE|[0-9][0-9].[0-9]-RELEASE|[0-9][0-9].[0-9][0-9]-RELEASE)
+                ;;
+            *)
+                echo "aifw-sudo-freebsd-update: target must match X.Y-RELEASE, got: $REL" >&2
+                exit 1
+                ;;
+        esac
+        # Refuse downgrades: the grant is forward-only. dot-versions compare
+        # numerically field by field.
+        CUR="$(/bin/freebsd-version -u | sed 's/-.*//')"
+        CUR_MAJ="${CUR%%.*}"; CUR_MIN="${CUR#*.}"
+        NEW="${REL%-RELEASE}"
+        NEW_MAJ="${NEW%%.*}"; NEW_MIN="${NEW#*.}"
+        if [ "$NEW_MAJ" -lt "$CUR_MAJ" ] || { [ "$NEW_MAJ" -eq "$CUR_MAJ" ] && [ "$NEW_MIN" -le "$CUR_MIN" ]; }; then
+            echo "aifw-sudo-freebsd-update: $REL is not newer than running $CUR" >&2
+            exit 1
+        fi
+        # Non-interactive: `yes` feeds the "Does this look reasonable?"
+        # prompt, PAGER=cat stops more(1) from blocking on the diff review,
+        # EDITOR=true auto-accepts config merges (our /etc is appliance-
+        # managed; conflicts are resolved by the next AiFw update anyway).
+        yes | env PAGER=cat EDITOR=true /usr/sbin/freebsd-update -r "$REL" upgrade
         ;;
     *)
         echo "aifw-sudo-freebsd-update: unsupported action: $ACTION" >&2

--- a/freebsd/release.sh
+++ b/freebsd/release.sh
@@ -119,6 +119,22 @@ if [ -n "$UPDATE_TARBALL" ]; then
     echo "Verified update tarball payload is v${VERSION}"
 fi
 
+# --- OS floor for the release body (#612) ---
+# Read the required-os stamp out of the tarball so the release notes carry
+# a machine-readable `Requires-OS:` line. The updater's check endpoint
+# parses it to warn operators BEFORE they download a release their OS
+# can't run. Empty for tarballs built before stamping.
+REQUIRED_OS=""
+if [ -n "$UPDATE_TARBALL" ]; then
+    REQUIRED_OS="$(tar -xJOf "$UPDATE_TARBALL" "${INNER}/required-os" 2>/dev/null | tr -d '[:space:]')"
+fi
+if [ -n "$REQUIRED_OS" ]; then
+    REQUIRES_OS_LINE="
+Requires-OS: FreeBSD ${REQUIRED_OS}"
+else
+    REQUIRES_OS_LINE=""
+fi
+
 if [ -z "$ISO_UPLOAD" ] && [ -z "$IMG_UPLOAD" ] && [ -z "$UPDATE_TARBALL" ]; then
     die "No artifacts to release. Run build-local.sh first."
 fi
@@ -230,7 +246,8 @@ fi
 
 BODY="## AiFw v${VERSION}
 
-AI-Powered Firewall for FreeBSD 15.1
+AI-Powered Firewall for FreeBSD ${REQUIRED_OS:-15.1}
+${REQUIRES_OS_LINE}
 ${TARBALL_ONLY_NOTE}
 
 ### Downloads


### PR DESCRIPTION
Closes #612, closes #613.

## What this does

**Dependency gate (#612)** — an AiFw release can no longer install onto a FreeBSD that can't run its binaries (the failure that took the appliance's management plane down yesterday: 15.1-built binaries needing libc `FBSD_1.9` crash-looping on a 15.0 box):

- `build-update.sh`, `build-local.sh`, and the CI tarball step stamp a `required-os` file into the tarball from the build host's `freebsd-version`.
- CI and `release.sh` write a machine-readable `Requires-OS: FreeBSD X.Y` line into release notes; `check_for_update` parses it into `required_os` / `os_upgrade_required`.
- `install_from_path` reads the tarball stamp right after extraction and refuses **before any file is swapped**. Unstamped (older) tarballs install as before; unparseable stamps fail open.
- The install API/CLI refuse pre-download with a message pointing at the OS upgrade flow; the UI disables the install button and explains.

**Guided OS release upgrade (#613)** — the updates page (and `aifw update os-upgrade <ver>`) can now move the OS itself:

- The `aifw-sudo-freebsd-update` helper gains an `upgrade` action: strictly validated `-r X.Y-RELEASE`, forward-only (refuses downgrades), non-interactive (yes-piped, `PAGER=cat`, `EDITOR=true`) so merge prompts can't hang the daemon. No sudoers change needed — the existing grant delegates arg validation to the helper, and the helper self-heals onto appliances via the embedded-script bootstrap.
- `POST /updates/os/upgrade` runs the fetch + kernel install as a background job with persisted phase state (`fetching → installing → reboot_required → finalizing → done/failed`); `GET` polls it. After the operator reboots, `aifw-api` startup detects the new kernel and runs the remaining `freebsd-update install` passes automatically.
- New `OsUpgradeCard` on the updates page drives the whole flow with progress, confirm steps, and the reboot handoff; a phase-aware guard test keeps the helper's `upgrade` action from regressing (sudoers-drift pattern).

**Transitional release** — `build-iso.yml` gains a `freebsd_version` dispatch input (default 15.1). Cut one release with it set to `15.0` so current appliances can install the version that carries this gate; every release after that builds on 15.1 and is protected.

## Verification

- `cargo check` zero warnings, fmt + clippy clean
- 829 tests pass (4 new: notes parsing, version compare fail-open semantics, helper guard)
- `npm run lint` + static export build pass
- Shell syntax validated on the helper and all three build scripts