### PR TITLE
release: v5.112.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "5.112.0"
+version = "5.112.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.0",
+  "version": "5.112.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.112.0",
+      "version": "5.112.1",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.0",
+  "version": "5.112.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Version bump for the **Step 1 / transitional** release (see two-step plan for the FreeBSD 15.1 transition).

v5.112.1 is the release that carries the OS dependency gate and the guided OS upgrade flow (#612, #613, PR #614) to appliances still on FreeBSD 15.0. It MUST be built on 15.0 so their current updaters can install it:

**After merging, build via workflow dispatch** — Actions → Build FreeBSD ISO → Run workflow with:
- `version` = `5.112.1`
- `freebsd_version` = `15.0`

Then test on the 15.0 appliance and promote to Latest. Step 2: all later releases build on 15.1 (default) — gated boxes get walked through the OS upgrade first.

⚠ Do NOT promote any 15.1-built release (v5.111.0 pre-release included) to Latest until the fleet has installed v5.112.1 — pre-gate updaters install whatever Latest offers.