### PR TITLE
Survive a busy database at startup; bound the 24h alert metric

### DIFF
--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -760,99 +760,123 @@ async fn create_state_from_db(
     // SQLite serializes the actual writes (busy_timeout covers contention),
     // but statement parsing and pool round-trips overlap, cutting cold-boot
     // latency.
-    tokio::try_join!(
-        async { nat_engine.migrate().await.map_err(anyhow::Error::from) },
-        async { vpn_engine.migrate().await.map_err(anyhow::Error::from) },
-        async { ipsec_engine.migrate().await.map_err(anyhow::Error::from) },
-        async { geoip_engine.migrate().await.map_err(anyhow::Error::from) },
-        async {
-            multiwan_engine
-                .migrate()
-                .await
-                .map_err(|e| anyhow::anyhow!(e))
-        },
-        async {
-            gateway_engine
-                .migrate()
-                .await
-                .map_err(|e| anyhow::anyhow!(e))
-        },
-        async { group_engine.migrate().await.map_err(|e| anyhow::anyhow!(e)) },
-        async {
-            policy_engine
-                .migrate()
-                .await
-                .map_err(|e| anyhow::anyhow!(e))
-        },
-        async { leak_engine.migrate().await.map_err(|e| anyhow::anyhow!(e)) },
-        async { sla_engine.migrate().await.map_err(|e| anyhow::anyhow!(e)) },
-        async { ca::migrate(&pool).await.map_err(anyhow::Error::from) },
-        async { dhcp::migrate(&pool).await.map_err(anyhow::Error::from) },
-        async { updates::migrate(&pool).await.map_err(anyhow::Error::from) },
-        async { iface::migrate(&pool).await.map_err(anyhow::Error::from) },
-        async {
-            dns_resolver::migrate(&pool)
-                .await
-                .map_err(anyhow::Error::from)
-        },
-        async {
-            dns_blocklists::migrate(&pool)
-                .await
-                .map_err(anyhow::Error::from)
-        },
-        async {
-            aifw_core::s3_backup::migrate(&pool)
-                .await
-                .map_err(anyhow::Error::from)
-        },
-        async {
-            aifw_core::smtp_notify::migrate(&pool)
-                .await
-                .map_err(anyhow::Error::from)
-        },
-        async {
-            aifw_core::acme::migrate(&pool)
-                .await
-                .map_err(anyhow::Error::from)
-        },
-        async {
-            aifw_core::ddns::migrate(&pool)
-                .await
-                .map_err(anyhow::Error::from)
-        },
-        async {
-            reverse_proxy::migrate(&pool)
-                .await
-                .map_err(anyhow::Error::from)
-        },
-        async { system::migrate(&pool).await.map_err(anyhow::Error::from) },
-        async {
-            time_service::migrate(&pool)
-                .await
-                .map_err(anyhow::Error::from)
-        },
-        async { plugins::migrate(&pool).await.map_err(anyhow::Error::from) },
-        async {
-            aifw_core::config_manager::ConfigManager::new(pool.clone())
-                .migrate()
-                .await
-                .map_err(|e| anyhow::anyhow!(e))
-        },
-        async { alias_engine.migrate().await.map_err(|e| anyhow::anyhow!(e)) },
-        async {
-            cluster_engine
-                .migrate()
-                .await
-                .map_err(|e| anyhow::anyhow!(e))
-        },
-        async {
-            shaping_engine
-                .migrate()
-                .await
-                .map_err(|e| anyhow::anyhow!(e))
-        },
-        async { tls_engine.migrate().await.map_err(|e| anyhow::anyhow!(e)) },
-    )?;
+    //
+    // #616: migrations are idempotent (CREATE TABLE IF NOT EXISTS), so a
+    // "database is locked" — a WAL checkpoint or the IDS retention purge
+    // holding the write lock past busy_timeout — gets retried with backoff
+    // instead of exiting into a supervisor crash-loop, which is how a busy
+    // database kept the whole management plane down on a live appliance.
+    let mut migrate_attempt = 0u32;
+    loop {
+        let migrate_result = tokio::try_join!(
+            async { nat_engine.migrate().await.map_err(anyhow::Error::from) },
+            async { vpn_engine.migrate().await.map_err(anyhow::Error::from) },
+            async { ipsec_engine.migrate().await.map_err(anyhow::Error::from) },
+            async { geoip_engine.migrate().await.map_err(anyhow::Error::from) },
+            async {
+                multiwan_engine
+                    .migrate()
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))
+            },
+            async {
+                gateway_engine
+                    .migrate()
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))
+            },
+            async { group_engine.migrate().await.map_err(|e| anyhow::anyhow!(e)) },
+            async {
+                policy_engine
+                    .migrate()
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))
+            },
+            async { leak_engine.migrate().await.map_err(|e| anyhow::anyhow!(e)) },
+            async { sla_engine.migrate().await.map_err(|e| anyhow::anyhow!(e)) },
+            async { ca::migrate(&pool).await.map_err(anyhow::Error::from) },
+            async { dhcp::migrate(&pool).await.map_err(anyhow::Error::from) },
+            async { updates::migrate(&pool).await.map_err(anyhow::Error::from) },
+            async { iface::migrate(&pool).await.map_err(anyhow::Error::from) },
+            async {
+                dns_resolver::migrate(&pool)
+                    .await
+                    .map_err(anyhow::Error::from)
+            },
+            async {
+                dns_blocklists::migrate(&pool)
+                    .await
+                    .map_err(anyhow::Error::from)
+            },
+            async {
+                aifw_core::s3_backup::migrate(&pool)
+                    .await
+                    .map_err(anyhow::Error::from)
+            },
+            async {
+                aifw_core::smtp_notify::migrate(&pool)
+                    .await
+                    .map_err(anyhow::Error::from)
+            },
+            async {
+                aifw_core::acme::migrate(&pool)
+                    .await
+                    .map_err(anyhow::Error::from)
+            },
+            async {
+                aifw_core::ddns::migrate(&pool)
+                    .await
+                    .map_err(anyhow::Error::from)
+            },
+            async {
+                reverse_proxy::migrate(&pool)
+                    .await
+                    .map_err(anyhow::Error::from)
+            },
+            async { system::migrate(&pool).await.map_err(anyhow::Error::from) },
+            async {
+                time_service::migrate(&pool)
+                    .await
+                    .map_err(anyhow::Error::from)
+            },
+            async { plugins::migrate(&pool).await.map_err(anyhow::Error::from) },
+            async {
+                aifw_core::config_manager::ConfigManager::new(pool.clone())
+                    .migrate()
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))
+            },
+            async { alias_engine.migrate().await.map_err(|e| anyhow::anyhow!(e)) },
+            async {
+                cluster_engine
+                    .migrate()
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))
+            },
+            async {
+                shaping_engine
+                    .migrate()
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e))
+            },
+            async { tls_engine.migrate().await.map_err(|e| anyhow::anyhow!(e)) },
+        );
+        match migrate_result {
+            Ok(_) => break,
+            Err(e) if migrate_attempt < 5 && e.to_string().to_lowercase().contains("locked") => {
+                migrate_attempt += 1;
+                let wait = 5u64 * (1 << migrate_attempt.min(3));
+                tracing::warn!(
+                    attempt = migrate_attempt,
+                    wait_secs = wait,
+                    error = %e,
+                    "migrations hit a locked database; retrying"
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(wait)).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
 
     // Read aifw_cluster_enabled once at startup. The flag only changes on
     // config writes, so a cached value is always correct for the process lifetime.
@@ -1594,14 +1618,54 @@ async fn main() -> anyhow::Result<()> {
         Err(e) => tracing::warn!("Failed to collect VPN rules: {e}"),
     }
 
-    // Apply firewall filter rules (includes VPN pass rules) and NAT rules
+    // Apply firewall filter rules (includes VPN pass rules) and NAT rules.
+    //
+    // #616: a busy database (WAL checkpoint, IDS retention purge) can make
+    // these reads fail at the exact moment of a service restart. A firewall
+    // whose rule apply silently stayed at "warn once and never retry" runs
+    // with stale (or on cold boot, NO) anchor rules — so keep retrying in
+    // the background until each apply succeeds.
     if let Err(e) = state.rule_engine.apply_rules().await {
-        tracing::warn!("Failed to apply filter rules on startup: {e}");
+        tracing::warn!("Failed to apply filter rules on startup: {e} — retrying in background");
+        let rule_engine = state.rule_engine.clone();
+        tokio::spawn(async move {
+            for wait in [5u64, 10, 20, 40, 60, 60, 60, 60, 60, 60] {
+                tokio::time::sleep(std::time::Duration::from_secs(wait)).await;
+                match rule_engine.apply_rules().await {
+                    Ok(_) => {
+                        tracing::info!("Filter rules applied after startup retry");
+                        return;
+                    }
+                    Err(e) => tracing::warn!("filter rule apply retry failed: {e}"),
+                }
+            }
+            tracing::error!(
+                "filter rules never applied after startup retries — anchor may be stale; \
+                 fix the underlying error and POST /api/v1/reload"
+            );
+        });
     } else {
         tracing::info!("Filter rules applied on startup");
     }
     if let Err(e) = state.nat_engine.apply_rules().await {
-        tracing::warn!("Failed to apply NAT rules on startup: {e}");
+        tracing::warn!("Failed to apply NAT rules on startup: {e} — retrying in background");
+        let nat_engine = state.nat_engine.clone();
+        tokio::spawn(async move {
+            for wait in [5u64, 10, 20, 40, 60, 60, 60, 60, 60, 60] {
+                tokio::time::sleep(std::time::Duration::from_secs(wait)).await;
+                match nat_engine.apply_rules().await {
+                    Ok(_) => {
+                        tracing::info!("NAT rules applied after startup retry");
+                        return;
+                    }
+                    Err(e) => tracing::warn!("NAT rule apply retry failed: {e}"),
+                }
+            }
+            tracing::error!(
+                "NAT rules never applied after startup retries — anchor may be stale; \
+                 fix the underlying error and POST /api/v1/reload"
+            );
+        });
     } else {
         tracing::info!("NAT rules applied on startup");
     }
@@ -1779,9 +1843,14 @@ async fn main() -> anyhow::Result<()> {
                 // ingestion). This is a health signal — recent persistence,
                 // not lifetime total — hence the _24h field name. Refreshed
                 // every 10 minutes, cached between (#601).
+                //
+                // #619: bounded on BOTH sides. Clock-skew rows with future
+                // timestamps made an open-ended `>= now-1day` report 415k
+                // "alerts in 24h" on a box whose IDS had been silent for a
+                // month — masking the real state during an outage triage.
                 if heartbeat_ticks.is_multiple_of(10) {
                     let (count,): (i64,) = sqlx::query_as(
-                        "SELECT COUNT(*) FROM ids_alerts WHERE timestamp >= datetime('now', '-1 day')",
+                        "SELECT COUNT(*) FROM ids_alerts WHERE timestamp >= datetime('now', '-1 day') AND timestamp <= datetime('now', '+1 hour')",
                     )
                     .fetch_one(&mem_state.pool)
                     .await

--- a/aifw-core/src/db.rs
+++ b/aifw-core/src/db.rs
@@ -31,7 +31,11 @@ impl Database {
             // concurrently without blocking the dashboard / metrics loops.
             .journal_mode(SqliteJournalMode::Wal)
             .synchronous(SqliteSynchronous::Normal)
-            .busy_timeout(std::time::Duration::from_secs(5))
+            // 30s, not the old 5s: a large WAL checkpoint or the IDS
+            // retention purge holds the write lock for tens of seconds on a
+            // multi-GB database, and 5s turned every service (re)start into
+            // a "database is locked" crash-loop (#616).
+            .busy_timeout(std::time::Duration::from_secs(30))
             // PERF-H1: default cache is 2 MB and mmap is off, so aggregate
             // queries over multi-GB tables (e.g. ids_alerts on /ids/stats)
             // fault in from disk. Run per-connection on connect.


### PR DESCRIPTION
Closes #616, closes #619.

From today's appliance outage triage (v5.112.1 install on a 3.1 GB database):

**#616 — busy DB must not take down the management plane**
- `busy_timeout` 5s → 30s: a WAL checkpoint or the IDS retention purge (#601) holds the SQLite write lock for tens of seconds on a large database; 5s made every service restart a coin flip.
- Startup migrations are idempotent, so a `database is locked` failure now retries with backoff (up to 5 attempts) instead of exiting into a supervisor crash-loop — the exact failure that kept aifw-api down today until the IDS was manually stopped.
- The startup filter/NAT rule applies now retry in the background until they succeed instead of warning once — a firewall that boots without applying its anchors should never shrug that off.

**#619 — 24h alert metric bounded on both sides**
- `ids_alerts_db_24h` counted `timestamp >= now-1day` open-ended, so clock-skew rows with future timestamps reported a 415k/day alert storm on a box whose newest real alert was a month old — actively misleading during the outage. Now also bounded by `<= now+1h`.

**Not in this PR** (already fixed by #601 in v5.110.1, verifying live on the appliance before closing): #617 — retention was configured-but-unenforced only because the appliance ran v5.109.2, which predates the retention worker; the initial purge is running on the box now. #618 — the disabled-mode capture gate exists in current code; the writes-while-disabled were from a pre-v5.97 version.

Verification: cargo check zero warnings, fmt + clippy clean, 829 tests pass.