### PR TITLE
release: v5.112.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "5.112.1"
+version = "5.112.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ids/src/lib.rs
+++ b/aifw-ids/src/lib.rs
@@ -500,6 +500,14 @@ impl IdsEngine {
             let output = crate::output::sqlite::SqliteOutput::new(retention_pool);
             let mut purged_since_vacuum: u64 = 0;
 
+            // Hold off the boot purge (#616): after an update install the
+            // whole service stack restarts together, and the first purge on
+            // a stale appliance is massive. Give a concurrently starting
+            // aifw-api a quiet window for its migrations and initial rule
+            // applies before contending for the write lock — the upgrade
+            // path must complete without operator intervention.
+            tokio::time::sleep(std::time::Duration::from_secs(180)).await;
+
             // Initial scrub on startup so a stale appliance cleans itself up
             // without waiting an hour.
             match output.purge_invalid_timestamps().await {

--- a/aifw-ids/src/output/sqlite.rs
+++ b/aifw-ids/src/output/sqlite.rs
@@ -252,11 +252,39 @@ impl SqliteOutput {
     pub async fn purge_old(&self, days: u32) -> Result<u64> {
         // PERF-M2: bind the modifier so every retention tick reuses one
         // cached prepared statement instead of compiling a fresh one.
-        let result = sqlx::query("DELETE FROM ids_alerts WHERE timestamp < datetime('now', ?)")
-            .bind(format!("-{days} days"))
-            .execute(&self.pool)
-            .await?;
-        Ok(result.rows_affected())
+        //
+        // Batched (#616/#617): a stale appliance's first purge deletes
+        // millions of rows, and a single DELETE holds the SQLite write
+        // lock for the whole transaction — minutes on a multi-GB file,
+        // which starved aifw-api's startup into a crash-loop on a live
+        // box. Small batches with a yield between let other writers
+        // interleave; the upgrade path must work without intervention.
+        self.purge_batched(
+            "DELETE FROM ids_alerts WHERE rowid IN \
+             (SELECT rowid FROM ids_alerts WHERE timestamp < datetime('now', ?1) LIMIT ?2)",
+            Some(format!("-{days} days")),
+        )
+        .await
+    }
+
+    /// Run a windowed DELETE repeatedly until it stops matching rows,
+    /// sleeping briefly between batches so concurrent writers (api
+    /// migrations, alert ingestion) are never starved for long.
+    async fn purge_batched(&self, sql: &'static str, modifier: Option<String>) -> Result<u64> {
+        const BATCH: i64 = 20_000;
+        let mut total: u64 = 0;
+        loop {
+            let mut q = sqlx::query(sql);
+            if let Some(ref m) = modifier {
+                q = q.bind(m.clone());
+            }
+            let affected = q.bind(BATCH).execute(&self.pool).await?.rows_affected();
+            total += affected;
+            if (affected as i64) < BATCH {
+                return Ok(total);
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        }
     }
 
     /// Reclaim disk space after mass deletions. A bare DELETE only frees
@@ -278,14 +306,16 @@ impl SqliteOutput {
     /// the field. The companion guard at insert time (`sanitize_alert_timestamp`)
     /// prevents new ones; this method removes the existing pollution.
     pub async fn purge_invalid_timestamps(&self) -> Result<u64> {
-        let result = sqlx::query(
-            "DELETE FROM ids_alerts \
-             WHERE timestamp < '2020-01-01' \
-                OR timestamp > datetime('now', '+1 day')",
+        // Batched for the same reason as purge_old: hundreds of thousands
+        // of clock-skew rows in one DELETE monopolize the write lock.
+        self.purge_batched(
+            "DELETE FROM ids_alerts WHERE rowid IN \
+             (SELECT rowid FROM ids_alerts \
+              WHERE timestamp < '2020-01-01' \
+                 OR timestamp > datetime('now', '+1 day') LIMIT ?1)",
+            None,
         )
-        .execute(&self.pool)
-        .await?;
-        Ok(result.rows_affected())
+        .await
     }
 
     /// Get alert count by severity over the last 24 hours.

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.1",
+  "version": "5.112.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.112.1",
+      "version": "5.112.2",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.1",
+  "version": "5.112.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Version bump + the remaining hardening for a **zero-intervention** upgrade path. This supersedes v5.112.1 as the transitional 15.0-built release.

What a stock v5.109.2 / FreeBSD 15.0 appliance gets from this single update, with no SSH and no operator action beyond clicking install:

1. **OS dependency gate + guided OS upgrade** (#612, #613 / PR #614) — refuses 15.1-built releases until the OS is upgraded, and the updates page can drive the 15.0 → 15.1 upgrade itself.
2. **Busy-database startup resilience** (#616 / PR #620) — busy_timeout 30s, migration retries, background rule-apply retries.
3. **Retention purge hardening** (this PR) — the #601 retention worker's first purge on a stale box (2.9M rows here) now runs in 20k-row batches with yields, and waits 3 minutes after boot so the post-install service restart never fights it for the write lock. This is the failure that required manual IDS-stopping earlier today.

**After merging**: build on the 15.0 VM (172.29.50.110) via `build-update.sh 5.112.2` + `release.sh`, publish as pre-release, test the full journey on the snapshot-restored appliance, then promote.