### PR TITLE
release: v5.113.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "5.112.2"
+version = "5.113.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.2",
+  "version": "5.113.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.112.2",
+      "version": "5.113.0",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.2",
+  "version": "5.113.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
First **FreeBSD 15.1-built** release (Step 2 of the transition). Same code as v5.112.2 — the version marks the OS-floor jump to 15.1.

Built via the normal local flow on the 15.1 build VM (172.29.50.220). Its `Requires-OS: FreeBSD 15.1` stamp is what makes gated appliances (v5.112.2+) show the guided OS-upgrade flow; pre-gate appliances must take v5.112.2 first (promote it to Latest before this one).

⚠ Never promote this to Latest until every appliance that auto-pulls has installed v5.112.2 — pre-gate updaters install whatever Latest offers and 15.1 binaries crash-loop on 15.0.