### PR TITLE
Create /var/db/freebsd-update before running freebsd-update

### DIFF
--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-freebsd-update
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-freebsd-update
@@ -29,6 +29,12 @@ fi
 ACTION="$1"
 shift
 
+# ISO-installed appliances lack freebsd-update's state directory — the
+# live ISO mounts /var as tmpfs, so it never reaches the installed
+# system, and freebsd-update refuses to run rather than create it
+# (#623). We run as root; make it exist before any action.
+[ -d /var/db/freebsd-update ] || install -d -o root -g wheel -m 700 /var/db/freebsd-update
+
 case "$ACTION" in
     updatesready)
         if [ $# -ne 0 ]; then


### PR DESCRIPTION
Closes #623.

First live run of the guided OS upgrade (#613) failed at fetch: `freebsd-update: Directory does not exist or is not writable: /var/db/freebsd-update`. ISO-installed appliances lack the directory because the live ISO mounts /var as tmpfs, and freebsd-update won't create it itself. The sudo helper (which runs as root) now ensures it exists before any action; the helper self-heals onto appliances via the embedded-scripts bootstrap at aifw-api startup.

Ships to 15.0 appliances as v5.112.3 — they need it before they can run the OS upgrade. #624 (updater offers only the newest release) tracks the delivery gap this exposes; for the test appliance the pre-release channel's publish-order behavior covers it.