### PR TITLE
release: v5.112.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "5.113.0"
+version = "5.112.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.113.0",
+  "version": "5.112.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.113.0",
+      "version": "5.112.3",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.113.0",
+  "version": "5.112.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Transitional (15.0-built) release carrying the #623 fix: the sudo helper now creates `/var/db/freebsd-update` so the guided OS upgrade works on ISO-installed appliances. 15.0 boxes install this, then the OS upgrade to 15.1 can proceed.

Note main's version field steps back from 5.113.0 to 5.112.3 by design — 5.113.0 marks the 15.1 era and was already cut; this slots the fix underneath it for 15.0 boxes. Once the appliance is on 15.1 we should cut **v5.113.1** from current main as the promoted 15.1-era release, since the published v5.113.0 predates the #625 helper fix.

After merge: build on the 15.0 VM (172.29.50.110), publish pre-release.