### PR TITLE
OS upgrade flow: reboot button and post-reboot finalize (#627, #628)

### DIFF
--- a/aifw-api/src/updates.rs
+++ b/aifw-api/src/updates.rs
@@ -632,10 +632,15 @@ pub async fn resume_os_upgrade(pool: SqlitePool) {
     };
     match job.phase.as_str() {
         "reboot_required" => {
-            let Some(current) = updater::current_os_release().await else {
+            // #628: gate on the RUNNING KERNEL, not the userland. After the
+            // mid-upgrade reboot the kernel is on the target release while
+            // the userland is still old — the userland only catches up when
+            // the install passes below run, so a userland gate deadlocks
+            // the flow at "reboot required" forever.
+            let Some(kernel) = updater::running_kernel_release().await else {
                 return;
             };
-            if !updater::os_satisfies(&current, &job.target) {
+            if !updater::os_satisfies(&kernel, &job.target) {
                 // Not rebooted into the new kernel yet — nothing to do.
                 return;
             }

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -477,6 +477,20 @@ fn parse_os_release(s: &str) -> Option<(u32, u32)> {
     Some((major, minor))
 }
 
+/// Running kernel release from `uname -r` ("15.1-RELEASE-p1"), or None
+/// when unavailable. Distinct from [`current_os_release`] (userland):
+/// mid-OS-upgrade the box boots the new kernel while the userland is
+/// still old — that window is exactly when the post-reboot install
+/// passes must run (#628).
+pub async fn running_kernel_release() -> Option<String> {
+    let out = Command::new("uname").arg("-r").output().await.ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let v = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!v.is_empty()).then_some(v)
+}
+
 /// Running FreeBSD userland release ("15.0-RELEASE-p11"), or None when
 /// `freebsd-version` isn't available (dev hosts, tests).
 pub async fn current_os_release() -> Option<String> {
@@ -1337,30 +1351,38 @@ pub async fn restart_services_sync() {
 /// the aifw user without a password. We deliberately don't go through
 /// `daemon(8)` here — that would need a separate sudoers entry, and
 /// shutdown is already detached from our process tree by init.
+/// shutdown(8) invocation for an operator-requested reboot. `+10s` is
+/// load-bearing (#627): the sudoers grant is `/sbin/shutdown -r +10s *`
+/// exactly — any other grace period is refused by sudo. Keep in sync with
+/// the grant in aifw-setup's sudoers content.
+pub const SHUTDOWN_REBOOT_ARGS: [&str; 4] = [
+    "/sbin/shutdown",
+    "-r",
+    "+10s",
+    "AiFw: operator-requested reboot",
+];
+
+/// Schedule a full system reboot via shutdown(8) (10-second grace).
 pub async fn schedule_reboot() -> Result<(), UpdaterError> {
-    let result = Command::new("/usr/local/bin/sudo")
-        .args([
-            "/sbin/shutdown",
-            "-r",
-            "+1",
-            "AiFw: operator-requested reboot",
-        ])
-        .spawn();
-    match result {
-        Ok(mut child) => {
-            match child.wait().await {
-                Ok(status) if !status.success() => warn!(
-                    %status,
-                    "shutdown exited non-zero — reboot may not be scheduled"
-                ),
-                Err(e) => warn!(error = %e, "failed to reap shutdown command"),
-                Ok(_) => {}
-            }
-            info!("reboot scheduled (+1 min)");
-            Ok(())
-        }
-        Err(e) => Err(UpdaterError::Install(format!("schedule reboot: {}", e))),
+    // #627: a refused shutdown must be an error, not a warning — the UI
+    // shows a "system is going down" overlay on success, and a silent
+    // failure strands the operator on it forever (live appliance, during
+    // the first guided OS upgrade).
+    let output = Command::new("/usr/local/bin/sudo")
+        .args(SHUTDOWN_REBOOT_ARGS)
+        .output()
+        .await
+        .map_err(|e| UpdaterError::Install(format!("schedule reboot: {}", e)))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(UpdaterError::Install(format!(
+            "shutdown was refused ({}): {}",
+            output.status,
+            stderr.trim()
+        )));
     }
+    info!("reboot scheduled (+10s)");
+    Ok(())
 }
 
 /// Restart a single service with a hard 60-second timeout. If the underlying

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -2649,6 +2649,22 @@ mod pf_conf_tests {
 mod sudoers_tests {
     use super::sudoers_content;
 
+    /// #627 guard: the reboot the updater actually runs must match a
+    /// sudoers grant EXACTLY. The grant is `/sbin/shutdown -r +10s *`;
+    /// schedule_reboot() drifting to any other form (it shipped with
+    /// `-r +1`) makes sudo refuse and the UI strand the operator on a
+    /// "system is going down" overlay for a reboot that never happens.
+    #[test]
+    fn shutdown_grant_matches_updater_invocation() {
+        let args = aifw_core::updater::SHUTDOWN_REBOOT_ARGS;
+        let grant_prefix = format!("{} {} {}", args[0], args[1], args[2]);
+        let grant = format!("aifw ALL=(root) NOPASSWD: {grant_prefix} *");
+        assert!(
+            sudoers_content().lines().any(|l| l.trim() == grant),
+            "sudoers has no grant matching the updater's reboot invocation: {grant}"
+        );
+    }
+
     /// Structural-validity check on the sudoers content. We can't run
     /// `visudo -cf` from a Linux dev box, but we can enforce that every
     /// non-empty, non-comment line is a well-formed `aifw ALL=(<runas>)


### PR DESCRIPTION
Closes #627, closes #628. Both found live during the first guided 15.0 → 15.1 run on the appliance.

**#627** — the updates-section reboot button showed the going-down overlay but never rebooted: `schedule_reboot()` ran `shutdown -r +1` against the sudoers grant `/sbin/shutdown -r +10s *`; sudo refused; the warning was swallowed and the UI got a success. Now uses the granted `+10s` form, a refused shutdown propagates as an error, and a sudoers guard test (the #204 pattern) pins the invocation to the grant so it can't drift again.

**#628** — after rebooting into the new kernel, auto-finalize never ran: the gate checked the *userland* release (still old until the finalize itself runs — a deadlock). It now gates on the running kernel via `uname -r`.

Verification: cargo check zero warnings, fmt + clippy clean, full suite passes (830 incl. the new guard test).

Ships to the appliance as **v5.112.4** (15.0-userland box can install it; on the restart the fixed resume sees kernel 15.1 and completes the userland install automatically — the zero-intervention path, resumed).