### PR TITLE
release: v5.112.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "5.112.3"
+version = "5.112.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.3",
+  "version": "5.112.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.112.3",
+      "version": "5.112.4",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.3",
+  "version": "5.112.4",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Transitional (15.0-built) release carrying the #627/#628 fixes (PR #629): the updates-section reboot button actually reboots, and the OS-upgrade auto-finalize gates on the running kernel so it completes after the mid-upgrade reboot.

The appliance (15.1 kernel / 15.0 userland, upgrade parked at 'Reboot required') installs this and the service restart auto-finalizes the userland — resuming the zero-intervention flow where it stalled.

After merge: build on the 15.0 VM, publish pre-release.