### PR TITLE
fix: remove last two UI eslint-disable suppressions

### DIFF
--- a/aifw-ui/src/app/nat/flows/page.tsx
+++ b/aifw-ui/src/app/nat/flows/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useMemo, useRef, useCallback } from "react";
+import Image from "next/image";
 import { useWs } from "@/context/WsContext";
 import { fetchApi } from "@/lib/api";
 import { usePolling } from "@/lib/usePolling";
@@ -575,10 +576,12 @@ export default function NatFlowsPage() {
           {/* Firewall — uses the AiFw sidebar logo so this node matches the
               brand mark shown in the top-left. */}
           <div className="w-28 h-28 rounded-2xl bg-[var(--bg-primary)] border-2 border-[var(--border)] flex flex-col items-center justify-center shadow-lg shadow-black/40 px-2">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
+            <Image
               src="/logo-sidebar.png"
               alt="AiFw"
+              width={220}
+              height={44}
+              unoptimized
               className="h-10 w-auto object-contain opacity-95"
             />
             <p className="text-[8px] text-gray-500 mt-1">{connections.length} states</p>

--- a/aifw-ui/src/app/page.tsx
+++ b/aifw-ui/src/app/page.tsx
@@ -322,8 +322,10 @@ export default function Dashboard() {
       bpsIn: bIn,
       bpsOut: bOut,
     }].slice(-MAX_PTS));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ws.status]);
+    // WsContext sets status/system/interfaces in one batched commit per
+    // status_update frame, so these deps change together and this runs
+    // exactly once per tick — safe to append a history point unguarded.
+  }, [status, system, ifaces, pickNic]);
 
   const interfaceList = useMemo(() =>
     ifaces.map(i => ({ name: i.name })),


### PR DESCRIPTION
Closes #450 (QUAL-M15).

The audit flagged 9 `eslint-disable` comments; 7 were already cleaned up. This removes the final two:

**`src/app/page.tsx` — `react-hooks/exhaustive-deps`**
The live-metrics effect appends one history point per websocket tick, so it must not double-fire. `WsContext` sets `status`/`system`/`interfaces` in one message handler — React batches them into a single commit, so `ifaces`/`system` never change identity without `status` changing in the same commit. The honest dep list `[status, system, ifaces, pickNic]` therefore runs exactly once per tick, identical to the old `[ws.status]` behavior. A comment documents the invariant.

**`src/app/nat/flows/page.tsx` — `@next/next/no-img-element`**
Replaced the raw `<img>` logo with `next/image` `<Image ... unoptimized>`, matching the existing Sidebar usage (the UI is a static export, so the optimizer never runs anyway).

Verified: `npm run lint` clean, `npm run build` (static export) succeeds, `grep -r eslint-disable aifw-ui/src` returns nothing.