### PR TITLE
release: v5.112.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "5.112.4"
+version = "5.112.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.4",
+  "version": "5.112.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.112.4",
+      "version": "5.112.5",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.4",
+  "version": "5.112.5",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Transitional (15.0-built) release carrying the #632/#633 fixes (PR #634): verified OS-upgrade completion (demotes the appliance's false 'Complete' to a retryable failure at startup) and patch-level freebsd-update stand-down during in-flight release upgrades.

After merge: build + publish from the 15.0 VM; the appliance installs it, gets the Retry Upgrade button, and re-runs the 15.1 upgrade end to end with the working reboot button and verified finalize.