### PR TITLE
OS upgrade hardening: retry from any state, verified essentials (#636)

### DIFF
--- a/aifw-api/src/updates.rs
+++ b/aifw-api/src/updates.rs
@@ -571,6 +571,19 @@ pub async fn start_os_upgrade(
 
     let pool = state.pool.clone();
     tokio::spawn(async move {
+        // #636: every upgrade run starts from a pristine state directory.
+        // freebsd-update's state is its only memory and a stale or
+        // corrupted one (a previous interrupted run, interleaved patch
+        // operations) wedges the run in ways a general user can't escape.
+        // Reset is always safe — the fetch below rebuilds everything.
+        if let Ok(o) = aifw_core::sudo::freebsd_update_reset().await
+            && !o.status.success()
+        {
+            tracing::warn!(
+                "freebsd-update state reset failed (continuing): {}",
+                String::from_utf8_lossy(&o.stderr).trim()
+            );
+        }
         // Phase 1: fetch + stage the release (the long part, minutes).
         match aifw_core::sudo::freebsd_update_upgrade(&job.target).await {
             Ok(o) if o.status.success() => {
@@ -749,6 +762,18 @@ pub async fn resume_os_upgrade(pool: SqlitePool) {
                     Some(u) => updater::os_satisfies(&u, &job.target),
                     None => false,
                 };
+                // #636: version alone can't see a mangled install that
+                // deleted files — canary-check the essentials too.
+                let missing = updater::missing_canaries(&updater::OS_CANARY_FILES);
+                if userland_ok && !missing.is_empty() {
+                    let detail = format!(
+                        "upgrade left essential files damaged ({}) — use Retry to re-run the upgrade cleanly",
+                        missing.join(", ")
+                    );
+                    set_os_upgrade_phase(&pool, &mut job, "failed", detail.clone()).await;
+                    log_update(&pool, "os_upgrade", &detail, "failed").await;
+                    return;
+                }
                 if userland_ok {
                     let done_detail = format!(
                         "running FreeBSD {} — AiFw updates are unblocked",

--- a/aifw-core/src/sudo.rs
+++ b/aifw-core/src/sudo.rs
@@ -203,6 +203,17 @@ pub async fn freebsd_update_upgrade(release: &str) -> std::io::Result<std::proce
         .await
 }
 
+/// Wipe freebsd-update's state directory via the helper (#636). Always
+/// safe — fetch/upgrade rebuild it from the mirrors — and the universal
+/// recovery from a corrupted state (interleaved runs, interrupted
+/// installs) that otherwise wedges every subsequent attempt.
+pub async fn freebsd_update_reset() -> std::io::Result<std::process::Output> {
+    Command::new(SUDO)
+        .args([HELPER_FREEBSD_UPDATE, "reset"])
+        .output()
+        .await
+}
+
 /// Run `pkg <action> [args...]` as root via the `aifw-sudo-pkg` helper.
 ///
 /// The helper restricts `action` to `update` / `install` / `upgrade`

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -477,6 +477,31 @@ fn parse_os_release(s: &str) -> Option<(u32, u32)> {
     Some((major, minor))
 }
 
+/// Essential system files that must exist and be non-empty after an OS
+/// upgrade. A corrupted freebsd-update install once deleted
+/// /bin/freebsd-version without replacing it (#636) — version checks alone
+/// can't see that class of damage.
+pub const OS_CANARY_FILES: [&str; 4] = [
+    "/bin/sh",
+    "/bin/freebsd-version",
+    "/sbin/init",
+    "/sbin/pfctl",
+];
+
+/// Return the canary files from `paths` that are missing or empty.
+/// Empty result = system passes the post-upgrade sanity check.
+pub fn missing_canaries(paths: &[&str]) -> Vec<String> {
+    paths
+        .iter()
+        .filter(|p| {
+            std::fs::metadata(p)
+                .map(|m| !m.is_file() || m.len() == 0)
+                .unwrap_or(true)
+        })
+        .map(|p| p.to_string())
+        .collect()
+}
+
 /// Running kernel release from `uname -r` ("15.1-RELEASE-p1"), or None
 /// when unavailable. Distinct from [`current_os_release`] (userland):
 /// mid-OS-upgrade the box boots the new kernel while the userland is
@@ -1741,6 +1766,27 @@ mod tests {
         assert!(
             helper.contains("yes |"),
             "upgrade must run non-interactively or merge prompts hang the daemon"
+        );
+        // #636 hardening: retries must survive half-upgraded and
+        // corrupted states.
+        assert!(
+            helper.contains("--currently-running"),
+            "upgrade must pin the source release to the userland (#636)"
+        );
+        assert!(
+            helper.contains("reset)"),
+            "helper lost its reset action — clean retry depends on it (#636)"
+        );
+    }
+
+    // #636: the canary check must flag missing/empty essentials and pass
+    // on files that exist.
+    #[test]
+    fn canary_check_flags_missing_files() {
+        assert!(missing_canaries(&["/bin/sh"]).is_empty());
+        assert_eq!(
+            missing_canaries(&["/nonexistent/aifw-canary-test"]),
+            vec!["/nonexistent/aifw-canary-test".to_string()]
         );
     }
 

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-freebsd-update
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-freebsd-update
@@ -83,8 +83,11 @@ case "$ACTION" in
                 ;;
         esac
         # Refuse downgrades: the grant is forward-only. dot-versions compare
-        # numerically field by field.
-        CUR="$(/bin/freebsd-version -u | sed 's/-.*//')"
+        # numerically field by field. Falls back to the kernel when
+        # freebsd-version is unavailable (a mangled install once deleted
+        # it, #636) — a broken tool must not make upgrades unreachable.
+        CUR="$(/bin/freebsd-version -u 2>/dev/null | sed 's/-.*//')"
+        CUR="${CUR:-$(uname -r | sed 's/-.*//')}"
         CUR_MAJ="${CUR%%.*}"; CUR_MIN="${CUR#*.}"
         NEW="${REL%-RELEASE}"
         NEW_MAJ="${NEW%%.*}"; NEW_MIN="${NEW#*.}"
@@ -96,7 +99,26 @@ case "$ACTION" in
         # prompt, PAGER=cat stops more(1) from blocking on the diff review,
         # EDITOR=true auto-accepts config merges (our /etc is appliance-
         # managed; conflicts are resolved by the next AiFw update anyway).
-        yes | env PAGER=cat EDITOR=true /usr/sbin/freebsd-update -r "$REL" upgrade
+        #
+        # --currently-running pins the source release to the USERLAND
+        # (#636): freebsd-update otherwise derives it from the kernel, so a
+        # half-upgraded box (new kernel booted, userland still old) gets
+        # "Cannot upgrade from X to itself" and can never retry.
+        yes | env PAGER=cat EDITOR=true /usr/sbin/freebsd-update \
+            --currently-running "$CUR-RELEASE" -r "$REL" upgrade
+        ;;
+    reset)
+        # Clean-slate recovery (#636): freebsd-update's state directory is
+        # its only memory, and a corrupted one (interleaved operations,
+        # interrupted installs) wedges every later run. Wiping it is always
+        # safe — fetch/upgrade rebuild it from the mirrors — and turns
+        # "broken beyond retry" into "retry works".
+        if [ $# -ne 0 ]; then
+            echo "aifw-sudo-freebsd-update: 'reset' takes no extra args" >&2
+            exit 1
+        fi
+        rm -rf /var/db/freebsd-update
+        install -d -o root -g wheel -m 700 /var/db/freebsd-update
         ;;
     *)
         echo "aifw-sudo-freebsd-update: unsupported action: $ACTION" >&2


### PR DESCRIPTION
Closes #636. The 'no bundling' answer to the broken upgrade process: keep freebsd-update (FreeBSD's servers and signatures), but treat it as a single-owner, verified state machine whose retry recovers from anything:

1. **`--currently-running` from the userland** — retries work from half-upgraded states (new kernel + old userland previously got 'Cannot upgrade from X to itself').
2. **Clean-slate start** — a new `reset` helper action wipes `/var/db/freebsd-update` before every upgrade run; corrupted state (this weekend's INDEX-NEW damage) can no longer wedge the flow. Retry IS the recovery — no SSH.
3. **Canary verification** — done additionally requires `/bin/sh`, `/bin/freebsd-version`, `/sbin/init`, `/sbin/pfctl` to exist and be non-empty (a mangled install deleted freebsd-version on the live box; version checks alone can't see that).
4. Helper's version probe falls back to `uname` if freebsd-version itself is damaged.

Together with the already-merged #616/#623/#627/#628/#632/#633 fixes, the failure chain that required SSH surgery this weekend has every link broken. Guard tests pin the helper's actions.

831 tests pass; fmt + clippy clean. Next: v5.112.6, THE transitional 15.0-built release with the complete fix stack, then the clean snapshot-to-15.1 validation run.