### PR TITLE
release: v5.112.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "5.112.5"
+version = "5.112.6"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.5",
+  "version": "5.112.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.112.5",
+      "version": "5.112.6",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.5",
+  "version": "5.112.6",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
THE transitional 15.0-built release — the complete fix stack for the zero-intervention 15.0 → 15.1 journey: OS gate (#612), guided upgrade (#613), busy-DB startup resilience (#616), batched retention (#617/#621), state-dir creation (#623), working reboot (#627), kernel-gated finalize (#628), verified completion (#632), patch-update stand-down (#633), and retry-from-any-state + canary verification (#636).

After merge: build + publish from the 15.0 VM; supersedes v5.112.2–.4 (pruned). Validation run follows on the freshly restored v5.109.2 appliance.