### PR TITLE
release: v5.113.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "5.112.6"
+version = "5.113.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.6",
+  "version": "5.113.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.112.6",
+      "version": "5.113.1",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.6",
+  "version": "5.113.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
The 15.1-era release: identical code to v5.112.6, built on the 15.1 VM so its `Requires-OS: FreeBSD 15.1` stamp drives the guided OS upgrade on gated appliances. Replaces the burned v5.113.0 (predated the reboot/finalize/hardening fixes).

After merge: build + publish from the 15.1 VM (172.29.50.220). Then the validation run: the restored v5.109.2 appliance installs v5.112.6, gets gated on v5.113.1, upgrades its OS through the card, and lands on v5.113.1 — zero intervention.