### PR TITLE
Never strip the base system; self-heal stripped appliances (#641)

### DIFF
--- a/aifw-api/src/updates.rs
+++ b/aifw-api/src/updates.rs
@@ -571,6 +571,63 @@ pub async fn start_os_upgrade(
 
     let pool = state.pool.clone();
     tokio::spawn(async move {
+        // #641 pre-flight: stripped ISO installs are missing base files
+        // that freebsd-update's component detection samples — without
+        // them it decides world/base isn't installed and upgrades ONLY
+        // the kernel, silently. Restore them from the running release's
+        // own base.txz first. Markers cover the two biggest stripped
+        // trees; the repair itself is idempotent.
+        let base_stripped =
+            !updater::missing_canaries(&["/rescue/sh", "/usr/share/man/man1/ls.1.gz"]).is_empty();
+        if base_stripped {
+            set_os_upgrade_phase(
+                &pool,
+                &mut job,
+                "fetching",
+                "restoring base system files stripped by the installer (one-time, ~160 MB)".into(),
+            )
+            .await;
+            match aifw_core::sudo::freebsd_update_repair_base().await {
+                Ok(o) if o.status.success() => {
+                    log_update(&pool, "os_upgrade", "base repair complete", "running").await;
+                }
+                Ok(o) => {
+                    let tail = output_tail(&o);
+                    set_os_upgrade_phase(
+                        &pool,
+                        &mut job,
+                        "failed",
+                        format!("base repair failed: {tail}"),
+                    )
+                    .await;
+                    log_update(
+                        &pool,
+                        "os_upgrade",
+                        &format!("base repair failed: {tail}"),
+                        "failed",
+                    )
+                    .await;
+                    return;
+                }
+                Err(e) => {
+                    set_os_upgrade_phase(
+                        &pool,
+                        &mut job,
+                        "failed",
+                        format!("base repair failed: {e}"),
+                    )
+                    .await;
+                    log_update(
+                        &pool,
+                        "os_upgrade",
+                        &format!("base repair failed: {e}"),
+                        "failed",
+                    )
+                    .await;
+                    return;
+                }
+            }
+        }
         // #636: every upgrade run starts from a pristine state directory.
         // freebsd-update's state is its only memory and a stale or
         // corrupted one (a previous interrupted run, interleaved patch

--- a/aifw-core/src/sudo.rs
+++ b/aifw-core/src/sudo.rs
@@ -203,6 +203,17 @@ pub async fn freebsd_update_upgrade(release: &str) -> std::io::Result<std::proce
         .await
 }
 
+/// Restore base files a stripped ISO install is missing, from the running
+/// release's own base.txz on FreeBSD's mirror (#641). Without them,
+/// freebsd-update's component detection judges world/base "not installed"
+/// and release upgrades silently touch only the kernel.
+pub async fn freebsd_update_repair_base() -> std::io::Result<std::process::Output> {
+    Command::new(SUDO)
+        .args([HELPER_FREEBSD_UPDATE, "repair-base"])
+        .output()
+        .await
+}
+
 /// Wipe freebsd-update's state directory via the helper (#636). Always
 /// safe — fetch/upgrade rebuild it from the mirrors — and the universal
 /// recovery from a corrupted state (interleaved runs, interrupted

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -1777,6 +1777,10 @@ mod tests {
             helper.contains("reset)"),
             "helper lost its reset action — clean retry depends on it (#636)"
         );
+        assert!(
+            helper.contains("repair-base)"),
+            "helper lost its repair-base action — stripped appliances can't upgrade without it (#641)"
+        );
     }
 
     // #636: the canary check must flag missing/empty essentials and pass

--- a/freebsd/build-iso.sh
+++ b/freebsd/build-iso.sh
@@ -80,26 +80,15 @@ echo "[3/9] Extracting base system..."
 tar -xf "${DISTDIR}/base.txz" -C "$STAGEDIR"
 tar -xf "${DISTDIR}/kernel.txz" -C "$STAGEDIR"
 
-# --- Strip unnecessary components (file deletions only, no binary stripping) ---
-echo "[4/9] Stripping unnecessary components..."
-rm -rf "$STAGEDIR/usr/share/doc"
-rm -rf "$STAGEDIR/usr/share/examples"
-rm -rf "$STAGEDIR/usr/share/games"
-rm -rf "$STAGEDIR/usr/share/man"
-rm -rf "$STAGEDIR/usr/share/info"
-rm -rf "$STAGEDIR/usr/lib/debug"
-rm -rf "$STAGEDIR/usr/tests"
-rm -rf "$STAGEDIR/usr/share/calendar"
-rm -rf "$STAGEDIR/usr/share/dict"
-rm -rf "$STAGEDIR/usr/share/groff_font"
-rm -rf "$STAGEDIR/usr/share/me"
-rm -rf "$STAGEDIR/usr/share/openssl"
-rm -rf "$STAGEDIR/rescue"
-rm -rf "$STAGEDIR/usr/lib32"
-rm -rf "$STAGEDIR/var/db/etcupdate"
-echo "  Stripped size: $(du -sm "$STAGEDIR" | awk '{print $1}')MB"
-
-echo "  Stripped size: $(du -sh "$STAGEDIR" | awk '{print $1}')"
+# --- Base system ships COMPLETE (#641) ---
+# We used to strip ~43MB of base files (man pages, /rescue, docs) here.
+# freebsd-update's component detection samples exactly those files, so
+# every stripped appliance was silently judged to have no world/base
+# installed and release upgrades only ever touched the kernel. The
+# savings were ~15MB of compressed ISO; the cost was a broken OS upgrade
+# path on every deployed box. Never strip base files again.
+echo "[4/9] Base system kept complete (freebsd-update needs it, #641)"
+echo "  Base size: $(du -sh "$STAGEDIR" | awk '{print $1}')"
 
 # --- Install packages into staging via chroot ---
 echo "[5/9] Installing packages..."

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-freebsd-update
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-freebsd-update
@@ -107,6 +107,36 @@ case "$ACTION" in
         yes | env PAGER=cat EDITOR=true /usr/sbin/freebsd-update \
             --currently-running "$CUR-RELEASE" -r "$REL" upgrade
         ;;
+    repair-base)
+        # Restore base files that stripped ISO installs are missing (#641).
+        # freebsd-update's component detection samples those files; without
+        # them it decides world/base isn't installed and release upgrades
+        # silently touch only the kernel. Files come from the RUNNING
+        # userland release's own base.txz on FreeBSD's mirror — nothing of
+        # ours. Idempotent; extraction of paths absent from an archive is
+        # tolerated (base contents drift between releases).
+        if [ $# -ne 0 ]; then
+            echo "aifw-sudo-freebsd-update: 'repair-base' takes no extra args" >&2
+            exit 1
+        fi
+        REL="$(/bin/freebsd-version -u 2>/dev/null | sed 's/-.*//')"
+        REL="${REL:-$(uname -r | sed 's/-.*//')}"
+        case "$REL" in
+            [0-9].[0-9]|[0-9].[0-9][0-9]|[0-9][0-9].[0-9]|[0-9][0-9].[0-9][0-9]) ;;
+            *) echo "aifw-sudo-freebsd-update: cannot determine release" >&2; exit 1 ;;
+        esac
+        ARCH="$(uname -m)"
+        TARBALL="/tmp/aifw-base-repair.txz"
+        fetch -o "$TARBALL" "https://download.freebsd.org/releases/${ARCH}/${REL}-RELEASE/base.txz"
+        for p in rescue usr/share/man usr/share/doc usr/share/examples \
+                 usr/share/games usr/share/calendar usr/share/dict \
+                 usr/share/openssl var/db/etcupdate; do
+            tar -xf "$TARBALL" -C / "$p" 2>/dev/null || \
+                tar -xf "$TARBALL" -C / "./$p" 2>/dev/null || true
+        done
+        rm -f "$TARBALL"
+        echo "base repair complete for ${REL}-RELEASE"
+        ;;
     reset)
         # Clean-slate recovery (#636): freebsd-update's state directory is
         # its only memory, and a corrupted one (interleaved operations,


### PR DESCRIPTION
Closes #641 — the root cause of every failed guided OS upgrade.

**Diagnosis** (live, on the appliance): freebsd-update's component inspection reported `world/base ... do not seem to be installed` because the ISO build strips ~43MB of base files (man pages, /rescue, docs) that its detection samples. Result: silent kernel-only upgrades on every ISO-installed box, four consecutive validation failures, all with 'success' at the CLI level.

**Fix 1 — ISO**: the strip block in build-iso.sh is removed with a tombstone comment. Cost: ~15MB of compressed ISO.

**Fix 2 — deployed fleet self-heal**: new `repair-base` helper action fetches the *running* release's own base.txz from download.freebsd.org and restores the stripped paths (idempotent, FreeBSD's files, no bundling). The upgrade job runs it as a pre-flight when marker files are missing, with a visible 'restoring base system files' phase detail.

**Pilot result**: after repair, detection reports `kernel/generic world/base` and the 15.0→15.1 fetch staged **11,197 files** (vs ~40 before).

Also done alongside (release-channel hygiene, per operator request): ISO/IMG assets built with stripped bases were removed from ALL published releases — update tarballs remain; fresh install media returns with the first release cut after this merge.

831 tests pass (helper guard extended to pin repair-base); fmt + clippy clean.