### PR TITLE
release: v5.112.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "5.113.1"
+version = "5.112.7"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.113.1",
+  "version": "5.112.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.113.1",
+      "version": "5.112.7",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.113.1",
+  "version": "5.112.7",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
The final transitional (15.0-built) release: everything in v5.112.6 plus compatible-release selection (#624) and the base self-heal + un-stripped ISO (#641). Supersedes v5.112.6.

After merge: build + publish from the 15.0 VM. Once fleet boxes carry this, release ordering never matters again — #624 lets 15.0 and 15.1 releases coexist correctly.