### PR TITLE
release: v5.113.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "5.112.7"
+version = "5.113.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.7",
+  "version": "5.113.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.112.7",
+      "version": "5.113.2",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.112.7",
+  "version": "5.113.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
The 15.1-era release: identical code to v5.112.7, built on the 15.1 VM. Supersedes the withdrawn v5.113.0/v5.113.1.

⚠ Publish ONLY after the fleet's boxes have v5.112.7 (or any gated version) installed — pre-gate updaters take whatever is newest. After merge I'll build it on the 15.1 VM but hold publication until the test appliance is on v5.112.7.