### PR TITLE
Remote syslog forwarding (pf logs, IDS alerts, app logs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,7 @@ Base: `http://<ip>:8080/api/v1/`
 - **Status**: `GET /status`, `/connections`, `/metrics`, `/logs`, `POST /reload`
 - **IDS**: `GET/PUT /ids/config`, `POST /ids/reload`, `GET /ids/alerts`, `GET/PUT /ids/alerts/{id}`, `PUT /ids/alerts/{id}/acknowledge`, `GET/POST /ids/rulesets`, `PUT/DELETE /ids/rulesets/{id}`, `GET /ids/rules`, `GET/PUT /ids/rules/{id}`, `GET/POST /ids/suppressions` (paginated via `?limit=&offset=`), `DELETE /ids/suppressions/{id}`, `GET /ids/stats`
 - **DNS**: `GET/PUT /dns`
+- **Remote syslog**: `GET/PUT /settings/syslog`, `POST /settings/syslog/test`, `GET /settings/syslog/status` — forward pf logs / IDS alerts / app logs to a syslog server (shared client in `aifw-common/src/syslog/`, CLI `aifw syslog`, UI Settings → Remote Logging)
 - **Multiwan**: `GET/POST /multiwan/instances`, gateways/groups/policies/leak/preflight/sla under `/multiwan/{gateways,groups,policies,leak,preflight,sla}` — load-balancing, SLA-driven failover, leak detection. Implementation in `aifw-core/src/multiwan/` + `aifw-api/src/multiwan.rs`.
 - **Reverse proxy** (control plane for the external TrafficCop daemon): HTTP/TCP/UDP routers, services, middlewares, TLS certs under `/reverse-proxy/*`. Implementation in `aifw-api/src/reverse_proxy.rs`; data plane is the `trafficcop` service shipped via `freebsd/manifest.json`.
 - **ACME**: `GET/POST /acme/certs`, providers, exports under `/acme/*` — Let's Encrypt cert issuance + push to local TLS store / file / webhook.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ High-performance firewall for FreeBSD built in Rust on top of pf. Optional AI/ML
 - **TLS inspection** — JA3/JA3S fingerprinting, SNI filtering, cert validation, version enforcement
 - **Plugin system** — native Rust + WASM sandboxed plugins with 7 hook points
 - **High availability (active-passive pair)** — Two AiFw nodes share a CARP virtual IP and pfsync state. Reboot the master and TCP sessions survive on the standby with no operator intervention. Setup via the UI in <15 minutes. See [docs/ha.md](docs/ha.md) for setup, ops, and failure modes.
+- **Remote syslog** — forward pf packet logs, IDS alerts, and app logs to a syslog server/SIEM (UDP/TCP, BSD or RFC 5424, per-category toggles, optional local-storage off)
 - **Metrics engine** — RRD-style ring buffers (1s/1m/1h/1d tiers), optional PostgreSQL backend
 - **REST API** — Axum with JWT auth, API keys, full CRUD for all resources
 - **Terminal UI** — ratatui dashboard with 5 tabs

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -2285,9 +2285,11 @@ pub(crate) async fn apply_firewall_config(
     // service may be absent (dev hosts); the DB rows are authoritative and
     // switch_backend probes + auto-rolls-back on a failed start.
     // Remote syslog: the rows are already committed; apply in this process
-    // immediately (daemon/IDS pick it up via their 60s pollers).
+    // immediately (daemon/IDS pick it up via their 60s pollers) and
+    // reconcile the pflogd local-storage policy.
     if let Some(syslog_cfg) = &config.syslog {
         state.syslog.apply(syslog_cfg.clone());
+        aifw_core::local_log::apply_local_log_policy(syslog_cfg).await;
     }
 
     if let Some(resolver) = &config.dns_resolver {

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -859,6 +859,7 @@ pub(crate) async fn build_current_config(state: &AppState) -> Result<FirewallCon
         aliases: build_aliases_section(state).await,
         static_routes: build_static_routes_section(&state.pool).await,
         dns_resolver: Some(crate::dns_resolver::load_config(&state.pool).await),
+        syslog: Some(aifw_common::syslog::load(&state.pool).await),
     };
 
     Ok(config)
@@ -2139,6 +2140,14 @@ pub(crate) async fn apply_firewall_config(
             .map_err(|e| apply_fail("dns resolver config restore", e))?;
     }
 
+    // Remote syslog settings. `None` = backup predates the section; leave
+    // the box's config untouched. Applied in-process after commit.
+    if let Some(syslog_cfg) = &config.syslog {
+        aifw_common::syslog::save_on(&mut tx, syslog_cfg)
+            .await
+            .map_err(|e| apply_fail("syslog config restore", e))?;
+    }
+
     // One audit row for the whole restore, committed atomically with it.
     // (Pre-#158 each engine `add` wrote a per-row audit entry; a restore is
     // one operator action, not N rule additions.)
@@ -2275,6 +2284,12 @@ pub(crate) async fn apply_firewall_config(
     // settings take effect (#589). Best-effort like rDHCP above: the backend
     // service may be absent (dev hosts); the DB rows are authoritative and
     // switch_backend probes + auto-rolls-back on a failed start.
+    // Remote syslog: the rows are already committed; apply in this process
+    // immediately (daemon/IDS pick it up via their 60s pollers).
+    if let Some(syslog_cfg) = &config.syslog {
+        state.syslog.apply(syslog_cfg.clone());
+    }
+
     if let Some(resolver) = &config.dns_resolver {
         let report = crate::dns_resolver::switch_backend(state, &resolver.backend, resolver).await;
         if report.rolled_back || (resolver.enabled && !report.probe_udp) {

--- a/aifw-api/src/ids.rs
+++ b/aifw-api/src/ids.rs
@@ -89,6 +89,9 @@ pub struct UpdateConfigRequest {
     pub alert_retention_days: Option<u32>,
     pub eve_log_enabled: Option<bool>,
     pub eve_log_path: Option<String>,
+    /// Deprecated no-op — use the global `/api/v1/settings/syslog` config
+    /// (`ids_enabled` category) instead. Accepted and stored for backward
+    /// compatibility but nothing reads it.
     pub syslog_target: Option<String>,
     pub worker_count: Option<u32>,
     pub flow_table_size: Option<u32>,

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -1717,8 +1717,9 @@ async fn main() -> anyhow::Result<()> {
         Err(e) => tracing::warn!("Failed to restart WireGuard tunnels: {e}"),
     }
 
-    // Start persistent pflog0 live capture for blocked traffic page (background, non-blocking)
-    ws::start_pflog_collector(state.plugin_manager.clone());
+    // Start persistent pflog0 live capture for blocked traffic page
+    // (background, non-blocking); also tees entries to remote syslog.
+    ws::start_pflog_collector(state.plugin_manager.clone(), state.syslog.handle());
 
     // Start plugin timer hook — fires every 60 seconds for cron-like plugins
     {

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -1464,12 +1464,23 @@ async fn main() -> anyhow::Result<()> {
     // create_app_state once the pool is ready.
     let syslog_mgr = aifw_common::syslog::SyslogManager::start();
 
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| args.log_level.parse().unwrap_or_default()),
-        )
-        .init();
+    // Registry: fmt layer (stdout, EnvFilter-scoped so console filtering
+    // never starves the forwarder) + remote-syslog forwarding layer, which
+    // self-filters on the App category toggle and app_min_level.
+    {
+        use tracing_subscriber::Layer as _;
+        use tracing_subscriber::layer::SubscriberExt;
+        use tracing_subscriber::util::SubscriberInitExt;
+        let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| args.log_level.parse().unwrap_or_default());
+        tracing_subscriber::registry()
+            .with(tracing_subscriber::fmt::layer().with_filter(env_filter))
+            .with(aifw_common::syslog::SyslogLayer::new(
+                syslog_mgr.handle(),
+                "aifw-api",
+            ))
+            .init();
+    }
 
     // Temporary AuthSettings so create_app_state has a DB pool. The real
     // JWT secret is loaded from the key file below, then swapped in.

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -20,6 +20,7 @@ mod plugins;
 mod reverse_proxy;
 mod router;
 mod routes;
+mod syslog;
 mod system;
 mod time_service;
 mod updates;
@@ -169,6 +170,10 @@ pub struct AppState {
     pub alias_engine: Arc<AliasEngine>,
     pub conntrack: Arc<ConnectionTracker>,
     pub ids_client: Arc<aifw_ids_ipc::IdsClient>,
+    /// Remote syslog forwarding for this process (pf logs + API app logs).
+    /// Created in `main` before the tracing subscriber so the forwarding
+    /// layer can attach; config is applied once the DB pool is ready.
+    pub syslog: Arc<aifw_common::syslog::SyslogManager>,
     pub plugin_manager: Arc<RwLock<aifw_plugins::PluginManager>>,
     pub metrics_store: Arc<aifw_metrics::MetricsStore>,
     pub auth_settings: auth::AuthSettings,
@@ -677,13 +682,14 @@ pub async fn create_app_state(
     db_path: &std::path::Path,
     auth_settings: auth::AuthSettings,
     ids_socket: PathBuf,
+    syslog_mgr: Arc<aifw_common::syslog::SyslogManager>,
 ) -> anyhow::Result<AppState> {
     if let Some(parent) = db_path.parent() {
         tokio::fs::create_dir_all(parent).await?;
     }
 
     let db = Database::new(db_path).await?;
-    create_state_from_db(db, auth_settings, ids_socket).await
+    create_state_from_db(db, auth_settings, ids_socket, syslog_mgr).await
 }
 
 #[cfg(test)]
@@ -700,13 +706,20 @@ pub async fn create_app_state_in_memory(
         std::process::id(),
         uuid::Uuid::new_v4()
     ));
-    create_state_from_db(db, auth_settings, ids_socket).await
+    create_state_from_db(
+        db,
+        auth_settings,
+        ids_socket,
+        aifw_common::syslog::SyslogManager::start(),
+    )
+    .await
 }
 
 async fn create_state_from_db(
     db: Database,
     auth_settings: auth::AuthSettings,
     ids_socket: PathBuf,
+    syslog_mgr: Arc<aifw_common::syslog::SyslogManager>,
 ) -> anyhow::Result<AppState> {
     let pool = db.pool().clone();
     let pf: Arc<dyn PfBackend> = Arc::from(aifw_pf::create_backend());
@@ -835,6 +848,11 @@ async fn create_state_from_db(
             },
             async { system::migrate(&pool).await.map_err(anyhow::Error::from) },
             async {
+                aifw_common::syslog::migrate(&pool)
+                    .await
+                    .map_err(anyhow::Error::from)
+            },
+            async {
                 time_service::migrate(&pool)
                     .await
                     .map_err(anyhow::Error::from)
@@ -877,6 +895,11 @@ async fn create_state_from_db(
             Err(e) => return Err(e),
         }
     }
+
+    // Apply persisted remote-syslog settings and watch for out-of-process
+    // edits (the CLI writes SQLite directly).
+    syslog_mgr.apply(aifw_common::syslog::load(&pool).await);
+    aifw_common::syslog::spawn_config_poller(pool.clone(), syslog_mgr.clone());
 
     // Read aifw_cluster_enabled once at startup. The flag only changes on
     // config writes, so a cached value is always correct for the process lifetime.
@@ -1058,6 +1081,7 @@ async fn create_state_from_db(
         alias_engine,
         conntrack,
         ids_client,
+        syslog: syslog_mgr,
         plugin_manager: Arc::new(RwLock::new(plugin_mgr)),
         metrics_store: metrics_store.clone(),
         auth_settings,
@@ -1435,6 +1459,11 @@ async fn main() -> anyhow::Result<()> {
     // it; doing this before any TLS is used.
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
+    // Remote syslog manager exists before the tracing subscriber so the
+    // forwarding layer can attach to it; the DB config is applied inside
+    // create_app_state once the pool is ready.
+    let syslog_mgr = aifw_common::syslog::SyslogManager::start();
+
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -1446,7 +1475,13 @@ async fn main() -> anyhow::Result<()> {
     // JWT secret is loaded from the key file below, then swapped in.
     let auth_settings = auth::AuthSettings::default();
 
-    let mut state = create_app_state(&args.db, auth_settings, args.ids_socket.clone()).await?;
+    let mut state = create_app_state(
+        &args.db,
+        auth_settings,
+        args.ids_socket.clone(),
+        syslog_mgr.clone(),
+    )
+    .await?;
 
     // Resolve the JWT secret: explicit override > key file (migrating any
     // legacy DB-stored secret on first run) > freshly generated in file.

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -899,7 +899,7 @@ async fn create_state_from_db(
     // Apply persisted remote-syslog settings and watch for out-of-process
     // edits (the CLI writes SQLite directly).
     syslog_mgr.apply(aifw_common::syslog::load(&pool).await);
-    aifw_common::syslog::spawn_config_poller(pool.clone(), syslog_mgr.clone());
+    aifw_common::syslog::spawn_config_poller(pool.clone(), syslog_mgr.clone(), "aifw-api");
 
     // Read aifw_cluster_enabled once at startup. The flag only changes on
     // config writes, so a cached value is always correct for the process lifetime.

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -1474,7 +1474,13 @@ async fn main() -> anyhow::Result<()> {
         let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| args.log_level.parse().unwrap_or_default());
         tracing_subscriber::registry()
-            .with(tracing_subscriber::fmt::layer().with_filter(env_filter))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_filter(env_filter)
+                    .with_filter(aifw_common::syslog::LocalStorageGate::new(
+                        syslog_mgr.handle(),
+                    )),
+            )
             .with(aifw_common::syslog::SyslogLayer::new(
                 syslog_mgr.handle(),
                 "aifw-api",

--- a/aifw-api/src/router.rs
+++ b/aifw-api/src/router.rs
@@ -17,7 +17,8 @@ use crate::AppState;
 use crate::perm_check;
 use crate::{
     acme, ai_analysis, aliases, backup, backup_s3, ca, cluster, dhcp, dns_blocklists, dns_resolver,
-    ids, iface, multiwan, opnsense, plugins, reverse_proxy, routes, system, time_service, updates,
+    ids, iface, multiwan, opnsense, plugins, reverse_proxy, routes, syslog, system, time_service,
+    updates,
 };
 use axum::middleware;
 
@@ -486,6 +487,8 @@ pub(crate) fn settings_read() -> Router<AppState> {
             get(routes::get_ids_alert_settings),
         )
         .route("/api/v1/settings/pf-tuning", get(routes::get_pf_tuning))
+        .route("/api/v1/settings/syslog", get(syslog::get_syslog_config))
+        .route("/api/v1/settings/syslog/status", get(syslog::syslog_status))
         .route(
             "/api/v1/settings/{section}",
             get(routes::get_generic_settings),
@@ -544,6 +547,8 @@ pub(crate) fn settings_write() -> Router<AppState> {
             put(routes::update_ids_alert_settings),
         )
         .route("/api/v1/settings/pf-tuning", put(routes::put_pf_tuning))
+        .route("/api/v1/settings/syslog", put(syslog::put_syslog_config))
+        .route("/api/v1/settings/syslog/test", post(syslog::test_syslog))
         .route(
             "/api/v1/settings/{section}",
             put(routes::update_generic_settings),

--- a/aifw-api/src/syslog.rs
+++ b/aifw-api/src/syslog.rs
@@ -66,7 +66,7 @@ pub async fn test_syslog(
         }),
         Err(e) => Json(TestResponse {
             ok: false,
-            message: e,
+            message: e.to_string(),
         }),
     }
 }

--- a/aifw-api/src/syslog.rs
+++ b/aifw-api/src/syslog.rs
@@ -1,0 +1,73 @@
+//! Remote syslog settings API — thin shims over `aifw_common::syslog`.
+//!
+//! Routes are registered in `router::settings_read` / `router::settings_write`,
+//! which enforce `Permission::SettingsRead` / `SettingsWrite`.
+
+use aifw_common::syslog as sys;
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use serde::Serialize;
+
+use crate::AppState;
+
+/// `GET /api/v1/settings/syslog` — current remote syslog configuration.
+pub async fn get_syslog_config(State(state): State<AppState>) -> Json<sys::SyslogConfig> {
+    Json(sys::load(&state.pool).await)
+}
+
+/// `PUT /api/v1/settings/syslog` — validate, persist, and apply immediately
+/// in this process. aifw-daemon and aifw-ids pick the change up via their
+/// 60s config pollers.
+pub async fn put_syslog_config(
+    State(state): State<AppState>,
+    Json(cfg): Json<sys::SyslogConfig>,
+) -> Result<Json<sys::SyslogConfig>, (StatusCode, String)> {
+    cfg.validate().map_err(|e| (StatusCode::BAD_REQUEST, e))?;
+    sys::save(&state.pool, &cfg)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    state.syslog.apply(cfg);
+    Ok(Json(sys::load(&state.pool).await))
+}
+
+/// Result of a one-shot test delivery.
+#[derive(Serialize)]
+pub struct TestResponse {
+    ok: bool,
+    message: String,
+}
+
+/// `POST /api/v1/settings/syslog/test` — send one test message. An unsaved
+/// draft config in the body wins over the stored one so the UI can test
+/// before saving; with no/empty body the saved config is used.
+pub async fn test_syslog(
+    State(state): State<AppState>,
+    Json(req): Json<Option<sys::SyslogConfig>>,
+) -> Json<TestResponse> {
+    let cfg = match req {
+        Some(c) if !c.host.trim().is_empty() => c,
+        _ => sys::load(&state.pool).await,
+    };
+    match sys::test_send(&cfg, "AiFw remote syslog test message").await {
+        Ok(()) => Json(TestResponse {
+            ok: true,
+            message: format!(
+                "test message sent to {}:{} over {}",
+                cfg.host,
+                cfg.port,
+                cfg.transport.as_str()
+            ),
+        }),
+        Err(e) => Json(TestResponse {
+            ok: false,
+            message: e,
+        }),
+    }
+}
+
+/// `GET /api/v1/settings/syslog/status` — delivery counters for the API
+/// process (pf logs and API app logs; daemon/IDS forward independently).
+pub async fn syslog_status(State(state): State<AppState>) -> Json<sys::SyslogStatsSnapshot> {
+    Json(state.syslog.stats())
+}

--- a/aifw-api/src/syslog.rs
+++ b/aifw-api/src/syslog.rs
@@ -27,7 +27,12 @@ pub async fn put_syslog_config(
     sys::save(&state.pool, &cfg)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-    state.syslog.apply(cfg);
+    state.syslog.apply(cfg.clone());
+    // Reconcile pflogd with disable_local right away (best-effort; the
+    // daemon also reconciles on its 60s poll). Off the request path.
+    tokio::spawn(async move {
+        aifw_core::local_log::apply_local_log_policy(&cfg).await;
+    });
     Ok(Json(sys::load(&state.pool).await))
 }
 

--- a/aifw-api/src/syslog.rs
+++ b/aifw-api/src/syslog.rs
@@ -45,12 +45,13 @@ pub struct TestResponse {
 
 /// `POST /api/v1/settings/syslog/test` — send one test message. An unsaved
 /// draft config in the body wins over the stored one so the UI can test
-/// before saving; with no/empty body the saved config is used.
+/// before saving; with no body, an empty body, or JSON `null` the saved
+/// config is used (the outer `Option` absorbs the missing-body rejection).
 pub async fn test_syslog(
     State(state): State<AppState>,
-    Json(req): Json<Option<sys::SyslogConfig>>,
+    body: Option<Json<Option<sys::SyslogConfig>>>,
 ) -> Json<TestResponse> {
-    let cfg = match req {
+    let cfg = match body.and_then(|Json(b)| b) {
         Some(c) if !c.host.trim().is_empty() => c,
         _ => sys::load(&state.pool).await,
     };
@@ -71,8 +72,20 @@ pub async fn test_syslog(
     }
 }
 
-/// `GET /api/v1/settings/syslog/status` — delivery counters for the API
-/// process (pf logs and API app logs; daemon/IDS forward independently).
-pub async fn syslog_status(State(state): State<AppState>) -> Json<sys::SyslogStatsSnapshot> {
-    Json(state.syslog.stats())
+/// `GET /api/v1/settings/syslog/status` — delivery counters per AiFw
+/// process. Rows for aifw-daemon / aifw-ids come from the `syslog_stats`
+/// table (refreshed by their 60s pollers); the API process's row is its
+/// live in-memory snapshot.
+pub async fn syslog_status(State(state): State<AppState>) -> Json<Vec<sys::ProcessSyslogStats>> {
+    let mut rows = sys::read_stats(&state.pool).await.unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "failed to read persisted syslog stats");
+        Vec::new()
+    });
+    rows.retain(|r| r.process != "aifw-api");
+    rows.push(sys::ProcessSyslogStats::from_snapshot(
+        "aifw-api",
+        &state.syslog.stats(),
+    ));
+    rows.sort_by(|a, b| a.process.cmp(&b.process));
+    Json(rows)
 }

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -2398,6 +2398,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_restore_round_trips_syslog_config() {
+        let state = crate::create_app_state_in_memory(plain_auth_settings())
+            .await
+            .unwrap();
+
+        let syslog_cfg = aifw_common::syslog::SyslogConfig {
+            enabled: true,
+            host: "192.0.2.50".into(),
+            port: 5514,
+            transport: aifw_common::syslog::Transport::Tcp,
+            pf_enabled: true,
+            ..Default::default()
+        };
+        aifw_common::syslog::save(&state.pool, &syslog_cfg)
+            .await
+            .unwrap();
+
+        let config = crate::backup::build_current_config(&state).await.unwrap();
+        let exported = config.syslog.as_ref().expect("export must include syslog");
+        assert_eq!(exported.host, "192.0.2.50");
+        assert!(exported.pf_enabled);
+
+        // Simulate drift after the backup was taken.
+        aifw_common::syslog::save(&state.pool, &Default::default())
+            .await
+            .unwrap();
+
+        crate::backup::apply_firewall_config(&state, &config, &Default::default())
+            .await
+            .expect("restore must succeed");
+
+        let restored = aifw_common::syslog::load(&state.pool).await;
+        assert_eq!(restored, syslog_cfg, "restore must reinstate syslog config");
+        // The API process applied it immediately.
+        assert_eq!(*state.syslog.current(), syslog_cfg);
+    }
+
+    #[tokio::test]
     async fn test_restore_without_resolver_section_leaves_config_untouched() {
         // A pre-#589 backup has no dns_resolver section — restoring it must
         // not reset the box's resolver config to defaults.

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -3340,14 +3340,30 @@ mod tests {
             "got: {text}"
         );
 
-        // Status endpoint responds with counters
+        // Status endpoint responds with per-process counters; the API
+        // process's live row is always present.
         let resp = server
             .get("/api/v1/settings/syslog/status")
             .authorization_bearer(&token)
             .await;
         resp.assert_status_ok();
         let body: Value = resp.json();
-        assert!(body["sent"].is_u64());
-        assert!(body["dropped"].is_u64());
+        let rows = body.as_array().expect("status is a per-process array");
+        let api_row = rows
+            .iter()
+            .find(|r| r["process"] == "aifw-api")
+            .expect("aifw-api row present");
+        assert!(api_row["sent"].is_u64());
+        assert!(api_row["dropped"].is_u64());
+
+        // Test endpoint without a body falls back to the saved config —
+        // nothing saved yet, so it reports a clean failure, not a 4xx.
+        let resp = server
+            .post("/api/v1/settings/syslog/test")
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["ok"], false);
     }
 }

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -3188,4 +3188,128 @@ mod tests {
         assert_eq!(body["totp_required"], true);
         assert!(set_cookies(&resp).is_empty(), "no cookies before 2FA");
     }
+
+    #[tokio::test]
+    async fn test_syslog_settings_defaults_and_roundtrip() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        // Defaults
+        let resp = server
+            .get("/api/v1/settings/syslog")
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["enabled"], false);
+        assert_eq!(body["port"], 514);
+        assert_eq!(body["transport"], "udp");
+        assert_eq!(body["format"], "rfc3164");
+        assert_eq!(body["facility"], 16);
+
+        // Save a full config and read it back
+        let cfg = json!({
+            "enabled": true,
+            "host": "192.0.2.99",
+            "port": 5514,
+            "transport": "tcp",
+            "format": "rfc5424",
+            "facility": 17,
+            "hostname_override": "fw-test",
+            "pf_enabled": true,
+            "ids_enabled": false,
+            "app_enabled": true,
+            "app_min_level": "warn",
+            "disable_local": false
+        });
+        let resp = server
+            .put("/api/v1/settings/syslog")
+            .authorization_bearer(&token)
+            .json(&cfg)
+            .await;
+        resp.assert_status_ok();
+
+        let resp = server
+            .get("/api/v1/settings/syslog")
+            .authorization_bearer(&token)
+            .await;
+        let body: Value = resp.json();
+        assert_eq!(body["host"], "192.0.2.99");
+        assert_eq!(body["transport"], "tcp");
+        assert_eq!(body["format"], "rfc5424");
+        assert_eq!(body["pf_enabled"], true);
+        assert_eq!(body["app_min_level"], "warn");
+
+        // Invalid facility is rejected
+        let mut bad = cfg.clone();
+        bad["facility"] = json!(42);
+        let resp = server
+            .put("/api/v1/settings/syslog")
+            .authorization_bearer(&token)
+            .json(&bad)
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+
+        // Enabled without a host is rejected
+        let mut no_host = cfg.clone();
+        no_host["host"] = json!("");
+        let resp = server
+            .put("/api/v1/settings/syslog")
+            .authorization_bearer(&token)
+            .json(&no_host)
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+
+        // Unauthenticated read is rejected
+        let resp = server.get("/api/v1/settings/syslog").await;
+        resp.assert_status(StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_syslog_test_endpoint_delivers_udp() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        let sock = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let port = sock.local_addr().unwrap().port();
+
+        // Draft config in the body — nothing saved, forwarding disabled.
+        let resp = server
+            .post("/api/v1/settings/syslog/test")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "enabled": false,
+                "host": "127.0.0.1",
+                "port": port,
+                "transport": "udp",
+                "format": "rfc3164",
+                "facility": 16
+            }))
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert_eq!(body["ok"], true, "body: {body}");
+
+        let mut buf = [0u8; 1024];
+        let (n, _) =
+            tokio::time::timeout(std::time::Duration::from_secs(5), sock.recv_from(&mut buf))
+                .await
+                .expect("test datagram should arrive")
+                .unwrap();
+        let text = std::str::from_utf8(&buf[..n]).unwrap();
+        assert!(
+            text.contains("AiFw remote syslog test message"),
+            "got: {text}"
+        );
+
+        // Status endpoint responds with counters
+        let resp = server
+            .get("/api/v1/settings/syslog/status")
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        assert!(body["sent"].is_u64());
+        assert!(body["dropped"].is_u64());
+    }
 }

--- a/aifw-api/src/ws.rs
+++ b/aifw-api/src/ws.rs
@@ -1165,6 +1165,21 @@ fn parse_pflog_line(line: &str) -> Option<BlockedPayload> {
     })
 }
 
+/// Render one pf log entry as a compact key=value syslog message body.
+fn format_pf_msg(e: &BlockedPayload) -> String {
+    format!(
+        "action={} dir={} if={} proto={} src={}:{} dst={}:{}",
+        e.action,
+        e.direction,
+        e.interface,
+        e.protocol,
+        e.src_addr,
+        e.src_port,
+        e.dst_addr,
+        e.dst_port
+    )
+}
+
 // VecDeque keeps push (push_back) and trim (pop_front) both O(1) even under
 // high block rates (DDoS). Vec::drain(..N) on a 10k buffer was O(N) per
 // insert → O(N²) under sustained traffic above the cap.
@@ -1181,8 +1196,11 @@ fn blocked_buffer() -> &'static BlockedBuffer {
 
 /// Call once on API startup to bootstrap from pflog file and start live capture.
 /// Both bootstrap and live capture run in a background task so the API starts immediately.
+/// Live entries (not the bootstrap replay) are also forwarded to remote
+/// syslog when the pf category is enabled.
 pub fn start_pflog_collector(
     plugin_mgr: std::sync::Arc<tokio::sync::RwLock<aifw_plugins::PluginManager>>,
+    syslog: aifw_common::syslog::SyslogHandle,
 ) {
     let buf = blocked_buffer().clone();
     let buf2 = buf.clone();
@@ -1253,6 +1271,18 @@ pub fn start_pflog_collector(
                                     };
                                     let _ = plugins.dispatch(&event).await;
                                 }
+                            }
+                            // Tee to remote syslog. enabled_for is an O(1)
+                            // atomic load, so the format! only runs when the
+                            // pf category is actually on; enqueue never blocks.
+                            if syslog.enabled_for(aifw_common::syslog::Category::Pf) {
+                                let severity = if entry.action == "block" { 5 } else { 6 };
+                                syslog.enqueue(
+                                    aifw_common::syslog::Category::Pf,
+                                    severity,
+                                    "aifw-pf",
+                                    format_pf_msg(&entry),
+                                );
                             }
                             let mut buf = buf2.write().await;
                             if buf.len() == PFLOG_MAX_ENTRIES {
@@ -1363,6 +1393,17 @@ mod tests {
         assert_eq!(e.src_port, 51234);
         assert_eq!(e.dst_addr, "10.0.0.2");
         assert_eq!(e.dst_port, 443);
+    }
+
+    #[test]
+    fn formats_pf_syslog_msg() {
+        let line = "2026-04-01 13:09:28.475326 rule 5/0(match): block in on igb0: \
+                    203.0.113.5.51234 > 10.0.0.2.443: Flags [S], seq 12345, win 65535, length 0";
+        let e = parse_pflog_line(line).expect("line should parse");
+        assert_eq!(
+            format_pf_msg(&e),
+            "action=block dir=in if=igb0 proto=tcp src=203.0.113.5:51234 dst=10.0.0.2:443"
+        );
     }
 
     #[test]

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -3619,3 +3619,278 @@ pub async fn ids_retention(db_path: &Path, days: Option<u32>) -> anyhow::Result<
     }
     Ok(())
 }
+
+// ============================================================================
+// Remote syslog forwarding (aifw syslog ...)
+// ============================================================================
+
+/// Optional field updates for `aifw syslog set`; `None` = keep current value.
+pub struct SyslogSetOpts {
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub transport: Option<String>,
+    pub format: Option<String>,
+    pub facility: Option<String>,
+    pub hostname: Option<String>,
+    pub pf: Option<bool>,
+    pub ids: Option<bool>,
+    pub app: Option<bool>,
+    pub app_min_level: Option<String>,
+    pub disable_local: Option<bool>,
+}
+
+async fn syslog_load(
+    db_path: &Path,
+) -> anyhow::Result<(Database, aifw_common::syslog::SyslogConfig)> {
+    let db = Database::new(db_path).await?;
+    aifw_common::syslog::migrate(db.pool()).await?;
+    let cfg = aifw_common::syslog::load(db.pool()).await;
+    Ok((db, cfg))
+}
+
+fn syslog_print_effect() {
+    println!("Change takes effect within 60 seconds (all AiFw services poll for syslog config).");
+}
+
+pub async fn syslog_show(db_path: &Path, json: bool) -> anyhow::Result<()> {
+    let (_db, cfg) = syslog_load(db_path).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&cfg)?);
+        return Ok(());
+    }
+    let facility_label = aifw_common::syslog::facility_name(cfg.facility)
+        .map(|n| format!("{} ({n})", cfg.facility))
+        .unwrap_or_else(|| cfg.facility.to_string());
+    println!("Remote syslog forwarding");
+    println!(
+        "  Enabled:        {}",
+        if cfg.enabled { "yes" } else { "no" }
+    );
+    println!(
+        "  Server:         {}",
+        if cfg.host.is_empty() {
+            "(not configured)".to_string()
+        } else {
+            format!("{}:{}", cfg.host, cfg.port)
+        }
+    );
+    println!("  Transport:      {}", cfg.transport.as_str());
+    println!("  Format:         {}", cfg.format.as_str());
+    println!("  Facility:       {facility_label}");
+    println!(
+        "  Hostname:       {}",
+        if cfg.hostname_override.is_empty() {
+            "(system hostname)"
+        } else {
+            &cfg.hostname_override
+        }
+    );
+    println!("  Categories:");
+    println!(
+        "    pf logs:      {}",
+        if cfg.pf_enabled { "on" } else { "off" }
+    );
+    println!(
+        "    IDS alerts:   {}",
+        if cfg.ids_enabled { "on" } else { "off" }
+    );
+    println!(
+        "    app logs:     {}{}",
+        if cfg.app_enabled { "on" } else { "off" },
+        if cfg.app_enabled {
+            format!(" (min level {})", cfg.app_min_level)
+        } else {
+            String::new()
+        }
+    );
+    println!(
+        "  Local storage:  {}",
+        if cfg.disable_local {
+            "disabled while forwarding"
+        } else {
+            "kept"
+        }
+    );
+    Ok(())
+}
+
+pub async fn syslog_enable(db_path: &Path, enabled: bool) -> anyhow::Result<()> {
+    let (db, mut cfg) = syslog_load(db_path).await?;
+    cfg.enabled = enabled;
+    if let Err(e) = cfg.validate() {
+        anyhow::bail!("{e} — set one with: aifw syslog set --host <server>");
+    }
+    aifw_common::syslog::save(db.pool(), &cfg).await?;
+    if enabled {
+        println!(
+            "Remote syslog forwarding enabled ({}:{} over {}).",
+            cfg.host,
+            cfg.port,
+            cfg.transport.as_str()
+        );
+        if !cfg.pf_enabled && !cfg.ids_enabled && !cfg.app_enabled {
+            println!(
+                "  Note: no categories are on yet — enable some with e.g. 'aifw syslog set --pf true'."
+            );
+        }
+    } else {
+        println!("Remote syslog forwarding disabled.");
+    }
+    syslog_print_effect();
+    Ok(())
+}
+
+pub async fn syslog_set(db_path: &Path, opts: SyslogSetOpts) -> anyhow::Result<()> {
+    let (db, mut cfg) = syslog_load(db_path).await?;
+    if let Some(h) = opts.host {
+        cfg.host = h;
+    }
+    if let Some(p) = opts.port {
+        cfg.port = p;
+    }
+    if let Some(t) = opts.transport {
+        cfg.transport = match t.to_ascii_lowercase().as_str() {
+            "udp" => aifw_common::syslog::Transport::Udp,
+            "tcp" => aifw_common::syslog::Transport::Tcp,
+            other => anyhow::bail!("transport must be udp or tcp (got '{other}')"),
+        };
+    }
+    if let Some(f) = opts.format {
+        cfg.format = match f.to_ascii_lowercase().as_str() {
+            "rfc3164" | "bsd" => aifw_common::syslog::SyslogFormat::Rfc3164,
+            "rfc5424" => aifw_common::syslog::SyslogFormat::Rfc5424,
+            other => anyhow::bail!("format must be rfc3164 (bsd) or rfc5424 (got '{other}')"),
+        };
+    }
+    if let Some(f) = opts.facility {
+        cfg.facility = aifw_common::syslog::facility_from_name(&f).ok_or_else(|| {
+            anyhow::anyhow!("unknown facility '{f}' (use a name like local0 or a number 0-23)")
+        })?;
+    }
+    if let Some(h) = opts.hostname {
+        cfg.hostname_override = h;
+    }
+    if let Some(v) = opts.pf {
+        cfg.pf_enabled = v;
+    }
+    if let Some(v) = opts.ids {
+        cfg.ids_enabled = v;
+    }
+    if let Some(v) = opts.app {
+        cfg.app_enabled = v;
+    }
+    if let Some(l) = opts.app_min_level {
+        cfg.app_min_level = l.to_ascii_lowercase();
+    }
+    if let Some(v) = opts.disable_local {
+        cfg.disable_local = v;
+    }
+    cfg.validate().map_err(|e| anyhow::anyhow!(e))?;
+    aifw_common::syslog::save(db.pool(), &cfg).await?;
+    println!("Syslog settings updated.");
+    if !cfg.enabled {
+        println!("  Forwarding is currently disabled — turn it on with 'aifw syslog enable'.");
+    }
+    syslog_print_effect();
+    Ok(())
+}
+
+pub async fn syslog_test(
+    db_path: &Path,
+    host: Option<String>,
+    port: Option<u16>,
+) -> anyhow::Result<()> {
+    let (_db, mut cfg) = syslog_load(db_path).await?;
+    if let Some(h) = host {
+        cfg.host = h;
+    }
+    if let Some(p) = port {
+        cfg.port = p;
+    }
+    anyhow::ensure!(
+        !cfg.host.trim().is_empty(),
+        "no syslog server configured — set one with 'aifw syslog set --host <server>' or pass --host"
+    );
+    match aifw_common::syslog::test_send(&cfg, "AiFw remote syslog test message (CLI)").await {
+        Ok(()) => {
+            println!(
+                "Test message sent to {}:{} over {} ({}).",
+                cfg.host,
+                cfg.port,
+                cfg.transport.as_str(),
+                cfg.format.as_str()
+            );
+            if cfg.transport == aifw_common::syslog::Transport::Udp {
+                println!("  UDP is fire-and-forget — check the server received it.");
+            }
+        }
+        Err(e) => anyhow::bail!("test send failed: {e}"),
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod syslog_cli_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn set_and_show_round_trip() {
+        let dir = std::env::temp_dir().join(format!("aifw-cli-syslog-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db_path = dir.join("test.db");
+
+        syslog_set(
+            &db_path,
+            SyslogSetOpts {
+                host: Some("192.0.2.20".into()),
+                port: Some(1514),
+                transport: Some("tcp".into()),
+                format: Some("rfc5424".into()),
+                facility: Some("local3".into()),
+                hostname: None,
+                pf: Some(true),
+                ids: None,
+                app: None,
+                app_min_level: None,
+                disable_local: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let (_db, cfg) = syslog_load(&db_path).await.unwrap();
+        assert_eq!(cfg.host, "192.0.2.20");
+        assert_eq!(cfg.port, 1514);
+        assert_eq!(cfg.transport, aifw_common::syslog::Transport::Tcp);
+        assert_eq!(cfg.format, aifw_common::syslog::SyslogFormat::Rfc5424);
+        assert_eq!(cfg.facility, 19);
+        assert!(cfg.pf_enabled);
+        assert!(!cfg.enabled);
+
+        syslog_enable(&db_path, true).await.unwrap();
+        let (_db, cfg) = syslog_load(&db_path).await.unwrap();
+        assert!(cfg.enabled);
+
+        // Invalid facility is rejected before anything is saved.
+        let bad = syslog_set(
+            &db_path,
+            SyslogSetOpts {
+                host: None,
+                port: None,
+                transport: None,
+                format: None,
+                facility: Some("nope".into()),
+                hostname: None,
+                pf: None,
+                ids: None,
+                app: None,
+                app_min_level: None,
+                disable_local: None,
+            },
+        )
+        .await;
+        assert!(bad.is_err());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/aifw-cli/src/main.rs
+++ b/aifw-cli/src/main.rs
@@ -41,6 +41,11 @@ enum Commands {
         #[command(subcommand)]
         action: IdsAction,
     },
+    /// Manage remote syslog forwarding
+    Syslog {
+        #[command(subcommand)]
+        action: SyslogAction,
+    },
     /// Manage traffic queues
     Queue {
         #[command(subcommand)]
@@ -788,6 +793,80 @@ EXAMPLES:
 }
 
 #[derive(Subcommand)]
+enum SyslogAction {
+    /// Show the current remote syslog configuration
+    Show {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Enable remote syslog forwarding (requires a host to be set)
+    Enable,
+    /// Disable remote syslog forwarding
+    Disable,
+    /// Update settings — only the flags you pass change
+    #[command(after_help = "\
+EXAMPLES:
+    # Point at a syslog server and enable pf log forwarding
+    aifw syslog set --host 192.168.1.10 --port 514 --pf true
+    aifw syslog enable
+
+    # Switch to TCP with RFC 5424 framing on facility local3
+    aifw syslog set --transport tcp --format rfc5424 --facility local3
+
+    # Forward everything, app logs at warn and above
+    aifw syslog set --pf true --ids true --app true --app-min-level warn")]
+    Set {
+        /// Syslog server hostname or IP
+        #[arg(long)]
+        host: Option<String>,
+        /// Syslog server port (default 514)
+        #[arg(long)]
+        port: Option<u16>,
+        /// Transport: udp or tcp
+        #[arg(long)]
+        transport: Option<String>,
+        /// Message format: rfc3164 (BSD) or rfc5424
+        #[arg(long)]
+        format: Option<String>,
+        /// Facility name (kern, daemon, auth, local0-local7, ...) or number 0-23
+        #[arg(long)]
+        facility: Option<String>,
+        /// HOSTNAME field override; pass an empty string for the system hostname
+        #[arg(long)]
+        hostname: Option<String>,
+        /// Forward pf packet logs (true/false)
+        #[arg(long)]
+        pf: Option<bool>,
+        /// Forward IDS alerts (true/false)
+        #[arg(long)]
+        ids: Option<bool>,
+        /// Forward application logs (true/false)
+        #[arg(long)]
+        app: Option<bool>,
+        /// Minimum app-log level to forward: error, warn, info, or debug
+        #[arg(long)]
+        app_min_level: Option<String>,
+        /// Stop writing local log files while forwarding is active (true/false)
+        #[arg(long)]
+        disable_local: Option<bool>,
+    },
+    /// Send a test message using the saved config (or --host/--port overrides)
+    #[command(after_help = "\
+EXAMPLES:
+    aifw syslog test                          # use the saved configuration
+    aifw syslog test --host 10.0.0.9 --port 5514")]
+    Test {
+        /// Override the target host for this test only
+        #[arg(long)]
+        host: Option<String>,
+        /// Override the target port for this test only
+        #[arg(long)]
+        port: Option<u16>,
+    },
+}
+
+#[derive(Subcommand)]
 enum NatAction {
     /// Add a NAT rule
     #[command(after_help = "\
@@ -994,6 +1073,51 @@ async fn main() -> anyhow::Result<()> {
             }
             IdsAction::Retention { days } => {
                 commands::ids_retention(&cli.db, days).await?;
+            }
+        },
+        Commands::Syslog { action } => match action {
+            SyslogAction::Show { json } => {
+                commands::syslog_show(&cli.db, json).await?;
+            }
+            SyslogAction::Enable => {
+                commands::syslog_enable(&cli.db, true).await?;
+            }
+            SyslogAction::Disable => {
+                commands::syslog_enable(&cli.db, false).await?;
+            }
+            SyslogAction::Set {
+                host,
+                port,
+                transport,
+                format,
+                facility,
+                hostname,
+                pf,
+                ids,
+                app,
+                app_min_level,
+                disable_local,
+            } => {
+                commands::syslog_set(
+                    &cli.db,
+                    commands::SyslogSetOpts {
+                        host,
+                        port,
+                        transport,
+                        format,
+                        facility,
+                        hostname,
+                        pf,
+                        ids,
+                        app,
+                        app_min_level,
+                        disable_local,
+                    },
+                )
+                .await?;
+            }
+            SyslogAction::Test { host, port } => {
+                commands::syslog_test(&cli.db, host, port).await?;
             }
         },
         Commands::Nat { action } => match action {

--- a/aifw-common/Cargo.toml
+++ b/aifw-common/Cargo.toml
@@ -14,6 +14,7 @@ sqlx = { workspace = true }
 tokio = { workspace = true, features = ["sync", "net", "rt", "macros", "time", "io-util"] }
 arc-swap = "1"
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
 x25519-dalek = { workspace = true }
 getrandom = { workspace = true }

--- a/aifw-common/Cargo.toml
+++ b/aifw-common/Cargo.toml
@@ -11,7 +11,8 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 sqlx = { workspace = true }
-tokio = { workspace = true, features = ["sync", "net", "rt", "macros"] }
+tokio = { workspace = true, features = ["sync", "net", "rt", "macros", "time", "io-util"] }
+arc-swap = "1"
 url = { workspace = true }
 x25519-dalek = { workspace = true }
 getrandom = { workspace = true }

--- a/aifw-common/Cargo.toml
+++ b/aifw-common/Cargo.toml
@@ -13,6 +13,7 @@ thiserror = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true, features = ["sync", "net", "rt", "macros", "time", "io-util"] }
 arc-swap = "1"
+tracing = { workspace = true }
 url = { workspace = true }
 x25519-dalek = { workspace = true }
 getrandom = { workspace = true }

--- a/aifw-common/src/ids.rs
+++ b/aifw-common/src/ids.rs
@@ -367,7 +367,10 @@ pub struct IdsConfig {
     pub eve_log_enabled: bool,
     /// Path for the EVE JSON log; `None` = engine default
     pub eve_log_path: Option<String>,
-    /// Syslog host:port to forward alerts to; `None` = disabled
+    /// Deprecated no-op: alert forwarding now goes through the global
+    /// remote-syslog settings (`/api/v1/settings/syslog`, `ids_enabled`
+    /// category). This field was never wired to a sender; it is kept only
+    /// so old configs keep deserializing.
     pub syslog_target: Option<String>,
     /// Number of inspection worker threads; `None` = auto-sized
     pub worker_count: Option<u32>,

--- a/aifw-common/src/lib.rs
+++ b/aifw-common/src/lib.rs
@@ -42,6 +42,8 @@ pub mod schedule;
 pub mod schemas;
 #[cfg(unix)]
 pub mod single_instance;
+/// Remote syslog forwarding: config, RFC 3164/5424 formatting, async client
+pub mod syslog;
 #[cfg(test)]
 mod tests;
 /// TLS inspection types: versions, JA3/JA3S fingerprints, SNI rules, cert policy, MITM proxy config

--- a/aifw-common/src/syslog/client.rs
+++ b/aifw-common/src/syslog/client.rs
@@ -1,0 +1,533 @@
+//! Async syslog client: bounded queue, background writer, UDP/TCP transports.
+//!
+//! Producers call [`SyslogHandle::enqueue`] which never blocks (`try_send`
+//! into a bounded channel; overflow is counted, not waited on). A single
+//! writer task owns the socket, reconnects TCP with capped backoff, and
+//! re-resolves the target on (re)configure and on error.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Duration;
+
+use arc_swap::ArcSwap;
+use chrono::Utc;
+use serde::Serialize;
+use sqlx::SqlitePool;
+use tokio::io::AsyncWriteExt;
+use tokio::net::{TcpStream, UdpSocket, lookup_host};
+use tokio::sync::{mpsc, watch};
+use tokio::time::{Instant, timeout};
+
+use super::config::{Category, SyslogConfig, Transport, load};
+use super::format::{SyslogRecord, format_message};
+
+/// Bounded queue size shared by all producers in a process.
+const QUEUE_CAPACITY: usize = 2048;
+/// Connect/write/resolve timeout for one send attempt.
+const IO_TIMEOUT: Duration = Duration::from_secs(5);
+/// TCP reconnect backoff bounds.
+const BACKOFF_MIN: Duration = Duration::from_secs(1);
+const BACKOFF_MAX: Duration = Duration::from_secs(30);
+/// How often [`spawn_config_poller`] re-reads the DB.
+const POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Delivery counters for the current process (the writer task's view).
+#[derive(Default)]
+pub struct SyslogStats {
+    sent: AtomicU64,
+    dropped: AtomicU64,
+    errors: AtomicU64,
+    connected: AtomicBool,
+    last_error: std::sync::Mutex<Option<String>>,
+}
+
+/// Point-in-time copy of [`SyslogStats`] for the API/UI.
+#[derive(Debug, Clone, Serialize)]
+pub struct SyslogStatsSnapshot {
+    /// Messages successfully handed to the transport
+    pub sent: u64,
+    /// Messages dropped because the queue was full or the target unreachable
+    pub dropped: u64,
+    /// Send/connect failures
+    pub errors: u64,
+    /// Whether the last send attempt succeeded (UDP) / stream is up (TCP)
+    pub connected: bool,
+    /// Most recent transport error, if any
+    pub last_error: Option<String>,
+}
+
+impl SyslogStats {
+    fn record_error(&self, e: String) {
+        self.errors.fetch_add(1, Ordering::Relaxed);
+        self.connected.store(false, Ordering::Relaxed);
+        if let Ok(mut g) = self.last_error.lock() {
+            *g = Some(e);
+        }
+    }
+
+    fn snapshot(&self) -> SyslogStatsSnapshot {
+        SyslogStatsSnapshot {
+            sent: self.sent.load(Ordering::Relaxed),
+            dropped: self.dropped.load(Ordering::Relaxed),
+            errors: self.errors.load(Ordering::Relaxed),
+            connected: self.connected.load(Ordering::Relaxed),
+            last_error: self.last_error.lock().ok().and_then(|g| g.clone()),
+        }
+    }
+}
+
+/// State shared between the manager/handles and the writer task.
+struct Shared {
+    config: ArcSwap<SyslogConfig>,
+    stats: SyslogStats,
+    hostname: String,
+}
+
+impl Shared {
+    fn hostname_for<'a>(&'a self, cfg: &'a SyslogConfig) -> &'a str {
+        if cfg.hostname_override.is_empty() {
+            &self.hostname
+        } else {
+            &cfg.hostname_override
+        }
+    }
+}
+
+/// Owns the writer task and the live configuration for one process.
+///
+/// Create once at startup with [`SyslogManager::start`], apply the DB config
+/// when the pool is ready, and pass [`SyslogHandle`]s to producers.
+pub struct SyslogManager {
+    shared: Arc<Shared>,
+    tx: mpsc::Sender<SyslogRecord>,
+    reload: watch::Sender<u64>,
+}
+
+impl SyslogManager {
+    /// Spawn the writer task and return the manager. Starts with forwarding
+    /// disabled; call [`SyslogManager::apply`] once config is loaded.
+    /// Must be called from within a tokio runtime.
+    pub fn start() -> Arc<Self> {
+        let (tx, rx) = mpsc::channel(QUEUE_CAPACITY);
+        let (reload_tx, reload_rx) = watch::channel(0u64);
+        let shared = Arc::new(Shared {
+            config: ArcSwap::from_pointee(SyslogConfig::default()),
+            stats: SyslogStats::default(),
+            hostname: detect_hostname(),
+        });
+        tokio::spawn(writer_task(shared.clone(), rx, reload_rx));
+        Arc::new(Self {
+            shared,
+            tx,
+            reload: reload_tx,
+        })
+    }
+
+    /// Swap in a new configuration; the writer drops its connection and
+    /// re-resolves the target.
+    pub fn apply(&self, cfg: SyslogConfig) {
+        self.shared.config.store(Arc::new(cfg));
+        self.reload.send_modify(|g| *g = g.wrapping_add(1));
+    }
+
+    /// Current configuration as seen by producers.
+    pub fn current(&self) -> Arc<SyslogConfig> {
+        self.shared.config.load_full()
+    }
+
+    /// Cheap-clone producer handle for hot paths.
+    pub fn handle(&self) -> SyslogHandle {
+        SyslogHandle {
+            shared: self.shared.clone(),
+            tx: self.tx.clone(),
+        }
+    }
+
+    /// Delivery counters for this process.
+    pub fn stats(&self) -> SyslogStatsSnapshot {
+        self.shared.stats.snapshot()
+    }
+}
+
+/// Non-blocking producer handle; clone freely.
+#[derive(Clone)]
+pub struct SyslogHandle {
+    shared: Arc<Shared>,
+    tx: mpsc::Sender<SyslogRecord>,
+}
+
+impl SyslogHandle {
+    /// True when forwarding is enabled for this category. O(1); check this
+    /// before building an expensive message body.
+    pub fn enabled_for(&self, cat: Category) -> bool {
+        self.shared.config.load().category_enabled(cat)
+    }
+
+    /// Current configuration (for callers that need more than the toggles).
+    pub fn config(&self) -> Arc<SyslogConfig> {
+        self.shared.config.load_full()
+    }
+
+    /// Queue one message. Never blocks: on a full queue the message is
+    /// dropped and counted. No-op when the category is disabled.
+    pub fn enqueue(&self, cat: Category, severity: u8, app_name: &'static str, msg: String) {
+        if !self.enabled_for(cat) {
+            return;
+        }
+        let rec = SyslogRecord {
+            severity,
+            app_name,
+            timestamp: Utc::now(),
+            msg,
+        };
+        if self.tx.try_send(rec).is_err() {
+            self.shared.stats.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Re-read the config from the DB every 60s and apply changes (covers edits
+/// made by other processes, e.g. the CLI writing SQLite directly).
+pub fn spawn_config_poller(pool: SqlitePool, mgr: Arc<SyslogManager>) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(POLL_INTERVAL).await;
+            let cfg = load(&pool).await;
+            if *mgr.current() != cfg {
+                mgr.apply(cfg);
+            }
+        }
+    });
+}
+
+/// One-shot delivery of a test message using `cfg` (which need not be saved
+/// or enabled). Returns a human-readable error on failure. Note UDP is
+/// fire-and-forget: success means the datagram left this host, not that the
+/// server received it.
+pub async fn test_send(cfg: &SyslogConfig, msg: &str) -> Result<(), String> {
+    if cfg.host.trim().is_empty() {
+        return Err("host is required".into());
+    }
+    let hostname = detect_hostname();
+    let hostname = if cfg.hostname_override.is_empty() {
+        hostname.as_str()
+    } else {
+        cfg.hostname_override.as_str()
+    };
+    let rec = SyslogRecord {
+        severity: 5,
+        app_name: "aifw",
+        timestamp: Utc::now(),
+        msg: msg.to_string(),
+    };
+    let line = format_message(cfg, hostname, &rec);
+    let mut conn = open_conn(cfg).await?;
+    send_line(&mut conn, &line).await
+}
+
+fn detect_hostname() -> String {
+    #[cfg(unix)]
+    {
+        nix::unistd::gethostname()
+            .ok()
+            .and_then(|h| h.into_string().ok())
+            .filter(|h| !h.is_empty())
+            .unwrap_or_else(|| "aifw".into())
+    }
+    #[cfg(not(unix))]
+    {
+        "aifw".into()
+    }
+}
+
+enum Conn {
+    Udp {
+        sock: UdpSocket,
+        peer: std::net::SocketAddr,
+    },
+    Tcp(TcpStream),
+}
+
+async fn open_conn(cfg: &SyslogConfig) -> Result<Conn, String> {
+    let target = format!("{}:{}", cfg.host, cfg.port);
+    let peer = timeout(IO_TIMEOUT, lookup_host(&target))
+        .await
+        .map_err(|_| format!("DNS lookup for {target} timed out"))?
+        .map_err(|e| format!("cannot resolve {target}: {e}"))?
+        .next()
+        .ok_or_else(|| format!("no addresses for {target}"))?;
+    match cfg.transport {
+        Transport::Udp => {
+            let bind = if peer.is_ipv4() {
+                "0.0.0.0:0"
+            } else {
+                "[::]:0"
+            };
+            let sock = UdpSocket::bind(bind)
+                .await
+                .map_err(|e| format!("cannot bind UDP socket: {e}"))?;
+            Ok(Conn::Udp { sock, peer })
+        }
+        Transport::Tcp => {
+            let stream = timeout(IO_TIMEOUT, TcpStream::connect(peer))
+                .await
+                .map_err(|_| format!("connect to {target} timed out"))?
+                .map_err(|e| format!("cannot connect to {target}: {e}"))?;
+            Ok(Conn::Tcp(stream))
+        }
+    }
+}
+
+async fn send_line(conn: &mut Conn, line: &str) -> Result<(), String> {
+    match conn {
+        Conn::Udp { sock, peer } => {
+            timeout(IO_TIMEOUT, sock.send_to(line.as_bytes(), *peer))
+                .await
+                .map_err(|_| "UDP send timed out".to_string())?
+                .map_err(|e| format!("UDP send failed: {e}"))?;
+        }
+        Conn::Tcp(stream) => {
+            // RFC 6587 non-transparent framing: LF-terminated records.
+            let mut buf = Vec::with_capacity(line.len() + 1);
+            buf.extend_from_slice(line.as_bytes());
+            buf.push(b'\n');
+            timeout(IO_TIMEOUT, stream.write_all(&buf))
+                .await
+                .map_err(|_| "TCP write timed out".to_string())?
+                .map_err(|e| format!("TCP write failed: {e}"))?;
+        }
+    }
+    Ok(())
+}
+
+async fn writer_task(
+    shared: Arc<Shared>,
+    mut rx: mpsc::Receiver<SyslogRecord>,
+    mut reload: watch::Receiver<u64>,
+) {
+    let mut conn: Option<Conn> = None;
+    let mut backoff = BACKOFF_MIN;
+    let mut retry_at: Option<Instant> = None;
+    let mut was_failing = false;
+
+    loop {
+        tokio::select! {
+            changed = reload.changed() => {
+                if changed.is_err() {
+                    return; // manager dropped
+                }
+                conn = None;
+                backoff = BACKOFF_MIN;
+                retry_at = None;
+            }
+            rec = rx.recv() => {
+                let Some(rec) = rec else { return }; // all senders dropped
+                let cfg = shared.config.load_full();
+                if !cfg.enabled || cfg.host.is_empty() {
+                    continue; // drain silently while disabled
+                }
+                // While in backoff after a failure, shed load instead of
+                // stalling the queue behind a dead target.
+                if let Some(t) = retry_at
+                    && Instant::now() < t
+                {
+                    shared.stats.dropped.fetch_add(1, Ordering::Relaxed);
+                    continue;
+                }
+                let line = format_message(&cfg, shared.hostname_for(&cfg), &rec);
+                let result = match &mut conn {
+                    Some(c) => send_line(c, &line).await,
+                    None => match open_conn(&cfg).await {
+                        Ok(mut c) => {
+                            let r = send_line(&mut c, &line).await;
+                            if r.is_ok() {
+                                conn = Some(c);
+                            }
+                            r
+                        }
+                        Err(e) => Err(e),
+                    },
+                };
+                match result {
+                    Ok(()) => {
+                        shared.stats.sent.fetch_add(1, Ordering::Relaxed);
+                        shared.stats.connected.store(true, Ordering::Relaxed);
+                        backoff = BACKOFF_MIN;
+                        retry_at = None;
+                        if was_failing {
+                            was_failing = false;
+                            tracing::info!("remote syslog delivery recovered");
+                        }
+                    }
+                    Err(e) => {
+                        conn = None;
+                        // Warn once per outage, not per message; the layer's
+                        // recursion guard also drops this module's events.
+                        if !was_failing {
+                            was_failing = true;
+                            tracing::warn!(error = %e, "remote syslog delivery failing; backing off");
+                        }
+                        shared.stats.record_error(e);
+                        retry_at = Some(Instant::now() + backoff);
+                        backoff = (backoff * 2).min(BACKOFF_MAX);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::config::SyslogFormat;
+    use super::*;
+
+    fn cfg_to(port: u16, transport: Transport) -> SyslogConfig {
+        SyslogConfig {
+            enabled: true,
+            host: "127.0.0.1".into(),
+            port,
+            transport,
+            format: SyslogFormat::Rfc3164,
+            pf_enabled: true,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn udp_delivery_and_gating() {
+        let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let port = server.local_addr().unwrap().port();
+
+        let mgr = SyslogManager::start();
+        mgr.apply(cfg_to(port, Transport::Udp));
+        let handle = mgr.handle();
+
+        assert!(handle.enabled_for(Category::Pf));
+        assert!(!handle.enabled_for(Category::Ids)); // toggle off → gated
+
+        handle.enqueue(Category::Ids, 6, "aifw-test", "must not arrive".into());
+        handle.enqueue(
+            Category::Pf,
+            5,
+            "aifw-pf",
+            "action=block src=1.2.3.4".into(),
+        );
+
+        let mut buf = [0u8; 4096];
+        let (n, _) = timeout(Duration::from_secs(5), server.recv_from(&mut buf))
+            .await
+            .expect("datagram should arrive")
+            .unwrap();
+        let got = std::str::from_utf8(&buf[..n]).unwrap();
+        assert!(got.contains("aifw-pf"), "got: {got}");
+        assert!(got.contains("action=block src=1.2.3.4"));
+        assert!(got.starts_with("<133>")); // local0(16)*8 + notice(5)
+
+        // Nothing else queued: the gated IDS message never went out.
+        let extra = timeout(Duration::from_millis(200), server.recv_from(&mut buf)).await;
+        assert!(extra.is_err(), "gated message unexpectedly delivered");
+
+        let stats = mgr.stats();
+        assert_eq!(stats.sent, 1);
+        assert!(stats.connected);
+    }
+
+    #[tokio::test]
+    async fn tcp_delivery_lf_framed() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let mgr = SyslogManager::start();
+        let mut cfg = cfg_to(port, Transport::Tcp);
+        cfg.format = SyslogFormat::Rfc5424;
+        cfg.ids_enabled = true;
+        mgr.apply(cfg);
+        let handle = mgr.handle();
+
+        handle.enqueue(Category::Ids, 2, "aifw-ids", "alert one".into());
+        handle.enqueue(Category::Ids, 2, "aifw-ids", "alert two".into());
+
+        let (mut sock, _) = timeout(Duration::from_secs(5), listener.accept())
+            .await
+            .expect("client should connect")
+            .unwrap();
+        let mut data = Vec::new();
+        let mut buf = [0u8; 4096];
+        while data.iter().filter(|b| **b == b'\n').count() < 2 {
+            let n = timeout(
+                Duration::from_secs(5),
+                tokio::io::AsyncReadExt::read(&mut sock, &mut buf),
+            )
+            .await
+            .expect("read should not time out")
+            .unwrap();
+            if n == 0 {
+                break;
+            }
+            data.extend_from_slice(&buf[..n]);
+        }
+        let text = String::from_utf8(data).unwrap();
+        let lines: Vec<&str> = text.split('\n').filter(|l| !l.is_empty()).collect();
+        assert_eq!(lines.len(), 2, "text: {text:?}");
+        assert!(lines[0].contains("alert one"));
+        assert!(lines[1].contains("alert two"));
+        // RFC 5424: VERSION "1" right after PRI
+        assert!(lines[0].starts_with("<130>1 "), "line: {}", lines[0]);
+    }
+
+    #[tokio::test]
+    async fn disabled_config_sends_nothing() {
+        let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let port = server.local_addr().unwrap().port();
+
+        let mgr = SyslogManager::start();
+        let mut cfg = cfg_to(port, Transport::Udp);
+        cfg.enabled = false;
+        mgr.apply(cfg);
+        let handle = mgr.handle();
+        handle.enqueue(Category::Pf, 5, "aifw-pf", "nope".into());
+
+        let mut buf = [0u8; 64];
+        let r = timeout(Duration::from_millis(200), server.recv_from(&mut buf)).await;
+        assert!(r.is_err());
+        assert_eq!(mgr.stats().sent, 0);
+    }
+
+    #[tokio::test]
+    async fn test_send_reports_connection_refused() {
+        // Reserve a port, then close it so the connect is refused.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let cfg = cfg_to(port, Transport::Tcp);
+        let err = test_send(&cfg, "test message").await.unwrap_err();
+        assert!(err.contains("cannot connect"), "err: {err}");
+    }
+
+    #[tokio::test]
+    async fn test_send_requires_host() {
+        let cfg = SyslogConfig::default();
+        assert!(test_send(&cfg, "x").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_send_udp_ok() {
+        let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let port = server.local_addr().unwrap().port();
+        let mut cfg = cfg_to(port, Transport::Udp);
+        cfg.enabled = false; // test_send works even when forwarding is off
+        test_send(&cfg, "hello from test").await.unwrap();
+        let mut buf = [0u8; 512];
+        let (n, _) = timeout(Duration::from_secs(5), server.recv_from(&mut buf))
+            .await
+            .expect("test datagram should arrive")
+            .unwrap();
+        assert!(
+            std::str::from_utf8(&buf[..n])
+                .unwrap()
+                .contains("hello from test")
+        );
+    }
+}

--- a/aifw-common/src/syslog/client.rs
+++ b/aifw-common/src/syslog/client.rs
@@ -303,20 +303,35 @@ async fn send_line(conn: &mut Conn, line: &str) -> Result<(), String> {
 async fn writer_task(
     shared: Arc<Shared>,
     mut rx: mpsc::Receiver<SyslogRecord>,
-    mut reload: watch::Receiver<u64>,
+    reload: watch::Receiver<u64>,
 ) {
-    let mut conn: Option<Conn> = None;
+    // The connection is tagged with the config Arc it was opened for; a
+    // pointer comparison per message replaces "drop the connection on every
+    // reload notification", which tore down healthy connections when the
+    // notification raced with already-processed messages.
+    let mut conn: Option<(Conn, Arc<SyslogConfig>)> = None;
     let mut backoff = BACKOFF_MIN;
     let mut retry_at: Option<Instant> = None;
     let mut was_failing = false;
+    // None once the manager is dropped: keep draining messages from
+    // still-live handles instead of exiting with queued records unsent.
+    let mut reload = Some(reload);
 
     loop {
         tokio::select! {
-            changed = reload.changed() => {
-                if changed.is_err() {
-                    return; // manager dropped
+            changed = async {
+                match reload.as_mut() {
+                    Some(r) => r.changed().await,
+                    None => std::future::pending().await,
                 }
-                conn = None;
+            } => {
+                if changed.is_err() {
+                    reload = None; // manager dropped; drain remaining messages
+                    continue;
+                }
+                // A config change ends any backoff immediately; the stale
+                // connection (if the config really changed) is detected by
+                // the per-message pointer check below.
                 backoff = BACKOFF_MIN;
                 retry_at = None;
             }
@@ -334,14 +349,21 @@ async fn writer_task(
                     shared.stats.dropped.fetch_add(1, Ordering::Relaxed);
                     continue;
                 }
+                // Reconnect when the config this connection was opened for
+                // is no longer current.
+                if let Some((_, conn_cfg)) = &conn
+                    && !Arc::ptr_eq(conn_cfg, &cfg)
+                {
+                    conn = None;
+                }
                 let line = format_message(&cfg, shared.hostname_for(&cfg), &rec);
                 let result = match &mut conn {
-                    Some(c) => send_line(c, &line).await,
+                    Some((c, _)) => send_line(c, &line).await,
                     None => match open_conn(&cfg).await {
                         Ok(mut c) => {
                             let r = send_line(&mut c, &line).await;
                             if r.is_ok() {
-                                conn = Some(c);
+                                conn = Some((c, cfg.clone()));
                             }
                             r
                         }

--- a/aifw-common/src/syslog/client.rs
+++ b/aifw-common/src/syslog/client.rs
@@ -192,9 +192,97 @@ impl SyslogHandle {
     }
 }
 
+/// One process's persisted delivery counters (`syslog_stats` row).
+#[derive(Debug, Clone, Serialize)]
+pub struct ProcessSyslogStats {
+    /// Reporting process (`aifw-api` / `aifw-daemon` / `aifw-ids`)
+    pub process: String,
+    /// Messages successfully handed to the transport
+    pub sent: u64,
+    /// Messages dropped (queue full or target in backoff)
+    pub dropped: u64,
+    /// Send/connect failures
+    pub errors: u64,
+    /// Whether the last send succeeded / stream is up
+    pub connected: bool,
+    /// Most recent transport error, if any
+    pub last_error: Option<String>,
+    /// UTC `datetime('now')` of the last refresh
+    pub updated_at: String,
+}
+
+impl ProcessSyslogStats {
+    /// Build a row from a live snapshot (used for the calling process,
+    /// which is fresher than its persisted row).
+    pub fn from_snapshot(process: &str, snap: &SyslogStatsSnapshot) -> Self {
+        Self {
+            process: process.to_string(),
+            sent: snap.sent,
+            dropped: snap.dropped,
+            errors: snap.errors,
+            connected: snap.connected,
+            last_error: snap.last_error.clone(),
+            updated_at: Utc::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+        }
+    }
+}
+
+/// Persist a process's delivery counters for cross-process status views.
+pub async fn write_stats(
+    pool: &SqlitePool,
+    process: &str,
+    snap: &SyslogStatsSnapshot,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"INSERT INTO syslog_stats (process, sent, dropped, errors, connected, last_error, updated_at)
+           VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'))
+           ON CONFLICT(process) DO UPDATE SET
+             sent = excluded.sent, dropped = excluded.dropped,
+             errors = excluded.errors, connected = excluded.connected,
+             last_error = excluded.last_error, updated_at = excluded.updated_at"#,
+    )
+    .bind(process)
+    .bind(snap.sent as i64)
+    .bind(snap.dropped as i64)
+    .bind(snap.errors as i64)
+    .bind(snap.connected as i64)
+    .bind(&snap.last_error)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Read every process's persisted delivery counters.
+pub async fn read_stats(pool: &SqlitePool) -> Result<Vec<ProcessSyslogStats>, sqlx::Error> {
+    type Row = (String, i64, i64, i64, i64, Option<String>, String);
+    let rows: Vec<Row> = sqlx::query_as(
+        "SELECT process, sent, dropped, errors, connected, last_error, updated_at
+           FROM syslog_stats ORDER BY process",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(
+            |(process, sent, dropped, errors, connected, last_error, updated_at)| {
+                ProcessSyslogStats {
+                    process,
+                    sent: sent as u64,
+                    dropped: dropped as u64,
+                    errors: errors as u64,
+                    connected: connected != 0,
+                    last_error,
+                    updated_at,
+                }
+            },
+        )
+        .collect())
+}
+
 /// Re-read the config from the DB every 60s and apply changes (covers edits
-/// made by other processes, e.g. the CLI writing SQLite directly).
-pub fn spawn_config_poller(pool: SqlitePool, mgr: Arc<SyslogManager>) {
+/// made by other processes, e.g. the CLI writing SQLite directly), and
+/// persist this process's delivery counters for cross-process status.
+pub fn spawn_config_poller(pool: SqlitePool, mgr: Arc<SyslogManager>, process: &'static str) {
     tokio::spawn(async move {
         loop {
             tokio::time::sleep(POLL_INTERVAL).await;
@@ -206,6 +294,9 @@ pub fn spawn_config_poller(pool: SqlitePool, mgr: Arc<SyslogManager>) {
                 Err(e) => {
                     tracing::warn!(error = %e, "syslog config poll failed; keeping current config");
                 }
+            }
+            if let Err(e) = write_stats(&pool, process, &mgr.stats()).await {
+                tracing::debug!(error = %e, "failed to persist syslog delivery stats");
             }
         }
     });

--- a/aifw-common/src/syslog/client.rs
+++ b/aifw-common/src/syslog/client.rs
@@ -18,7 +18,8 @@ use tokio::net::{TcpStream, UdpSocket, lookup_host};
 use tokio::sync::{mpsc, watch};
 use tokio::time::{Instant, timeout};
 
-use super::config::{Category, SyslogConfig, Transport, load};
+use super::config::{Category, SyslogConfig, Transport, try_load};
+use super::error::SyslogError;
 use super::format::{SyslogRecord, format_message};
 
 /// Bounded queue size shared by all producers in a process.
@@ -124,8 +125,13 @@ impl SyslogManager {
     }
 
     /// Swap in a new configuration; the writer drops its connection and
-    /// re-resolves the target.
+    /// re-resolves the target. No-op when the config is unchanged, so a
+    /// no-op Save/poll never tears down a healthy TCP connection (the
+    /// writer reconnects on config *pointer* change).
     pub fn apply(&self, cfg: SyslogConfig) {
+        if *self.current() == cfg {
+            return;
+        }
         self.shared.config.store(Arc::new(cfg));
         self.reload.send_modify(|g| *g = g.wrapping_add(1));
     }
@@ -192,21 +198,25 @@ pub fn spawn_config_poller(pool: SqlitePool, mgr: Arc<SyslogManager>) {
     tokio::spawn(async move {
         loop {
             tokio::time::sleep(POLL_INTERVAL).await;
-            let cfg = load(&pool).await;
-            if *mgr.current() != cfg {
-                mgr.apply(cfg);
+            // A transient read failure (SQLITE_BUSY on the shared WAL DB)
+            // must not masquerade as "config reset to defaults" — that
+            // would flap forwarding off for a poll interval. Skip the tick.
+            match try_load(&pool).await {
+                Ok(cfg) => mgr.apply(cfg),
+                Err(e) => {
+                    tracing::warn!(error = %e, "syslog config poll failed; keeping current config");
+                }
             }
         }
     });
 }
 
 /// One-shot delivery of a test message using `cfg` (which need not be saved
-/// or enabled). Returns a human-readable error on failure. Note UDP is
-/// fire-and-forget: success means the datagram left this host, not that the
-/// server received it.
-pub async fn test_send(cfg: &SyslogConfig, msg: &str) -> Result<(), String> {
+/// or enabled). Note UDP is fire-and-forget: success means the datagram
+/// left this host, not that the server received it.
+pub async fn test_send(cfg: &SyslogConfig, msg: &str) -> Result<(), SyslogError> {
     if cfg.host.trim().is_empty() {
-        return Err("host is required".into());
+        return Err(SyslogError::HostRequired);
     }
     let hostname = detect_hostname();
     let hostname = if cfg.hostname_override.is_empty() {
@@ -248,43 +258,80 @@ enum Conn {
     Tcp(TcpStream),
 }
 
-async fn open_conn(cfg: &SyslogConfig) -> Result<Conn, String> {
-    let target = format!("{}:{}", cfg.host, cfg.port);
-    let peer = timeout(IO_TIMEOUT, lookup_host(&target))
+/// `host:port` target string, bracketing bare IPv6 literals so
+/// `lookup_host` can parse them (`2001:db8::1` -> `[2001:db8::1]:514`;
+/// already-bracketed input is passed through).
+fn target_string(host: &str, port: u16) -> String {
+    if host.parse::<std::net::Ipv6Addr>().is_ok() {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    }
+}
+
+async fn open_conn(cfg: &SyslogConfig) -> Result<Conn, SyslogError> {
+    let target = target_string(&cfg.host, cfg.port);
+    let addrs: Vec<std::net::SocketAddr> = timeout(IO_TIMEOUT, lookup_host(&target))
         .await
-        .map_err(|_| format!("DNS lookup for {target} timed out"))?
-        .map_err(|e| format!("cannot resolve {target}: {e}"))?
-        .next()
-        .ok_or_else(|| format!("no addresses for {target}"))?;
+        .map_err(|_| SyslogError::ResolveTimeout {
+            target: target.clone(),
+        })?
+        .map_err(|e| SyslogError::Resolve {
+            target: target.clone(),
+            source: e,
+        })?
+        .collect();
+    if addrs.is_empty() {
+        return Err(SyslogError::NoAddresses { target });
+    }
     match cfg.transport {
         Transport::Udp => {
+            let peer = addrs[0];
             let bind = if peer.is_ipv4() {
                 "0.0.0.0:0"
             } else {
                 "[::]:0"
             };
-            let sock = UdpSocket::bind(bind)
-                .await
-                .map_err(|e| format!("cannot bind UDP socket: {e}"))?;
+            let sock = UdpSocket::bind(bind).await.map_err(SyslogError::Bind)?;
             Ok(Conn::Udp { sock, peer })
         }
         Transport::Tcp => {
-            let stream = timeout(IO_TIMEOUT, TcpStream::connect(peer))
-                .await
-                .map_err(|_| format!("connect to {target} timed out"))?
-                .map_err(|e| format!("cannot connect to {target}: {e}"))?;
-            Ok(Conn::Tcp(stream))
+            // Try every resolved address (a dual-stack hostname may
+            // resolve v6-first on a v4-only deployment); keep the last
+            // error for the report.
+            let mut last: Option<SyslogError> = None;
+            for peer in addrs {
+                match timeout(IO_TIMEOUT, TcpStream::connect(peer)).await {
+                    Ok(Ok(stream)) => return Ok(Conn::Tcp(stream)),
+                    Ok(Err(e)) => {
+                        last = Some(SyslogError::Connect {
+                            target: target.clone(),
+                            source: e,
+                        });
+                    }
+                    Err(_) => {
+                        last = Some(SyslogError::ConnectTimeout {
+                            target: target.clone(),
+                        });
+                    }
+                }
+            }
+            // Non-empty addrs guarantees at least one attempt ran.
+            Err(last.unwrap_or(SyslogError::NoAddresses { target }))
         }
     }
 }
 
-async fn send_line(conn: &mut Conn, line: &str) -> Result<(), String> {
+async fn send_line(conn: &mut Conn, line: &str) -> Result<(), SyslogError> {
     match conn {
         Conn::Udp { sock, peer } => {
             timeout(IO_TIMEOUT, sock.send_to(line.as_bytes(), *peer))
                 .await
-                .map_err(|_| "UDP send timed out".to_string())?
-                .map_err(|e| format!("UDP send failed: {e}"))?;
+                .map_err(|_| SyslogError::SendTimeout { transport: "UDP" })?
+                .map_err(|e| SyslogError::Send {
+                    transport: "UDP",
+                    source: e,
+                })?;
         }
         Conn::Tcp(stream) => {
             // RFC 6587 non-transparent framing: LF-terminated records.
@@ -293,8 +340,11 @@ async fn send_line(conn: &mut Conn, line: &str) -> Result<(), String> {
             buf.push(b'\n');
             timeout(IO_TIMEOUT, stream.write_all(&buf))
                 .await
-                .map_err(|_| "TCP write timed out".to_string())?
-                .map_err(|e| format!("TCP write failed: {e}"))?;
+                .map_err(|_| SyslogError::SendTimeout { transport: "TCP" })?
+                .map_err(|e| SyslogError::Send {
+                    transport: "TCP",
+                    source: e,
+                })?;
         }
     }
     Ok(())
@@ -389,7 +439,7 @@ async fn writer_task(
                             was_failing = true;
                             tracing::warn!(error = %e, "remote syslog delivery failing; backing off");
                         }
-                        shared.stats.record_error(e);
+                        shared.stats.record_error(e.to_string());
                         retry_at = Some(Instant::now() + backoff);
                         backoff = (backoff * 2).min(BACKOFF_MAX);
                     }
@@ -524,8 +574,22 @@ mod tests {
         drop(listener);
 
         let cfg = cfg_to(port, Transport::Tcp);
-        let err = test_send(&cfg, "test message").await.unwrap_err();
+        let err = test_send(&cfg, "test message")
+            .await
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("cannot connect"), "err: {err}");
+    }
+
+    #[test]
+    fn target_string_brackets_bare_ipv6() {
+        assert_eq!(target_string("2001:db8::1", 514), "[2001:db8::1]:514");
+        assert_eq!(target_string("[2001:db8::1]", 514), "[2001:db8::1]:514");
+        assert_eq!(target_string("192.0.2.1", 514), "192.0.2.1:514");
+        assert_eq!(
+            target_string("log.example.com", 6514),
+            "log.example.com:6514"
+        );
     }
 
     #[tokio::test]

--- a/aifw-common/src/syslog/config.rs
+++ b/aifw-common/src/syslog/config.rs
@@ -244,6 +244,22 @@ pub async fn migrate(pool: &SqlitePool) -> crate::Result<()> {
     sqlx::query("INSERT OR IGNORE INTO syslog_config (id) VALUES (1)")
         .execute(pool)
         .await?;
+    // Per-process delivery counters, refreshed by each process's config
+    // poller so the UI can show daemon/IDS delivery health, not just the
+    // API process's.
+    sqlx::query(
+        r#"CREATE TABLE IF NOT EXISTS syslog_stats (
+            process    TEXT PRIMARY KEY,
+            sent       INTEGER NOT NULL DEFAULT 0,
+            dropped    INTEGER NOT NULL DEFAULT 0,
+            errors     INTEGER NOT NULL DEFAULT 0,
+            connected  INTEGER NOT NULL DEFAULT 0,
+            last_error TEXT,
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )"#,
+    )
+    .execute(pool)
+    .await?;
     Ok(())
 }
 

--- a/aifw-common/src/syslog/config.rs
+++ b/aifw-common/src/syslog/config.rs
@@ -141,11 +141,30 @@ impl SyslogConfig {
         if self.host.len() > 255 {
             return Err("host must be at most 255 characters".into());
         }
+        if self
+            .host
+            .chars()
+            .any(|c| c.is_whitespace() || c.is_ascii_control())
+        {
+            return Err("host must not contain whitespace or control characters".into());
+        }
         if self.port == 0 {
             return Err("port must be 1-65535".into());
         }
         if self.facility > 23 {
             return Err("facility must be 0-23".into());
+        }
+        if self.hostname_override.len() > 255 {
+            return Err("hostname_override must be at most 255 characters".into());
+        }
+        if self
+            .hostname_override
+            .chars()
+            .any(|c| c.is_whitespace() || c.is_ascii_control())
+        {
+            return Err(
+                "hostname_override must not contain whitespace or control characters".into(),
+            );
         }
         if !APP_LEVELS.contains(&self.app_min_level.as_str()) {
             return Err(format!(
@@ -278,15 +297,30 @@ const LOAD_SQL: &str = r#"SELECT enabled, host, port, transport, format, facilit
         hostname_override, pf_enabled, ids_enabled, app_enabled, app_min_level, disable_local
       FROM syslog_config WHERE id = 1"#;
 
-/// Read the singleton config row; falls back to defaults if missing.
-pub async fn load(pool: &SqlitePool) -> SyslogConfig {
-    sqlx::query_as::<_, Row>(LOAD_SQL)
+/// Read the singleton config row. A missing row (fresh DB) is defaults; a
+/// query error (e.g. SQLITE_BUSY on the shared WAL database) is an `Err` so
+/// callers can distinguish "not configured" from "could not read" — the
+/// config pollers must NOT treat a transient read failure as "forwarding
+/// was disabled".
+pub async fn try_load(pool: &SqlitePool) -> Result<SyslogConfig, sqlx::Error> {
+    Ok(sqlx::query_as::<_, Row>(LOAD_SQL)
         .fetch_optional(pool)
-        .await
-        .ok()
-        .flatten()
+        .await?
         .map(row_to_config)
-        .unwrap_or_default()
+        .unwrap_or_default())
+}
+
+/// Read the singleton config row; falls back to defaults if missing or on
+/// error (logged). Use [`try_load`] where a transient failure must not be
+/// mistaken for a disabled config.
+pub async fn load(pool: &SqlitePool) -> SyslogConfig {
+    match try_load(pool).await {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to load syslog config; using defaults");
+            SyslogConfig::default()
+        }
+    }
 }
 
 const SAVE_SQL: &str = r#"UPDATE syslog_config
@@ -395,6 +429,22 @@ mod tests {
         cfg.facility = 23;
         cfg.app_min_level = "verbose".into();
         assert!(cfg.validate().is_err());
+
+        cfg.app_min_level = "info".into();
+        cfg.host = "log server".into(); // whitespace in host
+        assert!(cfg.validate().is_err());
+        cfg.host = "log\nserver".into(); // control char in host
+        assert!(cfg.validate().is_err());
+        cfg.host = "192.0.2.1".into();
+        cfg.hostname_override = "fw one".into(); // whitespace in override
+        assert!(cfg.validate().is_err());
+        cfg.hostname_override = "h".repeat(256);
+        assert!(cfg.validate().is_err());
+        cfg.hostname_override = "fw1".into();
+        assert!(cfg.validate().is_ok());
+        // Bare IPv6 literals are valid hosts (bracketed on the wire).
+        cfg.host = "2001:db8::1".into();
+        assert!(cfg.validate().is_ok());
     }
 
     #[test]

--- a/aifw-common/src/syslog/config.rs
+++ b/aifw-common/src/syslog/config.rs
@@ -1,0 +1,439 @@
+//! Remote syslog configuration: the `syslog_config` singleton row.
+
+use serde::{Deserialize, Serialize};
+use sqlx::{SqliteConnection, SqlitePool};
+
+/// How syslog messages travel to the server. Wire values are lowercase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Transport {
+    /// Classic fire-and-forget datagrams (RFC 5426-style)
+    #[default]
+    Udp,
+    /// Stream with LF framing (RFC 6587 non-transparent), reconnects with backoff
+    Tcp,
+}
+
+impl Transport {
+    fn from_str(s: &str) -> Self {
+        match s.to_ascii_lowercase().as_str() {
+            "tcp" => Transport::Tcp,
+            _ => Transport::Udp,
+        }
+    }
+    /// Lowercase wire/DB value (`udp` / `tcp`)
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Transport::Udp => "udp",
+            Transport::Tcp => "tcp",
+        }
+    }
+}
+
+/// On-the-wire message format. Wire values are lowercase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SyslogFormat {
+    /// BSD syslog (RFC 3164): `<PRI>MMM dd HH:MM:SS host app[pid]: msg`
+    #[default]
+    Rfc3164,
+    /// Modern syslog (RFC 5424): `<PRI>1 TIMESTAMP host app pid - - msg`
+    Rfc5424,
+}
+
+impl SyslogFormat {
+    fn from_str(s: &str) -> Self {
+        match s.to_ascii_lowercase().as_str() {
+            "rfc5424" => SyslogFormat::Rfc5424,
+            _ => SyslogFormat::Rfc3164,
+        }
+    }
+    /// Lowercase wire/DB value (`rfc3164` / `rfc5424`)
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SyslogFormat::Rfc3164 => "rfc3164",
+            SyslogFormat::Rfc5424 => "rfc5424",
+        }
+    }
+}
+
+/// Log category a message belongs to; each has its own enable toggle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Category {
+    /// pf packet logs (pass/block lines captured from pflog0)
+    Pf,
+    /// IDS alerts
+    Ids,
+    /// Application logs (tracing output of the AiFw services)
+    App,
+}
+
+/// Remote syslog settings — a singleton row (`syslog_config`, id = 1).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SyslogConfig {
+    /// Master switch; when false nothing is forwarded (test-send still works)
+    pub enabled: bool,
+    /// Syslog server hostname or IP; empty means unconfigured
+    pub host: String,
+    /// Syslog server port (default 514)
+    pub port: u16,
+    /// UDP or TCP (default UDP)
+    #[serde(default)]
+    pub transport: Transport,
+    /// BSD (RFC 3164) or RFC 5424 framing (default BSD)
+    #[serde(default)]
+    pub format: SyslogFormat,
+    /// Syslog facility 0-23 (default 16 = local0)
+    pub facility: u8,
+    /// HOSTNAME field override; empty = use the system hostname
+    #[serde(default)]
+    pub hostname_override: String,
+    /// Forward pf packet logs
+    #[serde(default)]
+    pub pf_enabled: bool,
+    /// Forward IDS alerts
+    #[serde(default)]
+    pub ids_enabled: bool,
+    /// Forward application (tracing) logs
+    #[serde(default)]
+    pub app_enabled: bool,
+    /// Minimum app-log level forwarded: `error` | `warn` | `info` | `debug`
+    #[serde(default = "default_app_min_level")]
+    pub app_min_level: String,
+    /// Stop writing local log files (pf log file + app stdout logs) while
+    /// remote forwarding is active. IDS alerts always stay in the local DB.
+    #[serde(default)]
+    pub disable_local: bool,
+}
+
+fn default_app_min_level() -> String {
+    "info".into()
+}
+
+impl Default for SyslogConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            host: String::new(),
+            port: 514,
+            transport: Transport::Udp,
+            format: SyslogFormat::Rfc3164,
+            facility: 16,
+            hostname_override: String::new(),
+            pf_enabled: false,
+            ids_enabled: false,
+            app_enabled: false,
+            app_min_level: default_app_min_level(),
+            disable_local: false,
+        }
+    }
+}
+
+/// Valid `app_min_level` values, most to least severe.
+const APP_LEVELS: [&str; 4] = ["error", "warn", "info", "debug"];
+
+impl SyslogConfig {
+    /// Human-readable validation for API/CLI input.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.enabled && self.host.trim().is_empty() {
+            return Err("host is required when remote syslog is enabled".into());
+        }
+        if self.host.len() > 255 {
+            return Err("host must be at most 255 characters".into());
+        }
+        if self.port == 0 {
+            return Err("port must be 1-65535".into());
+        }
+        if self.facility > 23 {
+            return Err("facility must be 0-23".into());
+        }
+        if !APP_LEVELS.contains(&self.app_min_level.as_str()) {
+            return Err(format!(
+                "app_min_level must be one of: {}",
+                APP_LEVELS.join(", ")
+            ));
+        }
+        Ok(())
+    }
+
+    /// True when forwarding is on overall and for this category.
+    pub fn category_enabled(&self, cat: Category) -> bool {
+        self.enabled
+            && !self.host.is_empty()
+            && match cat {
+                Category::Pf => self.pf_enabled,
+                Category::Ids => self.ids_enabled,
+                Category::App => self.app_enabled,
+            }
+    }
+
+    /// Rank of `app_min_level` for comparisons: error=3 … debug=7 (syslog
+    /// severity numbers; a message passes when its severity <= this).
+    pub fn app_min_severity(&self) -> u8 {
+        match self.app_min_level.as_str() {
+            "error" => 3,
+            "warn" => 4,
+            "debug" => 7,
+            _ => 6, // info
+        }
+    }
+}
+
+/// Well-known facility names, indexed by facility number 0-23.
+const FACILITY_NAMES: [&str; 24] = [
+    "kern", "user", "mail", "daemon", "auth", "syslog", "lpr", "news", "uucp", "cron", "authpriv",
+    "ftp", "ntp", "audit", "alert", "clock", "local0", "local1", "local2", "local3", "local4",
+    "local5", "local6", "local7",
+];
+
+/// Parse a facility given as a name (`local0`, `daemon`, …) or a number 0-23.
+pub fn facility_from_name(s: &str) -> Option<u8> {
+    let lower = s.to_ascii_lowercase();
+    if let Some(idx) = FACILITY_NAMES.iter().position(|n| *n == lower) {
+        return Some(idx as u8);
+    }
+    lower.parse::<u8>().ok().filter(|n| *n <= 23)
+}
+
+/// Name for a facility number, or `None` when out of range.
+pub fn facility_name(facility: u8) -> Option<&'static str> {
+    FACILITY_NAMES.get(facility as usize).copied()
+}
+
+/// Create the `syslog_config` table if missing and seed the singleton row.
+/// Idempotent; called at startup by all AiFw services.
+pub async fn migrate(pool: &SqlitePool) -> crate::Result<()> {
+    sqlx::query(
+        r#"CREATE TABLE IF NOT EXISTS syslog_config (
+            id                INTEGER PRIMARY KEY CHECK (id = 1),
+            enabled           INTEGER NOT NULL DEFAULT 0,
+            host              TEXT    NOT NULL DEFAULT '',
+            port              INTEGER NOT NULL DEFAULT 514,
+            transport         TEXT    NOT NULL DEFAULT 'udp',
+            format            TEXT    NOT NULL DEFAULT 'rfc3164',
+            facility          INTEGER NOT NULL DEFAULT 16,
+            hostname_override TEXT    NOT NULL DEFAULT '',
+            pf_enabled        INTEGER NOT NULL DEFAULT 0,
+            ids_enabled       INTEGER NOT NULL DEFAULT 0,
+            app_enabled       INTEGER NOT NULL DEFAULT 0,
+            app_min_level     TEXT    NOT NULL DEFAULT 'info',
+            disable_local     INTEGER NOT NULL DEFAULT 0
+        )"#,
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query("INSERT OR IGNORE INTO syslog_config (id) VALUES (1)")
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+type Row = (
+    i64,
+    String,
+    i64,
+    String,
+    String,
+    i64,
+    String,
+    i64,
+    i64,
+    i64,
+    String,
+    i64,
+);
+
+fn row_to_config(r: Row) -> SyslogConfig {
+    let (
+        enabled,
+        host,
+        port,
+        transport,
+        format,
+        facility,
+        hostname_override,
+        pf_enabled,
+        ids_enabled,
+        app_enabled,
+        app_min_level,
+        disable_local,
+    ) = r;
+    SyslogConfig {
+        enabled: enabled != 0,
+        host,
+        port: port as u16,
+        transport: Transport::from_str(&transport),
+        format: SyslogFormat::from_str(&format),
+        facility: (facility as u8).min(23),
+        hostname_override,
+        pf_enabled: pf_enabled != 0,
+        ids_enabled: ids_enabled != 0,
+        app_enabled: app_enabled != 0,
+        app_min_level,
+        disable_local: disable_local != 0,
+    }
+}
+
+const LOAD_SQL: &str = r#"SELECT enabled, host, port, transport, format, facility,
+        hostname_override, pf_enabled, ids_enabled, app_enabled, app_min_level, disable_local
+      FROM syslog_config WHERE id = 1"#;
+
+/// Read the singleton config row; falls back to defaults if missing.
+pub async fn load(pool: &SqlitePool) -> SyslogConfig {
+    sqlx::query_as::<_, Row>(LOAD_SQL)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten()
+        .map(row_to_config)
+        .unwrap_or_default()
+}
+
+const SAVE_SQL: &str = r#"UPDATE syslog_config
+      SET enabled=?, host=?, port=?, transport=?, format=?, facility=?,
+          hostname_override=?, pf_enabled=?, ids_enabled=?, app_enabled=?,
+          app_min_level=?, disable_local=?
+    WHERE id=1"#;
+
+/// Persist the singleton config row.
+pub async fn save(pool: &SqlitePool, cfg: &SyslogConfig) -> crate::Result<()> {
+    bind_save(sqlx::query(SAVE_SQL), cfg).execute(pool).await?;
+    Ok(())
+}
+
+/// Persist within an existing transaction/connection (config-restore path).
+pub async fn save_on(conn: &mut SqliteConnection, cfg: &SyslogConfig) -> Result<(), sqlx::Error> {
+    bind_save(sqlx::query(SAVE_SQL), cfg).execute(conn).await?;
+    Ok(())
+}
+
+fn bind_save<'q>(
+    q: sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments>,
+    cfg: &'q SyslogConfig,
+) -> sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments> {
+    q.bind(cfg.enabled as i64)
+        .bind(&cfg.host)
+        .bind(cfg.port as i64)
+        .bind(cfg.transport.as_str())
+        .bind(cfg.format.as_str())
+        .bind(cfg.facility as i64)
+        .bind(&cfg.hostname_override)
+        .bind(cfg.pf_enabled as i64)
+        .bind(cfg.ids_enabled as i64)
+        .bind(cfg.app_enabled as i64)
+        .bind(&cfg.app_min_level)
+        .bind(cfg.disable_local as i64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn mem_pool() -> SqlitePool {
+        sqlx::sqlite::SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite always connects")
+    }
+
+    #[tokio::test]
+    async fn defaults_when_table_missing() {
+        let pool = mem_pool().await;
+        assert_eq!(load(&pool).await, SyslogConfig::default());
+    }
+
+    #[tokio::test]
+    async fn save_load_round_trip() {
+        let pool = mem_pool().await;
+        migrate(&pool).await.unwrap();
+        assert_eq!(load(&pool).await, SyslogConfig::default());
+
+        let cfg = SyslogConfig {
+            enabled: true,
+            host: "192.0.2.10".into(),
+            port: 5514,
+            transport: Transport::Tcp,
+            format: SyslogFormat::Rfc5424,
+            facility: 17,
+            hostname_override: "fw1".into(),
+            pf_enabled: true,
+            ids_enabled: true,
+            app_enabled: true,
+            app_min_level: "warn".into(),
+            disable_local: true,
+        };
+        save(&pool, &cfg).await.unwrap();
+        assert_eq!(load(&pool).await, cfg);
+        // migrate is idempotent and must not clobber the row
+        migrate(&pool).await.unwrap();
+        assert_eq!(load(&pool).await, cfg);
+    }
+
+    #[test]
+    fn validate_rejects_bad_input() {
+        let mut cfg = SyslogConfig {
+            enabled: true,
+            host: "log.example.com".into(),
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_ok());
+
+        cfg.host.clear();
+        assert!(cfg.validate().is_err()); // enabled without host
+
+        cfg.host = "h".repeat(256);
+        assert!(cfg.validate().is_err());
+
+        cfg.host = "ok".into();
+        cfg.port = 0;
+        assert!(cfg.validate().is_err());
+
+        cfg.port = 514;
+        cfg.facility = 24;
+        assert!(cfg.validate().is_err());
+
+        cfg.facility = 23;
+        cfg.app_min_level = "verbose".into();
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn category_gating() {
+        let cfg = SyslogConfig {
+            enabled: true,
+            host: "s".into(),
+            pf_enabled: true,
+            ..Default::default()
+        };
+        assert!(cfg.category_enabled(Category::Pf));
+        assert!(!cfg.category_enabled(Category::Ids));
+        assert!(!cfg.category_enabled(Category::App));
+        let off = SyslogConfig {
+            enabled: false,
+            ..cfg.clone()
+        };
+        assert!(!off.category_enabled(Category::Pf));
+    }
+
+    #[test]
+    fn facility_names_round_trip() {
+        assert_eq!(facility_from_name("local0"), Some(16));
+        assert_eq!(facility_from_name("LOCAL7"), Some(23));
+        assert_eq!(facility_from_name("daemon"), Some(3));
+        assert_eq!(facility_from_name("4"), Some(4));
+        assert_eq!(facility_from_name("24"), None);
+        assert_eq!(facility_from_name("nope"), None);
+        assert_eq!(facility_name(16), Some("local0"));
+        assert_eq!(facility_name(24), None);
+    }
+
+    #[test]
+    fn app_min_severity_ranks() {
+        let mut cfg = SyslogConfig::default();
+        assert_eq!(cfg.app_min_severity(), 6);
+        cfg.app_min_level = "error".into();
+        assert_eq!(cfg.app_min_severity(), 3);
+        cfg.app_min_level = "debug".into();
+        assert_eq!(cfg.app_min_severity(), 7);
+    }
+}

--- a/aifw-common/src/syslog/error.rs
+++ b/aifw-common/src/syslog/error.rs
@@ -1,0 +1,60 @@
+//! Typed errors for the syslog client (repo error-handling policy #188).
+
+/// Delivery/connection errors from the syslog client.
+#[derive(Debug, thiserror::Error)]
+pub enum SyslogError {
+    /// No server host configured for a send/test.
+    #[error("host is required")]
+    HostRequired,
+    /// DNS resolution exceeded the I/O timeout.
+    #[error("DNS lookup for {target} timed out")]
+    ResolveTimeout {
+        /// `host:port` being resolved
+        target: String,
+    },
+    /// DNS resolution failed.
+    #[error("cannot resolve {target}: {source}")]
+    Resolve {
+        /// `host:port` being resolved
+        target: String,
+        /// Underlying resolver error
+        source: std::io::Error,
+    },
+    /// Resolution succeeded but returned no addresses.
+    #[error("no addresses for {target}")]
+    NoAddresses {
+        /// `host:port` being resolved
+        target: String,
+    },
+    /// Local UDP socket could not be bound.
+    #[error("cannot bind UDP socket: {0}")]
+    Bind(#[source] std::io::Error),
+    /// TCP connect exceeded the I/O timeout (all addresses tried).
+    #[error("connect to {target} timed out")]
+    ConnectTimeout {
+        /// `host:port` being connected to
+        target: String,
+    },
+    /// TCP connect failed (all addresses tried; last error kept).
+    #[error("cannot connect to {target}: {source}")]
+    Connect {
+        /// `host:port` being connected to
+        target: String,
+        /// Underlying connect error
+        source: std::io::Error,
+    },
+    /// Send exceeded the I/O timeout.
+    #[error("{transport} send timed out")]
+    SendTimeout {
+        /// `"UDP"` or `"TCP"`
+        transport: &'static str,
+    },
+    /// Send failed at the socket layer.
+    #[error("{transport} send failed: {source}")]
+    Send {
+        /// `"UDP"` or `"TCP"`
+        transport: &'static str,
+        /// Underlying socket error
+        source: std::io::Error,
+    },
+}

--- a/aifw-common/src/syslog/format.rs
+++ b/aifw-common/src/syslog/format.rs
@@ -26,16 +26,73 @@ pub fn priority(facility: u8, severity: u8) -> u8 {
     facility.min(23) * 8 + severity.min(7)
 }
 
+/// Neutralize control characters so a message body can never break syslog
+/// framing (CWE-117 log forging): an embedded newline would otherwise split
+/// into extra receiver records with attacker-chosen PRI/timestamp/hostname
+/// under RFC 6587 LF framing. `\n`/`\r` become visible escapes (multi-line
+/// stderr stays readable), every other C0 control char and DEL becomes a
+/// space. Returns a borrowed str when nothing needed changing (hot path).
+fn sanitize_msg(msg: &str) -> std::borrow::Cow<'_, str> {
+    if !msg
+        .bytes()
+        .any(|b| b.is_ascii_control() && b != b'\t' || b == 0x7f)
+    {
+        return std::borrow::Cow::Borrowed(msg);
+    }
+    let mut out = String::with_capacity(msg.len() + 8);
+    for c in msg.chars() {
+        match c {
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push(c),
+            c if c.is_ascii_control() || c == '\u{7f}' => out.push(' '),
+            c => out.push(c),
+        }
+    }
+    std::borrow::Cow::Owned(out)
+}
+
+/// Sanitize a HOSTNAME field value: syslog headers are space-delimited, so
+/// whitespace or control chars here would corrupt every message's framing.
+fn sanitize_hostname(hostname: &str) -> std::borrow::Cow<'_, str> {
+    if !hostname
+        .chars()
+        .any(|c| c.is_whitespace() || c.is_ascii_control())
+    {
+        return std::borrow::Cow::Borrowed(hostname);
+    }
+    std::borrow::Cow::Owned(
+        hostname
+            .chars()
+            .map(|c| {
+                if c.is_whitespace() || c.is_ascii_control() {
+                    '-'
+                } else {
+                    c
+                }
+            })
+            .collect(),
+    )
+}
+
 /// Render a record in the configured format. `hostname` is the already
 /// resolved HOSTNAME field value (override applied by the caller).
 pub fn format_message(cfg: &SyslogConfig, hostname: &str, rec: &SyslogRecord) -> String {
     let pri = priority(cfg.facility, rec.severity);
-    let msg = truncate_msg(&rec.msg);
+    let sanitized = sanitize_msg(&rec.msg);
+    let msg = truncate_msg(&sanitized);
+    let hostname = sanitize_hostname(hostname);
     let pid = std::process::id();
     match cfg.format {
         SyslogFormat::Rfc3164 => {
-            // <PRI>MMM dd HH:MM:SS HOSTNAME TAG[pid]: MSG  (day is space-padded)
-            let ts = rec.timestamp.format("%b %e %H:%M:%S");
+            // <PRI>MMM dd HH:MM:SS HOSTNAME TAG[pid]: MSG  (day is
+            // space-padded). RFC 3164 timestamps carry no zone and are
+            // local time by convention — receivers on non-UTC boxes would
+            // otherwise record events offset by the TZ delta.
+            let ts = rec
+                .timestamp
+                .with_timezone(&chrono::Local)
+                .format("%b %e %H:%M:%S");
             format!("<{pri}>{ts} {hostname} {}[{pid}]: {msg}", rec.app_name)
         }
         SyslogFormat::Rfc5424 => {
@@ -85,11 +142,13 @@ mod tests {
         let cfg = SyslogConfig::default(); // rfc3164, facility 16
         let out = format_message(&cfg, "fw", &rec("hello world"));
         let pid = std::process::id();
-        // Day 5 must be space-padded per RFC 3164
-        assert_eq!(
-            out,
-            format!("<134>Jul  5 08:09:10 fw aifw-test[{pid}]: hello world")
-        );
+        // RFC 3164 timestamps are local time; recompute the expectation the
+        // same way so the test passes in any TZ. Day is space-padded.
+        let ts = rec("x")
+            .timestamp
+            .with_timezone(&chrono::Local)
+            .format("%b %e %H:%M:%S");
+        assert_eq!(out, format!("<134>{ts} fw aifw-test[{pid}]: hello world"));
     }
 
     #[test]
@@ -105,6 +164,28 @@ mod tests {
             out,
             format!("<38>1 2026-07-05T08:09:10.000000Z fw1 aifw-test {pid} - - hi")
         );
+    }
+
+    #[test]
+    fn newlines_cannot_forge_records() {
+        let cfg = SyslogConfig::default();
+        let forged = "legit\n<0>Jan  1 00:00:00 evil sshd[1]: fake root login\r\nmore";
+        let out = format_message(&cfg, "fw", &rec(forged));
+        assert!(!out.contains('\n'), "no raw LF may survive: {out:?}");
+        assert!(!out.contains('\r'), "no raw CR may survive: {out:?}");
+        assert!(out.contains("legit\\n<0>"), "escaped form kept: {out}");
+        // Other control chars become spaces; tab survives.
+        let out2 = format_message(&cfg, "fw", &rec("a\x1b[31mred\x07b\tc"));
+        assert!(!out2.bytes().any(|b| b.is_ascii_control() && b != b'\t'));
+        assert!(out2.contains("a [31mred b\tc"), "got: {out2}");
+    }
+
+    #[test]
+    fn hostname_field_is_sanitized() {
+        let cfg = SyslogConfig::default();
+        let out = format_message(&cfg, "bad host\nname", &rec("m"));
+        assert!(!out.contains('\n'));
+        assert!(out.contains("bad-host-name"), "got: {out}");
     }
 
     #[test]

--- a/aifw-common/src/syslog/format.rs
+++ b/aifw-common/src/syslog/format.rs
@@ -1,0 +1,122 @@
+//! RFC 3164 (BSD) and RFC 5424 syslog message rendering.
+
+use chrono::{DateTime, Utc};
+
+use super::config::{SyslogConfig, SyslogFormat};
+
+/// Maximum rendered message length in bytes; longer payloads are truncated at
+/// a char boundary. Matches common syslog receiver limits.
+const MAX_MSG_BYTES: usize = 2048;
+
+/// One message to forward, before syslog framing is applied.
+#[derive(Debug, Clone)]
+pub struct SyslogRecord {
+    /// Syslog severity 0-7 (0=emerg … 7=debug)
+    pub severity: u8,
+    /// APP-NAME / TAG field (e.g. `aifw-pf`, `aifw-api`)
+    pub app_name: &'static str,
+    /// Event time
+    pub timestamp: DateTime<Utc>,
+    /// Free-form message body
+    pub msg: String,
+}
+
+/// PRI value: `facility * 8 + severity` (RFC 5424 §6.2.1).
+pub fn priority(facility: u8, severity: u8) -> u8 {
+    facility.min(23) * 8 + severity.min(7)
+}
+
+/// Render a record in the configured format. `hostname` is the already
+/// resolved HOSTNAME field value (override applied by the caller).
+pub fn format_message(cfg: &SyslogConfig, hostname: &str, rec: &SyslogRecord) -> String {
+    let pri = priority(cfg.facility, rec.severity);
+    let msg = truncate_msg(&rec.msg);
+    let pid = std::process::id();
+    match cfg.format {
+        SyslogFormat::Rfc3164 => {
+            // <PRI>MMM dd HH:MM:SS HOSTNAME TAG[pid]: MSG  (day is space-padded)
+            let ts = rec.timestamp.format("%b %e %H:%M:%S");
+            format!("<{pri}>{ts} {hostname} {}[{pid}]: {msg}", rec.app_name)
+        }
+        SyslogFormat::Rfc5424 => {
+            // <PRI>1 TIMESTAMP HOSTNAME APP-NAME PROCID MSGID SD MSG
+            let ts = rec.timestamp.format("%Y-%m-%dT%H:%M:%S%.6fZ");
+            format!("<{pri}>1 {ts} {hostname} {} {pid} - - {msg}", rec.app_name)
+        }
+    }
+}
+
+/// Truncate at [`MAX_MSG_BYTES`] without splitting a UTF-8 char.
+fn truncate_msg(msg: &str) -> &str {
+    if msg.len() <= MAX_MSG_BYTES {
+        return msg;
+    }
+    let mut end = MAX_MSG_BYTES;
+    while !msg.is_char_boundary(end) {
+        end -= 1;
+    }
+    &msg[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn rec(msg: &str) -> SyslogRecord {
+        SyslogRecord {
+            severity: 6,
+            app_name: "aifw-test",
+            timestamp: Utc.with_ymd_and_hms(2026, 7, 5, 8, 9, 10).unwrap(),
+            msg: msg.into(),
+        }
+    }
+
+    #[test]
+    fn pri_calculation() {
+        assert_eq!(priority(16, 6), 134); // local0.info
+        assert_eq!(priority(4, 1), 33); // auth.alert
+        assert_eq!(priority(0, 0), 0);
+        assert_eq!(priority(99, 99), 23 * 8 + 7); // clamped
+    }
+
+    #[test]
+    fn rfc3164_shape() {
+        let cfg = SyslogConfig::default(); // rfc3164, facility 16
+        let out = format_message(&cfg, "fw", &rec("hello world"));
+        let pid = std::process::id();
+        // Day 5 must be space-padded per RFC 3164
+        assert_eq!(
+            out,
+            format!("<134>Jul  5 08:09:10 fw aifw-test[{pid}]: hello world")
+        );
+    }
+
+    #[test]
+    fn rfc5424_shape() {
+        let cfg = SyslogConfig {
+            format: SyslogFormat::Rfc5424,
+            facility: 4,
+            ..Default::default()
+        };
+        let out = format_message(&cfg, "fw1", &rec("hi"));
+        let pid = std::process::id();
+        assert_eq!(
+            out,
+            format!("<38>1 2026-07-05T08:09:10.000000Z fw1 aifw-test {pid} - - hi")
+        );
+    }
+
+    #[test]
+    fn truncation_at_char_boundary() {
+        // 2047 ASCII bytes + one 3-byte char straddling the 2048 limit
+        let msg = "a".repeat(2047) + "€€";
+        let out = format_message(&SyslogConfig::default(), "h", &rec(&msg));
+        assert!(out.len() < msg.len() + 64);
+        assert!(out.ends_with('a')); // the € straddling the cut is dropped whole
+        let long = "b".repeat(4096);
+        let out2 = format_message(&SyslogConfig::default(), "h", &rec(&long));
+        assert!(out2.contains(&"b".repeat(2048)));
+        assert!(!out2.contains(&"b".repeat(2049)));
+    }
+}

--- a/aifw-common/src/syslog/layer.rs
+++ b/aifw-common/src/syslog/layer.rs
@@ -70,9 +70,13 @@ impl<S: Subscriber> Layer<S> for SyslogLayer {
 ///
 /// The appliance's `/var/log/aifw/*.log` files are `daemon(8)` stdout
 /// redirects, so silencing stdout stops file growth with no rc.d changes or
-/// service restarts. The gate closes only while remote forwarding is on,
-/// `disable_local` is set, AND app-log forwarding is enabled — app logs are
-/// never dropped from both destinations at once.
+/// service restarts. The gate closes only for events the forwarder will
+/// actually accept: remote forwarding on, `disable_local` set, app-log
+/// forwarding enabled, AND the event at or above `app_min_level` — so at
+/// the configuration level an event is never dropped from both
+/// destinations at once. (Delivery failures while the gate is closed are
+/// still possible — that is the disk-vs-remote trade the toggle opts into —
+/// and are visible in the dropped/error counters.)
 pub struct LocalStorageGate {
     handle: SyslogHandle,
 }
@@ -85,9 +89,15 @@ impl LocalStorageGate {
 }
 
 impl<S: Subscriber> tracing_subscriber::layer::Filter<S> for LocalStorageGate {
-    fn enabled(&self, _meta: &tracing::Metadata<'_>, _cx: &Context<'_, S>) -> bool {
+    fn enabled(&self, meta: &tracing::Metadata<'_>, _cx: &Context<'_, S>) -> bool {
         let cfg = self.handle.config();
-        !(cfg.enabled && cfg.disable_local && cfg.app_enabled)
+        if !(cfg.enabled && cfg.disable_local && cfg.app_enabled) {
+            return true;
+        }
+        // Below-min-level events are NOT forwarded (SyslogLayer filters
+        // them), so they must keep going to stdout — silencing them here
+        // would drop them from both destinations.
+        level_to_severity(meta.level()) > cfg.app_min_severity()
     }
 }
 
@@ -224,6 +234,26 @@ mod tests {
             tracing::info!(target: "test_app", "must also pass");
         });
         assert_eq!(count.load(Ordering::Relaxed), 2, "no forwarding, no gate");
+
+        // Gate closed but min level warn: info is NOT forwarded, so it must
+        // keep reaching stdout; warn IS forwarded, so it is silenced.
+        mgr.apply(SyslogConfig {
+            enabled: true,
+            host: "127.0.0.1".into(),
+            disable_local: true,
+            app_enabled: true,
+            app_min_level: "warn".into(),
+            ..Default::default()
+        });
+        tracing::dispatcher::with_default(&dispatch, || {
+            tracing::info!(target: "test_app", "below min level, must pass");
+            tracing::warn!(target: "test_app", "forwarded, must be silenced");
+        });
+        assert_eq!(
+            count.load(Ordering::Relaxed),
+            3,
+            "info passes (not forwarded), warn silenced (forwarded)"
+        );
     }
 
     #[tokio::test]

--- a/aifw-common/src/syslog/layer.rs
+++ b/aifw-common/src/syslog/layer.rs
@@ -1,0 +1,188 @@
+//! `tracing` layer that forwards application log events to remote syslog.
+
+use tracing::field::{Field, Visit};
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::layer::{Context, Layer};
+
+use super::client::SyslogHandle;
+use super::config::Category;
+
+/// Forwards `tracing` events to remote syslog as the App category.
+///
+/// Attach to a `tracing_subscriber::registry()` alongside the normal fmt
+/// layer. Filtering is self-contained: the layer checks the App category
+/// toggle and `app_min_level` per event, so console filtering (EnvFilter on
+/// the fmt layer) never starves the forwarder.
+pub struct SyslogLayer {
+    handle: SyslogHandle,
+    app_name: &'static str,
+}
+
+impl SyslogLayer {
+    /// `app_name` becomes the syslog APP-NAME/TAG (e.g. `aifw-api`).
+    pub fn new(handle: SyslogHandle, app_name: &'static str) -> Self {
+        Self { handle, app_name }
+    }
+}
+
+fn level_to_severity(level: &Level) -> u8 {
+    match *level {
+        Level::ERROR => 3,
+        Level::WARN => 4,
+        Level::INFO => 6,
+        // TRACE has no syslog equivalent below debug
+        Level::DEBUG | Level::TRACE => 7,
+    }
+}
+
+impl<S: Subscriber> Layer<S> for SyslogLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let meta = event.metadata();
+        // Recursion guard: the syslog client's own diagnostics (delivery
+        // failures etc.) must never be forwarded through itself.
+        if meta.target().starts_with("aifw_common::syslog") {
+            return;
+        }
+        if !self.handle.enabled_for(Category::App) {
+            return;
+        }
+        let severity = level_to_severity(meta.level());
+        if severity > self.handle.config().app_min_severity() {
+            return;
+        }
+        let mut visitor = MsgVisitor::default();
+        event.record(&mut visitor);
+        let mut body = visitor.message;
+        if !visitor.fields.is_empty() {
+            if !body.is_empty() {
+                body.push(' ');
+            }
+            body.push_str(&visitor.fields);
+        }
+        let msg = format!("[{}] {}", meta.target(), body);
+        self.handle
+            .enqueue(Category::App, severity, self.app_name, msg);
+    }
+}
+
+/// Collects the `message` field and renders the rest as `key=value` pairs.
+#[derive(Default)]
+struct MsgVisitor {
+    message: String,
+    fields: String,
+}
+
+impl MsgVisitor {
+    fn push_field(&mut self, name: &str, value: impl std::fmt::Display) {
+        if !self.fields.is_empty() {
+            self.fields.push(' ');
+        }
+        // Infallible: fmt::Write on String never errors.
+        use std::fmt::Write;
+        let _ = write!(self.fields, "{name}={value}");
+    }
+}
+
+impl Visit for MsgVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            use std::fmt::Write;
+            let _ = write!(self.message, "{value:?}");
+        } else {
+            self.push_field(field.name(), format_args!("{value:?}"));
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message.push_str(value);
+        } else {
+            self.push_field(field.name(), value);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::client::SyslogManager;
+    use super::super::config::{SyslogConfig, Transport};
+    use super::*;
+    use std::time::Duration;
+    use tokio::net::UdpSocket;
+    use tokio::time::timeout;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    async fn setup(min_level: &str) -> (UdpSocket, tracing::Dispatch) {
+        let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let port = server.local_addr().unwrap().port();
+        let mgr = SyslogManager::start();
+        mgr.apply(SyslogConfig {
+            enabled: true,
+            host: "127.0.0.1".into(),
+            port,
+            transport: Transport::Udp,
+            app_enabled: true,
+            app_min_level: min_level.into(),
+            ..Default::default()
+        });
+        let subscriber =
+            tracing_subscriber::registry().with(SyslogLayer::new(mgr.handle(), "aifw-test"));
+        (server, tracing::Dispatch::new(subscriber))
+    }
+
+    async fn recv_with_timeout(server: &UdpSocket, ms: u64) -> Option<String> {
+        let mut buf = [0u8; 4096];
+        match timeout(Duration::from_millis(ms), server.recv_from(&mut buf)).await {
+            Ok(Ok((n, _))) => Some(String::from_utf8_lossy(&buf[..n]).into_owned()),
+            _ => None,
+        }
+    }
+
+    #[tokio::test]
+    async fn forwards_events_with_fields() {
+        let (server, dispatch) = setup("info").await;
+        // Explicit target: the test module's own path starts with
+        // aifw_common::syslog, which the recursion guard (correctly) drops.
+        tracing::dispatcher::with_default(&dispatch, || {
+            tracing::info!(target: "test_app", user = "admin", attempts = 3, "login succeeded");
+        });
+        let got = recv_with_timeout(&server, 5000)
+            .await
+            .expect("event should be forwarded");
+        assert!(got.contains("aifw-test"), "got: {got}");
+        assert!(got.contains("login succeeded"), "got: {got}");
+        assert!(got.contains("user=admin"), "got: {got}");
+        assert!(got.contains("attempts=3"), "got: {got}");
+        assert!(got.starts_with("<134>"), "local0.info PRI, got: {got}");
+    }
+
+    #[tokio::test]
+    async fn respects_min_level() {
+        let (server, dispatch) = setup("warn").await;
+        tracing::dispatcher::with_default(&dispatch, || {
+            tracing::info!(target: "test_app", "too quiet to forward");
+            tracing::warn!(target: "test_app", "loud enough");
+        });
+        let got = recv_with_timeout(&server, 5000)
+            .await
+            .expect("warn event should be forwarded");
+        assert!(got.contains("loud enough"), "got: {got}");
+        // The info event was filtered — nothing else arrives.
+        assert!(recv_with_timeout(&server, 200).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn recursion_guard_drops_own_events() {
+        let (server, dispatch) = setup("debug").await;
+        tracing::dispatcher::with_default(&dispatch, || {
+            tracing::warn!(
+                target: "aifw_common::syslog::client",
+                "delivery failing"
+            );
+        });
+        assert!(
+            recv_with_timeout(&server, 300).await.is_none(),
+            "syslog-internal event must not be forwarded"
+        );
+    }
+}

--- a/aifw-common/src/syslog/layer.rs
+++ b/aifw-common/src/syslog/layer.rs
@@ -65,6 +65,32 @@ impl<S: Subscriber> Layer<S> for SyslogLayer {
     }
 }
 
+/// Per-event filter for the stdout `fmt` layer implementing the
+/// "stop storing logs locally" toggle for app logs.
+///
+/// The appliance's `/var/log/aifw/*.log` files are `daemon(8)` stdout
+/// redirects, so silencing stdout stops file growth with no rc.d changes or
+/// service restarts. The gate closes only while remote forwarding is on,
+/// `disable_local` is set, AND app-log forwarding is enabled — app logs are
+/// never dropped from both destinations at once.
+pub struct LocalStorageGate {
+    handle: SyslogHandle,
+}
+
+impl LocalStorageGate {
+    /// Wrap a handle from the process's `SyslogManager`.
+    pub fn new(handle: SyslogHandle) -> Self {
+        Self { handle }
+    }
+}
+
+impl<S: Subscriber> tracing_subscriber::layer::Filter<S> for LocalStorageGate {
+    fn enabled(&self, _meta: &tracing::Metadata<'_>, _cx: &Context<'_, S>) -> bool {
+        let cfg = self.handle.config();
+        !(cfg.enabled && cfg.disable_local && cfg.app_enabled)
+    }
+}
+
 /// Collects the `message` field and renders the rest as `key=value` pairs.
 #[derive(Default)]
 struct MsgVisitor {
@@ -140,6 +166,64 @@ mod tests {
             Ok(Ok((n, _))) => Some(String::from_utf8_lossy(&buf[..n]).into_owned()),
             _ => None,
         }
+    }
+
+    #[tokio::test]
+    async fn local_storage_gate_silences_layer_only_when_forwarding() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tracing_subscriber::Layer as _;
+
+        struct CountLayer(Arc<AtomicUsize>);
+        impl<S: Subscriber> tracing_subscriber::layer::Layer<S> for CountLayer {
+            fn on_event(&self, _e: &Event<'_>, _c: Context<'_, S>) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let mgr = SyslogManager::start();
+        let count = Arc::new(AtomicUsize::new(0));
+        let subscriber = tracing_subscriber::registry()
+            .with(CountLayer(count.clone()).with_filter(LocalStorageGate::new(mgr.handle())));
+        let dispatch = tracing::Dispatch::new(subscriber);
+
+        // Gate closed: forwarding on + disable_local + app category on.
+        mgr.apply(SyslogConfig {
+            enabled: true,
+            host: "127.0.0.1".into(),
+            disable_local: true,
+            app_enabled: true,
+            ..Default::default()
+        });
+        tracing::dispatcher::with_default(&dispatch, || {
+            tracing::info!(target: "test_app", "must be silenced");
+        });
+        assert_eq!(count.load(Ordering::Relaxed), 0, "gate should silence");
+
+        // disable_local off → gate open again.
+        mgr.apply(SyslogConfig {
+            enabled: true,
+            host: "127.0.0.1".into(),
+            app_enabled: true,
+            ..Default::default()
+        });
+        tracing::dispatcher::with_default(&dispatch, || {
+            tracing::info!(target: "test_app", "must pass");
+        });
+        assert_eq!(count.load(Ordering::Relaxed), 1, "gate should open");
+
+        // app forwarding off → never silence (logs must go somewhere).
+        mgr.apply(SyslogConfig {
+            enabled: true,
+            host: "127.0.0.1".into(),
+            disable_local: true,
+            app_enabled: false,
+            ..Default::default()
+        });
+        tracing::dispatcher::with_default(&dispatch, || {
+            tracing::info!(target: "test_app", "must also pass");
+        });
+        assert_eq!(count.load(Ordering::Relaxed), 2, "no forwarding, no gate");
     }
 
     #[tokio::test]

--- a/aifw-common/src/syslog/layer.rs
+++ b/aifw-common/src/syslog/layer.rs
@@ -112,6 +112,10 @@ mod tests {
     use tokio::time::timeout;
     use tracing_subscriber::layer::SubscriberExt;
 
+    // Note: the SyslogManager is dropped inside setup(); only the handle
+    // embedded in the layer keeps the pipeline alive. This doubles as a
+    // regression test for the writer task surviving a manager drop with
+    // queued messages still to deliver.
     async fn setup(min_level: &str) -> (UdpSocket, tracing::Dispatch) {
         let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
         let port = server.local_addr().unwrap().port();

--- a/aifw-common/src/syslog/mod.rs
+++ b/aifw-common/src/syslog/mod.rs
@@ -14,6 +14,7 @@
 mod client;
 mod config;
 mod format;
+mod layer;
 
 pub use client::{
     SyslogHandle, SyslogManager, SyslogStats, SyslogStatsSnapshot, spawn_config_poller, test_send,
@@ -23,3 +24,4 @@ pub use config::{
     migrate, save, save_on,
 };
 pub use format::{SyslogRecord, format_message, priority};
+pub use layer::SyslogLayer;

--- a/aifw-common/src/syslog/mod.rs
+++ b/aifw-common/src/syslog/mod.rs
@@ -18,7 +18,8 @@ mod format;
 mod layer;
 
 pub use client::{
-    SyslogHandle, SyslogManager, SyslogStats, SyslogStatsSnapshot, spawn_config_poller, test_send,
+    ProcessSyslogStats, SyslogHandle, SyslogManager, SyslogStats, SyslogStatsSnapshot, read_stats,
+    spawn_config_poller, test_send, write_stats,
 };
 pub use config::{
     Category, SyslogConfig, SyslogFormat, Transport, facility_from_name, facility_name, load,

--- a/aifw-common/src/syslog/mod.rs
+++ b/aifw-common/src/syslog/mod.rs
@@ -24,4 +24,4 @@ pub use config::{
     migrate, save, save_on,
 };
 pub use format::{SyslogRecord, format_message, priority};
-pub use layer::SyslogLayer;
+pub use layer::{LocalStorageGate, SyslogLayer};

--- a/aifw-common/src/syslog/mod.rs
+++ b/aifw-common/src/syslog/mod.rs
@@ -13,6 +13,7 @@
 
 mod client;
 mod config;
+mod error;
 mod format;
 mod layer;
 
@@ -21,7 +22,8 @@ pub use client::{
 };
 pub use config::{
     Category, SyslogConfig, SyslogFormat, Transport, facility_from_name, facility_name, load,
-    migrate, save, save_on,
+    migrate, save, save_on, try_load,
 };
+pub use error::SyslogError;
 pub use format::{SyslogRecord, format_message, priority};
 pub use layer::{LocalStorageGate, SyslogLayer};

--- a/aifw-common/src/syslog/mod.rs
+++ b/aifw-common/src/syslog/mod.rs
@@ -5,13 +5,19 @@
 //! - [`config`] — the `syslog_config` singleton row (server target, transport,
 //!   format, per-category toggles) with `migrate`/`load`/`save`.
 //! - [`format`] — RFC 3164 (BSD) and RFC 5424 message rendering.
+//! - [`client`] — the async delivery pipeline: [`SyslogManager`] owns a
+//!   background writer task; producers use non-blocking [`SyslogHandle`]s.
 //!
 //! Forwarding is opt-in per category ([`Category`]): pf packet logs, IDS
 //! alerts, and application (tracing) logs.
 
+mod client;
 mod config;
 mod format;
 
+pub use client::{
+    SyslogHandle, SyslogManager, SyslogStats, SyslogStatsSnapshot, spawn_config_poller, test_send,
+};
 pub use config::{
     Category, SyslogConfig, SyslogFormat, Transport, facility_from_name, facility_name, load,
     migrate, save, save_on,

--- a/aifw-common/src/syslog/mod.rs
+++ b/aifw-common/src/syslog/mod.rs
@@ -1,0 +1,19 @@
+//! Remote syslog forwarding.
+//!
+//! One shared subsystem used by aifw-api, aifw-daemon, and aifw-ids-bin:
+//!
+//! - [`config`] — the `syslog_config` singleton row (server target, transport,
+//!   format, per-category toggles) with `migrate`/`load`/`save`.
+//! - [`format`] — RFC 3164 (BSD) and RFC 5424 message rendering.
+//!
+//! Forwarding is opt-in per category ([`Category`]): pf packet logs, IDS
+//! alerts, and application (tracing) logs.
+
+mod config;
+mod format;
+
+pub use config::{
+    Category, SyslogConfig, SyslogFormat, Transport, facility_from_name, facility_name, load,
+    migrate, save, save_on,
+};
+pub use format::{SyslogRecord, format_message, priority};

--- a/aifw-core/src/config.rs
+++ b/aifw-core/src/config.rs
@@ -74,6 +74,11 @@ pub struct FirewallConfig {
     /// it to defaults.
     #[serde(default)]
     pub dns_resolver: Option<DnsResolverSection>,
+    /// Remote syslog forwarding settings (the `syslog_config` table).
+    /// `None` means the backup predates this section — restore leaves the
+    /// box's syslog config untouched rather than resetting it to defaults.
+    #[serde(default)]
+    pub syslog: Option<aifw_common::syslog::SyslogConfig>,
 }
 
 impl Default for FirewallConfig {
@@ -95,6 +100,7 @@ impl Default for FirewallConfig {
             aliases: Vec::new(),
             static_routes: Vec::new(),
             dns_resolver: None,
+            syslog: None,
         }
     }
 }
@@ -246,6 +252,9 @@ impl FirewallConfig {
             {
                 return Err("dns_resolver list length exceeds cap".to_string());
             }
+        }
+        if let Some(s) = &self.syslog {
+            s.validate().map_err(|e| format!("syslog: {e}"))?;
         }
         Ok(())
     }

--- a/aifw-core/src/lib.rs
+++ b/aifw-core/src/lib.rs
@@ -32,6 +32,8 @@ pub mod geoip;
 pub mod ha;
 pub mod ipsec;
 pub mod ipsec_status;
+/// Local log storage policy for the remote-syslog `disable_local` toggle
+pub mod local_log;
 pub mod migrations;
 pub mod multiwan;
 /// [`NatEngine`] — SNAT/DNAT/masquerade rule CRUD and application to pf

--- a/aifw-core/src/local_log.rs
+++ b/aifw-core/src/local_log.rs
@@ -10,25 +10,33 @@
 //! are just `daemon(8)` stdout redirects.
 //!
 //! Callers: aifw-api applies on every settings PUT / config restore for
-//! immediate effect; aifw-daemon reconciles at boot and on 60s config-poll
-//! changes (covers CLI edits and crash recovery).
+//! immediate effect; aifw-daemon reconciles at boot, on 60s config-poll
+//! changes, after failed attempts, and enforces the stopped state each tick
+//! (covers CLI edits, crash recovery, and external pflogd restarts).
 
 use aifw_common::syslog::SyslogConfig;
 
 use crate::sudo;
 
-/// True when the config asks for local pf log storage to be off.
+/// True when the config asks for local pf log storage to be off. Requires
+/// pf forwarding to be enabled too — the same "logs must go somewhere"
+/// guard the app-log gate has: stopping the pf log file while pf logs are
+/// not forwarded would leave packet history nowhere but the small in-memory
+/// buffer.
 pub fn local_pf_log_disabled(cfg: &SyslogConfig) -> bool {
-    cfg.enabled && cfg.disable_local
+    cfg.enabled && cfg.disable_local && cfg.pf_enabled
 }
 
 /// Reconcile pflogd with the config. Best-effort: failures are logged, not
-/// fatal — the DB config stays authoritative and the daemon re-reconciles.
-/// No-op on non-FreeBSD dev hosts.
-pub async fn apply_local_log_policy(cfg: &SyslogConfig) {
+/// fatal — the DB config stays authoritative and the daemon retries.
+/// Returns `true` when every required command succeeded (callers use this
+/// to decide whether to retry on the next tick). No-op `true` on
+/// non-FreeBSD dev hosts.
+pub async fn apply_local_log_policy(cfg: &SyslogConfig) -> bool {
     if !cfg!(target_os = "freebsd") {
-        return;
+        return true;
     }
+    let mut ok = true;
     if local_pf_log_disabled(cfg) {
         // Stop the file writer. "not running" is a normal outcome for an
         // idempotent reconcile, so only log other failures.
@@ -37,20 +45,30 @@ pub async fn apply_local_log_policy(cfg: &SyslogConfig) {
                 let err = String::from_utf8_lossy(&out.stderr);
                 if !err.contains("not running") {
                     tracing::warn!(error = %err.trim(), "failed to stop pflogd for disable_local");
+                    ok = false;
                 }
             }
-            Err(e) => tracing::warn!(error = %e, "failed to run service pflogd onestop"),
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to run service pflogd onestop");
+                ok = false;
+            }
             _ => tracing::info!("pflogd stopped (local pf log storage disabled)"),
         }
         // Keep pflog0 alive for tcpdump live capture + forwarding. Create
         // fails harmlessly when the interface already exists.
-        if let Ok(out) = sudo::ifconfig("pflog0", "create", &[]).await
-            && !out.status.success()
-        {
-            let err = String::from_utf8_lossy(&out.stderr);
-            if !err.contains("exists") {
-                tracing::warn!(error = %err.trim(), "failed to create pflog0");
+        match sudo::ifconfig("pflog0", "create", &[]).await {
+            Ok(out) if !out.status.success() => {
+                let err = String::from_utf8_lossy(&out.stderr);
+                if !err.contains("exists") {
+                    tracing::warn!(error = %err.trim(), "failed to create pflog0");
+                    ok = false;
+                }
             }
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to run ifconfig pflog0 create");
+                ok = false;
+            }
+            _ => {}
         }
         match sudo::ifconfig("pflog0", "up", &[]).await {
             Ok(out) if !out.status.success() => {
@@ -58,8 +76,12 @@ pub async fn apply_local_log_policy(cfg: &SyslogConfig) {
                     error = %String::from_utf8_lossy(&out.stderr).trim(),
                     "failed to bring pflog0 up — pf log capture/forwarding may stop"
                 );
+                ok = false;
             }
-            Err(e) => tracing::warn!(error = %e, "failed to run ifconfig pflog0 up"),
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to run ifconfig pflog0 up");
+                ok = false;
+            }
             _ => {}
         }
     } else {
@@ -70,12 +92,17 @@ pub async fn apply_local_log_policy(cfg: &SyslogConfig) {
                 let err = String::from_utf8_lossy(&out.stderr);
                 if !err.contains("already running") {
                     tracing::warn!(error = %err.trim(), "failed to start pflogd");
+                    ok = false;
                 }
             }
-            Err(e) => tracing::warn!(error = %e, "failed to run service pflogd onestart"),
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to run service pflogd onestart");
+                ok = false;
+            }
             _ => {}
         }
     }
+    ok
 }
 
 #[cfg(test)]
@@ -83,12 +110,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn policy_requires_both_flags() {
+    fn policy_requires_forwarding_and_toggle_and_pf_category() {
         let mut cfg = SyslogConfig::default();
         assert!(!local_pf_log_disabled(&cfg));
         cfg.disable_local = true;
         assert!(!local_pf_log_disabled(&cfg), "disabled master switch wins");
         cfg.enabled = true;
+        assert!(
+            !local_pf_log_disabled(&cfg),
+            "pf logs not forwarded — the file must keep being written"
+        );
+        cfg.pf_enabled = true;
         assert!(local_pf_log_disabled(&cfg));
     }
 }

--- a/aifw-core/src/local_log.rs
+++ b/aifw-core/src/local_log.rs
@@ -1,0 +1,94 @@
+//! Local log storage policy for the remote-syslog `disable_local` toggle.
+//!
+//! When "stop storing logs locally" is active alongside remote forwarding,
+//! the pf packet-log file writer (`pflogd`) is stopped while the `pflog0`
+//! interface is kept up, so live capture (Blocked page) and remote
+//! forwarding keep working. Re-enabling local storage restarts `pflogd`.
+//!
+//! App-log files are handled separately: the tracing stdout layer is gated
+//! by `aifw_common::syslog::LocalStorageGate`, since `/var/log/aifw/*.log`
+//! are just `daemon(8)` stdout redirects.
+//!
+//! Callers: aifw-api applies on every settings PUT / config restore for
+//! immediate effect; aifw-daemon reconciles at boot and on 60s config-poll
+//! changes (covers CLI edits and crash recovery).
+
+use aifw_common::syslog::SyslogConfig;
+
+use crate::sudo;
+
+/// True when the config asks for local pf log storage to be off.
+pub fn local_pf_log_disabled(cfg: &SyslogConfig) -> bool {
+    cfg.enabled && cfg.disable_local
+}
+
+/// Reconcile pflogd with the config. Best-effort: failures are logged, not
+/// fatal — the DB config stays authoritative and the daemon re-reconciles.
+/// No-op on non-FreeBSD dev hosts.
+pub async fn apply_local_log_policy(cfg: &SyslogConfig) {
+    if !cfg!(target_os = "freebsd") {
+        return;
+    }
+    if local_pf_log_disabled(cfg) {
+        // Stop the file writer. "not running" is a normal outcome for an
+        // idempotent reconcile, so only log other failures.
+        match sudo::service("pflogd", "onestop").await {
+            Ok(out) if !out.status.success() => {
+                let err = String::from_utf8_lossy(&out.stderr);
+                if !err.contains("not running") {
+                    tracing::warn!(error = %err.trim(), "failed to stop pflogd for disable_local");
+                }
+            }
+            Err(e) => tracing::warn!(error = %e, "failed to run service pflogd onestop"),
+            _ => tracing::info!("pflogd stopped (local pf log storage disabled)"),
+        }
+        // Keep pflog0 alive for tcpdump live capture + forwarding. Create
+        // fails harmlessly when the interface already exists.
+        if let Ok(out) = sudo::ifconfig("pflog0", "create", &[]).await
+            && !out.status.success()
+        {
+            let err = String::from_utf8_lossy(&out.stderr);
+            if !err.contains("exists") {
+                tracing::warn!(error = %err.trim(), "failed to create pflog0");
+            }
+        }
+        match sudo::ifconfig("pflog0", "up", &[]).await {
+            Ok(out) if !out.status.success() => {
+                tracing::warn!(
+                    error = %String::from_utf8_lossy(&out.stderr).trim(),
+                    "failed to bring pflog0 up — pf log capture/forwarding may stop"
+                );
+            }
+            Err(e) => tracing::warn!(error = %e, "failed to run ifconfig pflog0 up"),
+            _ => {}
+        }
+    } else {
+        // Restore the normal file writer. "already running" is the normal
+        // idempotent outcome.
+        match sudo::service("pflogd", "onestart").await {
+            Ok(out) if !out.status.success() => {
+                let err = String::from_utf8_lossy(&out.stderr);
+                if !err.contains("already running") {
+                    tracing::warn!(error = %err.trim(), "failed to start pflogd");
+                }
+            }
+            Err(e) => tracing::warn!(error = %e, "failed to run service pflogd onestart"),
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_requires_both_flags() {
+        let mut cfg = SyslogConfig::default();
+        assert!(!local_pf_log_disabled(&cfg));
+        cfg.disable_local = true;
+        assert!(!local_pf_log_disabled(&cfg), "disabled master switch wins");
+        cfg.enabled = true;
+        assert!(local_pf_log_disabled(&cfg));
+    }
+}

--- a/aifw-daemon/src/main.rs
+++ b/aifw-daemon/src/main.rs
@@ -99,19 +99,30 @@ async fn main() -> anyhow::Result<()> {
     aifw_common::syslog::spawn_config_poller(pool.clone(), syslog_mgr.clone());
 
     // Reconcile the pf local-log policy (pflogd on/off for disable_local):
-    // once at boot, then whenever the polled config flips the policy. This
-    // covers CLI DB edits and recovers state after crashes; the API also
-    // applies immediately on settings PUT for snappy UX.
+    // once at boot, on every polled policy change, again after a failed
+    // attempt (sudo errors don't mark the state applied), and — while the
+    // policy is "stopped" — re-enforced every tick so an externally
+    // restarted pflogd is corrected within a minute. Covers CLI DB edits
+    // and crash recovery; the API also applies immediately on settings PUT.
     {
         let pool = pool.clone();
         tokio::spawn(async move {
-            let mut last_applied: Option<bool> = None;
+            let mut last_ok: Option<bool> = None;
             loop {
-                let cfg = aifw_common::syslog::load(&pool).await;
-                let want = aifw_core::local_log::local_pf_log_disabled(&cfg);
-                if last_applied != Some(want) {
-                    aifw_core::local_log::apply_local_log_policy(&cfg).await;
-                    last_applied = Some(want);
+                // A transient DB read error must not read as "policy off" —
+                // that would start pflogd and flap the toggle (see the
+                // matching guard in the shared config poller).
+                match aifw_common::syslog::try_load(&pool).await {
+                    Ok(cfg) => {
+                        let want = aifw_core::local_log::local_pf_log_disabled(&cfg);
+                        if want || last_ok != Some(want) {
+                            let ok = aifw_core::local_log::apply_local_log_policy(&cfg).await;
+                            last_ok = if ok { Some(want) } else { None };
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "pf local-log policy poll failed; keeping current state");
+                    }
                 }
                 tokio::time::sleep(std::time::Duration::from_secs(60)).await;
             }

--- a/aifw-daemon/src/main.rs
+++ b/aifw-daemon/src/main.rs
@@ -68,7 +68,13 @@ async fn main() -> anyhow::Result<()> {
         let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| args.log_level.parse().unwrap_or_default());
         tracing_subscriber::registry()
-            .with(tracing_subscriber::fmt::layer().with_filter(env_filter))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_filter(env_filter)
+                    .with_filter(aifw_common::syslog::LocalStorageGate::new(
+                        syslog_mgr.handle(),
+                    )),
+            )
             .with(aifw_common::syslog::SyslogLayer::new(
                 syslog_mgr.handle(),
                 "aifw-daemon",
@@ -91,6 +97,26 @@ async fn main() -> anyhow::Result<()> {
     aifw_common::syslog::migrate(&pool).await?;
     syslog_mgr.apply(aifw_common::syslog::load(&pool).await);
     aifw_common::syslog::spawn_config_poller(pool.clone(), syslog_mgr.clone());
+
+    // Reconcile the pf local-log policy (pflogd on/off for disable_local):
+    // once at boot, then whenever the polled config flips the policy. This
+    // covers CLI DB edits and recovers state after crashes; the API also
+    // applies immediately on settings PUT for snappy UX.
+    {
+        let pool = pool.clone();
+        tokio::spawn(async move {
+            let mut last_applied: Option<bool> = None;
+            loop {
+                let cfg = aifw_common::syslog::load(&pool).await;
+                let want = aifw_core::local_log::local_pf_log_disabled(&cfg);
+                if last_applied != Some(want) {
+                    aifw_core::local_log::apply_local_log_policy(&cfg).await;
+                    last_applied = Some(want);
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            }
+        });
+    }
     let pf: Arc<dyn aifw_pf::PfBackend> = Arc::from(aifw_pf::create_backend());
     let engine =
         Arc::new(RuleEngine::new(pool.clone(), pf.clone()).with_anchor(args.anchor.clone()));

--- a/aifw-daemon/src/main.rs
+++ b/aifw-daemon/src/main.rs
@@ -58,12 +58,23 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| args.log_level.parse().unwrap_or_default()),
-        )
-        .init();
+    // Remote syslog manager exists before the subscriber so the forwarding
+    // layer can attach; DB config is applied below once the pool is up.
+    let syslog_mgr = aifw_common::syslog::SyslogManager::start();
+    {
+        use tracing_subscriber::Layer as _;
+        use tracing_subscriber::layer::SubscriberExt;
+        use tracing_subscriber::util::SubscriberInitExt;
+        let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| args.log_level.parse().unwrap_or_default());
+        tracing_subscriber::registry()
+            .with(tracing_subscriber::fmt::layer().with_filter(env_filter))
+            .with(aifw_common::syslog::SyslogLayer::new(
+                syslog_mgr.handle(),
+                "aifw-daemon",
+            ))
+            .init();
+    }
 
     info!("AiFw daemon starting");
 
@@ -74,6 +85,12 @@ async fn main() -> anyhow::Result<()> {
 
     let db = Database::new(&args.db).await?;
     let pool = db.pool().clone();
+
+    // Remote syslog: table may not exist yet if aifw-api never ran; the
+    // migrate is idempotent. Config refreshes via the shared 60s poller.
+    aifw_common::syslog::migrate(&pool).await?;
+    syslog_mgr.apply(aifw_common::syslog::load(&pool).await);
+    aifw_common::syslog::spawn_config_poller(pool.clone(), syslog_mgr.clone());
     let pf: Arc<dyn aifw_pf::PfBackend> = Arc::from(aifw_pf::create_backend());
     let engine =
         Arc::new(RuleEngine::new(pool.clone(), pf.clone()).with_anchor(args.anchor.clone()));

--- a/aifw-daemon/src/main.rs
+++ b/aifw-daemon/src/main.rs
@@ -96,7 +96,7 @@ async fn main() -> anyhow::Result<()> {
     // migrate is idempotent. Config refreshes via the shared 60s poller.
     aifw_common::syslog::migrate(&pool).await?;
     syslog_mgr.apply(aifw_common::syslog::load(&pool).await);
-    aifw_common::syslog::spawn_config_poller(pool.clone(), syslog_mgr.clone());
+    aifw_common::syslog::spawn_config_poller(pool.clone(), syslog_mgr.clone(), "aifw-daemon");
 
     // Reconcile the pf local-log policy (pflogd on/off for disable_local):
     // once at boot, on every polled policy change, again after a failed

--- a/aifw-ids-bin/src/main.rs
+++ b/aifw-ids-bin/src/main.rs
@@ -110,7 +110,7 @@ async fn main() -> anyhow::Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("syslog migrate: {e}"))?;
     syslog_mgr.apply(aifw_common::syslog::load(&pool).await);
-    aifw_common::syslog::spawn_config_poller(pool.clone(), syslog_mgr.clone());
+    aifw_common::syslog::spawn_config_poller(pool.clone(), syslog_mgr.clone(), "aifw-ids");
 
     let pf: Arc<dyn aifw_pf::PfBackend> = Arc::from(aifw_pf::create_backend());
 

--- a/aifw-ids-bin/src/main.rs
+++ b/aifw-ids-bin/src/main.rs
@@ -113,7 +113,7 @@ async fn main() -> anyhow::Result<()> {
     // by aifw-api today (PR 5 will move config knobs out of aifw-api).
     let alert_buffer = Arc::new(aifw_ids::output::memory::AlertBuffer::new(64, 86400));
     let engine = Arc::new(
-        IdsEngine::with_alert_buffer(pool, pf, Some(alert_buffer))
+        IdsEngine::with_alert_buffer(pool, pf, Some(alert_buffer), Some(syslog_mgr.handle()))
             .await
             .map_err(|e| anyhow::anyhow!("init engine: {e}"))?,
     );

--- a/aifw-ids-bin/src/main.rs
+++ b/aifw-ids-bin/src/main.rs
@@ -63,7 +63,13 @@ async fn main() -> anyhow::Result<()> {
         let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(&args.log_level));
         tracing_subscriber::registry()
-            .with(tracing_subscriber::fmt::layer().with_filter(env_filter))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_filter(env_filter)
+                    .with_filter(aifw_common::syslog::LocalStorageGate::new(
+                        syslog_mgr.handle(),
+                    )),
+            )
             .with(aifw_common::syslog::SyslogLayer::new(
                 syslog_mgr.handle(),
                 "aifw-ids",

--- a/aifw-ids-bin/src/main.rs
+++ b/aifw-ids-bin/src/main.rs
@@ -53,12 +53,23 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(&args.log_level)),
-        )
-        .init();
+    // Remote syslog manager exists before the subscriber so the forwarding
+    // layer can attach; DB config is applied below once the pool is up.
+    let syslog_mgr = aifw_common::syslog::SyslogManager::start();
+    {
+        use tracing_subscriber::Layer as _;
+        use tracing_subscriber::layer::SubscriberExt;
+        use tracing_subscriber::util::SubscriberInitExt;
+        let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(&args.log_level));
+        tracing_subscriber::registry()
+            .with(tracing_subscriber::fmt::layer().with_filter(env_filter))
+            .with(aifw_common::syslog::SyslogLayer::new(
+                syslog_mgr.handle(),
+                "aifw-ids",
+            ))
+            .init();
+    }
 
     // aifw-api and aifw-ids share aifw.db. Without WAL + busy_timeout we
     // see SQLITE_BUSY drops on concurrent INSERT (alert ingestion racing
@@ -86,6 +97,14 @@ async fn main() -> anyhow::Result<()> {
     IdsEngine::migrate(&pool)
         .await
         .map_err(|e| anyhow::anyhow!("migrate: {e}"))?;
+
+    // Remote syslog: apply persisted config and refresh via the shared
+    // 60s poller (picks up API/CLI edits).
+    aifw_common::syslog::migrate(&pool)
+        .await
+        .map_err(|e| anyhow::anyhow!("syslog migrate: {e}"))?;
+    syslog_mgr.apply(aifw_common::syslog::load(&pool).await);
+    aifw_common::syslog::spawn_config_poller(pool.clone(), syslog_mgr.clone());
 
     let pf: Arc<dyn aifw_pf::PfBackend> = Arc::from(aifw_pf::create_backend());
 

--- a/aifw-ids/src/lib.rs
+++ b/aifw-ids/src/lib.rs
@@ -104,14 +104,19 @@ impl IdsEngine {
     /// When mode is `Disabled`, uses minimal allocations (small flow table, no channel).
     /// Full resources are allocated only when IDS/IPS mode is active.
     pub async fn new(pool: SqlitePool, pf: Arc<dyn PfBackend>) -> Result<Self> {
-        Self::with_alert_buffer(pool, pf, None).await
+        Self::with_alert_buffer(pool, pf, None, None).await
     }
 
-    /// Create with an optional in-memory alert buffer (replaces SQLite for alert storage).
+    /// Create with an optional in-memory alert buffer (replaces SQLite for
+    /// alert storage) and an optional remote-syslog handle. When a handle is
+    /// given, a syslog alert sink is registered unconditionally — it
+    /// self-gates on the `ids_enabled` category toggle per emit, so config
+    /// changes need no pipeline rebuild.
     pub async fn with_alert_buffer(
         pool: SqlitePool,
         pf: Arc<dyn PfBackend>,
         alert_buffer: Option<Arc<crate::output::memory::AlertBuffer>>,
+        syslog: Option<aifw_common::syslog::SyslogHandle>,
     ) -> Result<Self> {
         Self::migrate(&pool).await?;
 
@@ -163,6 +168,11 @@ impl IdsEngine {
             let mut pipeline = AlertPipeline::new(pool.clone());
             if let Some(buf) = alert_buffer.clone() {
                 pipeline.add_output(Box::new(crate::output::memory::MemoryOutput::new(buf)));
+            }
+            if let Some(handle) = syslog {
+                pipeline.add_output(Box::new(crate::output::syslog::SyslogAlertOutput::new(
+                    handle,
+                )));
             }
             pipeline
         });

--- a/aifw-ids/src/output/mod.rs
+++ b/aifw-ids/src/output/mod.rs
@@ -10,7 +10,7 @@ pub mod memory;
 pub mod pipeline;
 /// SQLite alert sink — persistent storage powering the UI alert viewer
 pub mod sqlite;
-/// Syslog alert sink — RFC 5424 messages over UDP to a remote server
+/// Syslog alert sink — adapter over the shared `aifw_common::syslog` pipeline
 pub mod syslog;
 
 pub use pipeline::*;

--- a/aifw-ids/src/output/syslog.rs
+++ b/aifw-ids/src/output/syslog.rs
@@ -1,39 +1,27 @@
-use std::net::UdpSocket;
+//! Syslog alert sink — forwards IDS alerts through the process-wide
+//! remote-syslog pipeline (`aifw_common::syslog`).
+//!
+//! The sink is a thin adapter over a [`SyslogHandle`]: transport, format,
+//! target, and reconnect handling all live in the shared client. It is
+//! registered unconditionally at engine construction and self-gates on the
+//! `ids_enabled` category toggle per emit, so config changes take effect
+//! without rebuilding the pipeline.
 
 use aifw_common::ids::IdsAlert;
+use aifw_common::syslog::{Category, SyslogHandle};
 
 use super::AlertOutput;
 use crate::Result;
 
-/// Syslog alert output — sends alerts to a remote syslog server via UDP.
-pub struct SyslogOutput {
-    target: String,
-    socket: UdpSocket,
-    facility: u8,
+/// Forwards IDS alerts to the configured remote syslog server.
+pub struct SyslogAlertOutput {
+    handle: SyslogHandle,
 }
 
-impl SyslogOutput {
-    /// Construct a syslog sink bound to an ephemeral local UDP port.
-    ///
-    /// Returns an error (rather than silently dropping every alert) if the
-    /// local socket cannot be bound, so the caller can refuse to register a
-    /// sink that would never emit.
-    pub fn new(target: String) -> Result<Self> {
-        let socket = UdpSocket::bind("0.0.0.0:0").map_err(|e| {
-            tracing::error!(error = %e, "failed to bind local UDP socket for syslog output");
-            e
-        })?;
-        Ok(Self {
-            target,
-            socket,
-            facility: 4, // LOG_AUTH
-        })
-    }
-
-    /// Builder: set the syslog facility number (default 4 = LOG_AUTH)
-    pub fn with_facility(mut self, facility: u8) -> Self {
-        self.facility = facility;
-        self
+impl SyslogAlertOutput {
+    /// Wrap a handle from the process's `SyslogManager`.
+    pub fn new(handle: SyslogHandle) -> Self {
+        Self { handle }
     }
 
     fn severity_to_syslog(severity: u8) -> u8 {
@@ -44,21 +32,10 @@ impl SyslogOutput {
             _ => 6, // Info → Informational
         }
     }
-}
 
-#[async_trait::async_trait]
-impl AlertOutput for SyslogOutput {
-    async fn emit(&self, alert: &IdsAlert) -> Result<()> {
-        let socket = &self.socket;
-
-        let syslog_severity = Self::severity_to_syslog(alert.severity.0);
-        let priority = (self.facility as u16) * 8 + syslog_severity as u16;
-
-        // RFC 5424 format
-        let msg = format!(
-            "<{priority}>1 {timestamp} aifw aifw-ids - - - IDS Alert: [{action}] {sig} src={src}:{sport} dst={dst}:{dport} proto={proto} severity={sev}",
-            priority = priority,
-            timestamp = alert.timestamp.to_rfc3339(),
+    fn format_alert(alert: &IdsAlert) -> String {
+        format!(
+            "IDS Alert: [{action}] {sig} src={src}:{sport} dst={dst}:{dport} proto={proto} severity={sev}",
             action = alert.action,
             sig = alert.signature_msg,
             src = alert.src_ip,
@@ -67,15 +44,28 @@ impl AlertOutput for SyslogOutput {
             dport = alert.dst_port.unwrap_or(0),
             proto = alert.protocol,
             sev = alert.severity.label(),
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl AlertOutput for SyslogAlertOutput {
+    async fn emit(&self, alert: &IdsAlert) -> Result<()> {
+        // O(1) gate; the message is only built when forwarding is on.
+        if !self.handle.enabled_for(Category::Ids) {
+            return Ok(());
+        }
+        self.handle.enqueue(
+            Category::Ids,
+            Self::severity_to_syslog(alert.severity.0),
+            "aifw-ids",
+            Self::format_alert(alert),
         );
-
-        let _ = socket.send_to(msg.as_bytes(), &self.target);
-
         Ok(())
     }
 
     async fn flush(&self) -> Result<()> {
-        Ok(()) // UDP is fire-and-forget
+        Ok(()) // delivery is owned by the shared writer task
     }
 
     fn name(&self) -> &str {
@@ -86,12 +76,83 @@ impl AlertOutput for SyslogOutput {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aifw_common::ids::{IdsAction, IdsSeverity, RuleSource};
+    use aifw_common::syslog::{SyslogConfig, SyslogManager, Transport};
+    use std::time::Duration;
+
+    fn alert() -> IdsAlert {
+        let mut a = IdsAlert::new(
+            "ET SCAN test signature".into(),
+            IdsSeverity(2),
+            "203.0.113.7".parse().expect("valid test IP"),
+            "10.0.0.5".parse().expect("valid test IP"),
+            "tcp",
+            IdsAction::Alert,
+            RuleSource::Custom,
+        );
+        a.src_port = Some(4444);
+        a.dst_port = Some(22);
+        a
+    }
 
     #[test]
     fn test_severity_mapping() {
-        assert_eq!(SyslogOutput::severity_to_syslog(1), 1);
-        assert_eq!(SyslogOutput::severity_to_syslog(2), 2);
-        assert_eq!(SyslogOutput::severity_to_syslog(3), 4);
-        assert_eq!(SyslogOutput::severity_to_syslog(4), 6);
+        assert_eq!(SyslogAlertOutput::severity_to_syslog(1), 1);
+        assert_eq!(SyslogAlertOutput::severity_to_syslog(2), 2);
+        assert_eq!(SyslogAlertOutput::severity_to_syslog(3), 4);
+        assert_eq!(SyslogAlertOutput::severity_to_syslog(4), 6);
+    }
+
+    #[tokio::test]
+    async fn emits_alert_to_udp_server() {
+        let server = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let port = server.local_addr().unwrap().port();
+
+        let mgr = SyslogManager::start();
+        mgr.apply(SyslogConfig {
+            enabled: true,
+            host: "127.0.0.1".into(),
+            port,
+            transport: Transport::Udp,
+            ids_enabled: true,
+            ..Default::default()
+        });
+
+        let out = SyslogAlertOutput::new(mgr.handle());
+        out.emit(&alert()).await.unwrap();
+
+        let mut buf = [0u8; 2048];
+        let (n, _) = tokio::time::timeout(Duration::from_secs(5), server.recv_from(&mut buf))
+            .await
+            .expect("alert should be forwarded")
+            .unwrap();
+        let got = std::str::from_utf8(&buf[..n]).unwrap();
+        assert!(got.contains("aifw-ids"), "got: {got}");
+        assert!(got.contains("ET SCAN test signature"), "got: {got}");
+        assert!(got.contains("src=203.0.113.7:4444"), "got: {got}");
+        assert!(got.contains("dst=10.0.0.5:22"), "got: {got}");
+    }
+
+    #[tokio::test]
+    async fn disabled_category_sends_nothing() {
+        let server = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let port = server.local_addr().unwrap().port();
+
+        let mgr = SyslogManager::start();
+        mgr.apply(SyslogConfig {
+            enabled: true,
+            host: "127.0.0.1".into(),
+            port,
+            transport: Transport::Udp,
+            ids_enabled: false, // category off
+            ..Default::default()
+        });
+
+        let out = SyslogAlertOutput::new(mgr.handle());
+        out.emit(&alert()).await.unwrap();
+
+        let mut buf = [0u8; 256];
+        let r = tokio::time::timeout(Duration::from_millis(300), server.recv_from(&mut buf)).await;
+        assert!(r.is_err(), "gated alert must not be forwarded");
     }
 }

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -2665,6 +2665,20 @@ mod sudoers_tests {
         );
     }
 
+    /// The remote-syslog "stop storing logs locally" toggle stops/starts
+    /// `pflogd` through `aifw-sudo-service` (aifw_core::local_log). Guard
+    /// against the helper's allowlist dropping the service — sudo would
+    /// refuse and the toggle would silently stop working.
+    #[test]
+    fn service_helper_allows_pflogd() {
+        let script = include_str!("../../freebsd/overlay/usr/local/libexec/aifw-sudo-service");
+        assert!(
+            script.contains("pflogd)"),
+            "aifw-sudo-service allowlist must include pflogd for the \
+             remote-syslog disable_local toggle"
+        );
+    }
+
     /// Structural-validity check on the sudoers content. We can't run
     /// `visudo -cf` from a Linux dev box, but we can enforce that every
     /// non-empty, non-comment line is a well-formed `aifw ALL=(<runas>)

--- a/aifw-ui/src/app/ids/settings/page.tsx
+++ b/aifw-ui/src/app/ids/settings/page.tsx
@@ -11,7 +11,6 @@ interface IdsConfig {
   alert_retention_days: number;
   eve_log_enabled: boolean;
   eve_log_path: string;
-  syslog_target: string;
   worker_count: number | null;
   flow_table_size: number | null;
   stream_depth: number | null;
@@ -53,7 +52,6 @@ export default function IdsSettingsPage() {
     alert_retention_days: 7,
     eve_log_enabled: false,
     eve_log_path: "/var/log/aifw/eve.json",
-    syslog_target: "",
     worker_count: null,
     flow_table_size: null,
     stream_depth: null,
@@ -86,7 +84,6 @@ export default function IdsSettingsPage() {
         alert_retention_days: d.alert_retention_days ?? 7,
         eve_log_enabled: d.eve_log_enabled ?? false,
         eve_log_path: d.eve_log_path || "/var/log/aifw/eve.json",
-        syslog_target: d.syslog_target || "",
         worker_count: d.worker_count ?? null,
         flow_table_size: d.flow_table_size ?? null,
         stream_depth: d.stream_depth ?? null,
@@ -358,20 +355,18 @@ export default function IdsSettingsPage() {
             </p>
           </div>
 
-          {/* Syslog Target */}
+          {/* Syslog forwarding moved to the global Remote Logging settings */}
           <div>
             <label className="block text-xs text-[var(--text-muted)] mb-1">
-              Syslog Target
+              Syslog Forwarding
             </label>
-            <input
-              type="text"
-              value={config.syslog_target}
-              onChange={(e) =>
-                setConfig({ ...config, syslog_target: e.target.value })
-              }
-              placeholder="e.g. 192.168.1.10:514"
-              className="w-full bg-[var(--bg-primary)] border border-[var(--border)] rounded-md px-3 py-2 text-sm text-[var(--text-primary)] placeholder-[var(--text-muted)] focus:outline-none focus:border-[var(--accent)] transition-colors"
-            />
+            <p className="text-sm text-[var(--text-muted)] px-3 py-2 bg-[var(--bg-primary)] border border-[var(--border)] rounded-md">
+              IDS alerts are forwarded via{" "}
+              <a href="/settings?cat=logging" className="text-[var(--accent)] hover:underline">
+                Settings → Remote Logging
+              </a>{" "}
+              (enable the IDS alerts category).
+            </p>
           </div>
 
           {/* EVE Log */}

--- a/aifw-ui/src/app/settings/components/SyslogSection.tsx
+++ b/aifw-ui/src/app/settings/components/SyslogSection.tsx
@@ -205,7 +205,7 @@ export function SyslogSection({
             checked={config.disable_local}
             onChange={(v) => set({ disable_local: v })}
             label="Stop storing logs locally while forwarding"
-            hint="Stops the local pf log file (Blocked-page history becomes memory-only) and, when app-log forwarding is on, the /var/log/aifw files. IDS alerts always stay in the local database for the Alerts page."
+            hint="Only applies to categories that are actually being forwarded, so logs are never lost from both destinations: with pf forwarding on, the local pf log file stops (Blocked-page history becomes memory-only); with app-log forwarding on, the /var/log/aifw files stop growing (forwarded levels only). IDS alerts always stay in the local database for the Alerts page."
           />
         </div>
 

--- a/aifw-ui/src/app/settings/components/SyslogSection.tsx
+++ b/aifw-ui/src/app/settings/components/SyslogSection.tsx
@@ -7,7 +7,7 @@ import {
   SyslogAppLevel,
   SyslogConfig,
   SyslogFormat,
-  SyslogStatus,
+  SyslogProcessStatus,
   SyslogTransport,
 } from "@/lib/api/syslog";
 import { FeedbackBanner } from "./FeedbackBanner";
@@ -17,7 +17,7 @@ export interface SyslogSectionProps {
   visible: boolean;
   config: SyslogConfig;
   setConfig: Dispatch<SetStateAction<SyslogConfig>>;
-  status: SyslogStatus | null;
+  status: SyslogProcessStatus[] | null;
   refreshStatus: () => void;
   loading: boolean;
   saving: boolean;
@@ -109,8 +109,10 @@ export function SyslogSection({
               type="number"
               min={1}
               max={65535}
-              value={config.port}
-              onChange={(e) => set({ port: Number(e.target.value) || 514 })}
+              value={config.port === 0 ? "" : config.port}
+              onChange={(e) =>
+                set({ port: e.target.value === "" ? 0 : Number(e.target.value) || 0 })
+              }
               className={inputCls}
               disabled={loading}
             />
@@ -209,26 +211,36 @@ export function SyslogSection({
           />
         </div>
 
-        {status && (
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[var(--text-muted)] bg-[var(--bg-primary)] border border-[var(--border)] rounded-md px-3 py-2">
-            <span className="font-medium text-[var(--text-primary)]">Delivery (API process):</span>
-            <span>sent {status.sent}</span>
-            <span>dropped {status.dropped}</span>
-            <span>errors {status.errors}</span>
-            <span className={status.connected ? "text-green-400" : "text-[var(--text-muted)]"}>
-              {status.connected ? "connected" : "not connected"}
-            </span>
-            {status.last_error && (
-              <span className="text-red-400 truncate max-w-full" title={status.last_error}>
-                last error: {status.last_error}
-              </span>
-            )}
-            <button
-              onClick={refreshStatus}
-              className="ml-auto text-[var(--accent)] hover:underline"
-            >
-              Refresh
-            </button>
+        {status && status.length > 0 && (
+          <div className="space-y-1 text-xs text-[var(--text-muted)] bg-[var(--bg-primary)] border border-[var(--border)] rounded-md px-3 py-2">
+            <div className="flex items-center">
+              <span className="font-medium text-[var(--text-primary)]">Delivery by process</span>
+              <button
+                onClick={refreshStatus}
+                className="ml-auto text-[var(--accent)] hover:underline"
+              >
+                Refresh
+              </button>
+            </div>
+            {status.map((p) => (
+              <div key={p.process} className="flex flex-wrap items-center gap-x-4 gap-y-0.5">
+                <span className="w-28 font-mono text-[var(--text-primary)]">{p.process}</span>
+                <span>sent {p.sent}</span>
+                <span>dropped {p.dropped}</span>
+                <span>errors {p.errors}</span>
+                <span className={p.connected ? "text-green-400" : "text-[var(--text-muted)]"}>
+                  {p.connected ? "connected" : "not connected"}
+                </span>
+                {p.last_error && (
+                  <span className="text-red-400 truncate max-w-full" title={p.last_error}>
+                    last error: {p.last_error}
+                  </span>
+                )}
+              </div>
+            ))}
+            <p className="text-[10px] text-[var(--text-muted)]">
+              Daemon/IDS rows refresh on their 60s poll; the API row is live.
+            </p>
           </div>
         )}
 

--- a/aifw-ui/src/app/settings/components/SyslogSection.tsx
+++ b/aifw-ui/src/app/settings/components/SyslogSection.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { Dispatch, SetStateAction } from "react";
+import { Feedback } from "@/hooks/useFeedback";
+import {
+  SYSLOG_FACILITIES,
+  SyslogAppLevel,
+  SyslogConfig,
+  SyslogFormat,
+  SyslogStatus,
+  SyslogTransport,
+} from "@/lib/api/syslog";
+import { FeedbackBanner } from "./FeedbackBanner";
+import { inputCls, labelCls, saveBtnCls, sectionCls } from "./sectionStyles";
+
+export interface SyslogSectionProps {
+  visible: boolean;
+  config: SyslogConfig;
+  setConfig: Dispatch<SetStateAction<SyslogConfig>>;
+  status: SyslogStatus | null;
+  refreshStatus: () => void;
+  loading: boolean;
+  saving: boolean;
+  testing: boolean;
+  feedback: Feedback | null;
+  save: () => void;
+  test: () => void;
+}
+
+function Toggle({
+  checked,
+  onChange,
+  label,
+  hint,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+  hint?: string;
+}) {
+  return (
+    <label className="flex items-start gap-2 cursor-pointer select-none">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-0.5 accent-[var(--accent)]"
+      />
+      <span className="text-sm text-[var(--text-primary)]">
+        {label}
+        {hint && (
+          <span className="block text-[11px] text-[var(--text-muted)]">{hint}</span>
+        )}
+      </span>
+    </label>
+  );
+}
+
+export function SyslogSection({
+  visible,
+  config,
+  setConfig,
+  status,
+  refreshStatus,
+  loading,
+  saving,
+  testing,
+  feedback,
+  save,
+  test,
+}: SyslogSectionProps) {
+  if (!visible) return null;
+
+  const set = (patch: Partial<SyslogConfig>) =>
+    setConfig((c) => ({ ...c, ...patch }));
+
+  return (
+    <section className={sectionCls}>
+      <h2 className="text-base font-semibold mb-1">Remote Logging (Syslog)</h2>
+      <p className="text-xs text-[var(--text-muted)] mb-4">
+        Forward firewall, IDS, and application logs to a central syslog server / SIEM.
+      </p>
+
+      <div className="space-y-4">
+        <FeedbackBanner feedback={feedback} />
+
+        <Toggle
+          checked={config.enabled}
+          onChange={(v) => set({ enabled: v })}
+          label="Enable remote syslog server"
+          hint="Master switch — nothing is forwarded while this is off."
+        />
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className={labelCls}>Server Host</label>
+            <input
+              type="text"
+              value={config.host}
+              onChange={(e) => set({ host: e.target.value })}
+              placeholder="e.g. 192.168.1.10 or syslog.example.com"
+              className={inputCls}
+              disabled={loading}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Port</label>
+            <input
+              type="number"
+              min={1}
+              max={65535}
+              value={config.port}
+              onChange={(e) => set({ port: Number(e.target.value) || 514 })}
+              className={inputCls}
+              disabled={loading}
+            />
+          </div>
+          <div>
+            <label className={labelCls}>Transport</label>
+            <select
+              value={config.transport}
+              onChange={(e) => set({ transport: e.target.value as SyslogTransport })}
+              className={inputCls}
+            >
+              <option value="udp">UDP (classic, fire-and-forget)</option>
+              <option value="tcp">TCP (reliable, reconnects)</option>
+            </select>
+          </div>
+          <div>
+            <label className={labelCls}>Format</label>
+            <select
+              value={config.format}
+              onChange={(e) => set({ format: e.target.value as SyslogFormat })}
+              className={inputCls}
+            >
+              <option value="rfc3164">BSD (RFC 3164) — broadest compatibility</option>
+              <option value="rfc5424">RFC 5424 — modern structured receivers</option>
+            </select>
+          </div>
+          <div>
+            <label className={labelCls}>Facility</label>
+            <select
+              value={config.facility}
+              onChange={(e) => set({ facility: Number(e.target.value) })}
+              className={inputCls}
+            >
+              {SYSLOG_FACILITIES.map((name, num) => (
+                <option key={num} value={num}>
+                  {name} ({num})
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className={labelCls}>Hostname Override</label>
+            <input
+              type="text"
+              value={config.hostname_override}
+              onChange={(e) => set({ hostname_override: e.target.value })}
+              placeholder="(system hostname)"
+              className={inputCls}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className={labelCls}>Forwarded Categories</label>
+          <div className="space-y-2 mt-1">
+            <Toggle
+              checked={config.pf_enabled}
+              onChange={(v) => set({ pf_enabled: v })}
+              label="Firewall (pf) packet logs"
+              hint="Blocked traffic is always logged; passed traffic only for rules with the Log flag set."
+            />
+            <Toggle
+              checked={config.ids_enabled}
+              onChange={(v) => set({ ids_enabled: v })}
+              label="IDS alerts"
+            />
+            <div className="flex flex-wrap items-center gap-3">
+              <Toggle
+                checked={config.app_enabled}
+                onChange={(v) => set({ app_enabled: v })}
+                label="Application logs (API, daemon, IDS engine)"
+              />
+              {config.app_enabled && (
+                <select
+                  value={config.app_min_level}
+                  onChange={(e) => set({ app_min_level: e.target.value as SyslogAppLevel })}
+                  className="px-2 py-1 text-xs bg-[var(--bg-primary)] border border-[var(--border)] rounded-md text-[var(--text-primary)]"
+                  aria-label="Minimum app log level"
+                >
+                  <option value="error">error and above</option>
+                  <option value="warn">warn and above</option>
+                  <option value="info">info and above</option>
+                  <option value="debug">debug and above</option>
+                </select>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="border-t border-[var(--border)] pt-4">
+          <Toggle
+            checked={config.disable_local}
+            onChange={(v) => set({ disable_local: v })}
+            label="Stop storing logs locally while forwarding"
+            hint="Stops the local pf log file (Blocked-page history becomes memory-only) and, when app-log forwarding is on, the /var/log/aifw files. IDS alerts always stay in the local database for the Alerts page."
+          />
+        </div>
+
+        {status && (
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[var(--text-muted)] bg-[var(--bg-primary)] border border-[var(--border)] rounded-md px-3 py-2">
+            <span className="font-medium text-[var(--text-primary)]">Delivery (API process):</span>
+            <span>sent {status.sent}</span>
+            <span>dropped {status.dropped}</span>
+            <span>errors {status.errors}</span>
+            <span className={status.connected ? "text-green-400" : "text-[var(--text-muted)]"}>
+              {status.connected ? "connected" : "not connected"}
+            </span>
+            {status.last_error && (
+              <span className="text-red-400 truncate max-w-full" title={status.last_error}>
+                last error: {status.last_error}
+              </span>
+            )}
+            <button
+              onClick={refreshStatus}
+              className="ml-auto text-[var(--accent)] hover:underline"
+            >
+              Refresh
+            </button>
+          </div>
+        )}
+
+        <div className="flex items-center gap-3">
+          <button onClick={save} disabled={saving || loading} className={saveBtnCls}>
+            {saving ? "Saving..." : "Save Syslog Settings"}
+          </button>
+          <button
+            onClick={test}
+            disabled={testing || loading}
+            className="px-5 py-2 bg-[var(--bg-card-secondary)] hover:bg-[var(--bg-hover)] border border-[var(--border)] text-[var(--text-primary)] rounded-md text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            title="Sends one test message using the values in the form (works before saving)"
+          >
+            {testing ? "Sending..." : "Send Test Message"}
+          </button>
+          <span className="text-[11px] text-[var(--text-muted)]">
+            Other services apply changes within 60 seconds.
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/aifw-ui/src/app/settings/page.tsx
+++ b/aifw-ui/src/app/settings/page.tsx
@@ -14,6 +14,7 @@ import {
   usePfTuning,
   useS3Backup,
   useSmtpSettings,
+  useSyslogSettings,
   useSystemActions,
   useSystemBanner,
   useSystemConsole,
@@ -37,6 +38,7 @@ import { PfStateTableSection } from "./components/PfStateTableSection";
 import { S3BackupSection } from "./components/S3BackupSection";
 import { SmtpSection } from "./components/SmtpSection";
 import { SshSection } from "./components/SshSection";
+import { SyslogSection } from "./components/SyslogSection";
 import { SystemActionsSection } from "./components/SystemActionsSection";
 import { TlsPolicySection } from "./components/TlsPolicySection";
 import { ValkeySection } from "./components/ValkeySection";
@@ -52,6 +54,7 @@ const CATEGORIES: { key: string; label: string; sections: string[] }[] = [
   { key: "dns",     label: "DNS",             sections: ["DNS Configuration"] },
   { key: "storage", label: "Storage & Metrics", sections: ["Metrics Storage", "Dashboard History", "Metrics Persistence (Valkey)", "IDS Alert Storage"] },
   { key: "backup",  label: "Backup & History", sections: ["Config History", "S3 Backup Sync", "Email Notifications (SMTP)"] },
+  { key: "logging", label: "Logging",         sections: ["Remote Logging (Syslog)"] },
   { key: "ai",      label: "AI / LLM",        sections: ["AI / LLM Providers"] },
 ];
 
@@ -62,6 +65,7 @@ export default function SettingsPage() {
   const cfgRet = useConfigRetention();
   const s3 = useS3Backup();
   const smtp = useSmtpSettings();
+  const syslog = useSyslogSettings();
   const apiServer = useApiServerSettings();
   const tls = useTlsPolicy();
   const auth = useAuthSettings();
@@ -138,6 +142,7 @@ export default function SettingsPage() {
       <ConfigHistorySection visible={inCategory("Config History")} {...cfgRet} />
       <S3BackupSection visible={inCategory("S3 Backup Sync")} {...s3} />
       <SmtpSection visible={inCategory("Email Notifications (SMTP)")} {...smtp} />
+      <SyslogSection visible={inCategory("Remote Logging (Syslog)")} {...syslog} />
       <ApiServerSection visible={inCategory("API Server")} {...apiServer} />
       <TlsPolicySection visible={inCategory("TLS Policy")} {...tls} />
       <AuthSection visible={inCategory("Authentication")} {...auth} />

--- a/aifw-ui/src/components/Sidebar.tsx
+++ b/aifw-ui/src/components/Sidebar.tsx
@@ -145,6 +145,7 @@ const navItems: NavItem[] = [
       { href: "/settings?cat=dns",     label: "  DNS",               permission: "settings:read" },
       { href: "/settings?cat=storage", label: "  Storage & Metrics", permission: "settings:read" },
       { href: "/settings?cat=backup",  label: "  Backup & History",  permission: "settings:read" },
+      { href: "/settings?cat=logging", label: "  Remote Logging",    permission: "settings:read" },
       { href: "/settings?cat=ai",      label: "  AI / LLM",          permission: "settings:read" },
       { href: "/reboot", label: "Power", permission: "system:reboot" },
     ],

--- a/aifw-ui/src/hooks/useSettings.ts
+++ b/aifw-ui/src/hooks/useSettings.ts
@@ -12,7 +12,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Feedback, FeedbackType, useFeedback } from "@/hooks/useFeedback";
 import {
   SyslogConfig,
-  SyslogStatus,
+  SyslogProcessStatus,
   defaultSyslogConfig,
   getSyslogConfig,
   getSyslogStatus,
@@ -1126,7 +1126,7 @@ export function useSystemActions() {
 
 export function useSyslogSettings() {
   const [config, setConfig] = useState<SyslogConfig>(defaultSyslogConfig);
-  const [status, setStatus] = useState<SyslogStatus | null>(null);
+  const [status, setStatus] = useState<SyslogProcessStatus[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);

--- a/aifw-ui/src/hooks/useSettings.ts
+++ b/aifw-ui/src/hooks/useSettings.ts
@@ -11,6 +11,15 @@
 import { useCallback, useEffect, useState } from "react";
 import { Feedback, FeedbackType, useFeedback } from "@/hooks/useFeedback";
 import {
+  SyslogConfig,
+  SyslogStatus,
+  defaultSyslogConfig,
+  getSyslogConfig,
+  getSyslogStatus,
+  saveSyslogConfig,
+  testSyslog,
+} from "@/lib/api/syslog";
+import {
   AiProviderConfig,
   AiTestResult,
   ConsoleKind,
@@ -1111,4 +1120,84 @@ export function useSystemActions() {
   };
 
   return { confirmReboot, setConfirmReboot, rebooting, feedback, reboot };
+}
+
+// --- Remote Logging (Syslog) ---
+
+export function useSyslogSettings() {
+  const [config, setConfig] = useState<SyslogConfig>(defaultSyslogConfig);
+  const [status, setStatus] = useState<SyslogStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const { feedback, showFeedback, clearFeedback } = useFeedback(4000);
+
+  const refreshStatus = useCallback(async () => {
+    try {
+      setStatus(await getSyslogStatus());
+    } catch {
+      // endpoint may not exist yet (older API)
+    }
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setConfig(await getSyslogConfig());
+      } catch {
+        // endpoint may not exist yet
+      } finally {
+        setLoading(false);
+      }
+      refreshStatus();
+    })();
+  }, [refreshStatus]);
+
+  const save = async () => {
+    setSaving(true);
+    clearFeedback();
+    try {
+      await saveSyslogConfig(config);
+      showFeedback("success", "Syslog settings saved.");
+      refreshStatus();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Unknown error";
+      showFeedback("error", `Save failed: ${msg}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Tests with the CURRENT form values (unsaved drafts included) so the
+  // server can be verified before committing the config.
+  const test = async () => {
+    if (!config.host.trim()) {
+      showFeedback("error", "Enter a syslog server host first.");
+      return;
+    }
+    setTesting(true);
+    clearFeedback();
+    try {
+      const r = await testSyslog(config);
+      showFeedback(r.ok ? "success" : "error", r.message);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Unknown error";
+      showFeedback("error", `Test failed: ${msg}`);
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return {
+    config,
+    setConfig,
+    status,
+    refreshStatus,
+    loading,
+    saving,
+    testing,
+    feedback,
+    save,
+    test,
+  };
 }

--- a/aifw-ui/src/lib/api/syslog.ts
+++ b/aifw-ui/src/lib/api/syslog.ts
@@ -21,13 +21,15 @@ export interface SyslogConfig {
   disable_local: boolean;
 }
 
-/** Delivery counters for the API process. */
-export interface SyslogStatus {
+/** Delivery counters for one AiFw process (aifw-api / aifw-daemon / aifw-ids). */
+export interface SyslogProcessStatus {
+  process: string;
   sent: number;
   dropped: number;
   errors: number;
   connected: boolean;
   last_error: string | null;
+  updated_at: string;
 }
 
 export interface SyslogTestResult {
@@ -74,6 +76,6 @@ export function testSyslog(cfg: SyslogConfig): Promise<SyslogTestResult> {
   return api.post<SyslogTestResult>("/api/v1/settings/syslog/test", cfg);
 }
 
-export function getSyslogStatus(): Promise<SyslogStatus> {
-  return api.get<SyslogStatus>("/api/v1/settings/syslog/status");
+export function getSyslogStatus(): Promise<SyslogProcessStatus[]> {
+  return api.get<SyslogProcessStatus[]>("/api/v1/settings/syslog/status");
 }

--- a/aifw-ui/src/lib/api/syslog.ts
+++ b/aifw-ui/src/lib/api/syslog.ts
@@ -1,0 +1,79 @@
+import { api } from "@/lib/api";
+
+/* ------------------------------- Types ---------------------------------- */
+
+export type SyslogTransport = "udp" | "tcp";
+export type SyslogFormat = "rfc3164" | "rfc5424";
+export type SyslogAppLevel = "error" | "warn" | "info" | "debug";
+
+export interface SyslogConfig {
+  enabled: boolean;
+  host: string;
+  port: number;
+  transport: SyslogTransport;
+  format: SyslogFormat;
+  facility: number;
+  hostname_override: string;
+  pf_enabled: boolean;
+  ids_enabled: boolean;
+  app_enabled: boolean;
+  app_min_level: SyslogAppLevel;
+  disable_local: boolean;
+}
+
+/** Delivery counters for the API process. */
+export interface SyslogStatus {
+  sent: number;
+  dropped: number;
+  errors: number;
+  connected: boolean;
+  last_error: string | null;
+}
+
+export interface SyslogTestResult {
+  ok: boolean;
+  message: string;
+}
+
+/* ------------------------------ Helpers --------------------------------- */
+
+export const defaultSyslogConfig: SyslogConfig = {
+  enabled: false,
+  host: "",
+  port: 514,
+  transport: "udp",
+  format: "rfc3164",
+  facility: 16,
+  hostname_override: "",
+  pf_enabled: false,
+  ids_enabled: false,
+  app_enabled: false,
+  app_min_level: "info",
+  disable_local: false,
+};
+
+/** Facility names indexed by facility number 0-23 (same list as the API). */
+export const SYSLOG_FACILITIES: string[] = [
+  "kern", "user", "mail", "daemon", "auth", "syslog", "lpr", "news",
+  "uucp", "cron", "authpriv", "ftp", "ntp", "audit", "alert", "clock",
+  "local0", "local1", "local2", "local3", "local4", "local5", "local6", "local7",
+];
+
+/* ----------------------------- HTTP calls ------------------------------- */
+
+export function getSyslogConfig(): Promise<SyslogConfig> {
+  return api.get<SyslogConfig>("/api/v1/settings/syslog");
+}
+
+export function saveSyslogConfig(cfg: SyslogConfig): Promise<unknown> {
+  return api.put("/api/v1/settings/syslog", cfg);
+}
+
+/** Sends one test message using `cfg` (which need not be saved yet). */
+export function testSyslog(cfg: SyslogConfig): Promise<SyslogTestResult> {
+  return api.post<SyslogTestResult>("/api/v1/settings/syslog/test", cfg);
+}
+
+export function getSyslogStatus(): Promise<SyslogStatus> {
+  return api.get<SyslogStatus>("/api/v1/settings/syslog/status");
+}

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -467,7 +467,7 @@ Sensible defaults are applied when omitted; check the relevant subsystem doc for
 | `GET`,&nbsp;`PUT` | `/api/v1/settings/ids-alerts` | IDS alert ring / retention |
 | `GET`,&nbsp;`PUT` | `/api/v1/settings/syslog` | Remote syslog forwarding (server, transport, format, categories) |
 | `POST` | `/api/v1/settings/syslog/test` | Send one test message (body = draft config, optional) |
-| `GET` | `/api/v1/settings/syslog/status` | Delivery counters for the API process |
+| `GET` | `/api/v1/settings/syslog/status` | Delivery counters per AiFw process (API row live, daemon/IDS refreshed on their 60s poll) |
 | `GET`,&nbsp;`PUT` | `/api/v1/settings/{section}` | Generic key/value settings store |
 | `GET`,&nbsp;`PUT` | `/api/v1/notify/smtp/config` | SMTP notification settings |
 | `POST` | `/api/v1/notify/smtp/test` | Send a test email |

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -465,6 +465,9 @@ Sensible defaults are applied when omitted; check the relevant subsystem doc for
 | `POST` | `/api/v1/settings/ai/test` | Test AI provider credentials |
 | `GET`,&nbsp;`PUT` | `/api/v1/settings/dashboard-history` | Dashboard widget retention |
 | `GET`,&nbsp;`PUT` | `/api/v1/settings/ids-alerts` | IDS alert ring / retention |
+| `GET`,&nbsp;`PUT` | `/api/v1/settings/syslog` | Remote syslog forwarding (server, transport, format, categories) |
+| `POST` | `/api/v1/settings/syslog/test` | Send one test message (body = draft config, optional) |
+| `GET` | `/api/v1/settings/syslog/status` | Delivery counters for the API process |
 | `GET`,&nbsp;`PUT` | `/api/v1/settings/{section}` | Generic key/value settings store |
 | `GET`,&nbsp;`PUT` | `/api/v1/notify/smtp/config` | SMTP notification settings |
 | `POST` | `/api/v1/notify/smtp/test` | Send a test email |

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -63,6 +63,7 @@ Most list commands accept `--json` for machine-readable output. Most failures ex
 | `aifw config` | Versioned config history, import / export, rollback |
 | `aifw routes` | Manage static routes |
 | `aifw dns` | Manage DNS nameservers + post-switch probe |
+| `aifw syslog` | Remote syslog forwarding (server, categories, test) |
 | `aifw dhcp` | Manage the DHCP server (rDHCP) |
 | `aifw users` | Manage local users |
 | `aifw reverse-proxy` | Control TrafficCop |
@@ -238,6 +239,24 @@ aifw dns set "1.1.1.1, 9.9.9.9"
 aifw dns probe on        # enable auto-rollback
 aifw dns probe off
 aifw dns probe status
+```
+
+## syslog
+
+Forward pf packet logs, IDS alerts, and application logs to a remote syslog server / SIEM. `set` only changes the flags you pass; all AiFw services pick up changes within 60 seconds.
+
+```bash
+aifw syslog show                 # human-readable summary (--json for JSON)
+aifw syslog set --host 192.168.1.10 --port 514 --pf true
+aifw syslog enable               # master switch (requires a host)
+aifw syslog disable
+
+aifw syslog set --transport tcp --format rfc5424 --facility local3
+aifw syslog set --app true --app-min-level warn
+aifw syslog set --disable-local true   # stop local pf/app log files while forwarding
+
+aifw syslog test                 # one test message with the saved config
+aifw syslog test --host 10.0.0.9 --port 5514
 ```
 
 ## dhcp

--- a/docs/docs/ids.md
+++ b/docs/docs/ids.md
@@ -60,6 +60,8 @@ curl -X POST https://aifw.local/api/v1/ids/reload \
   -H "Authorization: Bearer $TOKEN"
 ```
 
+> **Deprecated:** the per-IDS `syslog_target` field is a no-op. Alert forwarding to a syslog server is configured globally at `/api/v1/settings/syslog` (enable the IDS alerts category), or in the UI under *Settings → Remote Logging*.
+
 ## Rule formats
 
 **Suricata-compatible.** The native format. AiFw parses Suricata 7.x syntax &mdash; `alert`, `drop`, `pass`, plus the common `content`, `pcre`, `flow`, `threshold`, and `metadata` keywords. This is a practical **subset**, not full Suricata engine parity: most ET Open-style rules drop in unchanged, but rules relying on unsupported keywords are skipped (visible in the ruleset parse stats).

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-service
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-service
@@ -26,6 +26,11 @@ case "$SERVICE" in
         ;;
     unbound|local_unbound|sshd|strongswan)
         ;;
+    pflogd)
+        # Remote-syslog "stop storing logs locally": pflogd (the
+        # /var/log/pflog writer) is stopped/started while the pflog0
+        # interface stays up for live capture + forwarding.
+        ;;
     *)
         echo "aifw-sudo-service: service not in allowlist: $SERVICE" >&2
         exit 1


### PR DESCRIPTION
## Summary

Adds configurable remote syslog forwarding — the first way to ship AiFw logs to a central syslog server / SIEM.

- **Forwarded categories** (individually toggleable): pf packet logs (live pflog0 capture, block=notice / pass=info, app-name `aifw-pf`), IDS alerts (`aifw-ids`), and application logs from aifw-api / aifw-daemon / aifw-ids via a tracing layer with a min-level setting.
- **Transport**: UDP or TCP (RFC 6587 LF framing, 1s–30s reconnect backoff, 5s timeouts). **Format**: BSD (RFC 3164) or RFC 5424, selectable facility and hostname override.
- **Shared client** in `aifw-common/src/syslog/`: singleton `syslog_config` table, bounded-queue (2048) writer task, non-blocking `try_send` producers with drop counters — hot paths (the tcpdump reader, alert pipeline, tracing) can never stall on a dead syslog server.
- **Propagation**: API applies changes instantly on PUT; all three services also poll the DB every 60s, so CLI edits propagate everywhere.
- **"Stop storing logs locally" toggle** (pfSense-style, separate from the forwarding switch): stops `pflogd` while keeping `pflog0` up (live Blocked page + forwarding keep working; sudo-service allowlist extended with a guard test), and silences the stdout fmt layer (the `/var/log/aifw` files are daemon(8) stdout redirects) — but only while app-log forwarding is on, so app logs are never lost from both destinations. IDS alerts always stay in SQLite for the Alerts page.
- **Surfaces**: Settings → Remote Logging UI section (with test button that works pre-save and a delivery-status strip), `aifw syslog` CLI (`show/enable/disable/set/test`), `GET/PUT /api/v1/settings/syslog` + `/test` + `/status`, backup/restore round-trip.
- Rewires the previously dead IDS `syslog_target` path: the field was stored and shown in the UI but no sender was ever constructed. It's now a documented no-op; the IDS pipeline forwards through the shared client instead.

## Testing

- 861 tests pass (`cargo test`), including ~30 new ones: RFC 3164/5424 formatting, UDP/TCP delivery against local listeners, queue gating and drop behavior, tracing-layer recursion guard and min-level, IDS adapter, API round-trip/validation/test endpoints, backup round-trip, CLI set/show, sudoers guard.
- `cargo check` zero warnings, clippy clean, `npm run build` + lint clean.
- Not yet exercised on FreeBSD hardware (pflogd stop/pflog0 persistence assumption needs a check on the test box before release).