### PR TITLE
Fix syslog disable_local: rc service is pflog, not pflogd

### DIFF
--- a/aifw-api/src/syslog.rs
+++ b/aifw-api/src/syslog.rs
@@ -28,7 +28,7 @@ pub async fn put_syslog_config(
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     state.syslog.apply(cfg.clone());
-    // Reconcile pflogd with disable_local right away (best-effort; the
+    // Reconcile the pflog service with disable_local right away (best-effort; the
     // daemon also reconciles on its 60s poll). Off the request path.
     tokio::spawn(async move {
         aifw_core::local_log::apply_local_log_policy(&cfg).await;

--- a/aifw-core/src/local_log.rs
+++ b/aifw-core/src/local_log.rs
@@ -1,7 +1,8 @@
 //! Local log storage policy for the remote-syslog `disable_local` toggle.
 //!
 //! When "stop storing logs locally" is active alongside remote forwarding,
-//! the pf packet-log file writer (`pflogd`) is stopped while the `pflog0`
+//! the pf packet-log file writer (`pflogd`, rc service name `pflog`) is
+//! stopped while the `pflog0`
 //! interface is kept up, so live capture (Blocked page) and remote
 //! forwarding keep working. Re-enabling local storage restarts `pflogd`.
 //!
@@ -40,7 +41,7 @@ pub async fn apply_local_log_policy(cfg: &SyslogConfig) -> bool {
     if local_pf_log_disabled(cfg) {
         // Stop the file writer. "not running" is a normal outcome for an
         // idempotent reconcile, so only log other failures.
-        match sudo::service("pflogd", "onestop").await {
+        match sudo::service("pflog", "onestop").await {
             Ok(out) if !out.status.success() => {
                 let err = String::from_utf8_lossy(&out.stderr);
                 if !err.contains("not running") {
@@ -49,7 +50,7 @@ pub async fn apply_local_log_policy(cfg: &SyslogConfig) -> bool {
                 }
             }
             Err(e) => {
-                tracing::warn!(error = %e, "failed to run service pflogd onestop");
+                tracing::warn!(error = %e, "failed to run service pflog onestop");
                 ok = false;
             }
             _ => tracing::info!("pflogd stopped (local pf log storage disabled)"),
@@ -87,7 +88,7 @@ pub async fn apply_local_log_policy(cfg: &SyslogConfig) -> bool {
     } else {
         // Restore the normal file writer. "already running" is the normal
         // idempotent outcome.
-        match sudo::service("pflogd", "onestart").await {
+        match sudo::service("pflog", "onestart").await {
             Ok(out) if !out.status.success() => {
                 let err = String::from_utf8_lossy(&out.stderr);
                 if !err.contains("already running") {
@@ -96,7 +97,7 @@ pub async fn apply_local_log_policy(cfg: &SyslogConfig) -> bool {
                 }
             }
             Err(e) => {
-                tracing::warn!(error = %e, "failed to run service pflogd onestart");
+                tracing::warn!(error = %e, "failed to run service pflog onestart");
                 ok = false;
             }
             _ => {}

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -2666,16 +2666,18 @@ mod sudoers_tests {
     }
 
     /// The remote-syslog "stop storing logs locally" toggle stops/starts
-    /// `pflogd` through `aifw-sudo-service` (aifw_core::local_log). Guard
-    /// against the helper's allowlist dropping the service — sudo would
-    /// refuse and the toggle would silently stop working.
+    /// the pflog service through `aifw-sudo-service` (aifw_core::local_log).
+    /// Guard against the helper's allowlist dropping the service — sudo
+    /// would refuse and the toggle would silently stop working. NOTE the
+    /// rc.d script is named `pflog` (the daemon binary is pflogd; verified
+    /// on FreeBSD 15.1 — /etc/rc.d/pflogd does not exist).
     #[test]
-    fn service_helper_allows_pflogd() {
+    fn service_helper_allows_pflog() {
         let script = include_str!("../../freebsd/overlay/usr/local/libexec/aifw-sudo-service");
         assert!(
-            script.contains("pflogd)"),
-            "aifw-sudo-service allowlist must include pflogd for the \
-             remote-syslog disable_local toggle"
+            script.lines().any(|l| l.trim() == "pflog)"),
+            "aifw-sudo-service allowlist must include the pflog service for \
+             the remote-syslog disable_local toggle"
         );
     }
 

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-service
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-service
@@ -26,10 +26,11 @@ case "$SERVICE" in
         ;;
     unbound|local_unbound|sshd|strongswan)
         ;;
-    pflogd)
-        # Remote-syslog "stop storing logs locally": pflogd (the
-        # /var/log/pflog writer) is stopped/started while the pflog0
-        # interface stays up for live capture + forwarding.
+    pflog)
+        # Remote-syslog "stop storing logs locally": the pflog service
+        # (pflogd, the /var/log/pflog writer; rc.d script name "pflog")
+        # is stopped/started while the pflog0 interface stays up for
+        # live capture + forwarding.
         ;;
     *)
         echo "aifw-sudo-service: service not in allowlist: $SERVICE" >&2


### PR DESCRIPTION
Found while validating #647's disable_local assumption on the FreeBSD 15.1 test VM: the pf log file writer's daemon binary is `pflogd`, but the rc.d service is `/etc/rc.d/pflog` — so every `service pflogd onestop/onestart` call in `aifw_core::local_log` failed with "pflogd does not exist" and the toggle was a no-op.

Validation results on the test box (with the corrected name):
- `service pflog onestop` leaves `pflog0` in existence but DOWN (flags=0)
- the already-coded `ifconfig pflog0 up` fallback revives it
- with pf enabled and a log rule, tcpdump on the revived `pflog0` captures pf log packets while the file writer is stopped — live Blocked-page capture and remote forwarding keep working, exactly as designed

Changes: `local_log.rs` service calls, the `aifw-sudo-service` allowlist entry, and the sudoers guard test (now asserts the exact `pflog)` case line).