### PR TITLE
release: v5.114.1 — remote syslog forwarding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "5.114.0"
+version = "5.114.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.114.0",
+  "version": "5.114.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.114.0",
+      "version": "5.114.1",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.114.0",
+  "version": "5.114.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Version bump for the v5.114.1 release. Supersedes v5.114.0, which was never published (draft only) because its USB image build failed mid-copy.

Ships:
- Remote syslog forwarding (#647, #648): pf logs / IDS alerts / app logs over UDP/TCP, BSD or RFC 5424, per-category toggles, disable-local option, `aifw syslog` CLI, Settings → Remote Logging UI. FreeBSD-validated.
- USB image build fixes (#650, #652): hardlink-preserving populate, 4 GB baked free space + firstboot growfs to the full stick, free-space sanity check, partial-image cleanup.

After merge: on the build VM `git pull && sudo ./build-local.sh && ./release.sh` publishes the pre-release; the v5.114.0 draft release and tag should then be deleted.