### PR TITLE
Install companion services from crates.io, retire git SHA pins (#651)

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -82,7 +82,7 @@ jobs:
           copyback: true
           prepare: |
             # Install build tools
-            pkg install -y curl gmake
+            pkg install -y curl gmake jq
 
             # Install Rust via rustup
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -105,32 +105,22 @@ jobs:
             visudo -cf /tmp/aifw-sudoers
             echo "sudoers OK"
 
-            # Build external repos from manifest, pinned to the reviewed
-            # commit recorded there (#538). An unpinned or unresolvable
-            # revision fails the build — never fall back to branch HEAD.
+            # Install companion services from crates.io at the versions
+            # pinned in the manifest (#651, replacing the #538 git SHA
+            # pins). A missing pin or an unpublished version fails the
+            # build — never fall back to branch HEAD.
             MANIFEST="freebsd/manifest.json"
-            for row in $(jq -c '.external_repos[]' "$MANIFEST"); do
-              NAME=$(echo "$row" | jq -r '.name')
-              REPO=$(echo "$row" | jq -r '.repo')
-              COMMIT=$(echo "$row" | jq -r '.commit // empty')
-              if [ -z "$COMMIT" ]; then
-                echo "ERROR: ${NAME} has no pinned commit in ${MANIFEST} (#538)" >&2
+            COMPANIONS_ROOT="/tmp/companions"
+            COMPANIONS_BIN="$COMPANIONS_ROOT/bin"
+            for NAME in $(jq -r '.external_repos[].name' "$MANIFEST"); do
+              CRATE=$(jq -r --arg n "$NAME" '.external_repos[] | select(.name == $n) | .crate // empty' "$MANIFEST")
+              VER=$(jq -r --arg n "$NAME" '.external_repos[] | select(.name == $n) | .version // empty' "$MANIFEST")
+              if [ -z "$CRATE" ] || [ -z "$VER" ]; then
+                echo "ERROR: ${NAME} has no crate/version pin in ${MANIFEST} (#651)" >&2
                 exit 1
               fi
-              echo "=== Building $NAME @ $COMMIT ==="
-              git clone "https://github.com/${REPO}.git" "/tmp/${NAME}"
-              git -C "/tmp/${NAME}" checkout --detach "$COMMIT" || {
-                echo "ERROR: pinned commit ${COMMIT} not found in ${REPO}" >&2
-                exit 1
-              }
-              ACTUAL=$(git -C "/tmp/${NAME}" rev-parse HEAD)
-              if [ "$ACTUAL" != "$COMMIT" ]; then
-                echo "ERROR: ${NAME} checked out ${ACTUAL}, expected ${COMMIT}" >&2
-                exit 1
-              fi
-              cd "/tmp/${NAME}"
-              cargo build --release
-              cd /home/runner/work/AiFw/AiFw
+              echo "=== Installing $NAME ($CRATE $VER from crates.io) ==="
+              cargo install --locked --version "$VER" --root "$COMPANIONS_ROOT" "$CRATE"
             done
 
             echo "=== Preparing build inputs ==="
@@ -139,17 +129,19 @@ jobs:
             for bin in $(jq -r '.binaries.local[]' "$MANIFEST"); do
               cp "target/release/${bin}" "freebsd/release/${bin}"
             done
-            # Copy external binaries
-            for row in $(jq -c '.external_repos[]' "$MANIFEST"); do
-              NAME=$(echo "$row" | jq -r '.name')
-              for bin in $(echo "$row" | jq -r '.binaries[]'); do
-                [ -f "/tmp/${NAME}/target/release/${bin}" ] && cp "/tmp/${NAME}/target/release/${bin}" "freebsd/release/${bin}"
-              done
+            # Copy companion binaries — installed from crates.io above, so
+            # a missing one is a bug; refuse to ship a partial artifact set.
+            for bin in $(jq -r '.external_repos[].binaries[]' "$MANIFEST"); do
+              if [ ! -f "$COMPANIONS_BIN/$bin" ]; then
+                echo "ERROR: companion binary $bin missing from $COMPANIONS_BIN" >&2
+                exit 1
+              fi
+              cp "$COMPANIONS_BIN/$bin" "freebsd/release/$bin"
             done
 
-            echo "=== Recording component revisions (#538) ==="
+            echo "=== Recording component versions (#538/#651) ==="
             # Machine-readable record of the exact source that produced this
-            # artifact set: AiFw commit + every pinned companion commit.
+            # artifact set: AiFw commit + every pinned companion crate version.
             # Ships as a release asset and inside the update tarball.
             VERSION="${{ steps.version.outputs.version }}"
             jq -n \
@@ -157,7 +149,7 @@ jobs:
               --arg aifw_commit "${{ github.sha }}" \
               --slurpfile manifest "$MANIFEST" \
               '{version: $version, aifw_commit: $aifw_commit,
-                components: [$manifest[0].external_repos[] | {name, repo, commit}]}' \
+                components: [$manifest[0].external_repos[] | {name, repo, crate, version}]}' \
               > /tmp/aifw-components.json
             cat /tmp/aifw-components.json
             mkdir -p /usr/obj/aifw-iso/output

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ Pages stay presentational; an ESLint `max-lines` guard caps `src/app/**/page.tsx
 - **rDNS** — DNS resolver
 - **rTIME** — NTP/PTP time sync
 
-The deploy script and CI pipeline build these from sibling directories or clone from GitHub.
+Release builds (CI, `build-local.sh`, `build-update.sh`) install them from crates.io (`trafficcop`, `rdhcpd`, `rdns-server`, `rtimed`) at the exact versions pinned in the manifest (#651). `deploy.sh` (dev flow) still builds sibling checkouts.
 
 ## FreeBSD Deployment
 

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -152,6 +152,13 @@ struct ExternalRepo {
     name: String,
     #[allow(dead_code)]
     repo: String,
+    /// crates.io package the build installs (#651, replaced the git SHA pins).
+    #[serde(rename = "crate")]
+    #[allow(dead_code)]
+    crate_name: String,
+    /// Exact published version pinned for appliance artifacts.
+    #[allow(dead_code)]
+    version: String,
 }
 
 /// OS packages this build requires, from the embedded manifest. Exposed
@@ -2138,6 +2145,66 @@ mod tests {
                     .split_whitespace()
                     .any(|w| w.trim_end_matches(';') == pkg),
                 "package {pkg:?} from manifest.json missing from deploy.sh dependency loop: {deploy_line}"
+            );
+        }
+    }
+
+    // Companion components are installed from crates.io at the versions
+    // pinned in manifest.json (#651, replacing the #538 git SHA pins).
+    // Every entry must carry a crate name and an exact published version,
+    // and the release build paths must consume those pins — a `.commit`
+    // reference reappearing means someone resurrected the retired
+    // clone-and-checkout scheme.
+    #[test]
+    fn test_external_repos_pin_crates_io_versions() {
+        let manifest = load_manifest();
+        assert!(
+            !manifest.external_repos.is_empty(),
+            "manifest.json external_repos list is empty"
+        );
+        for repo in &manifest.external_repos {
+            assert!(
+                !repo.crate_name.is_empty(),
+                "external repo {} has no crate name",
+                repo.name
+            );
+            assert!(
+                repo.version.split('.').count() == 3
+                    && repo
+                        .version
+                        .split('.')
+                        .all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit())),
+                "external repo {} version {:?} is not a plain x.y.z crates.io version",
+                repo.name,
+                repo.version
+            );
+            assert!(
+                !repo.binaries.is_empty(),
+                "external repo {} lists no binaries",
+                repo.name
+            );
+        }
+        for (path, content) in [
+            (
+                "freebsd/build-local.sh",
+                include_str!("../../freebsd/build-local.sh"),
+            ),
+            (
+                "freebsd/build-update.sh",
+                include_str!("../../freebsd/build-update.sh"),
+            ),
+            (
+                ".github/workflows/build-iso.yml",
+                include_str!("../../.github/workflows/build-iso.yml"),
+            ),
+        ] {
+            assert!(
+                content.contains("cargo install --locked --version"),
+                "{path} no longer installs companions from crates.io at the manifest pin"
+            );
+            assert!(
+                !content.contains(".commit"),
+                "{path} references the retired git SHA-pin field (.commit)"
             );
         }
     }

--- a/freebsd/build-local.sh
+++ b/freebsd/build-local.sh
@@ -115,70 +115,32 @@ BIN_VER="$("$PROJECT_ROOT/target/release/aifw" --version 2>/dev/null | grep -oE 
 [ "$BIN_VER" = "$VERSION" ] || die "version mismatch: building v${VERSION} but target/release/aifw reports v${BIN_VER:-unknown}. Bump Cargo.toml and rebuild (try 'cargo clean -p aifw') before releasing."
 echo "--- Verified compiled aifw binary is v${VERSION} ---"
 
-# Helper: clone-or-update a companion repo and FAIL LOUDLY on errors.
-# Builds the exact commit pinned in manifest.json (#538) — never branch
-# HEAD, so a rebuild of the same AiFw commit always bundles the same
-# companion source. (The pre-#538 version reset to origin/main; before
-# that, `git pull 2>/dev/null || true` silently shipped stale binaries.)
-build_companion() {
-    local name="$1" dir="$2" url="$3"
-    local pin
-    pin=$(jq -r --arg n "$name" \
-        '.external_repos[] | select(.name == $n) | .commit // empty' \
+# Install companion services (reverse proxy, DHCP, DNS, NTP) from
+# crates.io at the versions pinned in manifest.json (#651, replacing the
+# #538 git SHA pins — the published crates track the companion repo
+# releases, so there are no sibling checkouts to clone or branch-juggle).
+# cargo install is a no-op when the pinned version is already in
+# COMPANIONS_ROOT and fails loudly on a missing or unpublished pin.
+COMPANIONS_ROOT="$PROJECT_ROOT/target/companions"
+COMPANIONS_BIN="$COMPANIONS_ROOT/bin"
+for name in $(jq -r '.external_repos[].name' "$PROJECT_ROOT/freebsd/manifest.json"); do
+    crate=$(jq -r --arg n "$name" \
+        '.external_repos[] | select(.name == $n) | .crate // empty' \
         "$PROJECT_ROOT/freebsd/manifest.json")
-    [ -n "$pin" ] || die "no pinned commit for $name in manifest.json (#538)"
-    if [ ! -d "$dir" ]; then
-        echo "Cloning $name from $url ..."
-        git clone "$url" "$dir" || {
-            echo "ERROR: clone of $name failed" >&2
-            exit 1
-        }
-    fi
-    # Remember the operator's checkout so we can put it back: these are the
-    # same working repos they develop in, and leaving them detached at the
-    # pin meant manually switching back to main after every build.
-    local prev
-    prev=$(git -C "$dir" symbolic-ref --quiet --short HEAD || git -C "$dir" rev-parse HEAD)
-    echo "--- Checking out $name @ $pin (will restore '$prev' after build) ---"
-    ( cd "$dir" && \
-        git fetch --tags origin && \
-        git checkout --quiet --detach "$pin" ) || {
-        echo "ERROR: pinned commit $pin not found in $name ($dir), or the" >&2
-        echo "       working tree has uncommitted changes — commit/stash first" >&2
-        exit 1
-    }
-    local actual
-    actual=$(git -C "$dir" rev-parse HEAD)
-    [ "$actual" = "$pin" ] || die "$name checked out $actual, expected pinned $pin"
-    echo "--- $name commit: $actual ---"
-    local rc=0
-    ( cd "$dir" && cargo build --release ) || rc=1
-    # Restore the original ref even when the build fails.
-    git -C "$dir" checkout --quiet "$prev" || \
-        echo "WARN: could not restore $name to '$prev' — left detached at $pin" >&2
-    # Root-run builds litter the operator's repo with root-owned .git
-    # objects and target/ artifacts, breaking their later git/cargo use
-    # (seen live: 'insufficient permission for adding an object'). Hand
-    # the repo back to the invoking user.
-    if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
-        chown -R "$SUDO_USER" "$dir" 2>/dev/null || true
-    fi
-    if [ "$rc" -ne 0 ]; then
-        echo "ERROR: cargo build of $name failed" >&2
-        exit 1
-    fi
-}
-
-# Build companion services (reverse proxy, DHCP, DNS, NTP).
-TRAFFICCOP_DIR="$PROJECT_ROOT/../trafficcop"
-RDHCP_DIR="$PROJECT_ROOT/../rDHCP"
-RDNS_DIR="$PROJECT_ROOT/../rDNS"
-RTIME_DIR="$PROJECT_ROOT/../rTIME"
-
-build_companion TrafficCop "$TRAFFICCOP_DIR" https://github.com/ZerosAndOnesLLC/TrafficCop.git
-build_companion rDHCP      "$RDHCP_DIR"      https://github.com/ZerosAndOnesLLC/rDHCP.git
-build_companion rDNS       "$RDNS_DIR"       https://github.com/ZerosAndOnesLLC/rDNS.git
-build_companion rTIME      "$RTIME_DIR"      https://github.com/ZerosAndOnesLLC/rTIME.git
+    ver=$(jq -r --arg n "$name" \
+        '.external_repos[] | select(.name == $n) | .version // empty' \
+        "$PROJECT_ROOT/freebsd/manifest.json")
+    [ -n "$crate" ] || die "no crate name for $name in manifest.json (#651)"
+    [ -n "$ver" ] || die "no pinned version for $name in manifest.json (#651)"
+    echo "--- Installing $name ($crate $ver from crates.io) ---"
+    cargo install --locked --version "$ver" --root "$COMPANIONS_ROOT" "$crate" \
+        || die "cargo install of $crate $ver failed"
+    for bin in $(jq -r --arg n "$name" \
+        '.external_repos[] | select(.name == $n) | .binaries[]' \
+        "$PROJECT_ROOT/freebsd/manifest.json"); do
+        [ -f "$COMPANIONS_BIN/$bin" ] || die "$crate $ver did not produce binary $bin"
+    done
+done
 cd "$PROJECT_ROOT"
 
 # --- Stage build inputs ---
@@ -198,25 +160,13 @@ for bin in $LOCAL_BINS; do
     fi
     cp "$PROJECT_ROOT/target/release/${bin}" "$SCRIPT_DIR/release/${bin}"
 done
-# Stage TrafficCop binary if built
-if [ -f "$TRAFFICCOP_DIR/target/release/trafficcop" ]; then
-    cp "$TRAFFICCOP_DIR/target/release/trafficcop" "$SCRIPT_DIR/release/trafficcop"
-fi
-# Stage rDHCP binary if built
-if [ -f "$RDHCP_DIR/target/release/rdhcpd" ]; then
-    cp "$RDHCP_DIR/target/release/rdhcpd" "$SCRIPT_DIR/release/rdhcpd"
-fi
-# Stage rDNS binaries if built
-if [ -f "$RDNS_DIR/target/release/rdns" ]; then
-    cp "$RDNS_DIR/target/release/rdns" "$SCRIPT_DIR/release/rdns"
-fi
-# Stage rTIME binary if built
-if [ -f "$RTIME_DIR/target/release/rtime" ]; then
-    cp "$RTIME_DIR/target/release/rtime" "$SCRIPT_DIR/release/rtime"
-fi
-if [ -f "$RDNS_DIR/target/release/rdns-control" ]; then
-    cp "$RDNS_DIR/target/release/rdns-control" "$SCRIPT_DIR/release/rdns-control"
-fi
+# Stage companion binaries — installed from crates.io above, so a missing
+# one is a bug; refuse to ship a partial artifact set.
+EXT_BINS=$(jq -r '.external_repos[].binaries[]' "$PROJECT_ROOT/freebsd/manifest.json" | tr '\n' ' ')
+for bin in $EXT_BINS; do
+    [ -f "$COMPANIONS_BIN/$bin" ] || die "companion binary $bin missing from $COMPANIONS_BIN"
+    cp "$COMPANIONS_BIN/$bin" "$SCRIPT_DIR/release/$bin"
+done
 
 rm -rf "$SCRIPT_DIR/ui-export"
 cp -a "$PROJECT_ROOT/aifw-ui/out" "$SCRIPT_DIR/ui-export"
@@ -237,25 +187,12 @@ mkdir -p "$TARBALL_DIR/bin" "$TARBALL_DIR/ui"
 for bin in $LOCAL_BINS; do
     cp "$PROJECT_ROOT/target/release/${bin}" "$TARBALL_DIR/bin/"
 done
-# Include TrafficCop in update tarball
-if [ -f "$TRAFFICCOP_DIR/target/release/trafficcop" ]; then
-    cp "$TRAFFICCOP_DIR/target/release/trafficcop" "$TARBALL_DIR/bin/"
-fi
-# Include rDHCP in update tarball
-if [ -f "$RDHCP_DIR/target/release/rdhcpd" ]; then
-    cp "$RDHCP_DIR/target/release/rdhcpd" "$TARBALL_DIR/bin/"
-fi
-# Include rDNS in update tarball
-if [ -f "$RDNS_DIR/target/release/rdns" ]; then
-    cp "$RDNS_DIR/target/release/rdns" "$TARBALL_DIR/bin/"
-fi
-if [ -f "$RDNS_DIR/target/release/rdns-control" ]; then
-    cp "$RDNS_DIR/target/release/rdns-control" "$TARBALL_DIR/bin/"
-fi
-# Include rTIME in update tarball
-if [ -f "$RTIME_DIR/target/release/rtime" ]; then
-    cp "$RTIME_DIR/target/release/rtime" "$TARBALL_DIR/bin/"
-fi
+# Companion binaries from the crates.io install — same missing-binary
+# refusal as the staging step above.
+for bin in $EXT_BINS; do
+    [ -f "$COMPANIONS_BIN/$bin" ] || die "companion binary $bin missing from $COMPANIONS_BIN"
+    cp "$COMPANIONS_BIN/$bin" "$TARBALL_DIR/bin/"
+done
 cp -a "$PROJECT_ROOT/aifw-ui/out/"* "$TARBALL_DIR/ui/"
 
 # rc.d service scripts — the updater (aifw-core/src/updater.rs) iterates
@@ -291,19 +228,18 @@ echo "$VERSION" > "$TARBALL_DIR/version"
 # older than the build host — its binaries wouldn't link.
 freebsd-version -u | sed 's/-.*//' > "$TARBALL_DIR/required-os"
 
-# Write a manifest of what made it into the tarball — commit SHAs for every
-# component plus a quick sanity check on rDNS features. Makes stale companion
-# repos (which have burned us before — rdns 1.5.1 shipping in a v5.45.0
-# tarball) visible at build time.
+# Write a manifest of what made it into the tarball — the crates.io
+# version of every component plus a quick sanity check on rDNS features.
+# Makes a stale or mispinned companion (which has burned us before —
+# rdns 1.5.1 shipping in a v5.45.0 tarball) visible at build time.
 {
     echo "AiFw             $(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
-    # Companion SHAs come from the manifest pins — build_companion verified
-    # each checkout matched its pin and then RESTORED the operator's branch,
-    # so the repos' HEADs no longer reflect what was built.
-    for n in TrafficCop rDHCP rDNS rTIME; do
-        p=$(jq -r --arg n "$n" '.external_repos[] | select(.name == $n) | .commit // empty' \
-            "$PROJECT_ROOT/freebsd/manifest.json")
-        [ -n "$p" ] && printf '%-16s %.12s (manifest pin)\n' "$n" "$p"
+    # Companion versions come from the manifest crates.io pins — the
+    # install step verified each pinned version produced its binaries.
+    jq -r '.external_repos[] | "\(.name) \(.version) \(.crate)"' \
+        "$PROJECT_ROOT/freebsd/manifest.json" | \
+    while read -r n v c; do
+        printf '%-16s %s (crates.io %s)\n' "$n" "$v" "$c"
     done
     if [ -f "$TARBALL_DIR/bin/rdns" ]; then
         rver=$(grep -ao 'rDNS [0-9][0-9.]*' "$TARBALL_DIR/bin/rdns" | head -1 || true)
@@ -317,7 +253,7 @@ freebsd-version -u | sed 's/-.*//' > "$TARBALL_DIR/required-os"
 if [ -f "$TARBALL_DIR/bin/rdns" ]; then
     if ! grep -q 'stats-json' "$TARBALL_DIR/bin/rdns"; then
         echo "ERROR: rDNS binary does not contain 'stats-json' — this is a stale build (pre-v1.10)." >&2
-        echo "       Check that $RDNS_DIR is on origin/main before re-running." >&2
+        echo "       Check the rdns-server version pin in freebsd/manifest.json." >&2
         exit 1
     fi
 fi

--- a/freebsd/build-update.sh
+++ b/freebsd/build-update.sh
@@ -128,70 +128,33 @@ BIN_VER="$("$PROJECT_ROOT/target/release/aifw" --version 2>/dev/null | grep -oE 
 [ "$BIN_VER" = "$VERSION" ] || die "version mismatch: building v${VERSION} but target/release/aifw reports v${BIN_VER:-unknown}. Bump Cargo.toml and rebuild (try 'cargo clean -p aifw') before releasing."
 echo "--- Verified compiled aifw binary is v${VERSION} ---"
 
-# Clone-or-build a companion repo at its manifest pin, restoring the
-# operator's checkout afterwards. (Same function as in build-local.sh —
-# keep them in sync.)
-#
-# This used to `git reset --hard origin/main`, which (a) silently discarded
-# any uncommitted work in the operator's companion repos, (b) left them
-# moved off their branch, and (c) bypassed the #538 manifest pins — the
-# update tarball shipped whatever origin/main happened to be, not the
-# reviewed revision.
-build_companion() {
-    local name="$1" dir="$2" url="$3"
-    local pin
-    pin=$(jq -r --arg n "$name" \
-        '.external_repos[] | select(.name == $n) | .commit // empty' \
+echo "=== [4/6] Installing companion services from crates.io ==="
+# Companions come from crates.io at the versions pinned in manifest.json
+# (#651, replacing the #538 git SHA pins — the published crates track the
+# companion repo releases, so there are no sibling checkouts to clone or
+# branch-juggle). Same loop as build-local.sh — keep them in sync.
+# cargo install is a no-op when the pinned version is already in
+# COMPANIONS_ROOT and fails loudly on a missing or unpublished pin.
+COMPANIONS_ROOT="$PROJECT_ROOT/target/companions"
+COMPANIONS_BIN="$COMPANIONS_ROOT/bin"
+for name in $(jq -r '.external_repos[].name' "$PROJECT_ROOT/freebsd/manifest.json"); do
+    crate=$(jq -r --arg n "$name" \
+        '.external_repos[] | select(.name == $n) | .crate // empty' \
         "$PROJECT_ROOT/freebsd/manifest.json")
-    [ -n "$pin" ] || die "no pinned commit for $name in manifest.json (#538)"
-    if [ ! -d "$dir" ]; then
-        echo "Cloning $name from $url ..."
-        git clone "$url" "$dir" || {
-            echo "ERROR: clone of $name failed" >&2
-            exit 1
-        }
-    fi
-    local prev
-    prev=$(git -C "$dir" symbolic-ref --quiet --short HEAD || git -C "$dir" rev-parse HEAD)
-    echo "--- Checking out $name @ $pin (will restore '$prev' after build) ---"
-    ( cd "$dir" && \
-        git fetch --tags origin && \
-        git checkout --quiet --detach "$pin" ) || {
-        echo "ERROR: pinned commit $pin not found in $name ($dir), or the" >&2
-        echo "       working tree has uncommitted changes — commit/stash first" >&2
-        exit 1
-    }
-    local actual
-    actual=$(git -C "$dir" rev-parse HEAD)
-    [ "$actual" = "$pin" ] || die "$name checked out $actual, expected pinned $pin"
-    echo "--- $name commit: $actual ---"
-    local rc=0
-    ( cd "$dir" && cargo build --release ) || rc=1
-    git -C "$dir" checkout --quiet "$prev" || \
-        echo "WARN: could not restore $name to '$prev' — left detached at $pin" >&2
-    # Root-run builds litter the operator's repo with root-owned .git
-    # objects and target/ artifacts, breaking their later git/cargo use
-    # (seen live: 'insufficient permission for adding an object'). Hand
-    # the repo back to the invoking user.
-    if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
-        chown -R "$SUDO_USER" "$dir" 2>/dev/null || true
-    fi
-    if [ "$rc" -ne 0 ]; then
-        echo "ERROR: cargo build of $name failed" >&2
-        exit 1
-    fi
-}
-
-echo "=== [4/6] Building companion services ==="
-TRAFFICCOP_DIR="$PROJECT_ROOT/../trafficcop"
-RDHCP_DIR="$PROJECT_ROOT/../rDHCP"
-RDNS_DIR="$PROJECT_ROOT/../rDNS"
-RTIME_DIR="$PROJECT_ROOT/../rTIME"
-
-build_companion TrafficCop "$TRAFFICCOP_DIR" https://github.com/ZerosAndOnesLLC/TrafficCop.git
-build_companion rDHCP      "$RDHCP_DIR"      https://github.com/ZerosAndOnesLLC/rDHCP.git
-build_companion rDNS       "$RDNS_DIR"       https://github.com/ZerosAndOnesLLC/rDNS.git
-build_companion rTIME      "$RTIME_DIR"      https://github.com/ZerosAndOnesLLC/rTIME.git
+    ver=$(jq -r --arg n "$name" \
+        '.external_repos[] | select(.name == $n) | .version // empty' \
+        "$PROJECT_ROOT/freebsd/manifest.json")
+    [ -n "$crate" ] || die "no crate name for $name in manifest.json (#651)"
+    [ -n "$ver" ] || die "no pinned version for $name in manifest.json (#651)"
+    echo "--- Installing $name ($crate $ver from crates.io) ---"
+    cargo install --locked --version "$ver" --root "$COMPANIONS_ROOT" "$crate" \
+        || die "cargo install of $crate $ver failed"
+    for bin in $(jq -r --arg n "$name" \
+        '.external_repos[] | select(.name == $n) | .binaries[]' \
+        "$PROJECT_ROOT/freebsd/manifest.json"); do
+        [ -f "$COMPANIONS_BIN/$bin" ] || die "$crate $ver did not produce binary $bin"
+    done
+done
 cd "$PROJECT_ROOT"
 
 # Pull the binary list from manifest.json (same source-of-truth as build-local.sh).
@@ -213,21 +176,13 @@ mkdir -p "$TARBALL_DIR/bin" "$TARBALL_DIR/ui"
 for bin in $LOCAL_BINS; do
     cp "$PROJECT_ROOT/target/release/${bin}" "$TARBALL_DIR/bin/"
 done
-if [ -f "$TRAFFICCOP_DIR/target/release/trafficcop" ]; then
-    cp "$TRAFFICCOP_DIR/target/release/trafficcop" "$TARBALL_DIR/bin/"
-fi
-if [ -f "$RDHCP_DIR/target/release/rdhcpd" ]; then
-    cp "$RDHCP_DIR/target/release/rdhcpd" "$TARBALL_DIR/bin/"
-fi
-if [ -f "$RDNS_DIR/target/release/rdns" ]; then
-    cp "$RDNS_DIR/target/release/rdns" "$TARBALL_DIR/bin/"
-fi
-if [ -f "$RDNS_DIR/target/release/rdns-control" ]; then
-    cp "$RDNS_DIR/target/release/rdns-control" "$TARBALL_DIR/bin/"
-fi
-if [ -f "$RTIME_DIR/target/release/rtime" ]; then
-    cp "$RTIME_DIR/target/release/rtime" "$TARBALL_DIR/bin/"
-fi
+# Companion binaries — installed from crates.io above, so a missing one
+# is a bug; refuse to ship a partial artifact set.
+EXT_BINS=$(jq -r '.external_repos[].binaries[]' "$PROJECT_ROOT/freebsd/manifest.json" | tr '\n' ' ')
+for bin in $EXT_BINS; do
+    [ -f "$COMPANIONS_BIN/$bin" ] || die "companion binary $bin missing from $COMPANIONS_BIN"
+    cp "$COMPANIONS_BIN/$bin" "$TARBALL_DIR/bin/"
+done
 cp -a "$PROJECT_ROOT/aifw-ui/out/"* "$TARBALL_DIR/ui/"
 
 mkdir -p "$TARBALL_DIR/rc.d"
@@ -257,15 +212,16 @@ echo "$VERSION" > "$TARBALL_DIR/version"
 # every service. The build host's userland IS the compatibility floor.
 freebsd-version -u | sed 's/-.*//' > "$TARBALL_DIR/required-os"
 
-# Write a BUILD_MANIFEST so stale companion repos are visible at build time.
+# Write a BUILD_MANIFEST so a stale or mispinned companion is visible at
+# build time.
 {
     echo "AiFw             $(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
-    # Companion SHAs from the manifest pins — build_companion verified each
-    # checkout matched its pin, then restored the operator's branch.
-    for n in TrafficCop rDHCP rDNS rTIME; do
-        p=$(jq -r --arg n "$n" '.external_repos[] | select(.name == $n) | .commit // empty' \
-            "$PROJECT_ROOT/freebsd/manifest.json")
-        [ -n "$p" ] && printf '%-16s %.12s (manifest pin)\n' "$n" "$p"
+    # Companion versions come from the manifest crates.io pins — the
+    # install step verified each pinned version produced its binaries.
+    jq -r '.external_repos[] | "\(.name) \(.version) \(.crate)"' \
+        "$PROJECT_ROOT/freebsd/manifest.json" | \
+    while read -r n v c; do
+        printf '%-16s %s (crates.io %s)\n' "$n" "$v" "$c"
     done
     if [ -f "$TARBALL_DIR/bin/rdns" ]; then
         rver=$(grep -ao 'rDNS [0-9][0-9.]*' "$TARBALL_DIR/bin/rdns" | head -1 || true)
@@ -277,7 +233,7 @@ freebsd-version -u | sed 's/-.*//' > "$TARBALL_DIR/required-os"
 if [ -f "$TARBALL_DIR/bin/rdns" ]; then
     if ! grep -q 'stats-json' "$TARBALL_DIR/bin/rdns"; then
         echo "ERROR: rDNS binary does not contain 'stats-json' — this is a stale build (pre-v1.10)." >&2
-        echo "       Check that $RDNS_DIR is on origin/main before re-running." >&2
+        echo "       Check the rdns-server version pin in freebsd/manifest.json." >&2
         exit 1
     fi
 fi

--- a/freebsd/manifest.json
+++ b/freebsd/manifest.json
@@ -9,30 +9,34 @@
   "packages": ["curl", "minisign", "strongswan", "sudo", "unbound", "wireguard-tools"],
   "_packages_comment": "OS packages required at runtime. build-iso.sh installs them into the image; deploy.sh ensures them on the dev VM; the in-app updater installs any that are missing during upgrade. A workspace test (aifw-core packaging_tests) asserts the build scripts stay in sync with this list.",
 
+  "_external_repos_comment": "version pins the exact crates.io release built into appliance artifacts (#651, replacing the #538 git SHA pins). CI, build-local.sh and build-update.sh cargo-install crate@version and fail if the pin is missing or unpublished. To take a companion update: publish the new crate version, bump the pin here, and land it through a PR. deploy.sh (dev flow) still builds sibling checkouts.",
   "external_repos": [
     {
-      "_comment": "commit pins the exact revision built into appliance artifacts (#538). CI and build-local.sh check out and verify this SHA and fail if it is missing. To take a companion update: review the upstream diff, bump the SHA here, and land it through a PR.",
       "name": "TrafficCop",
       "repo": "ZerosAndOnesLLC/TrafficCop",
-      "commit": "3d4d96595bea1d4f29b8729a452c95dd1be0ed25",
+      "crate": "trafficcop",
+      "version": "1.4.11",
       "binaries": ["trafficcop"]
     },
     {
       "name": "rDHCP",
       "repo": "ZerosAndOnesLLC/rDHCP",
-      "commit": "bddd4868df6f5931b614f8412071daf31af7d0dd",
+      "crate": "rdhcpd",
+      "version": "0.16.0",
       "binaries": ["rdhcpd"]
     },
     {
       "name": "rDNS",
       "repo": "ZerosAndOnesLLC/rDNS",
-      "commit": "04d5975f2386f883db9b357424ca550a1bf72bce",
+      "crate": "rdns-server",
+      "version": "1.17.21",
       "binaries": ["rdns", "rdns-control"]
     },
     {
       "name": "rTIME",
       "repo": "ZerosAndOnesLLC/rTIME",
-      "commit": "444e104db55fa33f6aded7a6b0b7752509bc0a6f",
+      "crate": "rtimed",
+      "version": "0.14.1",
       "binaries": ["rtime"]
     }
   ],


### PR DESCRIPTION
Closes #651.

All four companion services are published on crates.io (`trafficcop`, `rdhcpd`, `rdns-server`, `rtimed`) and the published versions track the repo releases, so the #538 clone-and-checkout scheme is retired.

## What changed

- **manifest.json** — `external_repos` entries pin `crate` + `version` instead of a git `commit`. Pinned to the current crates.io releases: trafficcop 1.4.11, rdhcpd 0.16.0, rdns-server 1.17.21, rtimed 0.14.1 (these match the sibling checkouts; the retired SHA pins were behind for three of the four, so this also takes those companion updates).
- **build-local.sh / build-update.sh** — the whole `build_companion` clone/checkout/restore-branch/chown dance is replaced by `cargo install --locked --version <pin> --root target/companions`. Missing pin, unpublished version, or missing binary all fail the build; staging copies are now unconditional (no more silent partial artifact sets).
- **CI (build-iso.yml)** — same swap; `components.json` now records `{name, repo, crate, version}`. Added `jq` to the VM prepare step since the run section depends on it.
- **packaging test** — `test_external_repos_pin_crates_io_versions` asserts every entry carries a crate name and an exact x.y.z version, that all three build paths use `cargo install --locked --version`, and that no `.commit` reference reappears.

All four published crates package a `Cargo.lock`, verified, so `--locked` is safe.

**deploy.sh is intentionally untouched** — it's the dev flow that builds whatever sibling working copy is on the VM and never consulted the SHA pins, so it isn't part of the pin scheme.

## Testing

- `cargo check` clean, `cargo fmt`/`clippy -D warnings` pass (pre-commit)
- Full `cargo test`: 865 passed, 0 failed (includes the new guard test)
- `sh -n` syntax check on both build scripts; new jq extraction loops smoke-tested against the manifest