### PR TITLE
sec(auth): JWT iss/aud, browser hardening headers, shared Argon2id, transactional refresh rotate

### DIFF
--- a/aifw-api/src/auth/password.rs
+++ b/aifw-api/src/auth/password.rs
@@ -1,55 +1,31 @@
-//! Password hashing with explicitly-pinned Argon2id parameters.
+//! Password hashing for the API — a thin adapter over the workspace-wide
+//! [`aifw_common::password`] module so every binary (API, setup wizard,
+//! seed loader, CLI) writes identical Argon2id hashes (SEC-M4 #301).
 //!
-//! Using `Argon2::default()` was portable but exposed us to silent
-//! strengthening/weakening whenever the `argon2` crate bumped its
-//! defaults. We now pin the OWASP 2023 parameters: Argon2id, 19 MiB
-//! memory, 2 passes, 1 lane.
+//! The pinned parameters (OWASP 2023: Argon2id, 19 MiB, t=2, p=1) live in
+//! `aifw-common`; this file only maps errors to `StatusCode` for handler
+//! ergonomics and owns the login-timing [`dummy_hash`].
 //!
 //! [`dummy_hash`] returns a process-wide dummy hash used by the login
 //! handler to keep verification time constant when the supplied
-//! username does not exist. Unlike the previous hardcoded constant,
-//! this one is produced from a real random password using the same
-//! parameters as real users, so the attacker can't fingerprint the
-//! nonexistent-user path from hash parameters or verification time.
+//! username does not exist. It is produced from a real random password
+//! using the same parameters as real users, so the attacker can't
+//! fingerprint the nonexistent-user path from hash parameters or
+//! verification time.
 
-use argon2::{
-    Algorithm, Argon2, Params, PasswordHash, PasswordHasher, PasswordVerifier, Version,
-    password_hash::{SaltString, rand_core::OsRng},
-};
 use axum::http::StatusCode;
 use std::sync::OnceLock;
 use uuid::Uuid;
 
-/// OWASP 2023 Argon2id parameters:
-///   m = 19 456 KiB (≈ 19 MiB)
-///   t = 2
-///   p = 1
-fn params() -> Params {
-    Params::new(19_456, 2, 1, None).expect("argon2 params are valid")
-}
-
-fn hasher() -> Argon2<'static> {
-    Argon2::new(Algorithm::Argon2id, Version::V0x13, params())
-}
-
 pub fn hash_password(password: &str) -> Result<String, StatusCode> {
-    let salt = SaltString::generate(&mut OsRng);
-    hasher()
-        .hash_password(password.as_bytes(), &salt)
-        .map(|h| h.to_string())
-        .map_err(|e| {
-            tracing::error!(error = %e, "auth: password hashing failed");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })
+    aifw_common::password::hash_password(password).map_err(|e| {
+        tracing::error!(error = %e, "auth: password hashing failed");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
 }
 
 pub fn verify_password(password: &str, hash: &str) -> bool {
-    let Ok(parsed) = PasswordHash::new(hash) else {
-        return false;
-    };
-    hasher()
-        .verify_password(password.as_bytes(), &parsed)
-        .is_ok()
+    aifw_common::password::verify_password(password, hash)
 }
 
 /// Dummy hash used by the login handler to keep nonexistent-user timing
@@ -81,8 +57,10 @@ mod tests {
     #[test]
     fn hash_uses_argon2id_with_pinned_params() {
         let h = hash_password("x").unwrap();
-        // Encoded hash starts with the algorithm + version + params.
-        assert!(h.starts_with("$argon2id$v=19$m=19456,t=2,p=1$"), "got: {h}");
+        assert!(
+            h.starts_with(aifw_common::password::ARGON2_PHC_PREFIX),
+            "got: {h}"
+        );
     }
 
     #[test]
@@ -90,7 +68,6 @@ mod tests {
         let a = dummy_hash();
         let b = dummy_hash();
         assert_eq!(a, b);
-        // A guessed password shouldn't verify.
         assert!(!verify_password("password", a));
         assert!(!verify_password("", a));
     }

--- a/aifw-api/src/auth/password.rs
+++ b/aifw-api/src/auth/password.rs
@@ -47,16 +47,22 @@ pub fn dummy_hash() -> &'static str {
 mod tests {
     use super::*;
 
+    /// Random per-test secret so no credential literal lives in the tree.
+    fn random_secret() -> String {
+        Uuid::new_v4().simple().to_string()
+    }
+
     #[test]
     fn hash_verifies() {
-        let h = hash_password("hunter2").unwrap();
-        assert!(verify_password("hunter2", &h));
-        assert!(!verify_password("hunter3", &h));
+        let pw = random_secret();
+        let h = hash_password(&pw).unwrap();
+        assert!(verify_password(&pw, &h));
+        assert!(!verify_password(&random_secret(), &h));
     }
 
     #[test]
     fn hash_uses_argon2id_with_pinned_params() {
-        let h = hash_password("x").unwrap();
+        let h = hash_password(&random_secret()).unwrap();
         assert!(
             h.starts_with(aifw_common::password::ARGON2_PHC_PREFIX),
             "got: {h}"
@@ -68,7 +74,7 @@ mod tests {
         let a = dummy_hash();
         let b = dummy_hash();
         assert_eq!(a, b);
-        assert!(!verify_password("password", a));
+        assert!(!verify_password(&random_secret(), a));
         assert!(!verify_password("", a));
     }
 }

--- a/aifw-api/src/auth/tokens.rs
+++ b/aifw-api/src/auth/tokens.rs
@@ -1,5 +1,7 @@
 use chrono::{Duration, Utc};
-use jsonwebtoken::{DecodingKey, EncodingKey, Header, TokenData, Validation, decode, encode};
+use jsonwebtoken::{
+    Algorithm, DecodingKey, EncodingKey, Header, TokenData, Validation, decode, encode,
+};
 use serde::{Deserialize, Serialize};
 use sqlx::sqlite::SqlitePool;
 use uuid::Uuid;
@@ -11,6 +13,14 @@ use super::password::hash_password;
 // JWT Access Tokens
 // ============================================================
 
+/// `iss` claim stamped on every access token and required on verify.
+/// Together with [`JWT_AUDIENCE`] this scopes tokens to the AiFw API so a
+/// token minted by any other HS256 user of the same secret material (or a
+/// future second issuer sharing a key store) is rejected (SEC-M2 #299).
+pub const JWT_ISSUER: &str = "aifw-api";
+/// `aud` claim stamped on every access token and required on verify.
+pub const JWT_AUDIENCE: &str = "aifw";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Claims {
     pub sub: String,
@@ -18,6 +28,14 @@ pub struct Claims {
     pub exp: i64,
     pub iat: i64,
     pub jti: String, // unique token ID
+    /// Issuer — always [`JWT_ISSUER`]. Optional on the struct only so the
+    /// claims type can still describe pre-#299 tokens; validation rejects
+    /// tokens where it is missing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iss: Option<String>,
+    /// Audience — always [`JWT_AUDIENCE`]. See `iss`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aud: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub perm: Option<u64>, // permission bitmask
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -50,18 +68,30 @@ pub fn create_access_token(
         exp: exp.timestamp(),
         iat: now.timestamp(),
         jti: jti.clone(),
+        iss: Some(JWT_ISSUER.to_string()),
+        aud: Some(JWT_AUDIENCE.to_string()),
         perm: Some(permissions),
         role: Some(role_name.to_string()),
     };
 
     let token = encode(
-        &Header::default(),
+        &Header::new(Algorithm::HS256),
         &claims,
         &EncodingKey::from_secret(settings.jwt_secret.as_bytes()),
     )
     .map_err(|e| format!("token encode error: {e}"))?;
 
     Ok((token, exp.to_rfc3339()))
+}
+
+/// Validation rules for access tokens: HS256 only (no `alg` negotiation),
+/// `exp` enforced, and `iss`/`aud` must match this API's constants.
+fn access_token_validation() -> Validation {
+    let mut v = Validation::new(Algorithm::HS256);
+    v.set_issuer(&[JWT_ISSUER]);
+    v.set_audience(&[JWT_AUDIENCE]);
+    v.set_required_spec_claims(&["exp", "iss", "aud"]);
+    v
 }
 
 pub fn verify_access_token(
@@ -71,7 +101,7 @@ pub fn verify_access_token(
     decode::<Claims>(
         token,
         &DecodingKey::from_secret(settings.jwt_secret.as_bytes()),
-        &Validation::default(),
+        &access_token_validation(),
     )
     .map_err(|e| format!("token verify error: {e}"))
 }
@@ -218,20 +248,44 @@ pub async fn rotate_refresh_token(
         return Err("refresh token expired".to_string());
     }
 
-    // Revoke the old token
-    sqlx::query("UPDATE refresh_tokens SET revoked = 1 WHERE id = ?1")
-        .bind(&token_id)
-        .execute(pool)
-        .await
-        .map_err(|e| format!("db error: {e}"))?;
-
-    // Issue new refresh token in the same family
+    // Revoke the old token and insert its successor atomically (SEC-M15
+    // #312). Without the transaction a crash between the two writes leaves
+    // the family with either no live token (user logged out) or, worse, the
+    // old one still valid alongside a new one — which would let a stolen
+    // token be replayed without tripping reuse detection.
     let new_raw = format!("rfx_{}", Uuid::new_v4().to_string().replace('-', ""));
     let new_hash = hash_password(&new_raw).map_err(|_| "hash error".to_string())?;
     let new_prefix = refresh_prefix(&new_raw).to_string();
     let new_expires = Utc::now() + Duration::days(settings.refresh_token_expiry_days);
     let new_id = Uuid::new_v4().to_string();
 
+    let mut tx = pool.begin().await.map_err(|e| format!("db error: {e}"))?;
+
+    // Guard against a concurrent rotate of the same token: only proceed if
+    // *this* statement flipped the row. If another request got there first
+    // the row is already revoked and we must not mint a second successor.
+    let revoked_now =
+        sqlx::query("UPDATE refresh_tokens SET revoked = 1 WHERE id = ?1 AND revoked = 0")
+            .bind(&token_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| format!("db error: {e}"))?
+            .rows_affected();
+    if revoked_now == 0 {
+        // Lost the race — the other rotate owns the family now. Treat this
+        // exactly like a reuse attempt: revoke the family so neither the
+        // racing client nor a thief keeps a live token.
+        sqlx::query("UPDATE refresh_tokens SET revoked = 1 WHERE family_id = ?1")
+            .bind(&family_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| format!("db error: {e}"))?;
+        tx.commit().await.map_err(|e| format!("db error: {e}"))?;
+        tracing::warn!(family_id = %family_id, "concurrent refresh token rotate — family revoked");
+        return Err("token reuse detected — all sessions revoked".to_string());
+    }
+
+    // Issue new refresh token in the same family
     sqlx::query(
         r#"INSERT INTO refresh_tokens (id, user_id, token_hash, token_prefix, family_id, expires_at, revoked, created_at)
            VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7)"#,
@@ -243,9 +297,11 @@ pub async fn rotate_refresh_token(
     .bind(&family_id) // same family
     .bind(new_expires.to_rfc3339())
     .bind(Utc::now().to_rfc3339())
-    .execute(pool)
+    .execute(&mut *tx)
     .await
     .map_err(|e| format!("db error: {e}"))?;
+
+    tx.commit().await.map_err(|e| format!("db error: {e}"))?;
 
     // Opportunistic cleanup of revoked/expired rows keeps the table bounded.
     prune_refresh_tokens(pool).await;
@@ -349,4 +405,98 @@ pub struct RefreshRequest {
 #[derive(Debug, Deserialize)]
 pub struct LogoutRequest {
     pub refresh_token: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings() -> AuthSettings {
+        AuthSettings {
+            jwt_secret: "unit-test-secret".to_string(),
+            access_token_expiry_mins: 5,
+            refresh_token_expiry_days: 1,
+            require_totp: false,
+            require_totp_for_oauth: false,
+            auto_create_oauth_users: false,
+            max_login_attempts: 5,
+            lockout_duration_secs: 60,
+            allow_registration: false,
+            password_min_length: 8,
+        }
+    }
+
+    #[test]
+    fn access_token_carries_iss_and_aud_and_verifies() {
+        let s = settings();
+        let (tok, _) = create_access_token("u1", "alice", 0, "viewer", &s).unwrap();
+        let data = verify_access_token(&tok, &s).expect("freshly minted token verifies");
+        assert_eq!(data.claims.iss.as_deref(), Some(JWT_ISSUER));
+        assert_eq!(data.claims.aud.as_deref(), Some(JWT_AUDIENCE));
+        assert_eq!(data.header.alg, Algorithm::HS256);
+    }
+
+    /// SEC-M2 #299: a token signed with the right secret but lacking (or
+    /// carrying the wrong) iss/aud must be rejected — otherwise anything
+    /// else that ever shares the secret could mint API sessions.
+    #[test]
+    fn token_without_iss_aud_is_rejected() {
+        let s = settings();
+        let now = Utc::now();
+        let mut claims = Claims {
+            sub: "u1".into(),
+            username: "alice".into(),
+            exp: (now + Duration::minutes(5)).timestamp(),
+            iat: now.timestamp(),
+            jti: "x".into(),
+            iss: None,
+            aud: None,
+            perm: None,
+            role: None,
+        };
+        let key = EncodingKey::from_secret(s.jwt_secret.as_bytes());
+        let legacy = encode(&Header::new(Algorithm::HS256), &claims, &key).unwrap();
+        assert!(
+            verify_access_token(&legacy, &s).is_err(),
+            "no iss/aud must fail"
+        );
+
+        claims.iss = Some("someone-else".into());
+        claims.aud = Some(JWT_AUDIENCE.into());
+        let wrong_iss = encode(&Header::new(Algorithm::HS256), &claims, &key).unwrap();
+        assert!(
+            verify_access_token(&wrong_iss, &s).is_err(),
+            "wrong iss must fail"
+        );
+
+        claims.iss = Some(JWT_ISSUER.into());
+        claims.aud = Some("other-app".into());
+        let wrong_aud = encode(&Header::new(Algorithm::HS256), &claims, &key).unwrap();
+        assert!(
+            verify_access_token(&wrong_aud, &s).is_err(),
+            "wrong aud must fail"
+        );
+    }
+
+    /// The validator pins HS256; a token that names another HMAC alg in its
+    /// header must not be accepted even with the correct secret.
+    #[test]
+    fn token_with_other_alg_is_rejected() {
+        let s = settings();
+        let now = Utc::now();
+        let claims = Claims {
+            sub: "u1".into(),
+            username: "alice".into(),
+            exp: (now + Duration::minutes(5)).timestamp(),
+            iat: now.timestamp(),
+            jti: "x".into(),
+            iss: Some(JWT_ISSUER.into()),
+            aud: Some(JWT_AUDIENCE.into()),
+            perm: None,
+            role: None,
+        };
+        let key = EncodingKey::from_secret(s.jwt_secret.as_bytes());
+        let hs512 = encode(&Header::new(Algorithm::HS512), &claims, &key).unwrap();
+        assert!(verify_access_token(&hs512, &s).is_err());
+    }
 }

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -375,6 +375,43 @@ struct Args {
 /// Native clients (curl, native WS libraries) send no `Origin` and are allowed.
 /// A `None` policy means CORS is `*` (no meaningful allow-list) so any Origin
 /// passes; otherwise the Origin must be in the operator's configured list.
+/// Content-Security-Policy applied to every response. See the comment at
+/// the layer site in [`build_router`] for the reasoning behind each source.
+pub const CONTENT_SECURITY_POLICY: &str = "default-src 'self'; \
+script-src 'self' 'unsafe-inline'; \
+style-src 'self' 'unsafe-inline'; \
+img-src 'self' data: blob:; \
+font-src 'self' data:; \
+connect-src 'self'; \
+object-src 'none'; \
+base-uri 'self'; \
+form-action 'self'; \
+frame-ancestors 'none'";
+
+/// Static browser-hardening headers set on every response (SEC-M3 #300).
+pub fn security_headers() -> Vec<(axum::http::HeaderName, axum::http::HeaderValue)> {
+    use axum::http::{HeaderName, HeaderValue, header};
+    vec![
+        (
+            header::CONTENT_SECURITY_POLICY,
+            HeaderValue::from_static(CONTENT_SECURITY_POLICY),
+        ),
+        (
+            header::X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ),
+        (header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY")),
+        (
+            header::REFERRER_POLICY,
+            HeaderValue::from_static("no-referrer"),
+        ),
+        (
+            HeaderName::from_static("permissions-policy"),
+            HeaderValue::from_static("camera=(), microphone=(), geolocation=()"),
+        ),
+    ]
+}
+
 pub fn origin_allowed(origin: Option<&str>, allowed: &Option<Vec<String>>) -> bool {
     match origin {
         None => true,
@@ -595,16 +632,6 @@ pub fn build_router(
         )
         .with_state(state);
 
-    // HSTS: when TLS is on, tell browsers to refuse plaintext for this
-    // host for a year (and preload eligible). Skipped under --no-tls
-    // because HSTS over HTTP would pin the user to a broken origin.
-    if tls_enabled {
-        app = app.layer(SetResponseHeaderLayer::if_not_present(
-            axum::http::header::STRICT_TRANSPORT_SECURITY,
-            axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
-        ));
-    }
-
     // Serve static UI if directory is provided.
     //
     // - `precompressed_br` / `precompressed_gzip`: ServeDir auto-serves
@@ -636,6 +663,33 @@ pub fn build_router(
             "Serving web UI from {} (precompressed + cache headers enabled)",
             dir.display()
         );
+    }
+
+    // Browser hardening headers on every response (SEC-M3 #300). The UI is
+    // a static Next.js export served by this process, so all of these apply
+    // to it as well as to the JSON API. Layered outermost so they also
+    // cover 4xx/5xx and static-file responses.
+    //
+    // CSP notes: the static export inlines its hydration/RSC bootstrap
+    // scripts and Tailwind emits some inline styles, and a static export
+    // cannot carry per-response nonces, so `'unsafe-inline'` stays for
+    // script-src/style-src. Everything else is locked to the origin;
+    // `frame-ancestors 'none'` (plus X-Frame-Options) blocks clickjacking,
+    // `object-src 'none'` and `base-uri 'self'` close the plugin / <base>
+    // injection vectors. `connect-src 'self'` covers same-origin ws:/wss:
+    // under CSP3.
+    for (name, value) in security_headers() {
+        app = app.layer(SetResponseHeaderLayer::if_not_present(name, value));
+    }
+
+    // HSTS: when TLS is on, tell browsers to refuse plaintext for this
+    // host for a year (and preload eligible). Skipped under --no-tls
+    // because HSTS over HTTP would pin the user to a broken origin.
+    if tls_enabled {
+        app = app.layer(SetResponseHeaderLayer::if_not_present(
+            axum::http::header::STRICT_TRANSPORT_SECURITY,
+            axum::http::HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ));
     }
 
     app

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -1143,6 +1143,37 @@ mod tests {
             .assert_status(StatusCode::UNAUTHORIZED);
     }
 
+    /// SEC-M3 #300: browser-hardening headers are present on every
+    /// response — API JSON, errors, and (when served) the static UI.
+    #[tokio::test]
+    async fn test_security_headers_on_every_response() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        for resp in [
+            server
+                .get("/api/v1/status")
+                .authorization_bearer(&token)
+                .await,
+            server.get("/api/v1/rules").await,           // 401 path
+            server.get("/definitely/not/a/route").await, // 404 path
+        ] {
+            let h = resp.headers();
+            let csp = h
+                .get("content-security-policy")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default();
+            assert!(csp.contains("default-src 'self'"), "csp: {csp}");
+            assert!(csp.contains("frame-ancestors 'none'"), "csp: {csp}");
+            assert!(csp.contains("object-src 'none'"), "csp: {csp}");
+            assert_eq!(h.get("x-content-type-options").unwrap(), "nosniff");
+            assert_eq!(h.get("x-frame-options").unwrap(), "DENY");
+            assert_eq!(h.get("referrer-policy").unwrap(), "no-referrer");
+            // HSTS only when TLS is on; test_app builds with tls_enabled=false.
+            assert!(h.get("strict-transport-security").is_none());
+        }
+    }
+
     #[tokio::test]
     async fn test_invalid_token_returns_401() {
         let (server, _) = test_app().await;

--- a/aifw-cli/Cargo.toml
+++ b/aifw-cli/Cargo.toml
@@ -23,7 +23,6 @@ reqwest = { workspace = true, features = ["multipart", "stream"] }
 tokio-util = { version = "0.7", features = ["io"] }
 serde_yaml_ng = "0.10"
 uuid = { workspace = true }
-argon2 = { workspace = true }
 chrono = { workspace = true }
 
 [lints]

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -1509,13 +1509,8 @@ pub async fn users_add(
     let id = Uuid::new_v4().to_string();
     let now = chrono::Utc::now().to_rfc3339();
 
-    use argon2::{
-        Argon2, PasswordHasher, password_hash::SaltString, password_hash::rand_core::OsRng,
-    };
-    let salt = SaltString::generate(&mut OsRng);
-    let pw_hash = Argon2::default()
-        .hash_password(password.as_bytes(), &salt)
-        .map(|h| h.to_string())
+    // Same pinned Argon2id parameters as the API and setup wizard (SEC-M4 #301).
+    let pw_hash = aifw_common::password::hash_password(password)
         .map_err(|e| anyhow::anyhow!("hash error: {e}"))?;
 
     sqlx::query("INSERT INTO users (id, username, password_hash, totp_enabled, auth_provider, role, enabled, created_at) VALUES (?1, ?2, ?3, 0, 'local', ?4, 1, ?5)")

--- a/aifw-common/Cargo.toml
+++ b/aifw-common/Cargo.toml
@@ -14,6 +14,7 @@ sqlx = { workspace = true }
 tokio = { workspace = true, features = ["sync", "net", "rt", "macros", "time", "io-util"] }
 arc-swap = "1"
 tracing = { workspace = true }
+argon2 = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 x25519-dalek = { workspace = true }

--- a/aifw-common/src/lib.rs
+++ b/aifw-common/src/lib.rs
@@ -32,6 +32,7 @@ pub mod multiwan;
 /// NAT types: SNAT/DNAT/masquerade/binat/NAT64/NAT46 rules and pf rendering
 pub mod nat;
 pub mod net_safety;
+pub mod password;
 /// Granular permission bitmask model shared by JWT claims and role definitions
 pub mod permission;
 /// Traffic shaping (pf queues) and per-IP rate limiting / SYN flood protection

--- a/aifw-common/src/password.rs
+++ b/aifw-common/src/password.rs
@@ -1,0 +1,108 @@
+//! Password / secret hashing with explicitly-pinned Argon2id parameters.
+//!
+//! Every place that writes a credential hash into `aifw.db` — the API's
+//! runtime user management, the first-boot wizard (`aifw-setup`), the
+//! unattended seed loader, and `aifw users add` — must produce the same
+//! hash shape so the first admin account is never weaker than the ones
+//! created later (SEC-M4 #301). `Argon2::default()` is deliberately not
+//! used anywhere: its parameters silently change when the `argon2` crate
+//! bumps its defaults.
+//!
+//! Parameters are the OWASP 2023 recommendation for Argon2id:
+//! `m = 19 456 KiB (≈19 MiB), t = 2, p = 1`.
+
+use argon2::{
+    Algorithm, Argon2, Params, PasswordHash, PasswordHasher, PasswordVerifier, Version,
+    password_hash::{SaltString, rand_core::OsRng},
+};
+
+use crate::error::{AifwError, Result};
+
+/// Argon2id memory cost in KiB.
+pub const ARGON2_M_COST_KIB: u32 = 19_456;
+/// Argon2id time cost (iterations).
+pub const ARGON2_T_COST: u32 = 2;
+/// Argon2id parallelism (lanes).
+pub const ARGON2_P_COST: u32 = 1;
+
+/// PHC-string prefix every hash produced by [`hash_password`] starts with.
+/// Handy for tests and for spotting a legacy/default-parameter hash.
+pub const ARGON2_PHC_PREFIX: &str = "$argon2id$v=19$m=19456,t=2,p=1$";
+
+fn params() -> Params {
+    // The constants above are compile-time fixed and within the crate's
+    // documented bounds, so construction cannot fail.
+    Params::new(ARGON2_M_COST_KIB, ARGON2_T_COST, ARGON2_P_COST, None)
+        .expect("pinned argon2 params are valid")
+}
+
+/// The single hasher configuration used across all AiFw binaries.
+pub fn hasher() -> Argon2<'static> {
+    Argon2::new(Algorithm::Argon2id, Version::V0x13, params())
+}
+
+/// Hash `password` (or any secret: API key, refresh token, recovery code)
+/// with a fresh random salt. Returns the PHC-encoded string.
+pub fn hash_password(password: &str) -> Result<String> {
+    let salt = SaltString::generate(&mut OsRng);
+    hasher()
+        .hash_password(password.as_bytes(), &salt)
+        .map(|h| h.to_string())
+        .map_err(|e| AifwError::Crypto(format!("argon2 hash failed: {e}")))
+}
+
+/// Verify `password` against a PHC-encoded hash. Malformed hashes verify
+/// as `false` rather than erroring, so callers can treat any stored value
+/// uniformly. Hashes written with older parameters still verify — the
+/// parameters are read from the PHC string, not from [`hasher`].
+pub fn verify_password(password: &str, hash: &str) -> bool {
+    let Ok(parsed) = PasswordHash::new(hash) else {
+        return false;
+    };
+    hasher()
+        .verify_password(password.as_bytes(), &parsed)
+        .is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_round_trips() {
+        let h = hash_password("hunter2").unwrap();
+        assert!(verify_password("hunter2", &h));
+        assert!(!verify_password("hunter3", &h));
+    }
+
+    #[test]
+    fn hash_uses_pinned_argon2id_params() {
+        let h = hash_password("x").unwrap();
+        assert!(h.starts_with(ARGON2_PHC_PREFIX), "got: {h}");
+    }
+
+    #[test]
+    fn malformed_hash_never_verifies() {
+        assert!(!verify_password("x", ""));
+        assert!(!verify_password("x", "not-a-phc-string"));
+    }
+
+    #[test]
+    fn hash_with_other_params_still_verifies() {
+        // A hash written by an older build with different parameters must
+        // keep working so existing accounts survive the upgrade — the
+        // params come from the PHC string, not from `hasher()`.
+        let salt = SaltString::generate(&mut OsRng);
+        let other = Argon2::new(
+            Algorithm::Argon2id,
+            Version::V0x13,
+            Params::new(4096, 3, 1, None).unwrap(),
+        )
+        .hash_password(b"legacy-pw", &salt)
+        .unwrap()
+        .to_string();
+        assert!(!other.starts_with(ARGON2_PHC_PREFIX), "got: {other}");
+        assert!(verify_password("legacy-pw", &other));
+        assert!(!verify_password("wrong", &other));
+    }
+}

--- a/aifw-common/src/password.rs
+++ b/aifw-common/src/password.rs
@@ -68,23 +68,30 @@ pub fn verify_password(password: &str, hash: &str) -> bool {
 mod tests {
     use super::*;
 
+    /// Random per-test secret so no credential literal lives in the tree.
+    fn random_secret() -> String {
+        SaltString::generate(&mut OsRng).as_str().to_string()
+    }
+
     #[test]
     fn hash_round_trips() {
-        let h = hash_password("hunter2").unwrap();
-        assert!(verify_password("hunter2", &h));
-        assert!(!verify_password("hunter3", &h));
+        let pw = random_secret();
+        let h = hash_password(&pw).unwrap();
+        assert!(verify_password(&pw, &h));
+        assert!(!verify_password(&random_secret(), &h));
     }
 
     #[test]
     fn hash_uses_pinned_argon2id_params() {
-        let h = hash_password("x").unwrap();
+        let h = hash_password(&random_secret()).unwrap();
         assert!(h.starts_with(ARGON2_PHC_PREFIX), "got: {h}");
     }
 
     #[test]
     fn malformed_hash_never_verifies() {
-        assert!(!verify_password("x", ""));
-        assert!(!verify_password("x", "not-a-phc-string"));
+        let pw = random_secret();
+        assert!(!verify_password(&pw, ""));
+        assert!(!verify_password(&pw, "not-a-phc-string"));
     }
 
     #[test]
@@ -92,17 +99,18 @@ mod tests {
         // A hash written by an older build with different parameters must
         // keep working so existing accounts survive the upgrade — the
         // params come from the PHC string, not from `hasher()`.
+        let pw = random_secret();
         let salt = SaltString::generate(&mut OsRng);
         let other = Argon2::new(
             Algorithm::Argon2id,
             Version::V0x13,
             Params::new(4096, 3, 1, None).unwrap(),
         )
-        .hash_password(b"legacy-pw", &salt)
+        .hash_password(pw.as_bytes(), &salt)
         .unwrap()
         .to_string();
         assert!(!other.starts_with(ARGON2_PHC_PREFIX), "got: {other}");
-        assert!(verify_password("legacy-pw", &other));
-        assert!(!verify_password("wrong", &other));
+        assert!(verify_password(&pw, &other));
+        assert!(!verify_password(&random_secret(), &other));
     }
 }

--- a/aifw-setup/Cargo.toml
+++ b/aifw-setup/Cargo.toml
@@ -19,7 +19,6 @@ serde_json = { workspace = true }
 sqlx = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
-argon2 = { workspace = true }
 chrono = { workspace = true }
 anyhow = { workspace = true }
 libc = { workspace = true }

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -797,7 +797,7 @@ async fn init_database(config: &SetupConfig) -> Result<(), String> {
 
     // Save recovery codes (hashed)
     for code in &config.recovery_codes {
-        let code_hash = hash_for_db(code);
+        let code_hash = hash_for_db(code).map_err(|e| format!("recovery code hash: {e}"))?;
         sqlx::query(
             "INSERT INTO recovery_codes (id, user_id, code_hash, used) VALUES (?1, ?2, ?3, 0)",
         )
@@ -1053,7 +1053,8 @@ rate_limit = 1000
         // prefix: first 12 chars — matches the fast-lookup path in verify_api_key.
         let loopback_prefix = loopback_key[..12].to_string();
         // Hash with Argon2id (same algorithm as hash_password in aifw-api/src/auth/password.rs).
-        let loopback_key_hash = hash_for_db(&loopback_key);
+        let loopback_key_hash =
+            hash_for_db(&loopback_key).map_err(|e| format!("loopback key hash: {e}"))?;
 
         // Delete any pre-existing loopback key so re-running setup always yields
         // a fresh credential. The daemon must be restarted after re-running setup
@@ -1724,15 +1725,11 @@ async fn seed_default_rules(pool: &sqlx::SqlitePool, config: &SetupConfig) -> Re
     Ok(())
 }
 
-fn hash_for_db(password: &str) -> String {
-    use argon2::{
-        Argon2, PasswordHasher, password_hash::SaltString, password_hash::rand_core::OsRng,
-    };
-    let salt = SaltString::generate(&mut OsRng);
-    Argon2::default()
-        .hash_password(password.as_bytes(), &salt)
-        .map(|h| h.to_string())
-        .unwrap_or_default()
+/// Hash a secret for storage in `aifw.db` using the workspace-pinned
+/// Argon2id parameters (SEC-M4 #301). Errors surface to the caller instead
+/// of silently storing an empty hash that can never verify.
+fn hash_for_db(secret: &str) -> Result<String, String> {
+    aifw_common::password::hash_password(secret).map_err(|e| e.to_string())
 }
 
 /// Generate a pf.conf based on the setup configuration

--- a/aifw-setup/src/config.rs
+++ b/aifw-setup/src/config.rs
@@ -76,10 +76,8 @@ impl SetupConfig {
         if self.admin_password_hash.is_empty() {
             match self.admin_password.take() {
                 Some(p) if p.len() >= 8 => {
-                    self.admin_password_hash = hash_password(&p);
-                    if self.admin_password_hash.is_empty() {
-                        return Err("failed to hash admin_password".to_string());
-                    }
+                    self.admin_password_hash = hash_password(&p)
+                        .map_err(|e| format!("failed to hash admin_password: {e}"))?;
                 }
                 Some(_) => {
                     return Err("admin_password must be at least 8 characters".to_string());
@@ -157,18 +155,12 @@ impl SetupConfig {
     }
 }
 
-/// Argon2id password hashing — same algorithm and parameters as
-/// `aifw-api/src/auth/password.rs`. Shared by the wizard and the
-/// unattended seed loader.
-pub fn hash_password(password: &str) -> String {
-    use argon2::{
-        Argon2, PasswordHasher, password_hash::SaltString, password_hash::rand_core::OsRng,
-    };
-    let salt = SaltString::generate(&mut OsRng);
-    Argon2::default()
-        .hash_password(password.as_bytes(), &salt)
-        .map(|h| h.to_string())
-        .unwrap_or_default()
+/// Argon2id password hashing — delegates to the workspace-wide pinned
+/// parameters in `aifw_common::password` so the first admin's hash is
+/// identical in shape to every hash the API writes later (SEC-M4 #301).
+/// Shared by the wizard and the unattended seed loader.
+pub fn hash_password(password: &str) -> Result<String, String> {
+    aifw_common::password::hash_password(password).map_err(|e| e.to_string())
 }
 
 fn default_ram_mb() -> u64 {

--- a/aifw-setup/src/wizard.rs
+++ b/aifw-setup/src/wizard.rs
@@ -420,10 +420,12 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
         let password = console::prompt_password_confirm("Password");
         match console::validate_password(&password) {
             Ok(()) => {
-                config.admin_password_hash = hash_password(&password);
-                if config.admin_password_hash.is_empty() {
-                    console::error("Password hashing failed. Try again.");
-                    continue;
+                match hash_password(&password) {
+                    Ok(h) => config.admin_password_hash = h,
+                    Err(e) => {
+                        console::error(&format!("Password hashing failed: {e}. Try again."));
+                        continue;
+                    }
                 }
                 console::success("Password set.");
                 break;


### PR DESCRIPTION
Batch A of the auth-hardening triage. Closes #299, closes #300, closes #301, closes #312.

## Changes
- **#299 SEC-M2** — access tokens carry `iss=aifw-api` / `aud=aifw`; verification pins HS256 and requires `exp`/`iss`/`aud`. Tokens minted before this change are rejected — they are short-lived, and the refresh flow re-issues, so users at most re-login once after upgrade.
- **#300 SEC-M3** — every response (API JSON, static UI, 4xx/5xx) now gets `Content-Security-Policy`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, `Permissions-Policy`. The header layer sits outermost so it also wraps the UI fallback service. `script-src`/`style-src` keep `'unsafe-inline'` because the static Next.js export inlines its bootstrap and cannot carry nonces; everything else is origin-locked. **Not changed:** the `--cors-origins` default (`*`) — the UI is same-origin and cookies aren't sent under `Any`, so I left that for a separate decision rather than risk the dev flow.
- **#301 SEC-M4** — new `aifw_common::password` with pinned OWASP-2023 Argon2id params (`m=19456,t=2,p=1`). API, `aifw-setup` (wizard, seed loader, recovery codes, loopback API key) and `aifw users add` all hash through it; `Argon2::default()` is gone from the tree. Setup no longer swallows hash failures into an empty string.
- **#312 SEC-M15** — refresh-token rotation revokes the old row and inserts the successor in one transaction; a lost concurrent-rotate race (`rows_affected == 0`) is treated as reuse and revokes the family.

## Verification
- `cargo check` / `cargo clippy -D warnings` clean; new unit tests for iss/aud/alg rejection, pinned-params, legacy-params-still-verify; API integration test asserts the headers on 200/401/404.
- Built the UI export and ran the API locally with `--ui-dir`, drove it in headless Chrome: login, dashboard with live WebSocket, rules/NAT/IDS/settings/VPN pages — zero CSP violations in the console.