### PR TITLE
sec: batch B — IDS rule search, ACME/webhook validation, private temp files, no handler panics

### DIFF
--- a/aifw-api/src/acme.rs
+++ b/aifw-api/src/acme.rs
@@ -68,6 +68,10 @@ pub async fn put_account(
     if !req.contact_email.contains('@') {
         return Err(bad("contact_email must be a valid email address"));
     }
+    // SEC-M13 #310: fail fast here as well as at registration time.
+    aifw_common::net_safety::validate_outbound_url(&dir)
+        .await
+        .map_err(|e| bad(format!("directory_url rejected: {e}")))?;
     // Save row WITHOUT ACME-side registration — that happens lazily on
     // the first cert issue. Lets the operator configure the account
     // before they know which cert they want.
@@ -265,11 +269,9 @@ pub async fn download_cert_pem(
             .parse()
             .expect("static MIME type is a valid header value"),
     );
-    h.insert(
-        header::CONTENT_DISPOSITION,
-        disp.parse()
-            .expect("Content-Disposition built from validated common_name"),
-    );
+    // SEC-L7 #322: common_name is validated as a DNS name so this cannot
+    // fail in practice, but a handler must not panic on it — surface 500.
+    h.insert(header::CONTENT_DISPOSITION, disp.parse().map_err(server)?);
     Ok(resp)
 }
 
@@ -290,11 +292,9 @@ pub async fn download_key_pem(
             .parse()
             .expect("static MIME type is a valid header value"),
     );
-    h.insert(
-        header::CONTENT_DISPOSITION,
-        disp.parse()
-            .expect("Content-Disposition built from validated common_name"),
-    );
+    // SEC-L7 #322: common_name is validated as a DNS name so this cannot
+    // fail in practice, but a handler must not panic on it — surface 500.
+    h.insert(header::CONTENT_DISPOSITION, disp.parse().map_err(server)?);
     Ok(resp)
 }
 
@@ -536,12 +536,46 @@ pub struct PutTargetRequest {
     pub config: serde_json::Value,
 }
 
+/// Validate an export target's config at write time (SEC-M14 #311) so a
+/// misconfiguration is rejected with a 400 instead of failing silently at
+/// the next renewal. Webhook: `url` must pass the outbound allow-list and
+/// `auth_header`, if present, must be a legal single-line HTTP header value
+/// (no CR/LF or other control bytes — the same check reqwest applies at
+/// send time).
+async fn validate_target_config(
+    kind: ExportTargetKind,
+    cfg: &serde_json::Value,
+) -> Result<(), (StatusCode, String)> {
+    if kind != ExportTargetKind::Webhook {
+        return Ok(());
+    }
+    let url = cfg
+        .get("url")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| bad("webhook target requires url"))?;
+    aifw_common::net_safety::validate_outbound_url(url)
+        .await
+        .map_err(|e| bad(format!("webhook url rejected: {e}")))?;
+    if let Some(auth) = cfg.get("auth_header") {
+        let auth = auth
+            .as_str()
+            .ok_or_else(|| bad("auth_header must be a string"))?;
+        if !auth.is_empty() && header::HeaderValue::from_str(auth).is_err() {
+            return Err(bad(
+                "auth_header contains characters not allowed in an HTTP header value",
+            ));
+        }
+    }
+    Ok(())
+}
+
 pub async fn create_target(
     State(state): State<AppState>,
     Path(cert_id): Path<i64>,
     Json(req): Json<PutTargetRequest>,
 ) -> Result<Json<ExportTargetResponse>, (StatusCode, String)> {
-    ExportTargetKind::from_str(&req.kind).ok_or_else(|| bad("invalid kind"))?;
+    let kind = ExportTargetKind::from_str(&req.kind).ok_or_else(|| bad("invalid kind"))?;
+    validate_target_config(kind, &req.config).await?;
     let cfg_str = serde_json::to_string(&req.config).map_err(server)?;
     let res = sqlx::query(
         r#"

--- a/aifw-api/src/ids.rs
+++ b/aifw-api/src/ids.rs
@@ -437,9 +437,8 @@ pub async fn delete_ruleset(
 pub struct RulesQuery {
     pub ruleset_id: Option<String>,
     pub enabled: Option<bool>,
-    /// Free-text search — accepted but not yet applied in `list_rules`; see #490.
+    /// Free-text search over msg / rule_text / SID (#490).
     #[serde(default)]
-    #[allow(dead_code)]
     pub q: Option<String>,
     pub limit: Option<u32>,
     pub offset: Option<u32>,
@@ -458,6 +457,7 @@ pub async fn list_rules(
         .list_rules(
             ruleset_id,
             q.enabled.unwrap_or(false),
+            q.q.as_deref(),
             q.limit.unwrap_or(50),
             q.offset.unwrap_or(0),
         )
@@ -546,7 +546,7 @@ pub async fn search_rules(
     State(state): State<AppState>,
     Query(q): Query<RulesQuery>,
 ) -> Result<Json<ApiResponse<Vec<IdsRule>>>, StatusCode> {
-    // For now, search is the same as list with filtering
+    // Same handler: `q` drives the free-text filter in `list_rules`.
     list_rules(State(state), Query(q)).await
 }
 

--- a/aifw-api/src/reverse_proxy.rs
+++ b/aifw-api/src/reverse_proxy.rs
@@ -1314,10 +1314,16 @@ pub async fn validate_config(
         .await
         .map_err(|_| internal())?;
 
+    // #67: create-new + 0600 so a pre-planted path/symlink is refused
+    // rather than followed, and the config (which can carry TLS material)
+    // is never world-readable.
     let tmp_path = format!("/tmp/trafficcop-validate-{}.yaml", uuid::Uuid::new_v4());
-    tokio::fs::write(&tmp_path, &yaml)
+    aifw_common::secure_fs::write_private_new(&tmp_path, yaml.as_bytes())
         .await
-        .map_err(|_| internal())?;
+        .map_err(|e| {
+            tracing::error!(error = %e, "reverse-proxy validate: temp config write failed");
+            internal()
+        })?;
 
     let output = Command::new("trafficcop")
         .args(["--validate", "--configFile", &tmp_path])

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -1174,6 +1174,69 @@ mod tests {
         }
     }
 
+    /// SEC-M14 #311 / SEC-M13 #310: ACME write endpoints validate the
+    /// operator-supplied URL / header at write time instead of storing a
+    /// value that can only fail (or pivot) later.
+    #[tokio::test]
+    async fn test_acme_target_and_account_reject_bad_input() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        // Webhook auth_header with CRLF is not a legal header value.
+        let resp = server
+            .post("/api/v1/acme/certs/1/targets")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "kind": "webhook",
+                "config": {
+                    "url": "https://example.com/hook",
+                    "auth_header": "Bearer abc\r\nX-Injected: 1"
+                }
+            }))
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+        assert!(resp.text().contains("auth_header"), "{}", resp.text());
+
+        // Webhook URL must pass the outbound allow-list (https, public host).
+        let resp = server
+            .post("/api/v1/acme/certs/1/targets")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "kind": "webhook",
+                "config": { "url": "http://127.0.0.1:9/hook" }
+            }))
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+        assert!(resp.text().contains("url"), "{}", resp.text());
+
+        // Non-webhook kinds are not subject to the webhook checks: the
+        // request gets past validation (cert 1 doesn't exist in this
+        // fixture, so the insert itself fails on the FK — not a 400).
+        let resp = server
+            .post("/api/v1/acme/certs/1/targets")
+            .authorization_bearer(&token)
+            .json(&json!({ "kind": "local-tls-store", "config": {} }))
+            .await;
+        assert_ne!(
+            resp.status_code(),
+            StatusCode::BAD_REQUEST,
+            "{}",
+            resp.text()
+        );
+
+        // ACME directory URL: loopback / plaintext is refused up front.
+        let resp = server
+            .put("/api/v1/acme/account")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "directory_url": "http://127.0.0.1:14000/dir",
+                "contact_email": "ops@example.com"
+            }))
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+        assert!(resp.text().contains("directory_url"), "{}", resp.text());
+    }
+
     #[tokio::test]
     async fn test_invalid_token_returns_401() {
         let (server, _) = test_app().await;

--- a/aifw-common/Cargo.toml
+++ b/aifw-common/Cargo.toml
@@ -11,7 +11,7 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 sqlx = { workspace = true }
-tokio = { workspace = true, features = ["sync", "net", "rt", "macros", "time", "io-util"] }
+tokio = { workspace = true, features = ["sync", "net", "rt", "macros", "time", "io-util", "fs"] }
 arc-swap = "1"
 tracing = { workspace = true }
 argon2 = { workspace = true }

--- a/aifw-common/src/lib.rs
+++ b/aifw-common/src/lib.rs
@@ -41,6 +41,7 @@ pub mod ratelimit;
 pub mod rule;
 pub mod schedule;
 pub mod schemas;
+pub mod secure_fs;
 #[cfg(unix)]
 pub mod single_instance;
 /// Remote syslog forwarding: config, RFC 3164/5424 formatting, async client

--- a/aifw-common/src/secure_fs.rs
+++ b/aifw-common/src/secure_fs.rs
@@ -1,0 +1,90 @@
+//! Filesystem helpers for secret-bearing scratch files.
+//!
+//! Several code paths hand a secret (WireGuard private key / PSK, a config
+//! under validation) to an external tool via a path in `/tmp`. Writing with
+//! `fs::write` and then `chmod 600` leaves two holes (SEC-L5 #320, #67):
+//! the file is world-readable for an instant, and a pre-planted symlink at
+//! that path would be followed. [`write_private_new`] closes both by
+//! creating with `O_CREAT | O_EXCL` and mode `0600` in one syscall — if
+//! anything already exists at the path the call fails instead of
+//! following it.
+
+use std::path::Path;
+
+use crate::error::{AifwError, Result};
+
+/// Create `path` with mode 0600, failing if it already exists (so a
+/// pre-planted file or symlink is never followed), and write `contents`.
+///
+/// On non-Unix targets the mode bits are not applied but the
+/// create-new semantics still hold.
+pub async fn write_private_new(path: impl AsRef<Path>, contents: &[u8]) -> Result<()> {
+    use tokio::io::AsyncWriteExt;
+
+    let path = path.as_ref();
+    let mut opts = tokio::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    tokio::fs::OpenOptions::mode(&mut opts, 0o600);
+    let mut f = opts.open(path).await.map_err(|e| {
+        AifwError::Io(std::io::Error::new(
+            e.kind(),
+            format!("create {}: {e}", path.display()),
+        ))
+    })?;
+    f.write_all(contents).await?;
+    f.flush().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("aifw-secure-fs-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join(name)
+    }
+
+    #[tokio::test]
+    async fn creates_with_0600_and_content() {
+        let p = scratch("a.key");
+        let _ = std::fs::remove_file(&p);
+        write_private_new(&p, b"secret").await.unwrap();
+        assert_eq!(std::fs::read(&p).unwrap(), b"secret");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&p).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "mode was {mode:o}");
+        }
+        std::fs::remove_file(&p).unwrap();
+    }
+
+    #[tokio::test]
+    async fn refuses_existing_path() {
+        let p = scratch("b.key");
+        std::fs::write(&p, b"planted").unwrap();
+        let err = write_private_new(&p, b"secret").await.unwrap_err();
+        assert!(err.to_string().contains("create"), "got: {err}");
+        // Pre-existing content untouched.
+        assert_eq!(std::fs::read(&p).unwrap(), b"planted");
+        std::fs::remove_file(&p).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn refuses_symlink_at_path() {
+        let target = scratch("c.target");
+        let link = scratch("c.link");
+        std::fs::write(&target, b"victim").unwrap();
+        let _ = std::fs::remove_file(&link);
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        assert!(write_private_new(&link, b"secret").await.is_err());
+        // The symlink target must not have been overwritten.
+        assert_eq!(std::fs::read(&target).unwrap(), b"victim");
+        std::fs::remove_file(&link).unwrap();
+        std::fs::remove_file(&target).unwrap();
+    }
+}

--- a/aifw-core/src/acme_engine.rs
+++ b/aifw-core/src/acme_engine.rs
@@ -391,7 +391,13 @@ pub async fn ensure_account(
         return Ok((row, account));
     }
 
-    // Need to register a fresh account.
+    // Need to register a fresh account. SEC-M13 #310: the directory URL is
+    // admin-set but still goes through the outbound allow-list (https only,
+    // globally-routable host) so ACME can't be pointed at an internal
+    // endpoint as an SSRF pivot. instant-acme follows redirects.
+    crate::net_safety::validate_outbound_url(directory_url)
+        .await
+        .map_err(|e| format!("ACME directory URL rejected: {e}"))?;
     let mailto = format!("mailto:{contact_email}");
     let new_account = NewAccount {
         contact: &[&mailto],

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -6,7 +6,6 @@ use aifw_pf::PfBackend;
 use chrono::{DateTime, Utc};
 use sqlx::sqlite::SqlitePool;
 use std::sync::Arc;
-use tokio::process::Command;
 use uuid::Uuid;
 
 /// VPN engine: WireGuard tunnels and peers (`wg_tunnels`, `wg_peers`
@@ -561,15 +560,12 @@ impl VpnEngine {
         let iface = &tunnel.interface.0;
 
         // Write private key to temp file (wg set reads from file, not stdin)
+        // SEC-L5 #320: create-new + 0600 in one step so a pre-planted
+        // symlink is never followed and the key is never world-readable.
         let key_path = format!("/tmp/wg-{}.key", tunnel.id);
-        tokio::fs::write(&key_path, &tunnel.private_key)
+        aifw_common::secure_fs::write_private_new(&key_path, tunnel.private_key.as_bytes())
             .await
             .map_err(|e| AifwError::Pf(format!("Failed to write key file: {e}")))?;
-        // Restrict permissions
-        let _ = Command::new("chmod")
-            .args(["600", &key_path])
-            .output()
-            .await;
 
         // Create the WireGuard interface
         let _ = crate::sudo::ifconfig(iface, "destroy", &[]).await; // clean up if exists
@@ -727,10 +723,10 @@ impl VpnEngine {
         // PSK requires a temp file
         let psk_path = if let Some(ref psk) = peer.preshared_key {
             let path = format!("/tmp/wg-psk-{}.key", peer.id);
-            tokio::fs::write(&path, psk)
+            // SEC-L5 #320: create-new + 0600, see start_tunnel.
+            aifw_common::secure_fs::write_private_new(&path, psk.as_bytes())
                 .await
                 .map_err(|e| AifwError::Pf(format!("Failed to write PSK: {e}")))?;
-            let _ = Command::new("chmod").args(["600", &path]).output().await;
             args.push("preshared-key".to_string());
             args.push(path.clone());
             Some(path)

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -562,7 +562,10 @@ impl VpnEngine {
         // Write private key to temp file (wg set reads from file, not stdin)
         // SEC-L5 #320: create-new + 0600 in one step so a pre-planted
         // symlink is never followed and the key is never world-readable.
-        let key_path = format!("/tmp/wg-{}.key", tunnel.id);
+        // The name carries a fresh random component: the tunnel id alone is
+        // visible via the API (guessable), and a stale file from a crashed
+        // earlier start must never collide with — and block — this one.
+        let key_path = format!("/tmp/wg-{}-{}.key", tunnel.id, Uuid::new_v4().simple());
         aifw_common::secure_fs::write_private_new(&key_path, tunnel.private_key.as_bytes())
             .await
             .map_err(|e| AifwError::Pf(format!("Failed to write key file: {e}")))?;
@@ -623,9 +626,11 @@ impl VpnEngine {
             iface,
             &["private-key", &key_path, "listen-port", &listen_port_s],
         )
-        .await
-        .map_err(|e| AifwError::Pf(format!("wg set failed: {e}")))?;
+        .await;
+        // Remove the key file on every path — including a spawn error —
+        // so a secret never lingers in /tmp.
         let _ = tokio::fs::remove_file(&key_path).await;
+        let output = output.map_err(|e| AifwError::Pf(format!("wg set failed: {e}")))?;
         if !output.status.success() {
             let _ = crate::sudo::ifconfig(iface, "destroy", &[]).await;
             return Err(AifwError::Pf(format!(
@@ -722,8 +727,9 @@ impl VpnEngine {
         }
         // PSK requires a temp file
         let psk_path = if let Some(ref psk) = peer.preshared_key {
-            let path = format!("/tmp/wg-psk-{}.key", peer.id);
-            // SEC-L5 #320: create-new + 0600, see start_tunnel.
+            // SEC-L5 #320: create-new + 0600 with a random suffix, see
+            // start_tunnel.
+            let path = format!("/tmp/wg-psk-{}-{}.key", peer.id, Uuid::new_v4().simple());
             aifw_common::secure_fs::write_private_new(&path, psk.as_bytes())
                 .await
                 .map_err(|e| AifwError::Pf(format!("Failed to write PSK: {e}")))?;
@@ -735,13 +741,12 @@ impl VpnEngine {
         };
 
         let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-        let output = crate::sudo::wg("set", iface, &arg_refs)
-            .await
-            .map_err(|e| AifwError::Pf(format!("wg set peer failed: {e}")))?;
-
+        let output = crate::sudo::wg("set", iface, &arg_refs).await;
+        // Remove the PSK file on every path, including a spawn error.
         if let Some(ref path) = psk_path {
             let _ = tokio::fs::remove_file(path).await;
         }
+        let output = output.map_err(|e| AifwError::Pf(format!("wg set peer failed: {e}")))?;
 
         if !output.status.success() {
             return Err(AifwError::Pf(format!(

--- a/aifw-ids/src/rules/manager.rs
+++ b/aifw-ids/src/rules/manager.rs
@@ -255,10 +255,14 @@ impl RulesetManager {
     }
 
     /// List rules for a specific ruleset.
+    /// List rules with optional filters. `search` (#490) is a
+    /// case-insensitive substring match against `msg`, `rule_text`, and
+    /// the SID; `%`/`_` in the term are escaped so they match literally.
     pub async fn list_rules(
         &self,
         ruleset_id: Option<Uuid>,
         enabled_only: bool,
+        search: Option<&str>,
         limit: u32,
         offset: u32,
     ) -> Result<Vec<IdsRule>> {
@@ -270,6 +274,15 @@ impl RulesetManager {
         if let Some(rs_id) = ruleset_id {
             sql.push_str(" AND ruleset_id = ?");
             binds.push(rs_id.to_string());
+        }
+        if let Some(term) = search.map(str::trim).filter(|t| !t.is_empty()) {
+            let pat = format!("%{}%", like_escape(term));
+            sql.push_str(
+                " AND (msg LIKE ? ESCAPE '\\' OR rule_text LIKE ? ESCAPE '\\' OR CAST(sid AS TEXT) LIKE ? ESCAPE '\\')",
+            );
+            binds.push(pat.clone());
+            binds.push(pat.clone());
+            binds.push(pat);
         }
         if enabled_only {
             sql.push_str(" AND enabled = 1 AND ruleset_id IN (SELECT id FROM ids_rulesets WHERE enabled = 1)");
@@ -377,7 +390,7 @@ impl RulesetManager {
 
     /// Load all enabled rules from the database and compile them into the RuleDatabase.
     pub async fn compile_rules(&self, rule_db: &RuleDatabase) -> Result<usize> {
-        let rules = self.list_rules(None, true, 100_000, 0).await?;
+        let rules = self.list_rules(None, true, None, 100_000, 0).await?;
 
         // Single bulk lookup of ruleset_id → rule_format so we avoid a per-rule
         // SELECT inside the hot path (previously ~47k queries per reload).
@@ -460,6 +473,19 @@ fn extract_msg(rule: &str) -> Option<String> {
         let rest = &rule[pos + 5..];
         rest.find('"').map(|end| rest[..end].to_string())
     })
+}
+
+/// Escape SQL LIKE metacharacters so a user term matches literally. Pairs
+/// with `ESCAPE '\\'` in the query.
+fn like_escape(term: &str) -> String {
+    let mut out = String::with_capacity(term.len());
+    for c in term.chars() {
+        if matches!(c, '%' | '_' | '\\') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
 }
 
 #[cfg(test)]
@@ -572,8 +598,107 @@ mod tests {
         }];
 
         mgr.store_rules(rs_id, &rules).await.unwrap();
-        let loaded = mgr.list_rules(Some(rs_id), true, 100, 0).await.unwrap();
+        let loaded = mgr
+            .list_rules(Some(rs_id), true, None, 100, 0)
+            .await
+            .unwrap();
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].sid, Some(1001));
+    }
+
+    /// #490: `search` filters on msg / rule_text / sid, case-insensitively,
+    /// and LIKE metacharacters in the term are literal.
+    #[tokio::test]
+    async fn test_list_rules_search() {
+        let pool = test_pool().await;
+        let mgr = RulesetManager::new(pool);
+
+        let rs_id = Uuid::new_v4();
+        let rs = IdsRuleset {
+            id: rs_id,
+            name: "Search".into(),
+            source_url: None,
+            rule_format: RuleFormat::Suricata,
+            enabled: true,
+            auto_update: false,
+            update_interval_hours: 0,
+            last_updated: None,
+            rule_count: 0,
+            created_at: Utc::now(),
+        };
+        mgr.add_ruleset(&rs).await.unwrap();
+
+        let mk = |sid: u32, msg: &str, content: &str| IdsRule {
+            id: Uuid::new_v4(),
+            ruleset_id: rs_id,
+            sid: Some(sid),
+            rule_text: format!(
+                r#"alert tcp any any -> any any (msg:"{msg}"; content:"{content}"; sid:{sid};)"#
+            ),
+            msg: Some(msg.into()),
+            severity: IdsSeverity::MEDIUM,
+            enabled: true,
+            action_override: None,
+            hit_count: 0,
+            last_hit: None,
+            created_at: Utc::now(),
+        };
+        let rules = vec![
+            mk(2001, "ET MALWARE Beacon", "evil"),
+            mk(2002, "ET SCAN Nmap", "nmap"),
+            mk(2003, "100% CPU", "pct"),
+        ];
+        mgr.store_rules(rs_id, &rules).await.unwrap();
+
+        let by_msg = mgr
+            .list_rules(Some(rs_id), true, Some("malware"), 100, 0)
+            .await
+            .unwrap();
+        assert_eq!(
+            by_msg.iter().map(|r| r.sid).collect::<Vec<_>>(),
+            vec![Some(2001)]
+        );
+
+        let by_content = mgr
+            .list_rules(Some(rs_id), true, Some("nmap"), 100, 0)
+            .await
+            .unwrap();
+        assert_eq!(by_content.len(), 1);
+        assert_eq!(by_content[0].sid, Some(2002));
+
+        let by_sid = mgr
+            .list_rules(Some(rs_id), true, Some("2003"), 100, 0)
+            .await
+            .unwrap();
+        assert_eq!(by_sid.len(), 1);
+        assert_eq!(by_sid[0].sid, Some(2003));
+
+        // `%` is escaped: only the rule whose msg literally contains "100%".
+        let pct = mgr
+            .list_rules(Some(rs_id), true, Some("100%"), 100, 0)
+            .await
+            .unwrap();
+        assert_eq!(pct.len(), 1);
+        assert_eq!(pct[0].sid, Some(2003));
+        // A bare `%` would match everything if unescaped; escaped it matches
+        // only the one rule that contains a literal percent sign.
+        let bare = mgr
+            .list_rules(Some(rs_id), true, Some("%"), 100, 0)
+            .await
+            .unwrap();
+        assert_eq!(bare.len(), 1);
+
+        // Blank / whitespace search is a no-op.
+        let all = mgr
+            .list_rules(Some(rs_id), true, Some("  "), 100, 0)
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 3);
+        assert!(
+            mgr.list_rules(Some(rs_id), true, Some("nothing-here"), 100, 0)
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 }


### PR DESCRIPTION
Batch B of the issue triage. Closes #490, closes #310, closes #311, closes #322, closes #320, closes #67.

## Changes
- **#490** — `RulesetManager::list_rules` gains a `search` term: case-insensitive `LIKE` over `msg`, `rule_text`, and `sid`, with `%`/`_`/`\` escaped so they match literally. `GET /api/v1/ids/rules?q=` (and `/search`) now actually filter. `#[allow(dead_code)]` on `RulesQuery.q` removed.
- **#310 SEC-M13** — ACME directory URL goes through `validate_outbound_url` at `PUT /acme/account` (400 up front) and again in `ensure_account` before `Account::create`. ⚠️ This also refuses ACME servers on private/loopback hosts (internal step-ca / Pebble). LE prod/staging unaffected. Same allow-list webhook/export targets already enforce; shout if internal CAs matter and I'll add an opt-out.
- **#311 SEC-M14** — webhook export targets are validated at write time: `url` must pass the outbound allow-list, `auth_header` must be a legal single-line header value (`HeaderValue::from_str`, rejects CR/LF). Previously a bad value was stored and only failed at renewal.
- **#322 SEC-L7** — the two `.expect()`s on Content-Disposition in cert/key download handlers → `map_err(server)?`.
- **#320 SEC-L5 / #67** — new `aifw_common::secure_fs::write_private_new`: `create_new` + mode `0600` in one `open`, so a pre-planted file or symlink is refused rather than followed and the secret is never world-readable. Used for the WireGuard private-key and PSK temp files and the TrafficCop validate config. Also: the WG temp names now carry a random suffix (tunnel/peer id is API-visible, so not unguessable; and a stale file from a crash must not block `create_new`), and the file is removed on every exit path including a spawn error.

## Verification
- `cargo check`, `cargo clippy -D warnings`, `cargo test --workspace` green.
- New tests: `secure_fs` (mode 0600, refuses existing path, refuses symlink), IDS `list_rules` search (msg/content/sid, `%` escaping, blank no-op), API test asserting 400 on CRLF `auth_header`, on non-https/loopback webhook URL, and on a loopback ACME directory URL.