### PR TITLE
sec(sudoers): narrow wg/ifconfig/sysrc/pkg helper grammars + allowlist drift guards

### DIFF
--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -2901,4 +2901,284 @@ mod sudoers_tests {
             );
         }
     }
+
+    // ------------------------------------------------------------------
+    // Wrapper-allowlist drift guards (batch C: #302 #303 #309 #314 #316).
+    // The narrow helpers under freebsd/overlay/usr/local/libexec are the
+    // privilege boundary; every time a Rust call site and a helper's
+    // allowlist disagree, sudo refuses and a feature silently breaks
+    // (#601, #627, sudoers-drift history). These tests pin the pairs.
+    // ------------------------------------------------------------------
+
+    fn libexec(name: &str) -> String {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        let path = root.join("freebsd/overlay/usr/local/libexec").join(name);
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+    }
+
+    fn workspace_file(rel: &str) -> String {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        std::fs::read_to_string(root.join(rel)).unwrap_or_else(|e| panic!("read {rel}: {e}"))
+    }
+
+    /// Match `path` against a `case`-style allowlist entry where `*` is
+    /// the only wildcard (sh `case` semantics — `*` matches `/` too, but
+    /// the helper rejects `..`/`//` beforehand).
+    fn case_glob_matches(pattern: &str, path: &str) -> bool {
+        fn go(p: &[u8], s: &[u8]) -> bool {
+            match p.first() {
+                None => s.is_empty(),
+                Some(b'*') => (0..=s.len()).any(|i| go(&p[1..], &s[i..])),
+                Some(c) => s.first() == Some(c) && go(&p[1..], &s[1..]),
+            }
+        }
+        go(pattern.as_bytes(), path.as_bytes())
+    }
+
+    /// Extract the `case "$DEST" in` allowlist entries from aifw-sudo-write:
+    /// lines of the form `    /abs/path)` (possibly `a|b)`), before the `*)`.
+    fn write_allowlist() -> Vec<String> {
+        let script = libexec("aifw-sudo-write");
+        let mut out = Vec::new();
+        for line in script.lines() {
+            let t = line.trim();
+            if t.starts_with('/') && t.ends_with(')') {
+                for alt in t.trim_end_matches(')').split('|') {
+                    out.push(alt.trim().to_string());
+                }
+            }
+        }
+        assert!(
+            !out.is_empty(),
+            "no allowlist entries parsed from aifw-sudo-write"
+        );
+        out
+    }
+
+    /// SEC-M17 #314: every path the code hands to `sudo::write_file` must
+    /// be covered by the aifw-sudo-write allowlist. Paths listed here are
+    /// the literal targets at each call site (grep `sudo::write_file(`);
+    /// when you add a call site, add its path here AND to the helper.
+    #[test]
+    fn write_helper_allowlist_covers_call_sites() {
+        use aifw_core::ipsec::{
+            SWANCTL_CONF_DIR, SWANCTL_PRIVATE_DIR, SWANCTL_X509_DIR, SWANCTL_X509CA_DIR,
+        };
+        let allow = write_allowlist();
+        let example_id = "aifw-00000000-0000-0000-0000-000000000000";
+        let targets: Vec<(&str, String)> = vec![
+            (
+                "aifw-api main.rs / dhcp.rs / pf_tuning.rs pf.conf.aifw",
+                "/usr/local/etc/aifw/pf.conf.aifw".into(),
+            ),
+            (
+                "aifw-api cluster.rs daemon.key",
+                "/usr/local/etc/aifw/daemon.key".into(),
+            ),
+            (
+                "aifw-api reverse_proxy.rs / aifw-cli trafficcop config",
+                "/usr/local/etc/trafficcop/config.yaml".into(),
+            ),
+            (
+                "aifw-core ipsec.rs conn file",
+                format!("{SWANCTL_CONF_DIR}/{example_id}.conf"),
+            ),
+            (
+                "aifw-core ipsec.rs private key",
+                format!("{SWANCTL_PRIVATE_DIR}/{example_id}.pem"),
+            ),
+            (
+                "aifw-core ipsec.rs cert",
+                format!("{SWANCTL_X509_DIR}/{example_id}.pem"),
+            ),
+            (
+                "aifw-core ipsec.rs ca cert",
+                format!("{SWANCTL_X509CA_DIR}/{example_id}.pem"),
+            ),
+        ];
+        for (site, path) in &targets {
+            assert!(
+                allow.iter().any(|pat| case_glob_matches(pat, path)),
+                "aifw-sudo-write allowlist does not cover {path} (call site: {site}). allowlist: {allow:?}"
+            );
+        }
+        // Negative control: the matcher must not be trivially permissive.
+        assert!(
+            !allow
+                .iter()
+                .any(|pat| case_glob_matches(pat, "/etc/master.passwd"))
+        );
+    }
+
+    /// Drift guard companion to the test above: the number of
+    /// `sudo::write_file(` call sites in the tree must equal what the
+    /// target list accounts for. A new call site fails here until its
+    /// path is added to both the list above and the helper.
+    #[test]
+    fn write_file_call_site_count_is_accounted_for() {
+        // Known call sites (file → count). Any `sudo::write_file(` found in
+        // a file not listed here, or a count mismatch, fails the test.
+        let known: &[(&str, usize)] = &[
+            ("aifw-api/src/main.rs", 1),
+            ("aifw-api/src/dhcp.rs", 1),
+            ("aifw-api/src/cluster.rs", 1),
+            ("aifw-api/src/reverse_proxy.rs", 1),
+            ("aifw-cli/src/commands.rs", 1),
+            ("aifw-core/src/pf_tuning.rs", 1),
+            ("aifw-core/src/ipsec.rs", 1),
+            // the definition itself
+            ("aifw-core/src/sudo.rs", 0),
+        ];
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        let mut found: Vec<(String, usize)> = Vec::new();
+        fn walk(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+            for e in std::fs::read_dir(dir).unwrap().flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(&p, out);
+                } else if p.extension().is_some_and(|x| x == "rs") {
+                    out.push(p);
+                }
+            }
+        }
+        let mut files = Vec::new();
+        for e in std::fs::read_dir(&root).unwrap().flatten() {
+            let p = e.path();
+            if p.is_dir()
+                && p.file_name()
+                    .is_some_and(|n| n.to_string_lossy().starts_with("aifw-"))
+                && p.join("src").is_dir()
+            {
+                walk(&p.join("src"), &mut files);
+            }
+        }
+        let this_file = std::path::Path::new(file!());
+        for f in files {
+            // Skip this test's own source, which mentions the pattern.
+            if f.ends_with(this_file.file_name().unwrap())
+                && f.parent().is_some_and(|d| d.ends_with("aifw-setup/src"))
+            {
+                continue;
+            }
+            let text = std::fs::read_to_string(&f).unwrap();
+            let n = text.matches("sudo::write_file(").count();
+            if n > 0 {
+                let rel = f
+                    .strip_prefix(&root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                found.push((rel, n));
+            }
+        }
+        found.sort();
+        let mut expected: Vec<(String, usize)> = known
+            .iter()
+            .filter(|(_, n)| *n > 0)
+            .map(|(f, n)| (f.to_string(), *n))
+            .collect();
+        expected.sort();
+        assert_eq!(
+            found, expected,
+            "sudo::write_file( call sites changed — update \
+             write_helper_allowlist_covers_call_sites and aifw-sudo-write"
+        );
+    }
+
+    /// SEC-M12 #309: `aifw-sudo-pkg install` only accepts the closed set of
+    /// runtime packages. That set must equal freebsd/manifest.json
+    /// "packages" (which drives the updater's dependency install loop).
+    #[test]
+    fn pkg_helper_allowlist_matches_manifest_packages() {
+        let manifest: serde_json::Value =
+            serde_json::from_str(&workspace_file("freebsd/manifest.json")).unwrap();
+        let mut manifest_pkgs: Vec<String> = manifest["packages"]
+            .as_array()
+            .expect("manifest.packages")
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        manifest_pkgs.sort();
+
+        let script = libexec("aifw-sudo-pkg");
+        // The allowlist is the `case` arm inside valid_pkg_name():
+        //     curl|minisign|...) return 0 ;;
+        let arm = script
+            .lines()
+            .map(str::trim)
+            .find(|l| l.ends_with(") return 0 ;;") && l.contains('|'))
+            .expect("allowlist arm in aifw-sudo-pkg valid_pkg_name()");
+        let mut helper_pkgs: Vec<String> = arm
+            .trim_end_matches(") return 0 ;;")
+            .split('|')
+            .map(|s| s.trim().to_string())
+            .collect();
+        helper_pkgs.sort();
+        assert_eq!(
+            helper_pkgs, manifest_pkgs,
+            "aifw-sudo-pkg allowlist must equal manifest.json packages"
+        );
+    }
+
+    /// SEC-M5 #302: aifw-sudo-wg only accepts key-file paths of the shape
+    /// aifw-core stages them as. If vpn.rs changes the staging path
+    /// format, the helper's pattern must move with it (else wg set fails
+    /// and every tunnel start breaks).
+    #[test]
+    fn wg_helper_key_path_pattern_matches_vpn_staging() {
+        let vpn = workspace_file("aifw-core/src/vpn.rs");
+        assert!(
+            vpn.contains("\"/tmp/wg-{}-{}.key\""),
+            "vpn.rs private key staging path changed"
+        );
+        assert!(
+            vpn.contains("\"/tmp/wg-psk-{}-{}.key\""),
+            "vpn.rs psk staging path changed"
+        );
+        let wg = libexec("aifw-sudo-wg");
+        assert!(
+            wg.contains("/tmp/wg-*.key)"),
+            "aifw-sudo-wg staging path pattern changed"
+        );
+        // And the helper must know every `wg set` option vpn.rs emits.
+        for opt in [
+            "private-key",
+            "listen-port",
+            "peer",
+            "allowed-ips",
+            "endpoint",
+            "persistent-keepalive",
+            "preshared-key",
+        ] {
+            assert!(
+                vpn.contains(&format!("\"{opt}\"")),
+                "vpn.rs no longer uses wg option {opt}?"
+            );
+            assert!(wg.contains(opt), "aifw-sudo-wg missing wg option {opt}");
+        }
+    }
+
+    /// SEC-L1 #316: the `ifconfig_*` value templates aifw-api writes via
+    /// aifw-sudo-sysrc must be ones the helper's grammar accepts.
+    #[test]
+    fn sysrc_helper_accepts_iface_rs_templates() {
+        let iface = workspace_file("aifw-api/src/iface.rs");
+        let sysrc = libexec("aifw-sudo-sysrc");
+        // Templates emitted by iface.rs.
+        for tmpl in ["=DHCP\"", "=inet {}\"", "\"up\".to_string()"] {
+            assert!(iface.contains(tmpl), "iface.rs no longer emits {tmpl}?");
+        }
+        assert!(
+            sysrc.contains("DHCP|SYNCDHCP|up|down)"),
+            "sysrc helper word-form arm changed"
+        );
+        assert!(
+            sysrc.contains("\"inet \"*|\"inet6 \"*)"),
+            "sysrc helper inet arm changed"
+        );
+        assert!(
+            sysrc.contains("vlans_*)"),
+            "sysrc helper vlans_ arm changed"
+        );
+    }
 }

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-ifconfig
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-ifconfig
@@ -5,7 +5,9 @@
 # `aifw` user to the small set of subcommands AiFw legitimately needs
 # (bring an interface up/down, set address, set MTU, create/destroy a
 # cloned interface, set FIB, configure a VLAN child), with iface name
-# validation that rejects shell metacharacters and flag-shaped values.
+# validation that rejects shell metacharacters and flag-shaped values,
+# and address operands that must parse as IPv4/IPv6[/prefix] (SEC-M6
+# #303 — ifconfig would otherwise read `-alias`/`-lladdr` as a flag).
 #
 # Read-only `ifconfig` invocations (status/info, listing) don't need
 # root and don't go through this wrapper — call ifconfig directly.
@@ -43,6 +45,55 @@ is_numeric() {
     esac
 }
 
+# Helper: validate an IPv4 address with optional /prefix (SEC-M6 #303).
+# ifconfig treats leading-dash operands as flags (`-alias`, `-lladdr`,
+# ...), so an address operand must be structurally an address, never a
+# flag-shaped string.
+is_ipv4_cidr() {
+    addr="$1"
+    case "$addr" in
+        */*)
+            prefix="${addr#*/}"
+            addr="${addr%%/*}"
+            is_numeric "$prefix" || return 1
+            [ "$prefix" -le 32 ] || return 1
+            ;;
+    esac
+    case "$addr" in
+        ''|-*|*[!0-9.]*) return 1 ;;
+    esac
+    # Exactly four dotted octets, each 0-255.
+    oldifs="$IFS"; IFS=.
+    set -- $addr
+    IFS="$oldifs"
+    [ $# -eq 4 ] || return 1
+    for o; do
+        is_numeric "$o" || return 1
+        [ "$o" -le 255 ] || return 1
+    done
+    return 0
+}
+
+# Helper: validate an IPv6 address with optional /prefix. Character-class
+# plus structural check (must contain a colon, no leading dash); the
+# kernel rejects anything malformed beyond that.
+is_ipv6_cidr() {
+    addr="$1"
+    case "$addr" in
+        */*)
+            prefix="${addr#*/}"
+            addr="${addr%%/*}"
+            is_numeric "$prefix" || return 1
+            [ "$prefix" -le 128 ] || return 1
+            ;;
+    esac
+    case "$addr" in
+        ''|-*|*[!0-9a-fA-F:.]*) return 1 ;;
+        *:*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 # Helper: validate a parent iface name (same rules as the top-level
 # IFACE arg).
 is_valid_iface_name() {
@@ -77,25 +128,32 @@ case "$ACTION" in
         # inet <addr> -alias    — remove IPv4 alias
         # inet <addr> up        — set + bring up
         case $# in
-            1)
-                exec /sbin/ifconfig "$IFACE" inet "$1"
-                ;;
-            2)
-                if [ "$2" = "-alias" ] || [ "$2" = "up" ]; then
-                    exec /sbin/ifconfig "$IFACE" inet "$1" "$2"
-                fi
-                echo "aifw-sudo-ifconfig: inet second arg must be -alias or up" >&2
-                exit 1
-                ;;
+            1|2) ;;
             *)
                 echo "aifw-sudo-ifconfig: inet takes 1 or 2 args" >&2
                 exit 1
                 ;;
         esac
+        if ! is_ipv4_cidr "$1"; then
+            echo "aifw-sudo-ifconfig: inet address must be a.b.c.d[/N]: $1" >&2
+            exit 1
+        fi
+        if [ $# -eq 1 ]; then
+            exec /sbin/ifconfig "$IFACE" inet "$1"
+        fi
+        if [ "$2" = "-alias" ] || [ "$2" = "up" ]; then
+            exec /sbin/ifconfig "$IFACE" inet "$1" "$2"
+        fi
+        echo "aifw-sudo-ifconfig: inet second arg must be -alias or up" >&2
+        exit 1
         ;;
     inet6)
         if [ $# -ne 1 ]; then
             echo "aifw-sudo-ifconfig: inet6 takes one address arg" >&2
+            exit 1
+        fi
+        if ! is_ipv6_cidr "$1"; then
+            echo "aifw-sudo-ifconfig: inet6 address malformed: $1" >&2
             exit 1
         fi
         exec /sbin/ifconfig "$IFACE" inet6 "$1"

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-pkg
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-pkg
@@ -5,15 +5,16 @@
 # `aifw` user to:
 #
 #   - update                    — refresh package catalog
-#   - install -y <pkg> [<pkg>...]  — install packages (no scripts/repos)
+#   - install -y <pkg> [<pkg>...]  — install packages from the closed
+#                                    allowlist below (no scripts/repos)
 #   - upgrade -y                — apply all pending upgrades
 #   - upgrade -n                — dry-run pending upgrades
 #
 # Other subcommands (delete, set, lock, unlock, autoremove, audit
 # fetch-from-arbitrary-URL, install with `-r reponame`, install of
-# absolute paths, etc.) are denied. Package names are validated
-# character-class-wise so a compromised daemon can't smuggle shell
-# metacharacters or `-r` flags through.
+# absolute paths, etc.) are denied, and only allowlisted package names
+# may be installed, so a compromised daemon can't pull arbitrary
+# root-installed code from a misconfigured or poisoned repo.
 
 set -eu
 
@@ -25,18 +26,18 @@ fi
 ACTION="$1"
 shift
 
-# Validate a single package name: alnum, dot, underscore, plus, hyphen.
-# Reject empty and anything starting with `-` (which would smuggle a flag).
+# Installable package allowlist (SEC-M12 #309). `pkg install` as root
+# from whatever repo is configured is only as safe as that repo, so the
+# set of names is closed: exactly the runtime dependencies listed in
+# freebsd/manifest.json "packages" (the in-app updater installs any that
+# are missing during an upgrade — see aifw-core/src/updater.rs). A
+# workspace test (aifw-setup sudoers_tests) asserts this list and the
+# manifest stay in sync; add new deps in BOTH places.
 valid_pkg_name() {
     case "$1" in
-        ""|-*)
-            return 1
-            ;;
-        *[^A-Za-z0-9._+-]*)
-            return 1
-            ;;
+        curl|minisign|strongswan|sudo|unbound|wireguard-tools) return 0 ;;
+        *) return 1 ;;
     esac
-    return 0
 }
 
 case "$ACTION" in
@@ -55,7 +56,7 @@ case "$ACTION" in
         shift  # drop -y
         for p; do
             if ! valid_pkg_name "$p"; then
-                echo "aifw-sudo-pkg: invalid package name: $p" >&2
+                echo "aifw-sudo-pkg: package not in allowlist: $p" >&2
                 exit 1
             fi
         done

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-sysrc
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-sysrc
@@ -83,6 +83,63 @@ case "$KEY" in
         exit 1 ;;
 esac
 
+# Value validation (SEC-L1 #316). rc.conf is *sourced by sh* at boot, so
+# a value containing `$(...)`, backticks, or a quote that closes sysrc's
+# quoting is root code execution on the next boot. Two layers:
+#   1. every value: no shell metacharacters at all;
+#   2. ifconfig_* / vlans_* values must match the small template grammar
+#      AiFw actually writes (aifw-api/src/iface.rs) — not free text.
+if [ -z "$FLAG" ]; then
+    VALUE="${ARG#*=}"
+    if [ "$VALUE" = "$ARG" ]; then
+        echo "aifw-sudo-sysrc: set form requires key=value: $ARG" >&2
+        exit 1
+    fi
+    # Positive character allowlist: letters, digits, space, and . _ : / @ + , -
+    # cover every value AiFw writes (YES/NO, hostnames, IPv4/IPv6 with
+    # prefix, "inet a.b.c.d/N"). Everything else — quotes, $, backtick,
+    # ; | & < > ( ) { } * ? ! ~ # \ = and any control character — is refused.
+    case "$VALUE" in
+        ''|*[!A-Za-z0-9\ ._:/@+,-]*)
+            echo "aifw-sudo-sysrc: value contains disallowed characters: $KEY" >&2
+            exit 1 ;;
+    esac
+    case "$KEY" in
+        ifconfig_*)
+            # Accepted templates (exactly what aifw-api/src/iface.rs writes):
+            #   DHCP | SYNCDHCP | up | down
+            #   inet a.b.c.d[/N]
+            #   inet6 <addr>[/N]
+            case "$VALUE" in
+                DHCP|SYNCDHCP|up|down) ;;
+                "inet "*|"inet6 "*)
+                    rest="${VALUE#* }"
+                    # Single address token: address characters only, no
+                    # leading dash (ifconfig flag), no further words.
+                    case "$rest" in
+                        ''|-*|*\ *|*[!0-9a-fA-F.:/]*)
+                            echo "aifw-sudo-sysrc: ifconfig_* value must be 'inet <addr>[/N]' or 'inet6 <addr>[/N]': $VALUE" >&2
+                            exit 1 ;;
+                    esac
+                    ;;
+                *)
+                    echo "aifw-sudo-sysrc: ifconfig_* value must be DHCP|SYNCDHCP|up|down|inet <addr>|inet6 <addr>: $VALUE" >&2
+                    exit 1 ;;
+            esac
+            ;;
+        vlans_*)
+            # Space-separated VLAN ids / vlan<N> child names.
+            for w in $VALUE; do
+                case "$w" in
+                    ''|*[!A-Za-z0-9]*)
+                        echo "aifw-sudo-sysrc: vlans_* value must be ids or names: $VALUE" >&2
+                        exit 1 ;;
+                esac
+            done
+            ;;
+    esac
+fi
+
 if [ -n "$FLAG" ]; then
     exec /usr/sbin/sysrc "$FLAG" "$KEY"
 else

--- a/freebsd/overlay/usr/local/libexec/aifw-sudo-wg
+++ b/freebsd/overlay/usr/local/libexec/aifw-sudo-wg
@@ -6,9 +6,20 @@
 #
 #   - subcommands `set` and `show` (no `setconf`, `pubkey`, `genkey`, etc.)
 #   - interface names matching wg<N> (no `lo0`, no arbitrary system iface)
-#
-# Remaining args (peer pubkey, allowed-ips, key-file paths, etc.) are
-# passed through. wg's own argument validator catches malformed forms.
+#   - for `set`, a closed grammar of option/value pairs (SEC-M5 #302):
+#       private-key <path>       path must be an AiFw staging file
+#       preshared-key <path>     (see is_staging_key_path below)
+#       listen-port <n>
+#       peer <base64-key>
+#       allowed-ips <cidr[,cidr...]>
+#       endpoint <host:port>
+#       persistent-keepalive <n>
+#       remove
+#     Anything else — unknown options, flag-shaped values, key paths
+#     outside /tmp/wg-*.key — is refused before wg ever runs. Without
+#     this, `wg set wg0 private-key /etc/master.passwd` would read a
+#     root-only file as root.
+#   - for `show`, no args or `dump`.
 
 set -eu
 
@@ -21,22 +32,134 @@ SUBCMD="$1"
 IFACE="$2"
 shift 2
 
+die() {
+    echo "aifw-sudo-wg: $*" >&2
+    exit 1
+}
+
 case "$SUBCMD" in
     set|show) ;;
-    *)
-        echo "aifw-sudo-wg: unsupported subcommand: $SUBCMD" >&2
-        exit 1
-        ;;
+    *) die "unsupported subcommand: $SUBCMD" ;;
 esac
 
 # Whitelist iface names — wg<N> with up to 3 digits. AiFw's tunnel
 # allocator uses wg0, wg1, ... so 3 digits gives plenty of headroom.
 case "$IFACE" in
     wg[0-9]|wg[0-9][0-9]|wg[0-9][0-9][0-9]) ;;
-    *)
-        echo "aifw-sudo-wg: invalid iface (expected wg<N>): $IFACE" >&2
-        exit 1
-        ;;
+    *) die "invalid iface (expected wg<N>): $IFACE" ;;
 esac
 
-exec /usr/bin/wg "$SUBCMD" "$IFACE" "$@"
+is_numeric() {
+    case "$1" in
+        ''|*[!0-9]*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# Key material is staged by aifw-core (vpn.rs) as
+#   /tmp/wg-<uuid>-<rand>.key      (tunnel private key)
+#   /tmp/wg-psk-<uuid>-<rand>.key  (peer preshared key)
+# created O_EXCL mode 0600 by the aifw user. Accept only that shape, and
+# only if it is a regular file (not a symlink) owned by the invoking user,
+# so a pre-planted link to a root-only file is refused.
+is_staging_key_path() {
+    case "$1" in
+        /tmp/wg-*.key) ;;
+        *) return 1 ;;
+    esac
+    case "$1" in
+        *..*|*//*|*/./*|*[!A-Za-z0-9._/-]*) return 1 ;;
+    esac
+    [ -f "$1" ] || return 1
+    [ -L "$1" ] && return 1
+    # An EMPTY key file makes `wg set private-key` *clear* the interface
+    # key (same as /dev/null) — refuse it so a truncated/planted empty
+    # file can't silently disable a tunnel.
+    [ -s "$1" ] || return 1
+    # SUDO_UID is set by sudo; fall back to refusing if we can't tell.
+    [ -n "${SUDO_UID:-}" ] || return 1
+    [ "$(stat -f %u "$1")" = "$SUDO_UID" ] || return 1
+    return 0
+}
+
+# WireGuard keys on the wire are 44-char base64 (32 bytes + "=").
+is_wg_key() {
+    [ ${#1} -eq 44 ] || return 1
+    case "$1" in
+        *[!A-Za-z0-9+/=]*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# allowed-ips: comma-separated IPv4/IPv6 CIDRs. Character-class check —
+# wg itself parses the addresses strictly; we only need to keep flags and
+# metacharacters out.
+is_cidr_list() {
+    [ -n "$1" ] || return 1
+    case "$1" in
+        -*|*[!0-9a-fA-F.:/,]*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# endpoint: host:port, [v6]:port, or name:port. No flags/metachars.
+is_endpoint() {
+    [ -n "$1" ] || return 1
+    case "$1" in
+        -*|*[!A-Za-z0-9.:\[\]_-]*) return 1 ;;
+        *:*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Validate the `set` option grammar. Runs on a copy of the argument list
+# (a function's own "$@"), so the caller's arguments are untouched for
+# the final exec. Every option consumes exactly its declared operands;
+# the first unrecognised token aborts.
+validate_set_args() {
+    [ $# -ge 1 ] || die "set requires at least one option"
+    while [ $# -gt 0 ]; do
+        opt="$1"; shift
+        case "$opt" in
+            private-key|preshared-key)
+                [ $# -ge 1 ] || die "$opt requires a path"
+                is_staging_key_path "$1" || die "$opt path refused: $1"
+                shift ;;
+            listen-port|persistent-keepalive)
+                [ $# -ge 1 ] || die "$opt requires a number"
+                is_numeric "$1" || die "$opt must be numeric: $1"
+                shift ;;
+            peer)
+                [ $# -ge 1 ] || die "peer requires a public key"
+                is_wg_key "$1" || die "peer key malformed"
+                shift ;;
+            allowed-ips)
+                [ $# -ge 1 ] || die "allowed-ips requires a list"
+                is_cidr_list "$1" || die "allowed-ips malformed: $1"
+                shift ;;
+            endpoint)
+                [ $# -ge 1 ] || die "endpoint requires host:port"
+                is_endpoint "$1" || die "endpoint malformed: $1"
+                shift ;;
+            remove) ;;
+            *) die "unsupported set option: $opt" ;;
+        esac
+    done
+}
+
+case "$SUBCMD" in
+    show)
+        case $# in
+            0) exec /usr/bin/wg show "$IFACE" ;;
+            1)
+                [ "$1" = "dump" ] || die "show accepts only 'dump': $1"
+                exec /usr/bin/wg show "$IFACE" dump
+                ;;
+            *) die "show takes at most one arg" ;;
+        esac
+        ;;
+    set)
+        validate_set_args "$@"
+        exec /usr/bin/wg set "$IFACE" "$@"
+        ;;
+esac


### PR DESCRIPTION
Batch C of the issue triage. Closes #302, closes #303, closes #309, closes #314, closes #316.

## Wrapper changes (`freebsd/overlay/usr/local/libexec/`)
- **#302 `aifw-sudo-wg`** — `set` args walk a closed option grammar. `private-key`/`preshared-key` must be an AiFw staging file (`/tmp/wg-*.key`, regular file, not a symlink, **non-empty**, owned by the invoking uid); numeric options numeric; `peer` a 44-char base64 key; `allowed-ips` a CIDR list; `endpoint` host:port; `remove` allowed. `show` accepts only `dump`. `wg set wg0 private-key /etc/master.passwd` is now refused before wg runs.
- **#303 `aifw-sudo-ifconfig`** — `inet` operand must be `a.b.c.d[/N]` (octets checked), `inet6` operand must be an IPv6[/N]. Flag-shaped values (`-alias`, `-lladdr`) in the address slot are refused. Note: scoped link-locals (`fe80::1%em0`) are rejected — the API never writes those.
- **#316 `aifw-sudo-sysrc`** — values limited to `[A-Za-z0-9 ._:/@+,-]` (rc.conf is sourced by `sh` at boot, so quotes/`$`/backticks/`;` etc. are RCE on next boot). `ifconfig_*` values must be exactly the templates `iface.rs` writes: `DHCP|SYNCDHCP|up|down|inet <addr>[/N]|inet6 <addr>[/N]`; `vlans_*` values are id/name words.
- **#309 `aifw-sudo-pkg`** — `install -y` only accepts the closed set from `freebsd/manifest.json` `packages` (`curl minisign strongswan sudo unbound wireguard-tools`).
- **#314** — the `pf.conf.aifw` allowlist entry already landed in #601; this PR adds the drift guard.

## Drift guards (`aifw-setup` `sudoers_tests`, 5 new tests)
- every `sudo::write_file(` call-site path is covered by the `aifw-sudo-write` allowlist, **and** the set of call sites across the workspace equals the accounted-for list (a new call site fails until both are updated);
- pkg helper allowlist == manifest `packages`;
- wg helper key-path pattern and option set match `vpn.rs`;
- sysrc grammar accepts the `ifconfig_*` templates `iface.rs` emits.

## Verification
- `cargo check` / `clippy -D warnings` / `cargo test --workspace` green.
- Wrappers: rejection paths exercised locally (`bash --posix`) and on FreeBSD 15.1 `sh` (`[^…]`/`[!…]` classes, `stat -f`); read-only acceptance on FreeBSD (`wg show … dump`, `sysrc -n`) OK; write-path acceptance (`wg set`, `ifconfig inet`, `sysrc key=value`, `pkg install`) reached `exec` locally but was **not** exercised on FreeBSD — both dev VMs (.220/.110) were unreachable. Worth a `deploy.sh` + tunnel start / iface edit on the VM before release.

⚠️ Incident during verification: I ran one check on the live appliance that executed `wg set wg0 private-key <empty file>`, which clears the key. wg0 was down for ~2 min until I restored the key from the DB (no peer had handshaken in ~6 days). The wrapper now refuses empty key files because of this. My mistake — noted so it doesn't recur.