### PR TITLE
feat(nat): NAT bypass (no nat) + static-port; OPNsense import honours <nonat>/<staticnatport>

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ High-performance firewall for FreeBSD built in Rust on top of pf. Optional AI/ML
 ## Features
 
 - **Stateful packet filtering** via FreeBSD's pf with anchor isolation
-- **NAT** — SNAT, DNAT/RDR, masquerade, binat, NAT64/NAT46 (real cross-family translation via pf af-to, FreeBSD 15+, with DNS64 in the resolver)
+- **NAT** — SNAT, DNAT/RDR, masquerade, binat, NAT bypass (`no nat`), `static-port` on outbound rules, NAT64/NAT46 (real cross-family translation via pf af-to, FreeBSD 15+, with DNS64 in the resolver)
 - **Connection tracking** — real-time state table monitoring, top talkers, protocol breakdown
 - **Rate limiting & traffic shaping** — HFSC/PriQ queues, per-IP overload tables, SYN flood protection (CoDel via dummynet FQ-CoDel in development, #532)
 - **AI/ML threat detection** *(optional, WIP)* — experimental port scan, DDoS, brute force, C2 beacon, DNS tunnel detection with auto-response (disabled by default, not yet production-ready)

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -440,6 +440,7 @@ pub(crate) async fn capture_runtime_snapshot(state: &AppState) -> Result<String,
                 redirect_port_end: n.redirect.port.as_ref().map(|p| p.end),
                 label: n.label.clone(),
                 status: n.status,
+                static_port: n.static_port,
             })
             .collect(),
         aliases,
@@ -744,6 +745,7 @@ pub(crate) async fn build_current_config(state: &AppState) -> Result<FirewallCon
                 redirect_port_end: n.redirect.port.as_ref().map(|p| p.end),
                 label: n.label.clone(),
                 status: n.status,
+                static_port: n.static_port,
             })
             .collect(),
         queues: queues
@@ -2736,6 +2738,7 @@ fn nat_from_config(nc: &aifw_core::config::NatRuleConfig) -> Option<aifw_common:
         },
         label: nc.label.clone(),
         status,
+        static_port: nc.static_port,
         created_at: now,
         updated_at: now,
     })

--- a/aifw-api/src/opnsense/importer.rs
+++ b/aifw-api/src/opnsense/importer.rs
@@ -1289,6 +1289,7 @@ fn build_port_forward(
             },
             label: n.descr.clone(),
             status: NatStatus::Active,
+            static_port: false,
             created_at: now,
             updated_at: now,
         },
@@ -1301,18 +1302,6 @@ fn build_outbound(
     iface_map: &HashMap<String, String>,
     aliases: &HashSet<String>,
 ) -> Result<NatRule, String> {
-    if n.nonat {
-        return Err(
-            "<nonat> outbound NAT bypass not yet supported — leaves source rewriting on, opposite of intent. Configure manually after import."
-                .into(),
-        );
-    }
-    if n.staticnatport {
-        return Err(
-            "<staticnatport> (preserve source port) not yet supported — pf rule emits dynamic source port. Configure manually after import."
-                .into(),
-        );
-    }
     let interface = Interface(map_iface(&n.interface, iface_map));
     let protocol = Protocol::parse(&n.protocol).map_err(|e| e.to_string())?;
     let mut advisories: Vec<String> = Vec::new();
@@ -1325,12 +1314,19 @@ fn build_outbound(
         advisories.push(format!("destination: {a}"));
     }
 
-    // Empty target = masquerade (use interface address). Concrete IP = SNAT.
-    let (nat_type, redirect_addr) = match n.target.as_deref().filter(|s| !s.is_empty()) {
-        None => (NatType::Masquerade, Address::Any),
-        Some(t) => {
-            let a = Address::parse(t).map_err(|e| format!("outbound target '{t}': {e}"))?;
-            (NatType::Snat, a)
+    // <nonat> = NAT bypass → pf `no nat` (#253). No target; static-port
+    // is meaningless here (OPNsense greys it out too).
+    // Otherwise: empty target = masquerade (use interface address);
+    // concrete IP = SNAT. <staticnatport> → pf `static-port` on either.
+    let (nat_type, redirect_addr, static_port) = if n.nonat {
+        (NatType::NoNat, Address::Any, false)
+    } else {
+        match n.target.as_deref().filter(|s| !s.is_empty()) {
+            None => (NatType::Masquerade, Address::Any, n.staticnatport),
+            Some(t) => {
+                let a = Address::parse(t).map_err(|e| format!("outbound target '{t}': {e}"))?;
+                (NatType::Snat, a, n.staticnatport)
+            }
         }
     };
 
@@ -1351,6 +1347,7 @@ fn build_outbound(
         },
         label: n.descr.clone(),
         status: NatStatus::Active,
+        static_port,
         created_at: now,
         updated_at: now,
     })
@@ -1384,6 +1381,7 @@ fn build_one_to_one(
         },
         label: n.descr.clone(),
         status: NatStatus::Active,
+        static_port: false,
         created_at: now,
         updated_at: now,
     })

--- a/aifw-api/src/opnsense/tests.rs
+++ b/aifw-api/src/opnsense/tests.rs
@@ -591,3 +591,74 @@ async fn pre_import_snapshot_restores_clean_baseline() {
         "imported aliases must be gone after restore"
     );
 }
+
+/// #253: `<nonat>` imports as a `no nat` rule and `<staticnatport>` as
+/// `static-port` on the SNAT/masquerade rule, instead of being skipped.
+#[tokio::test]
+async fn import_outbound_nonat_and_staticnatport() {
+    let (server, _) = test_app().await;
+    let token = login(&server).await;
+
+    let outbound = r#"<outbound>
+      <mode>hybrid</mode>
+      <rule>
+        <interface>wan</interface>
+        <protocol>any</protocol>
+        <source><address>10.0.0.0/8</address></source>
+        <destination><address>10.50.0.0/16</address></destination>
+        <nonat>1</nonat>
+        <descr>no nat to site-to-site</descr>
+      </rule>
+      <rule>
+        <interface>wan</interface>
+        <protocol>udp</protocol>
+        <source><address>10.0.0.0/8</address></source>
+        <destination><any/></destination>
+        <staticnatport>1</staticnatport>
+        <descr>masq static port</descr>
+      </rule>
+    </outbound>"#;
+    let start = MEDIUM_FIXTURE
+        .find("<outbound>")
+        .expect("fixture has <outbound>");
+    let end = MEDIUM_FIXTURE
+        .find("</outbound>")
+        .expect("fixture has </outbound>")
+        + "</outbound>".len();
+    let xml = format!(
+        "{}{}{}",
+        &MEDIUM_FIXTURE[..start],
+        outbound,
+        &MEDIUM_FIXTURE[end..]
+    );
+
+    let resp = server
+        .post("/api/v1/config/import-opnsense")
+        .add_header("authorization", format!("Bearer {token}"))
+        .json(&json!({ "xml": xml, "commit_confirm": false }))
+        .await;
+    resp.assert_status_ok();
+
+    let nat = server
+        .get("/api/v1/nat")
+        .add_header("authorization", format!("Bearer {token}"))
+        .await;
+    nat.assert_status_ok();
+    let body: Value = nat.json();
+    let arr = body["data"].as_array().or_else(|| body.as_array()).unwrap();
+
+    let nonat = arr
+        .iter()
+        .find(|n| n["nat_type"] == "nonat")
+        .expect("<nonat> rule should import as nonat");
+    assert_eq!(nonat["dst_addr"], "10.50.0.0/16");
+    assert_eq!(nonat["static_port"], false);
+
+    let masq = arr
+        .iter()
+        .find(|n| n["label"] == "masq static port")
+        .expect("<staticnatport> masquerade rule should import");
+    assert_eq!(masq["nat_type"], "masquerade");
+    assert_eq!(masq["protocol"], "udp");
+    assert_eq!(masq["static_port"], true);
+}

--- a/aifw-api/src/routes/nat.rs
+++ b/aifw-api/src/routes/nat.rs
@@ -16,11 +16,17 @@ pub struct CreateNatRuleRequest {
     pub dst_addr: Option<String>,
     pub dst_port_start: Option<u16>,
     pub dst_port_end: Option<u16>,
-    pub redirect_addr: String,
+    /// Translation target. Optional: masquerade / nonat have none
+    /// (defaults to `any`).
+    pub redirect_addr: Option<String>,
     pub redirect_port_start: Option<u16>,
     pub redirect_port_end: Option<u16>,
     pub label: Option<String>,
     pub status: Option<String>,
+    /// pf `static-port` — keep the original source port (SNAT/masquerade
+    /// only; #253). Defaults false.
+    #[serde(default)]
+    pub static_port: bool,
 }
 
 pub async fn list_nat_rules(
@@ -88,7 +94,7 @@ pub async fn create_nat_rule(
         .map_err(|e| nat_bad_request(format!("invalid destination address: {e}")))?
         .unwrap_or(Address::Any);
 
-    let redirect_addr = Address::parse(&req.redirect_addr)
+    let redirect_addr = Address::parse(req.redirect_addr.as_deref().unwrap_or("any"))
         .map_err(|e| nat_bad_request(format!("invalid redirect address: {e}")))?;
 
     // Validate interface and label to prevent pf rule injection
@@ -112,6 +118,7 @@ pub async fn create_nat_rule(
     rule.src_port = port_range(req.src_port_start, req.src_port_end);
     rule.dst_port = port_range(req.dst_port_start, req.dst_port_end);
     rule.label = req.label;
+    rule.static_port = req.static_port;
 
     let rule = state
         .nat_engine
@@ -163,11 +170,12 @@ pub async fn update_nat_rule(
         .unwrap_or(Address::Any);
     rule.dst_port = port_range(req.dst_port_start, req.dst_port_end);
     rule.redirect = NatRedirect {
-        address: Address::parse(&req.redirect_addr)
+        address: Address::parse(req.redirect_addr.as_deref().unwrap_or("any"))
             .map_err(|e| nat_bad_request(format!("invalid redirect address: {e}")))?,
         port: port_range(req.redirect_port_start, req.redirect_port_end),
     };
     rule.label = req.label;
+    rule.static_port = req.static_port;
     if let Some(ref s) = req.status {
         rule.status = match s.as_str() {
             "active" => NatStatus::Active,

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -414,6 +414,7 @@ pub async fn nat_add(
     redirect: &str,
     redirect_port: Option<&str>,
     label: Option<&str>,
+    static_port: bool,
 ) -> anyhow::Result<()> {
     let nat = create_nat_engine(db_path).await?;
 
@@ -431,6 +432,7 @@ pub async fn nat_add(
     rule.src_port = src_port.map(parse_port).transpose()?;
     rule.dst_port = dst_port.map(parse_port).transpose()?;
     rule.label = label.map(String::from);
+    rule.static_port = static_port;
 
     let rule = nat.add_rule(rule).await.map_err(|e| {
         let msg = e.to_string();
@@ -466,6 +468,10 @@ fn nat_flag_hint(msg: &str) -> Option<&'static str> {
         Some("drop --redirect-port — af-to translates addresses, not ports")
     } else if msg.contains("source address must be") {
         Some("fix --src: it must match the rule's ingress family (IPv6 for nat64, IPv4 for nat46)")
+    } else if msg.contains("static_port is only valid") {
+        Some("drop --static-port — it only applies to --type snat / masquerade")
+    } else if msg.contains("no-nat rules") {
+        Some("drop --redirect / --redirect-port — nonat exempts traffic and has no target")
     } else {
         None
     }
@@ -535,7 +541,14 @@ pub async fn nat_list(db_path: &Path, json: bool) -> anyhow::Result<()> {
         let redir = match rule.nat_type {
             NatType::Nat64 => format!("v6->v4 via {}", rule.redirect.address),
             NatType::Nat46 => format!("v4->v6 via {}", rule.redirect.address),
+            NatType::NoNat => "(bypass — no NAT)".to_string(),
+            NatType::Masquerade => format!("({})", rule.interface),
             _ => format!("{}", rule.redirect),
+        };
+        let redir = if rule.static_port {
+            format!("{redir} static-port")
+        } else {
+            redir
         };
         let status = match rule.status {
             aifw_common::NatStatus::Active => "",

--- a/aifw-cli/src/main.rs
+++ b/aifw-cli/src/main.rs
@@ -885,9 +885,17 @@ EXAMPLES:
     # NAT46: IPv4-only clients reach an IPv6 service. The v6 server must
     # hold the RFC 6052 embedding of --dst in --redirect's /96 subnet
     # (print it with: aifw nat embed <redirect> <dst>).
-    aifw nat add --nat-type nat46 --interface em1 --dst 10.99.1.1 --redirect 2001:db8:2::1")]
+    aifw nat add --nat-type nat46 --interface em1 --dst 10.99.1.1 --redirect 2001:db8:2::1
+
+    # Masquerade keeping the source port (SIP/VPN friendly)
+    aifw nat add --nat-type masquerade --interface em0 --src 192.168.1.0/24 --static-port
+
+    # NAT bypass: don't NAT LAN → site-to-site VPN subnet (order before the masquerade rule)
+    aifw nat add --nat-type nonat --interface em0 --src 192.168.1.0/24 --dst 10.50.0.0/16")]
     Add {
-        /// NAT type: snat, dnat, masquerade, binat, nat64 (IPv6→IPv4 af-to), nat46 (IPv4→IPv6 af-to)
+        /// NAT type: snat, dnat, masquerade, binat, nat64 (IPv6→IPv4 af-to),
+        /// nat46 (IPv4→IPv6 af-to), nonat (bypass — exempt matching traffic
+        /// from later NAT rules; no --redirect)
         #[arg(long, name = "type")]
         nat_type: String,
 
@@ -917,9 +925,10 @@ EXAMPLES:
         dst_port: Option<String>,
 
         /// Redirect target. nat64/nat46: the translation source address the
-        /// firewall owns in the translated family (IPv4 for nat64, IPv6 for nat46)
+        /// firewall owns in the translated family (IPv4 for nat64, IPv6 for
+        /// nat46). Not used for masquerade / nonat (defaults to any).
         #[arg(long)]
-        redirect: String,
+        redirect: Option<String>,
 
         /// Redirect target port (not valid for nat64/nat46)
         #[arg(long)]
@@ -928,6 +937,12 @@ EXAMPLES:
         /// Rule label
         #[arg(long)]
         label: Option<String>,
+
+        /// Keep the original source port (pf static-port). snat/masquerade
+        /// only — needed by SIP, some VPNs and games that break when the
+        /// source port is rewritten.
+        #[arg(long)]
+        static_port: bool,
     },
     /// Remove a NAT rule by ID
     Remove {
@@ -1132,6 +1147,7 @@ async fn main() -> anyhow::Result<()> {
                 redirect,
                 redirect_port,
                 label,
+                static_port,
             } => {
                 // Smart default: nat64 practically always matches the
                 // well-known prefix; every other type keeps "any".
@@ -1142,6 +1158,19 @@ async fn main() -> anyhow::Result<()> {
                         "any".to_string()
                     }
                 });
+                // masquerade / nonat have no translation target; everything
+                // else needs one.
+                let redirect = match redirect {
+                    Some(r) => r,
+                    None if matches!(
+                        nat_type.as_str(),
+                        "masquerade" | "masq" | "nonat" | "no-nat"
+                    ) =>
+                    {
+                        "any".to_string()
+                    }
+                    None => anyhow::bail!("--redirect is required for --type {nat_type}"),
+                };
                 commands::nat_add(
                     &cli.db,
                     &nat_type,
@@ -1154,6 +1183,7 @@ async fn main() -> anyhow::Result<()> {
                     &redirect,
                     redirect_port.as_deref(),
                     label.as_deref(),
+                    static_port,
                 )
                 .await?;
             }

--- a/aifw-common/src/nat.rs
+++ b/aifw-common/src/nat.rs
@@ -19,6 +19,12 @@ pub enum NatType {
     Nat64,
     /// NAT46 — translate IPv4 to IPv6
     Nat46,
+    /// NAT bypass — pf `no nat`: matching traffic is exempted from any
+    /// later `nat` rule (e.g. keep site-to-site VPN traffic un-NATed).
+    /// Has no translation target. Order matters: place before the SNAT /
+    /// masquerade rule it should exempt (#253).
+    #[serde(rename = "nonat")]
+    NoNat,
 }
 
 impl std::fmt::Display for NatType {
@@ -30,6 +36,7 @@ impl std::fmt::Display for NatType {
             NatType::Binat => write!(f, "binat"),
             NatType::Nat64 => write!(f, "nat64"),
             NatType::Nat46 => write!(f, "nat46"),
+            NatType::NoNat => write!(f, "nonat"),
         }
     }
 }
@@ -46,6 +53,7 @@ impl NatType {
             "binat" => Ok(NatType::Binat),
             "nat64" => Ok(NatType::Nat64),
             "nat46" => Ok(NatType::Nat46),
+            "nonat" | "no-nat" | "no_nat" => Ok(NatType::NoNat),
             _ => Err(crate::AifwError::Validation(format!(
                 "unknown NAT type: {s}"
             ))),
@@ -107,6 +115,11 @@ pub struct NatRule {
     pub label: Option<String>,
     /// Whether the rule is active or disabled
     pub status: NatStatus,
+    /// Preserve the original source port on SNAT / masquerade (pf
+    /// `static-port`). Some protocols (SIP, some VPNs, games) break when
+    /// the source port is rewritten. Ignored for other NAT types (#253).
+    #[serde(default)]
+    pub static_port: bool,
     /// Creation timestamp (UTC)
     pub created_at: DateTime<Utc>,
     /// Last modification timestamp (UTC)
@@ -137,6 +150,7 @@ impl NatRule {
             redirect,
             label: None,
             status: NatStatus::Active,
+            static_port: false,
             created_at: now,
             updated_at: now,
         }
@@ -158,6 +172,7 @@ impl NatRule {
             NatType::Binat => vec![self.to_pf_binat()],
             NatType::Nat64 => vec![self.to_pf_nat64()],
             NatType::Nat46 => vec![self.to_pf_nat46()],
+            NatType::NoNat => vec![self.to_pf_no_nat()],
         }
     }
 
@@ -177,13 +192,23 @@ impl NatRule {
         parts.join(" ")
     }
 
-    /// `nat on <iface> [proto <proto>] from <src> to <dst> -> <redirect>`
+    /// `nat on <iface> [proto <proto>] from <src> to <dst> -> <redirect> [static-port]`
     fn to_pf_nat(&self) -> String {
         let mut parts = vec![format!("nat on {}", self.interface)];
         self.push_proto(&mut parts);
         self.push_from_to(&mut parts);
         parts.push(format!("-> {}", self.redirect));
+        self.push_static_port(&mut parts);
         self.push_label(&mut parts);
+        parts.join(" ")
+    }
+
+    /// `no nat on <iface> [proto <proto>] from <src> to <dst>` — exempts
+    /// matching traffic from later `nat` rules. No translation target.
+    fn to_pf_no_nat(&self) -> String {
+        let mut parts = vec![format!("no nat on {}", self.interface)];
+        self.push_proto(&mut parts);
+        self.push_from_to(&mut parts);
         parts.join(" ")
     }
 
@@ -211,12 +236,13 @@ impl NatRule {
         parts.join(" ")
     }
 
-    /// `nat on <iface> [proto <proto>] from <src> to <dst> -> (<iface>)`
+    /// `nat on <iface> [proto <proto>] from <src> to <dst> -> (<iface>) [static-port]`
     fn to_pf_masquerade(&self) -> String {
         let mut parts = vec![format!("nat on {}", self.interface)];
         self.push_proto(&mut parts);
         self.push_from_to(&mut parts);
         parts.push(format!("-> ({})", self.interface));
+        self.push_static_port(&mut parts);
         self.push_label(&mut parts);
         parts.join(" ")
     }
@@ -303,6 +329,13 @@ impl NatRule {
             to.push_str(&format!(" port {port}"));
         }
         parts.push(to);
+    }
+
+    /// pf `static-port` pool option (SNAT / masquerade only).
+    fn push_static_port(&self, parts: &mut Vec<String>) {
+        if self.static_port {
+            parts.push("static-port".to_string());
+        }
     }
 
     fn push_label(&self, _parts: &mut Vec<String>) {

--- a/aifw-common/src/tests.rs
+++ b/aifw-common/src/tests.rs
@@ -324,6 +324,68 @@ mod tests {
         assert_eq!(pf, "nat on em0 from 10.0.0.0/8 to any -> (em0)");
     }
 
+    /// #253: pf `static-port` is appended after the translation target on
+    /// SNAT and masquerade rules.
+    #[test]
+    fn test_nat_static_port_pf_rule() {
+        let mut masq = NatRule::new(
+            NatType::Masquerade,
+            Interface("em0".to_string()),
+            Protocol::Udp,
+            Address::Network(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)), 8),
+            Address::Any,
+            NatRedirect {
+                address: Address::Any,
+                port: None,
+            },
+        );
+        masq.static_port = true;
+        assert_eq!(
+            masq.to_pf_rule(),
+            "nat on em0 proto udp from 10.0.0.0/8 to any -> (em0) static-port"
+        );
+
+        let mut snat = NatRule::new(
+            NatType::Snat,
+            Interface("em0".to_string()),
+            Protocol::Any,
+            Address::Network(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 0)), 24),
+            Address::Any,
+            NatRedirect {
+                address: Address::Single(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))),
+                port: None,
+            },
+        );
+        snat.static_port = true;
+        assert_eq!(
+            snat.to_pf_rule(),
+            "nat on em0 from 192.168.1.0/24 to any -> 203.0.113.1 static-port"
+        );
+    }
+
+    /// #253: `nonat` renders as pf `no nat` with no translation target.
+    #[test]
+    fn test_nat_nonat_pf_rule() {
+        let rule = NatRule::new(
+            NatType::NoNat,
+            Interface("em0".to_string()),
+            Protocol::Any,
+            Address::Network(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 0)), 24),
+            Address::Network(IpAddr::V4(Ipv4Addr::new(10, 50, 0, 0)), 16),
+            NatRedirect {
+                address: Address::Any,
+                port: None,
+            },
+        );
+        assert_eq!(
+            rule.to_pf_rule(),
+            "no nat on em0 from 192.168.1.0/24 to 10.50.0.0/16"
+        );
+        assert_eq!(NatType::parse("nonat").unwrap(), NatType::NoNat);
+        assert_eq!(NatType::parse("no-nat").unwrap(), NatType::NoNat);
+        assert_eq!(NatType::NoNat.to_string(), "nonat");
+    }
+
     #[test]
     fn test_nat_binat_pf_rule() {
         let rule = NatRule::new(

--- a/aifw-core/src/config.rs
+++ b/aifw-core/src/config.rs
@@ -510,6 +510,10 @@ pub struct NatRuleConfig {
     pub label: Option<String>,
     /// Whether the rule is loaded into pf
     pub status: NatStatus,
+    /// pf `static-port` on SNAT/masquerade (#253). Defaults false so
+    /// snapshots taken before the field existed still load.
+    #[serde(default)]
+    pub static_port: bool,
 }
 
 /// A traffic-shaping queue as stored in a config snapshot

--- a/aifw-core/src/nat.rs
+++ b/aifw-core/src/nat.rs
@@ -77,6 +77,20 @@ impl NatEngine {
             .execute(&self.pool)
             .await?;
 
+        // #253: `static_port` column added after the table shipped. SQLite
+        // has no ADD COLUMN IF NOT EXISTS, so probe the schema first.
+        let has_static_port: bool = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM pragma_table_info('nat_rules') WHERE name = 'static_port'",
+        )
+        .fetch_one(&self.pool)
+        .await?
+            > 0;
+        if !has_static_port {
+            sqlx::query("ALTER TABLE nat_rules ADD COLUMN static_port INTEGER NOT NULL DEFAULT 0")
+                .execute(&self.pool)
+                .await?;
+        }
+
         Ok(())
     }
 
@@ -154,7 +168,7 @@ impl NatEngine {
                 src_addr = ?5, src_port_start = ?6, src_port_end = ?7,
                 dst_addr = ?8, dst_port_start = ?9, dst_port_end = ?10,
                 redirect_addr = ?11, redirect_port_start = ?12, redirect_port_end = ?13,
-                label = ?14, status = ?15, updated_at = ?16
+                label = ?14, status = ?15, updated_at = ?16, static_port = ?17
             WHERE id = ?1
             "#,
         )
@@ -177,6 +191,7 @@ impl NatEngine {
             NatStatus::Disabled => "disabled",
         })
         .bind(chrono::Utc::now().to_rfc3339())
+        .bind(rule.static_port as i64)
         .execute(&mut *tx)
         .await?;
 
@@ -376,8 +391,8 @@ impl NatEngine {
             INSERT INTO nat_rules (id, nat_type, interface, protocol, src_addr,
                 src_port_start, src_port_end, dst_addr, dst_port_start, dst_port_end,
                 redirect_addr, redirect_port_start, redirect_port_end,
-                label, status, created_at, updated_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
+                label, status, created_at, updated_at, static_port)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
             "#,
         )
         .bind(rule.id.to_string())
@@ -400,6 +415,7 @@ impl NatEngine {
         })
         .bind(rule.created_at.to_rfc3339())
         .bind(rule.updated_at.to_rfc3339())
+        .bind(rule.static_port as i64)
         .execute(exec)
         .await?;
 
@@ -445,6 +461,21 @@ pub fn validate_nat_rule(rule: &NatRule) -> Result<()> {
     // Masquerade redirect is the interface itself, no address needed
     if rule.nat_type == NatType::Masquerade && rule.redirect.address != Address::Any {
         // This is fine — we'll ignore the redirect address and use the interface
+    }
+
+    // #253: static-port is a pf pool option only valid on `nat` rules.
+    if rule.static_port && !matches!(rule.nat_type, NatType::Snat | NatType::Masquerade) {
+        return Err(AifwError::Validation(
+            "static_port is only valid for SNAT and masquerade rules".to_string(),
+        ));
+    }
+    // #253: `no nat` has no translation target.
+    if rule.nat_type == NatType::NoNat
+        && (rule.redirect.address != Address::Any || rule.redirect.port.is_some())
+    {
+        return Err(AifwError::Validation(
+            "no-nat rules exempt traffic from NAT and take no redirect target".to_string(),
+        ));
     }
 
     // Cross-family (af-to) rules: pf requires the matched side and the
@@ -533,7 +564,7 @@ fn validate_af_to(rule: &NatRule, inet6_match: bool) -> Result<()> {
 const NAT_RULE_COLUMNS: &str = "id, nat_type, interface, protocol, src_addr, \
     src_port_start, src_port_end, dst_addr, dst_port_start, dst_port_end, \
     redirect_addr, redirect_port_start, redirect_port_end, label, status, \
-    created_at, updated_at";
+    created_at, updated_at, static_port";
 
 #[derive(sqlx::FromRow)]
 struct NatRuleRow {
@@ -554,6 +585,7 @@ struct NatRuleRow {
     status: String,
     created_at: String,
     updated_at: String,
+    static_port: i64,
 }
 
 impl NatRuleRow {
@@ -587,6 +619,7 @@ impl NatRuleRow {
                 "active" => NatStatus::Active,
                 _ => NatStatus::Disabled,
             },
+            static_port: self.static_port != 0,
             created_at: DateTime::parse_from_rfc3339(&self.created_at)
                 .map_err(|e| AifwError::Database(format!("invalid date: {e}")))?
                 .with_timezone(&Utc),

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -534,6 +534,88 @@ mod tests {
         assert_eq!(fetched.label.as_deref(), Some("web-redirect"));
     }
 
+    /// #253: static_port persists through the DB and nonat/static_port
+    /// validation rejects nonsensical combinations.
+    #[tokio::test]
+    async fn test_nat_static_port_and_nonat_roundtrip() {
+        let engine = create_nat_engine().await;
+
+        let mut masq = NatRule::new(
+            NatType::Masquerade,
+            Interface("em0".to_string()),
+            Protocol::Any,
+            Address::Any,
+            Address::Any,
+            NatRedirect {
+                address: Address::Any,
+                port: None,
+            },
+        );
+        masq.static_port = true;
+        let masq_id = masq.id;
+        engine.add_rule(masq).await.unwrap();
+        let fetched = engine.get_rule(masq_id).await.unwrap();
+        assert!(fetched.static_port, "static_port must round-trip");
+        assert!(fetched.to_pf_rule().ends_with("static-port"));
+
+        // Update can clear it again.
+        let mut cleared = fetched.clone();
+        cleared.static_port = false;
+        engine.update_rule(&cleared).await.unwrap();
+        assert!(!engine.get_rule(masq_id).await.unwrap().static_port);
+
+        // nonat round-trips and renders `no nat`.
+        let nonat = NatRule::new(
+            NatType::NoNat,
+            Interface("em0".to_string()),
+            Protocol::Any,
+            Address::Any,
+            Address::Any,
+            NatRedirect {
+                address: Address::Any,
+                port: None,
+            },
+        );
+        let nonat_id = nonat.id;
+        engine.add_rule(nonat).await.unwrap();
+        let fetched = engine.get_rule(nonat_id).await.unwrap();
+        assert_eq!(fetched.nat_type, NatType::NoNat);
+        assert!(fetched.to_pf_rule().starts_with("no nat on em0"));
+
+        // static_port on a DNAT rule is rejected.
+        let mut bad = NatRule::new(
+            NatType::Dnat,
+            Interface("em0".to_string()),
+            Protocol::Tcp,
+            Address::Any,
+            Address::Any,
+            NatRedirect {
+                address: Address::Single(std::net::IpAddr::V4(std::net::Ipv4Addr::new(
+                    192, 168, 1, 10,
+                ))),
+                port: Some(PortRange { start: 80, end: 80 }),
+            },
+        );
+        bad.static_port = true;
+        assert!(engine.add_rule(bad).await.is_err());
+
+        // nonat with a redirect target is rejected.
+        let bad = NatRule::new(
+            NatType::NoNat,
+            Interface("em0".to_string()),
+            Protocol::Any,
+            Address::Any,
+            Address::Any,
+            NatRedirect {
+                address: Address::Single(std::net::IpAddr::V4(std::net::Ipv4Addr::new(
+                    203, 0, 113, 1,
+                ))),
+                port: None,
+            },
+        );
+        assert!(engine.add_rule(bad).await.is_err());
+    }
+
     #[tokio::test]
     async fn test_nat_apply_rules() {
         let db = Database::new_in_memory().await.unwrap();

--- a/aifw-ui/src/app/nat/outbound/page.tsx
+++ b/aifw-ui/src/app/nat/outbound/page.tsx
@@ -6,7 +6,7 @@ import { parsePortField } from "@/lib/ports";
 import { validateAddress, validatePort, validateIP } from "@/lib/validate";
 
 type AddrMode = "any" | "network";
-type TransMode = "interface" | "address";
+type TransMode = "interface" | "address" | "nonat";
 
 const defaultForm = {
   interface: "",
@@ -68,7 +68,9 @@ export default function OutboundNatPage() {
     try {
       setError(null);
       const res = await api.listNat();
-      setRules(res.data.filter((r) => r.nat_type === "snat" || r.nat_type === "masquerade"));
+      setRules(
+        res.data.filter((r) => r.nat_type === "snat" || r.nat_type === "masquerade" || r.nat_type === "nonat"),
+      );
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load outbound NAT rules");
     } finally {
@@ -122,9 +124,9 @@ export default function OutboundNatPage() {
       dst_mode: dstIsAny ? "any" : "network",
       dst_addr: dstIsAny ? "" : rule.dst_addr || "",
       dst_port: formatPort(rule.dst_port),
-      trans_mode: isInterfaceAddr ? "interface" : "address",
-      translation_addr: isInterfaceAddr ? "" : rule.redirect?.address || "",
-      static_port: false,
+      trans_mode: rule.nat_type === "nonat" ? "nonat" : isInterfaceAddr ? "interface" : "address",
+      translation_addr: isInterfaceAddr || rule.nat_type === "nonat" ? "" : rule.redirect?.address || "",
+      static_port: Boolean(rule.static_port),
       label: rule.label || "",
       enabled: rule.status === "active",
     });
@@ -155,7 +157,8 @@ export default function OutboundNatPage() {
     setError(null);
     try {
       const isInterface = form.trans_mode === "interface";
-      const natType = isInterface ? "masquerade" : "snat";
+      const isNoNat = form.trans_mode === "nonat";
+      const natType = isNoNat ? "nonat" : isInterface ? "masquerade" : "snat";
 
       const body: Record<string, unknown> = {
         nat_type: natType,
@@ -163,7 +166,10 @@ export default function OutboundNatPage() {
         protocol: form.protocol,
         src_addr: form.src_mode === "any" ? "any" : form.src_addr,
         dst_addr: form.dst_mode === "any" ? "any" : form.dst_addr,
-        redirect_addr: isInterface ? "interface" : form.translation_addr,
+        // masquerade / nonat have no translation target
+        redirect_addr: isInterface || isNoNat ? "any" : form.translation_addr,
+        // static-port only means something on snat / masquerade
+        static_port: !isNoNat && form.static_port,
         status: form.enabled ? "active" : "disabled",
       };
 
@@ -210,9 +216,10 @@ export default function OutboundNatPage() {
         protocol: rule.protocol,
         src_addr: rule.src_addr,
         dst_addr: rule.dst_addr,
-        redirect_addr: rule.redirect?.address || "interface",
+        redirect_addr: rule.redirect?.address || "any",
         redirect_port_start: rule.redirect?.port?.start,
         label: rule.label || undefined,
+        static_port: rule.static_port,
         status: newStatus,
       } as UpdateNatRequest);
       setRules((prev) =>
@@ -237,9 +244,14 @@ export default function OutboundNatPage() {
   const hintCls = "text-[10px] text-gray-500 mt-0.5";
 
   const formatTranslation = (rule: NatRule): string => {
-    if (rule.nat_type === "masquerade") return "Interface address";
-    if (!rule.redirect) return "-";
-    return formatAddrPort(rule.redirect.address, rule.redirect.port);
+    if (rule.nat_type === "nonat") return "No NAT (bypass)";
+    const base =
+      rule.nat_type === "masquerade"
+        ? "Interface address"
+        : rule.redirect
+          ? formatAddrPort(rule.redirect.address, rule.redirect.port)
+          : "-";
+    return rule.static_port ? `${base} · static port` : base;
   };
 
   const canSubmit =
@@ -303,12 +315,15 @@ export default function OutboundNatPage() {
             <svg className="w-4 h-4 text-gray-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" /></svg>
             <span className="px-2 py-0.5 rounded bg-gray-700 text-gray-300 font-medium">{form.interface || "Interface"}</span>
             <svg className="w-4 h-4 text-gray-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" /></svg>
-            <span className="px-2 py-0.5 rounded bg-green-500/15 text-green-400 font-medium">
-              {form.trans_mode === "interface" ? "Interface IP" : form.translation_addr || "NAT IP"}
+            <span className={`px-2 py-0.5 rounded font-medium ${form.trans_mode === "nonat" ? "bg-gray-700 text-gray-300 line-through" : "bg-green-500/15 text-green-400"}`}>
+              {form.trans_mode === "nonat" ? "No NAT" : form.trans_mode === "interface" ? "Interface IP" : form.translation_addr || "NAT IP"}
+              {form.trans_mode !== "nonat" && form.static_port ? " (static port)" : ""}
             </span>
             <svg className="w-4 h-4 text-gray-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6" /></svg>
             <span className="px-2 py-0.5 rounded bg-orange-500/15 text-orange-400 font-medium">Destination</span>
-            <span className="ml-auto text-[10px] text-gray-500 italic">Source address is rewritten to translation address</span>
+            <span className="ml-auto text-[10px] text-gray-500 italic">
+              {form.trans_mode === "nonat" ? "Source address is left untouched (bypasses later NAT rules)" : "Source address is rewritten to translation address"}
+            </span>
           </div>
 
           {/* Row 1: Interface, Protocol, Enabled */}
@@ -407,11 +422,16 @@ export default function OutboundNatPage() {
                 className={`${selectCls} !w-52`}>
                 <option value="interface">Interface Address (masquerade)</option>
                 <option value="address">Specific IP Address</option>
+                <option value="nonat">Do not NAT (bypass)</option>
               </select>
               <div>
                 {form.trans_mode === "address" ? (
                   <input type="text" value={form.translation_addr} onChange={(e) => updateField("translation_addr", e.target.value)}
                     placeholder="203.0.113.1" className={inputCls} />
+                ) : form.trans_mode === "nonat" ? (
+                  <div className={`${inputCls} !text-gray-500 !cursor-default`}>
+                    Matching traffic is exempted from NAT — place this rule above the masquerade rule it should bypass
+                  </div>
                 ) : (
                   <div className={`${inputCls} !text-gray-500 !cursor-default`}>Uses the outgoing interface IP</div>
                 )}
@@ -426,12 +446,15 @@ export default function OutboundNatPage() {
               <input type="text" value={form.label} onChange={(e) => updateField("label", e.target.value)}
                 placeholder="e.g. Default LAN outbound" className={inputCls} />
             </div>
-            <div className="flex items-end pb-0.5">
-              <label className="flex items-center gap-2 cursor-pointer select-none">
-                <input type="checkbox" checked={form.static_port} onChange={(e) => updateField("static_port", e.target.checked)}
+            <div className="flex flex-col justify-end pb-0.5">
+              <label className={`flex items-center gap-2 select-none ${form.trans_mode === "nonat" ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+                title="Keep the original source port (pf static-port). Needed by SIP, some VPNs and games that break when the port is rewritten.">
+                <input type="checkbox" checked={form.static_port} disabled={form.trans_mode === "nonat"}
+                  onChange={(e) => updateField("static_port", e.target.checked)}
                   className="w-4 h-4 rounded border-gray-600 bg-gray-900 text-blue-500 focus:ring-blue-500 focus:ring-offset-0" />
                 <span className="text-sm text-gray-300">Static port</span>
               </label>
+              <span className={hintCls}>Keep original source port (SIP / VPN friendly)</span>
             </div>
           </div>
 

--- a/aifw-ui/src/app/nat/page.tsx
+++ b/aifw-ui/src/app/nat/page.tsx
@@ -26,9 +26,15 @@ const defaultForm = {
   redirect_port_end: "",
   label: "",
   status: "active",
+  static_port: false,
 };
 
 type FormState = typeof defaultForm;
+
+/** Types with no translation target (redirect address not required). */
+const NO_TARGET_TYPES = new Set(["masquerade", "nonat"]);
+/** Types where pf `static-port` applies. */
+const STATIC_PORT_TYPES = new Set(["snat", "masquerade"]);
 
 function natTypeBadge(natType: string) {
   const colors: Record<string, string> = {
@@ -40,6 +46,7 @@ function natTypeBadge(natType: string) {
     binat: "bg-purple-500/20 text-purple-400 border-purple-500/30",
     nat64: "bg-cyan-500/20 text-cyan-400 border-cyan-500/30",
     nat46: "bg-orange-500/20 text-orange-400 border-orange-500/30",
+    nonat: "bg-gray-500/20 text-gray-300 border-gray-500/30",
   };
   const cls = colors[natType.toLowerCase()] || "bg-gray-500/20 text-gray-400 border-gray-500/30";
   return (
@@ -109,6 +116,7 @@ export default function NatPage() {
       redirect_port_end: rule.redirect?.port?.end?.toString() || "",
       label: rule.label || "",
       status: rule.status,
+      static_port: Boolean(rule.static_port),
     });
     setEditingId(rule.id);
     setShowForm(true);
@@ -121,7 +129,8 @@ export default function NatPage() {
       protocol: form.protocol,
       src_addr: form.src_addr || "any",
       dst_addr: form.dst_addr || "any",
-      redirect_addr: form.redirect_addr,
+      redirect_addr: NO_TARGET_TYPES.has(form.nat_type) ? "any" : form.redirect_addr,
+      static_port: STATIC_PORT_TYPES.has(form.nat_type) && form.static_port,
     };
 
     if (form.src_port_start) body.src_port_start = parseInt(form.src_port_start, 10);
@@ -133,8 +142,10 @@ export default function NatPage() {
     return body as unknown as CreateNatRequest | UpdateNatRequest;
   };
 
+  const redirectRequired = !NO_TARGET_TYPES.has(form.nat_type);
+
   const handleSubmit = async () => {
-    if (!form.redirect_addr.trim()) return;
+    if (redirectRequired && !form.redirect_addr.trim()) return;
     setSubmitting(true);
     try {
       if (editingId) {
@@ -170,9 +181,10 @@ export default function NatPage() {
         protocol: rule.protocol,
         src_addr: rule.src_addr,
         dst_addr: rule.dst_addr,
-        redirect_addr: rule.redirect?.address || "",
+        redirect_addr: rule.redirect?.address || "any",
         redirect_port_start: rule.redirect?.port?.start,
         label: rule.label || undefined,
+        static_port: rule.static_port,
         status: newStatus,
       } as UpdateNatRequest);
       setNatRules((prev) =>
@@ -185,7 +197,7 @@ export default function NatPage() {
     }
   };
 
-  const updateField = (field: keyof FormState, value: string) => {
+  const updateField = <K extends keyof FormState>(field: K, value: FormState[K]) => {
     setForm((f) => ({ ...f, [field]: value }));
   };
 
@@ -284,6 +296,7 @@ export default function NatPage() {
                 <option value="binat">binat (Bidirectional)</option>
                 <option value="nat64">nat64 (IPv6 → IPv4)</option>
                 <option value="nat46">nat46 (IPv4 → IPv6)</option>
+                <option value="nonat">nonat (NAT bypass)</option>
               </select>
             </div>
             {/* Interface */}
@@ -363,21 +376,49 @@ export default function NatPage() {
                 className={inputCls}
               />
             </div>
-            {/* Redirect Address */}
-            <div className={isCrossFamily(form.nat_type) ? "md:col-span-2" : ""}>
-              <label className={labelCls}>{meta.redirectLabel}</label>
-              <input
-                type="text"
-                value={form.redirect_addr}
-                onChange={(e) => updateField("redirect_addr", e.target.value)}
-                placeholder={meta.redirectPlaceholder}
-                className={inputCls}
-              />
-              {fieldErrors.redirect && <p className={fieldErrCls}>{fieldErrors.redirect}</p>}
-              {!fieldErrors.redirect && meta.redirectHelp && (
-                <p className="mt-1 text-[11px] text-gray-500">{meta.redirectHelp}</p>
-              )}
-            </div>
+            {/* Redirect Address — masquerade / nonat have no target */}
+            {redirectRequired ? (
+              <div className={isCrossFamily(form.nat_type) ? "md:col-span-2" : ""}>
+                <label className={labelCls}>{meta.redirectLabel}</label>
+                <input
+                  type="text"
+                  value={form.redirect_addr}
+                  onChange={(e) => updateField("redirect_addr", e.target.value)}
+                  placeholder={meta.redirectPlaceholder}
+                  className={inputCls}
+                />
+                {fieldErrors.redirect && <p className={fieldErrCls}>{fieldErrors.redirect}</p>}
+                {!fieldErrors.redirect && meta.redirectHelp && (
+                  <p className="mt-1 text-[11px] text-gray-500">{meta.redirectHelp}</p>
+                )}
+              </div>
+            ) : (
+              <div>
+                <label className={labelCls}>Translation</label>
+                <div className={`${inputCls} !text-gray-500 !cursor-default`}>
+                  {form.nat_type === "nonat" ? "None — traffic bypasses NAT" : "Outgoing interface address"}
+                </div>
+                {form.nat_type === "nonat" && (
+                  <p className="mt-1 text-[11px] text-gray-500">Order this rule above the NAT rule it should exempt.</p>
+                )}
+              </div>
+            )}
+            {/* Static port — pf static-port, snat / masquerade only */}
+            {STATIC_PORT_TYPES.has(form.nat_type) && (
+              <div className="flex flex-col justify-end pb-0.5">
+                <label className="flex items-center gap-2 cursor-pointer select-none"
+                  title="Keep the original source port (pf static-port). Needed by SIP, some VPNs and games that break when the port is rewritten.">
+                  <input
+                    type="checkbox"
+                    checked={form.static_port}
+                    onChange={(e) => updateField("static_port", e.target.checked)}
+                    className="w-4 h-4 rounded border-gray-600 bg-gray-900 text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
+                  />
+                  <span className="text-sm text-gray-300">Static port</span>
+                </label>
+                <span className="text-[10px] text-gray-500 mt-0.5">Keep original source port</span>
+              </div>
+            )}
             {/* Redirect Port — af-to translates addresses, not ports */}
             {meta.showRedirectPort && (
               <div>
@@ -411,7 +452,7 @@ export default function NatPage() {
           <div className="flex gap-2 mt-3">
             <button
               onClick={handleSubmit}
-              disabled={submitting || !form.redirect_addr.trim() || hasFieldErrors}
+              disabled={submitting || (redirectRequired && !form.redirect_addr.trim()) || hasFieldErrors}
               className="px-4 py-1.5 text-sm font-medium rounded-md bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors"
             >
               {submitting ? "Saving..." : editingId ? "Update" : "Add"}
@@ -493,11 +534,23 @@ export default function NatPage() {
                             <span className="text-gray-500">via</span>{" "}
                             <span className="text-green-400">{rule.redirect?.address || "-"}</span>
                           </span>
+                        ) : rule.nat_type === "nonat" ? (
+                          <span className="font-mono text-xs text-gray-400 italic">no NAT (bypass)</span>
                         ) : (
                           <span className="font-mono text-xs text-green-400">
-                            {rule.redirect
-                              ? formatAddrPort(rule.redirect.address, rule.redirect.port)
-                              : "-"}
+                            {rule.nat_type === "masquerade"
+                              ? `(${rule.interface})`
+                              : rule.redirect
+                                ? formatAddrPort(rule.redirect.address, rule.redirect.port)
+                                : "-"}
+                            {rule.static_port && (
+                              <span
+                                className="ml-1.5 inline-flex items-center rounded border border-gray-600 px-1 py-px text-[9px] uppercase tracking-wider text-gray-300 not-italic"
+                                title="pf static-port: original source port is preserved"
+                              >
+                                static port
+                              </span>
+                            )}
                           </span>
                         )}
                       </td>

--- a/aifw-ui/src/lib/api.ts
+++ b/aifw-ui/src/lib/api.ts
@@ -346,6 +346,8 @@ export interface NatRule {
   redirect: { address: string; port: { start: number; end: number } | null };
   label: string | null;
   status: string;
+  /** pf static-port: keep the original source port (snat/masquerade only). */
+  static_port: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -354,7 +356,8 @@ export interface CreateNatRequest {
   nat_type: string;
   interface: string;
   protocol: string;
-  redirect_addr: string;
+  /** Translation target. Omit / "any" for masquerade and nonat. */
+  redirect_addr?: string;
   src_addr?: string;
   src_port_start?: number;
   src_port_end?: number;
@@ -365,6 +368,7 @@ export interface CreateNatRequest {
   redirect_port_end?: number;
   label?: string;
   status?: string;
+  static_port?: boolean;
 }
 
 export interface UpdateNatRequest extends CreateNatRequest {


### PR DESCRIPTION
Closes #253.

## What
- **`NatType::NoNat`** (`nonat`) — renders pf `no nat on <if> [proto] from <src> to <dst>`; no translation target. Order it above the SNAT/masquerade rule it should exempt (UI/CLI say so).
- **`NatRule.static_port`** — renders pf `static-port` after the target on SNAT/masquerade (SIP/VPN/game-friendly). Rejected on other types.
- **Engine**: new `static_port` column (schema-probed `ALTER TABLE` in `migrate()`), persisted end-to-end; validation for the two new invalid combos; config snapshots carry the field (serde default → old snapshots load).
- **API**: `POST/PUT /api/v1/nat` accept `static_port`; `redirect_addr` is now optional (defaults `any`) so masquerade/nonat don't need a bogus target. `nat_type` serializes as `nonat` (pinned — Display, parse and JSON agree).
- **CLI**: `aifw nat add --type nonat …` (no `--redirect` needed), `--static-port`; `aifw nat list` shows `(bypass — no NAT)` / `static-port`; hint text for the two new validation errors.
- **UI**: Outbound NAT — new "Do not NAT (bypass)" translation mode; the existing **"Static port" checkbox was never sent to the API** (silently ignored) — now wired, disabled for nonat; list shows `No NAT (bypass)` / `· static port`; edit prefills both; flow diagram reflects it. Main NAT page — `nonat` type, redirect field hidden for masquerade/nonat, static-port checkbox for snat/masq, list badges.
- **OPNsense importer**: `<nonat>` → nonat rule, `<staticnatport>` → `static_port`; the two "not yet supported — configure manually" skips are removed.
- README NAT bullet updated.

## Tests / verification
- pf rendering (`test_nat_static_port_pf_rule`, `test_nat_nonat_pf_rule`), engine round-trip + validation (`test_nat_static_port_and_nonat_roundtrip`), importer end-to-end with a fixture carrying both subfields.
- `cargo test --workspace`, clippy `-D warnings`, `tsc`, `eslint`, `next build` all clean.
- Browser check on the static UI: Outbound NAT list rendering + edit prefill for a nonat rule and a static-port masquerade; API returns the intended 400s for `static_port` on DNAT and a redirect target on nonat. (Form *submit* couldn't be exercised on Linux — the interface dropdown depends on `/interfaces`, which needs FreeBSD.)