### PR TITLE
chore: audit and remove #[allow(dead_code)] directives (#200)

### DIFF
--- a/aifw-api/src/auth/middleware.rs
+++ b/aifw-api/src/auth/middleware.rs
@@ -239,9 +239,9 @@ fn query_ticket(q: Option<&str>) -> Option<String> {
 #[derive(Debug, Clone)]
 pub struct AuthUser {
     pub user_id: String,
-    /// Populated for logging/audit context and future per-request use; not
-    /// currently read by any guard (authz keys off `user_id` + `permissions`).
-    #[allow(dead_code)]
+    /// Display name of the acting user — recorded as the actor on
+    /// auto-snapshots (config history) so changes are attributable.
+    /// Authz itself keys off `user_id` + `permissions`.
     pub username: String,
     pub permissions: aifw_common::PermissionSet,
     pub role: String,

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -2905,6 +2905,10 @@ pub struct AutoSnapshotPending {
     scheduled: bool,
     coalesced: u32,
     last_comment: String,
+    /// Username of the request that most recently folded into the pending
+    /// snapshot; recorded as the snapshot's actor so config history shows
+    /// who changed what (was a hardcoded "auto").
+    last_actor: String,
 }
 
 /// How long a scheduled auto-snapshot waits so that a burst of mutations
@@ -2919,6 +2923,14 @@ pub async fn auto_snapshot_middleware(
 ) -> Response {
     let method = request.method().clone();
     let path = request.uri().path().to_string();
+    // Auth middleware runs before this layer, so the acting identity is
+    // already on the request. Fall back to "auto" for anything unauthenticated
+    // that still reaches here (shouldn't, but keeps history readable).
+    let actor = request
+        .extensions()
+        .get::<crate::auth::AuthUser>()
+        .map(|u| u.username.clone())
+        .unwrap_or_else(|| "auto".to_string());
     let mutating = matches!(
         &method,
         &Method::POST | &Method::PUT | &Method::DELETE | &Method::PATCH
@@ -2948,6 +2960,7 @@ pub async fn auto_snapshot_middleware(
         let mut pending = state.auto_snapshot_pending.lock().await;
         pending.coalesced += 1;
         pending.last_comment = format!("{method} {path}");
+        pending.last_actor = actor;
         !std::mem::replace(&mut pending.scheduled, true)
     };
     if !spawn_worker {
@@ -2955,16 +2968,21 @@ pub async fn auto_snapshot_middleware(
     }
 
     let bg_state = state.clone();
-    let bg_actor = "auto".to_string();
     tokio::spawn(async move {
         tokio::time::sleep(AUTO_SNAPSHOT_DEBOUNCE).await;
-        let (coalesced, last_comment) = {
+        let (coalesced, last_comment, bg_actor) = {
             let mut pending = bg_state.auto_snapshot_pending.lock().await;
             pending.scheduled = false;
             (
                 std::mem::take(&mut pending.coalesced),
                 std::mem::take(&mut pending.last_comment),
+                std::mem::take(&mut pending.last_actor),
             )
+        };
+        let bg_actor = if bg_actor.is_empty() {
+            "auto".to_string()
+        } else {
+            bg_actor
         };
         let bg_comment = if coalesced > 1 {
             format!("{last_comment} (+{} coalesced)", coalesced - 1)

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -1237,6 +1237,42 @@ mod tests {
         assert!(resp.text().contains("directory_url"), "{}", resp.text());
     }
 
+    /// #200 follow-through: auto-snapshots record the acting username as
+    /// the config-history actor (was a hardcoded "auto"). Waits out the
+    /// real 5s debounce (paused time breaks the sqlx pool's acquire timer).
+    #[tokio::test]
+    async fn test_auto_snapshot_records_acting_user() {
+        let (server, _) = test_app().await;
+        let token = create_user_and_login(&server).await;
+
+        // Any successful mutation on a snapshot-worthy path.
+        server
+            .post("/api/v1/aliases")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "name": "snap_actor_test",
+                "alias_type": "host",
+                "entries": ["10.9.9.9"]
+            }))
+            .await
+            .assert_status_success();
+
+        // Let the debounced background snapshot fire and finish.
+        tokio::time::sleep(std::time::Duration::from_secs(7)).await;
+
+        let resp = server
+            .get("/api/v1/config/history")
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        let versions = body["data"].as_array().expect("history array");
+        assert!(
+            versions.iter().any(|v| v["created_by"] == "admin"),
+            "expected an auto-snapshot attributed to 'admin', got: {versions:?}"
+        );
+    }
+
     #[tokio::test]
     async fn test_invalid_token_returns_401() {
         let (server, _) = test_app().await;

--- a/aifw-core/src/system_apply/freebsd_helpers.rs
+++ b/aifw-core/src/system_apply/freebsd_helpers.rs
@@ -1,6 +1,5 @@
 //! Pure string helpers for the FreeBSD apply layer — unit-testable
 //! on any host OS.
-#![allow(dead_code)]
 
 /// Rewrite (or append) the `127.0.1.1` line in `/etc/hosts` to reflect
 /// the new hostname + domain. Matches only lines whose first

--- a/aifw-core/src/updater.rs
+++ b/aifw-core/src/updater.rs
@@ -126,11 +126,9 @@ struct Manifest {
     binaries: ManifestBinaries,
     external_repos: Vec<ExternalRepo>,
     rc_scripts: Vec<String>,
-    #[allow(dead_code)]
-    sbin_scripts: Vec<String>,
-    #[allow(dead_code)]
-    #[serde(default)]
-    libexec_scripts: Vec<String>,
+    // `sbin_scripts` / `libexec_scripts` exist in manifest.json for the build
+    // scripts; the updater ships those via LIBEXEC_SCRIPTS below, so they are
+    // deliberately not deserialized here (serde ignores unknown keys).
     directories: Vec<String>,
     /// OS packages the appliance needs at runtime. Installed by
     /// build-iso.sh at image build; the updater installs any that are
@@ -148,16 +146,21 @@ struct ManifestBinaries {
 #[derive(Deserialize)]
 struct ExternalRepo {
     binaries: Vec<String>,
-    #[allow(dead_code)]
+    /// Human-readable companion name — used only in packaging-test failure
+    /// messages. (`repo` is build-script-only and not deserialized; serde
+    /// ignores unknown keys.)
+    #[cfg_attr(not(test), allow(dead_code))]
     name: String,
-    #[allow(dead_code)]
-    repo: String,
     /// crates.io package the build installs (#651, replaced the git SHA pins).
+    /// Read only by the packaging guard tests, which assert every companion
+    /// pin is a well-formed crate + semver so a bad manifest fails CI rather
+    /// than the release build.
     #[serde(rename = "crate")]
-    #[allow(dead_code)]
+    #[cfg_attr(not(test), allow(dead_code))]
     crate_name: String,
-    /// Exact published version pinned for appliance artifacts.
-    #[allow(dead_code)]
+    /// Exact published version pinned for appliance artifacts. Test-only
+    /// reader, see `crate_name`.
+    #[cfg_attr(not(test), allow(dead_code))]
     version: String,
 }
 

--- a/aifw-daemon/src/health_prober.rs
+++ b/aifw-daemon/src/health_prober.rs
@@ -81,29 +81,24 @@ impl HealthProber {
                 st.last_run = Some(Instant::now());
 
                 let ok = run_probe(c, &client).await;
-                if ok {
-                    if !st.healthy {
-                        st.healthy = true;
-                        let _ = self.notify_health(&client, &c.name, true, None).await;
-                    }
-                    st.failures = 0; // always reset so accumulated partial failures
-                // don't carry over and reduce the effective threshold
-                } else {
-                    st.failures += 1;
-                    if st.failures >= c.failures_before_down && st.healthy {
-                        st.healthy = false;
-                        let _ = self
-                            .notify_health(
-                                &client,
-                                &c.name,
-                                false,
-                                Some(format!("{} consecutive failures", st.failures)),
-                            )
-                            .await;
-                    }
-                    if !st.healthy {
-                        any_failing_local = true;
-                    }
+                let outcome = apply_probe_result(st, ok, c.failures_before_down);
+                if outcome.became_healthy {
+                    // Notification is best-effort — a failed POST must not
+                    // stall the probe loop; the next tick retries the state.
+                    let _ = self.notify_health(&client, &c.name, true, None).await;
+                } else if outcome.became_unhealthy {
+                    // Same best-effort rationale as above.
+                    let _ = self
+                        .notify_health(
+                            &client,
+                            &c.name,
+                            false,
+                            Some(format!("{} consecutive failures", outcome.failures_after)),
+                        )
+                        .await;
+                }
+                if !outcome.healthy_after {
+                    any_failing_local = true;
                 }
             }
 
@@ -206,7 +201,6 @@ impl ProbeState {
 // ============================================================
 
 /// The result of applying one probe tick to a ProbeState.
-#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, PartialEq, Eq)]
 struct ProbeOutcome {
     /// True when this tick causes a transition healthy → unhealthy.
@@ -218,9 +212,8 @@ struct ProbeOutcome {
 }
 
 /// Apply one probe result to a mutable ProbeState, returning the outcome.
-/// This mirrors the exact logic in `HealthProber::run` but operates on
-/// owned data so it can be unit-tested without spawning async infrastructure.
-#[cfg_attr(not(test), allow(dead_code))]
+/// This is the single implementation of the health state machine — used by
+/// `HealthProber::run` and unit-tested directly without async infrastructure.
 fn apply_probe_result(st: &mut ProbeState, ok: bool, failures_before_down: u32) -> ProbeOutcome {
     let was_healthy = st.healthy;
     if ok {

--- a/aifw-plugins/src/manager.rs
+++ b/aifw-plugins/src/manager.rs
@@ -8,8 +8,6 @@ use crate::plugin::{Plugin, PluginConfig, PluginInfo, PluginState};
 
 struct LoadedPlugin {
     plugin: Arc<dyn Plugin>,
-    #[allow(dead_code)]
-    config: PluginConfig,
     state: PluginState,
     info: PluginInfo,
 }
@@ -97,9 +95,10 @@ impl PluginManager {
 
         self.plugins.insert(
             name,
+            // `config` is consumed by init(); the plugin holds whatever
+            // it needs from it, and the persisted copy lives in the DB.
             LoadedPlugin {
                 plugin: Arc::from(plugin),
-                config,
                 state,
                 info,
             },

--- a/aifw-setup/src/apply.rs
+++ b/aifw-setup/src/apply.rs
@@ -2608,7 +2608,6 @@ pub mod tests_support {
     use super::*;
     use crate::config::SetupConfig;
 
-    #[allow(dead_code)]
     pub fn test_pf_conf() -> String {
         let config = SetupConfig {
             wan_interface: "em0".to_string(),


### PR DESCRIPTION
Closes #200.

13 `#[allow(dead_code)]` sites audited; 3 remain, all `#[cfg_attr(not(test), allow(dead_code))]` with the reason documented (manifest fields read only by the packaging guard tests).

| Site | Disposition |
|---|---|
| `aifw-core/updater.rs` manifest structs (×6) | Dropped never-read fields (`sbin_scripts`, `libexec_scripts`, `ExternalRepo.repo`) — serde ignores unknown keys, nothing else changes. `name`/`crate_name`/`version` are read only by the packaging guard tests → documented `cfg_attr(not(test))`. |
| `aifw-setup/apply.rs` `tests_support::test_pf_conf` | Stale — it's used by a test in the same `cfg(test)` module. Removed. |
| `aifw-core/system_apply/freebsd_helpers.rs` `#![allow(dead_code)]` | Removed; pub module, builds warning-free on Linux. |
| `aifw-api/auth/middleware.rs` `AuthUser.username` | **Now used**: the auto-snapshot middleware records the acting username as the config-history actor (was hardcoded `"auto"`; falls back to it if no identity is on the request). New test `test_auto_snapshot_records_acting_user` (waits out the real 5s debounce; paused time breaks sqlx's pool timer). |
| `aifw-plugins/manager.rs` `LoadedPlugin.config` | Never read after `init()`; field removed (persisted copy lives in `plugin_config`). |
| `aifw-daemon/health_prober.rs` `ProbeOutcome` / `apply_probe_result` (×2) | `HealthProber::run` now calls the extracted state machine instead of duplicating it inline — one implementation, and the allows go away. |

`cargo clippy --workspace --all-targets -D warnings` and `cargo test --workspace` green.