### PR TITLE
fix(ids): expand $HOME_NET/$EXTERNAL_NET and port variables in rule headers (#485)

### DIFF
--- a/aifw-ids/src/config.rs
+++ b/aifw-ids/src/config.rs
@@ -29,6 +29,14 @@ pub struct RuntimeConfig {
 }
 
 impl RuntimeConfig {
+    /// Build a runtime config from an in-memory `IdsConfig` (tests,
+    /// standalone engines).
+    pub fn from_config(cfg: IdsConfig) -> Self {
+        Self {
+            inner: ArcSwap::from_pointee(cfg),
+        }
+    }
+
     /// Load configuration from the database, falling back to defaults.
     pub async fn load(pool: &SqlitePool) -> Result<Self> {
         let cfg = Self::read_from_db(pool).await?;

--- a/aifw-ids/src/detect/engine.rs
+++ b/aifw-ids/src/detect/engine.rs
@@ -5,12 +5,14 @@
 
 use std::collections::HashMap;
 use std::net::IpAddr;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
-use aifw_common::ids::IdsAlert;
+use aifw_common::ids::{IdsAlert, IdsConfig};
 
 use super::matching::{content_match, ip_in_cidr};
 use super::threshold::ThresholdTracker;
+use super::vars::{self, AddressVar, MAX_VAR_DEPTH};
+use crate::config::RuntimeConfig;
 use crate::decode::DecodedPacket;
 use crate::flow::{Flow, FlowDirection, FlowTable};
 use crate::protocol::{ProtocolRegistry, StickyBuffers};
@@ -22,7 +24,13 @@ pub struct DetectionEngine {
     flow_table: Arc<FlowTable>,
     protocol_registry: ProtocolRegistry,
     threshold_tracker: ThresholdTracker,
+    /// Live IDS config for `$HOME_NET` / `$EXTERNAL_NET` expansion (#485).
+    /// `None` (tests, standalone use) falls back to `IdsConfig::default()`.
+    config: Option<Arc<RuntimeConfig>>,
 }
+
+/// Defaults used when the engine has no live config attached.
+static DEFAULT_CONFIG: LazyLock<Arc<IdsConfig>> = LazyLock::new(|| Arc::new(IdsConfig::default()));
 
 impl DetectionEngine {
     /// Create a detection engine over the shared rule database and flow
@@ -33,6 +41,23 @@ impl DetectionEngine {
             flow_table,
             protocol_registry: ProtocolRegistry::new(),
             threshold_tracker: ThresholdTracker::new(),
+            config: None,
+        }
+    }
+
+    /// Attach the live IDS config so rule-header variables resolve against
+    /// the operator's `home_net` / `external_net` (hot-reload aware).
+    pub fn with_config(mut self, config: Arc<RuntimeConfig>) -> Self {
+        self.config = Some(config);
+        self
+    }
+
+    /// Current config snapshot for variable expansion — an atomic load,
+    /// no clone of the address lists.
+    fn config_snapshot(&self) -> Arc<IdsConfig> {
+        match &self.config {
+            Some(c) => c.config(),
+            None => DEFAULT_CONFIG.clone(),
         }
     }
 
@@ -365,27 +390,56 @@ impl DetectionEngine {
     }
 
     fn match_address(&self, constraint: &str, ip: Option<IpAddr>) -> bool {
-        let ip = match ip {
-            Some(ip) => ip,
-            None => return false,
+        let Some(ip) = ip else {
+            return false;
         };
+        let cfg = self.config_snapshot();
+        self.match_address_inner(&cfg, constraint, ip, 0)
+    }
 
-        // Variable references (not expanded here — would need config)
+    fn match_address_inner(
+        &self,
+        cfg: &IdsConfig,
+        constraint: &str,
+        ip: IpAddr,
+        depth: u8,
+    ) -> bool {
+        let constraint = constraint.trim();
+        if depth > MAX_VAR_DEPTH {
+            tracing::warn!(
+                constraint,
+                "IDS address variable nesting too deep — treating as no match"
+            );
+            return false;
+        }
+
+        if constraint == "any" {
+            return true;
+        }
+
+        // Variable reference (#485): expand against the live config;
+        // unknown variables never match (fail closed).
         if constraint.starts_with('$') {
-            return true; // TODO(#485): expand variables
+            return match vars::resolve_address_var(cfg, constraint) {
+                AddressVar::Group(entries) => {
+                    self.match_address_list(cfg, entries.iter().map(String::as_str), ip, depth + 1)
+                }
+                AddressVar::Unknown => {
+                    vars::warn_unknown_once("address", constraint);
+                    false
+                }
+            };
         }
 
         // Negation
         if let Some(inner) = constraint.strip_prefix('!') {
-            return !self.match_address(inner, Some(ip));
+            return !self.match_address_inner(cfg, inner, ip, depth);
         }
 
-        // Group [addr1,addr2]
+        // Group [addr1,addr2,!addr3]
         if constraint.starts_with('[') && constraint.ends_with(']') {
             let inner = &constraint[1..constraint.len() - 1];
-            return inner
-                .split(',')
-                .any(|a| self.match_address(a.trim(), Some(ip)));
+            return self.match_address_list(cfg, split_group(inner), ip, depth + 1);
         }
 
         // CIDR match
@@ -403,26 +457,93 @@ impl DetectionEngine {
         true // If we can't parse, don't block
     }
 
-    fn match_port(&self, constraint: &str, port: Option<u16>) -> bool {
-        let port = match port {
-            Some(p) => p,
-            None => return false,
-        };
+    /// Suricata group semantics: the IP must not be in any negated entry,
+    /// and — if there are any positive entries — must be in at least one.
+    /// (`[!10.0.0.0/8,!192.168.0.0/16]` means "outside both", not "outside
+    /// either", which is what a plain `any()` over the entries would give.)
+    fn match_address_list<'a>(
+        &self,
+        cfg: &IdsConfig,
+        entries: impl Iterator<Item = &'a str>,
+        ip: IpAddr,
+        depth: u8,
+    ) -> bool {
+        let mut has_positive = false;
+        let mut positive_hit = false;
+        for entry in entries {
+            let entry = entry.trim();
+            if entry.is_empty() {
+                continue;
+            }
+            if let Some(inner) = entry.strip_prefix('!') {
+                if self.match_address_inner(cfg, inner, ip, depth) {
+                    return false;
+                }
+            } else {
+                has_positive = true;
+                if !positive_hit && self.match_address_inner(cfg, entry, ip, depth) {
+                    positive_hit = true;
+                }
+            }
+        }
+        !has_positive || positive_hit
+    }
 
+    fn match_port(&self, constraint: &str, port: Option<u16>) -> bool {
+        let Some(port) = port else {
+            return false;
+        };
+        self.match_port_inner(constraint, port, 0)
+    }
+
+    fn match_port_inner(&self, constraint: &str, port: u16, depth: u8) -> bool {
+        let constraint = constraint.trim();
+        if depth > MAX_VAR_DEPTH {
+            return false;
+        }
+
+        if constraint == "any" {
+            return true;
+        }
+
+        // Variable reference (#485): stock Suricata port groups; unknown
+        // variables never match.
         if constraint.starts_with('$') {
-            return true; // Variable reference
+            return match vars::resolve_port_var(constraint) {
+                Some(expansion) => self.match_port_inner(expansion, port, depth + 1),
+                None => {
+                    vars::warn_unknown_once("port", constraint);
+                    false
+                }
+            };
         }
 
         if let Some(inner) = constraint.strip_prefix('!') {
-            return !self.match_port(inner, Some(port));
+            return !self.match_port_inner(inner, port, depth);
         }
 
-        // Group [port1,port2]
+        // Group [port1,port2,!port3] — same semantics as address groups.
         if constraint.starts_with('[') && constraint.ends_with(']') {
             let inner = &constraint[1..constraint.len() - 1];
-            return inner
-                .split(',')
-                .any(|p| self.match_port(p.trim(), Some(port)));
+            let mut has_positive = false;
+            let mut positive_hit = false;
+            for entry in split_group(inner) {
+                let entry = entry.trim();
+                if entry.is_empty() {
+                    continue;
+                }
+                if let Some(neg) = entry.strip_prefix('!') {
+                    if self.match_port_inner(neg, port, depth + 1) {
+                        return false;
+                    }
+                } else {
+                    has_positive = true;
+                    if !positive_hit && self.match_port_inner(entry, port, depth + 1) {
+                        positive_hit = true;
+                    }
+                }
+            }
+            return !has_positive || positive_hit;
         }
 
         // Range
@@ -460,6 +581,27 @@ impl DetectionEngine {
             }
         }
     }
+}
+
+/// Split a group body on top-level commas, leaving nested `[...]` groups
+/// intact (`"a,[b,c],d"` → `["a", "[b,c]", "d"]`).
+fn split_group(inner: &str) -> impl Iterator<Item = &str> {
+    let mut depth = 0i32;
+    let mut start = 0usize;
+    let mut out = Vec::new();
+    for (i, ch) in inner.char_indices() {
+        match ch {
+            '[' => depth += 1,
+            ']' => depth -= 1,
+            ',' if depth == 0 => {
+                out.push(&inner[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    out.push(&inner[start..]);
+    out.into_iter()
 }
 
 impl std::fmt::Debug for DetectionEngine {
@@ -614,5 +756,95 @@ alert tcp any any -> any any (msg:"Rule 2"; content:"bad"; sid:2;)
 
         assert!(content_match(&content, b"this is a test"));
         assert!(!content_match(&content, b"no match here"));
+    }
+
+    // ---- #485: rule-header variable expansion ----
+
+    fn engine_with_home_net(rules_text: &str, home_net: &[&str]) -> DetectionEngine {
+        let cfg = IdsConfig {
+            home_net: home_net.iter().map(|s| s.to_string()).collect(),
+            ..IdsConfig::default()
+        };
+        setup_engine(rules_text).with_config(Arc::new(RuntimeConfig::from_config(cfg)))
+    }
+
+    #[test]
+    fn home_net_to_external_net_is_directional() {
+        let engine = engine_with_home_net(
+            r#"alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"outbound"; content:"beacon"; sid:10;)"#,
+            &["192.168.1.0/24"],
+        );
+        // inside -> outside: fires
+        let pkt = tcp_packet("192.168.1.10", "203.0.113.5", 40000, 443, b"beacon");
+        assert_eq!(engine.detect(&pkt).len(), 1);
+        // outside -> inside: must NOT fire (was a false positive before #485)
+        let pkt = tcp_packet("203.0.113.5", "192.168.1.10", 443, 40000, b"beacon");
+        assert!(engine.detect(&pkt).is_empty());
+        // inside -> inside: dst is not EXTERNAL_NET
+        let pkt = tcp_packet("192.168.1.10", "192.168.1.20", 40000, 443, b"beacon");
+        assert!(engine.detect(&pkt).is_empty());
+    }
+
+    #[test]
+    fn server_group_aliases_follow_home_net() {
+        let engine = engine_with_home_net(
+            r#"alert tcp $EXTERNAL_NET any -> $HTTP_SERVERS $HTTP_PORTS (msg:"inbound http"; content:"evil"; sid:11;)"#,
+            &["10.0.0.0/8"],
+        );
+        let pkt = tcp_packet("198.51.100.7", "10.1.2.3", 51000, 8080, b"evil");
+        assert_eq!(engine.detect(&pkt).len(), 1);
+        // wrong port for $HTTP_PORTS
+        let pkt = tcp_packet("198.51.100.7", "10.1.2.3", 51000, 2222, b"evil");
+        assert!(engine.detect(&pkt).is_empty());
+        // dst not in HOME_NET
+        let pkt = tcp_packet("198.51.100.7", "198.51.100.8", 51000, 8080, b"evil");
+        assert!(engine.detect(&pkt).is_empty());
+    }
+
+    #[test]
+    fn unknown_variables_never_match() {
+        let engine = engine_with_home_net(
+            r#"alert tcp $MYSTERY_NET any -> any any (msg:"unknown var"; content:"x"; sid:12;)"#,
+            &["10.0.0.0/8"],
+        );
+        let pkt = tcp_packet("10.0.0.1", "10.0.0.2", 1, 2, b"x");
+        assert!(engine.detect(&pkt).is_empty());
+        let engine = engine_with_home_net(
+            r#"alert tcp any any -> any $MYSTERY_PORTS (msg:"unknown port var"; content:"x"; sid:13;)"#,
+            &["10.0.0.0/8"],
+        );
+        assert!(engine.detect(&pkt).is_empty());
+    }
+
+    #[test]
+    fn negated_group_means_outside_all_entries() {
+        let engine = engine_with_home_net(
+            r#"alert tcp [!10.0.0.0/8,!192.168.0.0/16] any -> any any (msg:"from outside"; content:"x"; sid:14;)"#,
+            &["10.0.0.0/8"],
+        );
+        // 10.x is inside one negated entry → no match (plain any() would have matched)
+        let pkt = tcp_packet("10.9.9.9", "1.1.1.1", 1, 2, b"x");
+        assert!(engine.detect(&pkt).is_empty());
+        let pkt = tcp_packet("192.168.5.5", "1.1.1.1", 1, 2, b"x");
+        assert!(engine.detect(&pkt).is_empty());
+        let pkt = tcp_packet("8.8.8.8", "1.1.1.1", 1, 2, b"x");
+        assert_eq!(engine.detect(&pkt).len(), 1);
+    }
+
+    #[test]
+    fn engine_without_config_uses_rfc1918_defaults() {
+        let engine = setup_engine(
+            r#"alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"default home"; content:"x"; sid:15;)"#,
+        );
+        let pkt = tcp_packet("172.16.0.9", "8.8.8.8", 1, 2, b"x");
+        assert_eq!(engine.detect(&pkt).len(), 1);
+        let pkt = tcp_packet("8.8.8.8", "172.16.0.9", 1, 2, b"x");
+        assert!(engine.detect(&pkt).is_empty());
+    }
+
+    #[test]
+    fn split_group_keeps_nested_brackets() {
+        let parts: Vec<&str> = split_group("a,[b,c],d").collect();
+        assert_eq!(parts, vec!["a", "[b,c]", "d"]);
     }
 }

--- a/aifw-ids/src/detect/mod.rs
+++ b/aifw-ids/src/detect/mod.rs
@@ -9,5 +9,6 @@ pub mod matching;
 pub mod multi_pattern;
 /// Per-rule, per-IP threshold and rate-limit tracking
 pub mod threshold;
+pub mod vars;
 
 pub use engine::*;

--- a/aifw-ids/src/detect/vars.rs
+++ b/aifw-ids/src/detect/vars.rs
@@ -1,0 +1,133 @@
+//! Rule-header variable resolution (`$HOME_NET`, `$HTTP_PORTS`, …).
+//!
+//! Suricata rules reference address and port groups by name. Before #485
+//! the engine treated any `$`-prefixed constraint as "matches everything",
+//! so a rule scoped to `$HOME_NET -> $EXTERNAL_NET` fired on traffic in
+//! either direction — a silent false-positive source on every deployment.
+//!
+//! `$HOME_NET` / `$EXTERNAL_NET` come from [`IdsConfig`]; the remaining
+//! names carry the defaults from stock `suricata.yaml` (server groups all
+//! alias `$HOME_NET`). Unknown variables resolve to *nothing* — the
+//! constraint can never match, which is the fail-closed choice — and are
+//! logged once so the operator can see which rules are inert.
+
+use std::sync::LazyLock;
+
+use aifw_common::ids::IdsConfig;
+use dashmap::DashSet;
+
+/// Address-group variables that stock Suricata defines as `$HOME_NET`.
+const HOME_NET_ALIASES: &[&str] = &[
+    "HTTP_SERVERS",
+    "SMTP_SERVERS",
+    "SQL_SERVERS",
+    "DNS_SERVERS",
+    "TELNET_SERVERS",
+    "AIM_SERVERS",
+    "DC_SERVERS",
+    "DNP3_SERVER",
+    "DNP3_CLIENT",
+    "MODBUS_SERVER",
+    "MODBUS_CLIENT",
+    "ENIP_SERVER",
+    "ENIP_CLIENT",
+];
+
+/// Port-group variables and their stock `suricata.yaml` values.
+const PORT_VARS: &[(&str, &str)] = &[
+    (
+        "HTTP_PORTS",
+        "[80,81,311,383,591,593,901,1220,1414,1741,1830,2301,2381,2809,3037,3128,3702,4343,4848,5250,6988,7000,7001,7144,7145,7510,7777,7779,8000,8008,8014,8028,8080,8085,8088,8090,8118,8123,8180,8181,8243,8280,8300,8800,8888,8899,9000,9060,9080,9090,9091,9443,9999,11371,34443,34444,41080,50002,55555]",
+    ),
+    ("SHELLCODE_PORTS", "!80"),
+    ("ORACLE_PORTS", "1521"),
+    ("SSH_PORTS", "22"),
+    ("DNP3_PORTS", "20000"),
+    ("MODBUS_PORTS", "502"),
+    ("FILE_DATA_PORTS", "[$HTTP_PORTS,110,143]"),
+    ("FTP_PORTS", "21"),
+    ("GENEVE_PORTS", "6081"),
+    ("VXLAN_PORTS", "4789"),
+    ("TEREDO_PORTS", "3544"),
+];
+
+/// A resolved address-group variable.
+pub enum AddressVar<'a> {
+    /// The variable expands to these entries (each a CIDR, IP, `!`-negated
+    /// entry, or nested variable), matched with group semantics.
+    Group(&'a [String]),
+    /// Not a known variable: matches nothing.
+    Unknown,
+}
+
+/// Resolve `$NAME` (or `NAME`) to its address group under `cfg`.
+pub fn resolve_address_var<'a>(cfg: &'a IdsConfig, var: &str) -> AddressVar<'a> {
+    let name = var.strip_prefix('$').unwrap_or(var);
+    if name == "HOME_NET" || HOME_NET_ALIASES.contains(&name) {
+        return AddressVar::Group(&cfg.home_net);
+    }
+    if name == "EXTERNAL_NET" {
+        return AddressVar::Group(&cfg.external_net);
+    }
+    AddressVar::Unknown
+}
+
+/// Resolve `$NAME` (or `NAME`) to its port constraint text, or `None`
+/// for an unknown variable.
+pub fn resolve_port_var(var: &str) -> Option<&'static str> {
+    let name = var.strip_prefix('$').unwrap_or(var);
+    PORT_VARS.iter().find(|(n, _)| *n == name).map(|(_, v)| *v)
+}
+
+/// Maximum nesting when a variable's expansion references another
+/// variable (`$EXTERNAL_NET` → `!$HOME_NET`). Deeper than this is a
+/// configuration loop, not a real ruleset.
+pub const MAX_VAR_DEPTH: u8 = 8;
+
+static WARNED: LazyLock<DashSet<String>> = LazyLock::new(DashSet::new);
+
+/// Log an unknown-variable reference once per name per process so the
+/// operator learns which rules are inert without flooding the log.
+pub fn warn_unknown_once(kind: &str, var: &str) {
+    if WARNED.insert(var.to_string()) {
+        tracing::warn!(
+            variable = var,
+            "IDS rule references an undefined {kind} variable — the constraint will never match"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn home_net_and_aliases_resolve_to_config() {
+        let cfg = IdsConfig {
+            home_net: vec!["10.0.0.0/8".into()],
+            ..IdsConfig::default()
+        };
+        for v in ["$HOME_NET", "HOME_NET", "$HTTP_SERVERS", "$DNS_SERVERS"] {
+            match resolve_address_var(&cfg, v) {
+                AddressVar::Group(g) => assert_eq!(g, &["10.0.0.0/8".to_string()]),
+                AddressVar::Unknown => panic!("{v} should resolve"),
+            }
+        }
+        match resolve_address_var(&cfg, "$EXTERNAL_NET") {
+            AddressVar::Group(g) => assert_eq!(g, &["!$HOME_NET".to_string()]),
+            AddressVar::Unknown => panic!("EXTERNAL_NET should resolve"),
+        }
+        assert!(matches!(
+            resolve_address_var(&cfg, "$NOPE"),
+            AddressVar::Unknown
+        ));
+    }
+
+    #[test]
+    fn port_vars_have_suricata_defaults() {
+        assert_eq!(resolve_port_var("$SSH_PORTS"), Some("22"));
+        assert_eq!(resolve_port_var("SHELLCODE_PORTS"), Some("!80"));
+        assert!(resolve_port_var("$HTTP_PORTS").unwrap().contains(",8080,"));
+        assert_eq!(resolve_port_var("$WHATEVER_PORTS"), None);
+    }
+}

--- a/aifw-ids/src/lib.rs
+++ b/aifw-ids/src/lib.rs
@@ -158,7 +158,9 @@ impl IdsEngine {
                 .with_stream_depth(stream_depth_bytes)
                 .with_reassembly_budget(reassembly_budget_bytes),
         );
-        let detection = Arc::new(DetectionEngine::new(rule_db.clone(), flow_table.clone()));
+        let detection = Arc::new(
+            DetectionEngine::new(rule_db.clone(), flow_table.clone()).with_config(config.clone()),
+        );
         let action = Arc::new(ActionEngine::new(pf.clone(), config.clone()));
         // SQLite is the durable alert store (queried by /api/v1/ids/alerts,
         // AI analysis, suppression matching). When a memory buffer is also

--- a/docs/docs/ids.md
+++ b/docs/docs/ids.md
@@ -64,6 +64,8 @@ curl -X POST https://aifw.local/api/v1/ids/reload \
 
 ## Rule formats
 
+**Rule-header variables.** `$HOME_NET` and `$EXTERNAL_NET` expand to the `home_net` / `external_net` lists above (defaults: RFC 1918 and `!$HOME_NET`). The stock Suricata server groups (`$HTTP_SERVERS`, `$DNS_SERVERS`, `$SMTP_SERVERS`, `$SQL_SERVERS`, …) alias `$HOME_NET`, and port groups (`$HTTP_PORTS`, `$SSH_PORTS`, `$SHELLCODE_PORTS`, …) carry the `suricata.yaml` defaults. A rule that references an undefined variable never matches; the engine logs the variable name once so you can spot inert rules.
+
 **Suricata-compatible.** The native format. AiFw parses Suricata 7.x syntax &mdash; `alert`, `drop`, `pass`, plus the common `content`, `pcre`, `flow`, `threshold`, and `metadata` keywords. This is a practical **subset**, not full Suricata engine parity: most ET Open-style rules drop in unchanged, but rules relying on unsupported keywords are skipped (visible in the ruleset parse stats).
 
 **Sigma.** YAML detection rules originally designed for log events. AiFw maps the detection section to network flow fields, so a Sigma rule that targets HTTP request URIs or DNS query names will fire on matching traffic. Sigma rules always alert &mdash; they never drop, regardless of mode.


### PR DESCRIPTION
Closes #485.

Any `$`-prefixed address or port constraint in a rule header matched everything (`engine.rs` returned `true` on `starts_with('$')`), so a rule scoped `$HOME_NET any -> $EXTERNAL_NET any` fired in both directions — a silent false-positive source on every IDS deployment.

**Changes**
- New `detect::vars` resolver: `$HOME_NET` / `$EXTERNAL_NET` from the live `IdsConfig` (hot-reload aware through `RuntimeConfig`), Suricata's server-group aliases (`$HTTP_SERVERS`, `$DNS_SERVERS`, …→ `$HOME_NET`), and the stock `suricata.yaml` port groups (`$HTTP_PORTS`, `$SSH_PORTS`, `$SHELLCODE_PORTS`, …). Unknown variables never match (fail closed) and are logged once per name.
- `DetectionEngine::with_config` attaches the runtime config in `aifw-ids/src/lib.rs`; without one (tests/standalone) the RFC 1918 defaults apply.
- Group matching now follows Suricata semantics: `[!10.0.0.0/8,!192.168.0.0/16]` means *outside both* (a plain `any()` treated it as *outside either*), and nested `[…]` groups split correctly.
- Docs: variable behaviour documented in `docs/docs/ids.md`.
- Tests: direction scoping, aliases + port groups, unknown vars, negated groups, no-config defaults, group splitting.

**Verification:** `cargo test -p aifw-ids` 106 passed; `cargo check` zero warnings.
