### PR TITLE
feat(ui): error boundaries, loading skeleton and real 404 page (#452)

### DIFF
--- a/.github/workflows/freebsd-functional.yml
+++ b/.github/workflows/freebsd-functional.yml
@@ -45,7 +45,40 @@ jobs:
             cargo build -p aifw-api -p aifw-daemon
             echo "=== Running functional harness ==="
             mkdir -p func-artifacts
-            sh freebsd/tests/run-all.sh --artifacts "$(pwd)/func-artifacts"
+            # Do NOT let a harness failure fail this step: vmactions only
+            # copies the working tree back to the runner (copyback) when
+            # the step succeeds, so a failing run used to upload nothing and
+            # the per-test logs died with the VM. Record the exit code and
+            # let the next step fail the job after the artifacts are out.
+            rc=0
+            sh freebsd/tests/run-all.sh --artifacts "$(pwd)/func-artifacts" || rc=$?
+            echo "$rc" > func-artifacts/EXIT_CODE
+            echo "=== harness exit code: $rc ==="
+
+      - name: Harness result
+        if: always()
+        run: |
+          rc=$(cat func-artifacts/EXIT_CODE 2>/dev/null || echo 99)
+          if [ "$rc" != "0" ]; then
+            echo "::error::functional harness failed (exit $rc)"
+            # Surface every failing test's log inline so a red run is
+            # readable without downloading the artifact.
+            for f in func-artifacts/t*.log; do
+              [ -f "$f" ] || continue
+              if grep -q '^.*FAIL' "$f"; then
+                echo "::group::$(basename "$f")"
+                cat "$f"
+                echo "::endgroup::"
+              fi
+            done
+            for f in func-artifacts/aifw-api.log func-artifacts/aifw-daemon.log; do
+              [ -f "$f" ] || continue
+              echo "::group::$(basename "$f") (tail)"
+              tail -n 80 "$f"
+              echo "::endgroup::"
+            done
+            exit 1
+          fi
 
       - name: Upload artifacts
         if: always()

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -646,15 +646,32 @@ pub fn build_router(
     if let Some(dir) = ui_dir
         && dir.exists()
     {
-        let index = dir.join("index.html");
-        let serve = ServeDir::new(dir)
-            .precompressed_br()
-            .precompressed_gzip()
-            .fallback(
-                ServeFile::new(index)
+        // #452: unknown UI paths get the exported 404 page with a real 404
+        // status (the UI has no dynamic routes, so anything ServeDir can't
+        // find is genuinely missing). Older UI builds without 404.html fall
+        // back to index.html as before.
+        let not_found = dir.join("404.html");
+        let (fallback_file, fallback_status) = if not_found.is_file() {
+            (not_found, axum::http::StatusCode::NOT_FOUND)
+        } else {
+            (dir.join("index.html"), axum::http::StatusCode::OK)
+        };
+        let fallback = tower::ServiceBuilder::new()
+            .map_response(move |mut resp: axum::response::Response<_>| {
+                if fallback_status != axum::http::StatusCode::OK && resp.status().is_success() {
+                    *resp.status_mut() = fallback_status;
+                }
+                resp
+            })
+            .service(
+                ServeFile::new(fallback_file)
                     .precompressed_br()
                     .precompressed_gzip(),
             );
+        let serve = ServeDir::new(dir)
+            .precompressed_br()
+            .precompressed_gzip()
+            .fallback(fallback);
         let layered = tower::ServiceBuilder::new()
             .layer(axum::middleware::from_fn(ui_cache_headers))
             .service(serve);

--- a/aifw-ui/src/app/error.tsx
+++ b/aifw-ui/src/app/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { ErrorFallback } from "@/components/feedback/ErrorFallback";
+
+/**
+ * Route-segment error boundary (#452). Catches render/runtime errors in
+ * any page under `app/` while keeping the shell (sidebar, banners) alive.
+ * Next.js resets it automatically on navigation; "Try again" re-mounts
+ * the failed page in place.
+ */
+export default function PageError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="max-w-3xl">
+      <ErrorFallback error={error} reset={reset} scope="This page" />
+    </div>
+  );
+}

--- a/aifw-ui/src/app/global-error.tsx
+++ b/aifw-ui/src/app/global-error.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+/**
+ * Last-resort boundary (#452): only reached when the root layout itself
+ * throws (AppShell / providers). Must render its own <html>/<body> because
+ * the layout is gone. Kept dependency-free on purpose.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="en" className="dark">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#0f1524",
+          color: "#e2e8f0",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <div
+          role="alert"
+          style={{
+            maxWidth: 480,
+            padding: 24,
+            border: "1px solid rgba(239,68,68,0.4)",
+            borderRadius: 8,
+            background: "#1a2236",
+          }}
+        >
+          <h1 style={{ margin: "0 0 8px", fontSize: 18 }}>AiFw UI failed to start</h1>
+          <p style={{ margin: "0 0 16px", fontSize: 13, color: "#8494b0", wordBreak: "break-word" }}>
+            {error?.message || "Unknown error"}
+            {error?.digest ? ` (ref ${error.digest})` : ""}
+          </p>
+          <button
+            onClick={reset}
+            style={{
+              padding: "8px 14px",
+              background: "#3b82f6",
+              color: "#fff",
+              border: 0,
+              borderRadius: 6,
+              fontSize: 13,
+              cursor: "pointer",
+              marginRight: 8,
+            }}
+          >
+            Try again
+          </button>
+          <button
+            onClick={() => window.location.reload()}
+            style={{
+              padding: "8px 14px",
+              background: "transparent",
+              color: "#8494b0",
+              border: "1px solid #2a3650",
+              borderRadius: 6,
+              fontSize: 13,
+              cursor: "pointer",
+            }}
+          >
+            Reload
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/aifw-ui/src/app/loading.tsx
+++ b/aifw-ui/src/app/loading.tsx
@@ -1,0 +1,6 @@
+import { PageLoading } from "@/components/feedback/PageLoading";
+
+/** Root route loading state (#452) — see PageLoading. */
+export default function Loading() {
+  return <PageLoading />;
+}

--- a/aifw-ui/src/app/not-found.tsx
+++ b/aifw-ui/src/app/not-found.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+
+/**
+ * 404 page (#452). Rendered as `out/404.html`; aifw-api serves it (with a
+ * 404 status) for any UI path that isn't a known route or static file.
+ */
+export default function NotFound() {
+  return (
+    <div className="max-w-xl">
+      <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-6">
+        <p className="text-xs uppercase tracking-wider text-[var(--text-muted)]">404</p>
+        <h1 className="mt-1 text-lg font-semibold text-[var(--text-primary)]">Page not found</h1>
+        <p className="mt-2 text-sm text-[var(--text-muted)]">
+          There is no page at this address. It may have moved in a newer release, or the link
+          is out of date.
+        </p>
+        <div className="mt-4 flex items-center gap-3">
+          <Link
+            href="/"
+            className="px-3 py-1.5 bg-[var(--accent)] hover:bg-[var(--accent-hover)] text-white rounded-md text-xs font-medium transition-colors"
+          >
+            Go to dashboard
+          </Link>
+          <Link
+            href="/settings/"
+            className="text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+          >
+            Settings
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/aifw-ui/src/components/AppShell.tsx
+++ b/aifw-ui/src/components/AppShell.tsx
@@ -8,6 +8,7 @@ import Sidebar from "./Sidebar";
 import PendingBanner from "./PendingBanner";
 import { WsProvider } from "@/context/WsContext";
 import { AuthProvider } from "@/context/AuthContext";
+import { ErrorBoundary } from "@/components/feedback/ErrorBoundary";
 
 const PUBLIC_PATHS = ["/login", "/login/"];
 const MIN_WIDTH = 180;
@@ -102,7 +103,10 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
               `}
               style={{ width: sidebarWidth }}
             >
-              <Sidebar onClose={() => setSidebarOpen(false)} width={sidebarWidth} />
+              {/* #452: a sidebar crash must not take the whole shell down. */}
+              <ErrorBoundary scope="Sidebar" compact resetKey={pathname}>
+                <Sidebar onClose={() => setSidebarOpen(false)} width={sidebarWidth} />
+              </ErrorBoundary>
 
               {/* Resize handle — desktop only */}
               <div
@@ -127,7 +131,9 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                 </button>
                 <Image src="/logo-sidebar.png" alt="AiFw" width={120} height={24} className="h-6 w-auto" unoptimized />
               </div>
-              <PendingBanner />
+              <ErrorBoundary scope="Pending-changes banner" compact resetKey={pathname}>
+                <PendingBanner />
+              </ErrorBoundary>
               <div className="p-4 lg:p-6 overflow-auto">
                 {children}
               </div>

--- a/aifw-ui/src/components/feedback/ErrorBoundary.tsx
+++ b/aifw-ui/src/components/feedback/ErrorBoundary.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Component, ErrorInfo, ReactNode } from "react";
+import { ErrorFallback } from "./ErrorFallback";
+
+interface Props {
+  children: ReactNode;
+  /** Label for the fallback heading, e.g. "Sidebar", "Traffic chart". */
+  scope?: string;
+  /** Render a smaller fallback (widgets, banners). */
+  compact?: boolean;
+  /** Custom fallback; receives the error and a reset callback. */
+  fallback?: (error: Error, reset: () => void) => ReactNode;
+  /** Change this to force a reset (e.g. the current pathname). */
+  resetKey?: unknown;
+}
+
+interface State {
+  error: Error | null;
+}
+
+/**
+ * Widget-level error boundary (#452). Next.js `error.tsx` files isolate a
+ * whole route segment; this isolates anything smaller — a dashboard card,
+ * the sidebar, a banner — so one broken widget doesn't blank the page.
+ * Resets automatically when `resetKey` changes.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Surface in the console (and thus any error reporting) with the
+    // component stack; the fallback UI handles the operator side.
+    console.error(`[ErrorBoundary${this.props.scope ? `:${this.props.scope}` : ""}]`, error, info.componentStack);
+  }
+
+  componentDidUpdate(prev: Props) {
+    if (this.state.error && prev.resetKey !== this.props.resetKey) {
+      this.reset();
+    }
+  }
+
+  reset = () => this.setState({ error: null });
+
+  render() {
+    const { error } = this.state;
+    if (error) {
+      if (this.props.fallback) return this.props.fallback(error, this.reset);
+      return (
+        <ErrorFallback
+          error={error}
+          reset={this.reset}
+          scope={this.props.scope}
+          compact={this.props.compact}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/aifw-ui/src/components/feedback/ErrorFallback.tsx
+++ b/aifw-ui/src/components/feedback/ErrorFallback.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Link from "next/link";
+
+/**
+ * Shared "something broke here" panel (#452). Used by the Next.js
+ * `error.tsx` boundaries and by the widget-level <ErrorBoundary>. Keeps
+ * the rest of the shell usable: the operator can retry the failed
+ * section, go back to the dashboard, or reload.
+ */
+export interface ErrorFallbackProps {
+  /** The caught error (message shown; stack only in dev). */
+  error: Error & { digest?: string };
+  /** Re-mount the failed subtree. */
+  reset?: () => void;
+  /** Where the error happened, e.g. "Rules page" — shown in the heading. */
+  scope?: string;
+  /** Compact variant for small widgets. */
+  compact?: boolean;
+}
+
+export function ErrorFallback({ error, reset, scope, compact = false }: ErrorFallbackProps) {
+  const message = error?.message || "Unknown error";
+  const isDev = process.env.NODE_ENV !== "production";
+  return (
+    <div
+      role="alert"
+      className={`bg-[var(--bg-card)] border border-red-500/40 rounded-lg ${
+        compact ? "p-3" : "p-6"
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 text-red-400" aria-hidden="true">
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+            />
+          </svg>
+        </span>
+        <div className="min-w-0 flex-1">
+          <h2 className={`font-semibold text-[var(--text-primary)] ${compact ? "text-sm" : "text-base"}`}>
+            {scope ? `${scope} failed to render` : "Something went wrong"}
+          </h2>
+          <p className="mt-1 text-xs text-[var(--text-muted)] break-words">
+            {message}
+            {error?.digest && <span className="ml-1 opacity-70">(ref {error.digest})</span>}
+          </p>
+          {isDev && error?.stack && (
+            <pre className="mt-2 max-h-40 overflow-auto text-[10px] leading-snug text-[var(--text-muted)] bg-[var(--bg-primary)] border border-[var(--border)] rounded p-2">
+              {error.stack}
+            </pre>
+          )}
+          <div className={`flex flex-wrap items-center gap-2 ${compact ? "mt-2" : "mt-4"}`}>
+            {reset && (
+              <button
+                onClick={reset}
+                className="px-3 py-1.5 bg-[var(--accent)] hover:bg-[var(--accent-hover)] text-white rounded-md text-xs font-medium transition-colors"
+              >
+                Try again
+              </button>
+            )}
+            {!compact && (
+              <>
+                <Link
+                  href="/"
+                  className="px-3 py-1.5 bg-[var(--bg-card-secondary)] hover:bg-[var(--bg-hover)] border border-[var(--border)] text-[var(--text-primary)] rounded-md text-xs font-medium transition-colors"
+                >
+                  Go to dashboard
+                </Link>
+                <button
+                  onClick={() => window.location.reload()}
+                  className="px-3 py-1.5 text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+                >
+                  Reload page
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/aifw-ui/src/components/feedback/PageLoading.tsx
+++ b/aifw-ui/src/components/feedback/PageLoading.tsx
@@ -1,0 +1,20 @@
+/**
+ * Route-level loading state (#452): shown by `app/loading.tsx` while a
+ * page's chunk is fetched during client-side navigation. Skeleton rather
+ * than a bare spinner so the layout doesn't jump when content lands.
+ */
+export function PageLoading({ label = "Loading…" }: { label?: string }) {
+  return (
+    <div role="status" aria-live="polite" aria-label={label} className="animate-pulse space-y-4">
+      <div className="h-7 w-48 rounded bg-[var(--bg-card)]" />
+      <div className="h-4 w-80 max-w-full rounded bg-[var(--bg-card)]" />
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 pt-2">
+        <div className="h-24 rounded-lg bg-[var(--bg-card)]" />
+        <div className="h-24 rounded-lg bg-[var(--bg-card)]" />
+        <div className="h-24 rounded-lg bg-[var(--bg-card)]" />
+      </div>
+      <div className="h-64 rounded-lg bg-[var(--bg-card)]" />
+      <span className="sr-only">{label}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #452.

A runtime error anywhere in a page blanked the whole UI with the default Next.js error screen; there was no loading state for route chunks; and unknown paths silently rendered the dashboard (the API fell back to `index.html`).

**Changes**
- `app/error.tsx` — per-route boundary. Keeps the shell (sidebar, banners) alive and offers *Try again* (re-mounts the page), *Go to dashboard*, *Reload*. Next resets it on navigation.
- `app/global-error.tsx` — dependency-free last resort for errors thrown by the root layout / providers themselves (renders its own `<html>/<body>`).
- `components/feedback/` — shared `ErrorFallback` panel, a reusable class `ErrorBoundary` (auto-resets when `resetKey` changes; custom fallback supported) and a `PageLoading` skeleton. `AppShell` wraps `Sidebar` and `PendingBanner` in it so a crash in the chrome doesn't take the page down.
- `app/loading.tsx` — skeleton shown while a page chunk loads during client-side navigation.
- `app/not-found.tsx` — styled 404. `aifw-api` now serves `out/404.html` **with a 404 status** for unknown UI paths (the UI has no dynamic routes, so anything `ServeDir` can't find is genuinely missing); older UI builds without `404.html` keep the previous `index.html` fallback.

**Verification**
- `npm run lint` clean, `npm run build` static export OK, `cargo check` zero warnings.
- Ran the API against `aifw-ui/out`: `/` → 200, `/rules/` → 200, `/nope/` → 404 with the new page, `/api/v1/status` unauthenticated → 401 (API untouched).
