### PR TITLE
sec(secrets): seal secrets at rest with AES-256-GCM under a file master key (#298)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,10 @@ Engines: `RuleEngine` (engine.rs), `NatEngine` (nat.rs), `AliasEngine` (alias.rs
 
 Each engine has its own `migrate()` method that creates its SQLite tables. Migrations are **inline SQL** in Rust code (no separate migration files).
 
+### Secrets at Rest (#298)
+
+Secret columns are sealed with AES-256-GCM via `aifw_core::secrets` (`seal` on write, `open`/`open_opt`/`open_lossy` on read; values without the `enc:v1:` prefix are legacy plaintext and pass through). Master key: `/var/db/aifw/secrets.key`, derived as `<db dir>/secrets.key` (`secrets::configure_from_db_path`) so scratch DBs get their own key. When you add a new secret column: seal at every write site, open at every read site, and add it to `secrets::SEALED_COLUMNS` / `SEALED_KV` so the startup `seal_legacy_rows` pass covers upgrades.
+
 ### Database Layer
 
 Central type: `Database` struct in `aifw-core/src/db.rs` wrapping `SqlitePool`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,8 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "rus
 url = "2"
 x25519-dalek = { version = "3", features = ["static_secrets"] }
 getrandom = "0.4"
+aws-lc-rs = "1"
+base64 = "0.22"
 
 # Workspace-wide clippy lint posture. Stylistic-only lints are allowed —
 # documented engine constructors legitimately have many parameters, the

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ High-performance firewall for FreeBSD built in Rust on top of pf. Optional AI/ML
 - **Plugin system** — native Rust + WASM sandboxed plugins with 7 hook points
 - **High availability (active-passive pair)** — Two AiFw nodes share a CARP virtual IP and pfsync state. Reboot the master and TCP sessions survive on the standby with no operator intervention. Setup via the UI in <15 minutes. See [docs/ha.md](docs/ha.md) for setup, ops, and failure modes.
 - **Remote syslog** — forward pf packet logs, IDS alerts, and app logs to a syslog server/SIEM (UDP/TCP, BSD or RFC 5424, per-category toggles, optional local-storage off)
+- **Secrets sealed at rest** — WireGuard/IPsec keys, CARP and integration credentials, TOTP seeds and cluster keys are AES-256-GCM encrypted in the database under a master key kept outside it (`/var/db/aifw/secrets.key`); legacy plaintext rows are sealed automatically on the first start after upgrade
 - **Log rotation** — one size-based newsyslog policy (cap, generations, compression) for every AiFw service log, with per-log sizes and rotate-now in Settings → Logging and `aifw logrotate`
 - **Metrics engine** — RRD-style ring buffers (1s/1m/1h/1d tiers), optional PostgreSQL backend
 - **REST API** — Axum with JWT auth, API keys, full CRUD for all resources

--- a/aifw-api/src/acme.rs
+++ b/aifw-api/src/acme.rs
@@ -25,6 +25,12 @@ fn server(e: impl std::fmt::Display) -> (StatusCode, String) {
     (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
 }
 
+/// #298: seal an optional credential column for storage.
+fn seal_opt(v: Option<&str>) -> Result<Option<String>, (StatusCode, String)> {
+    v.map(|s| aifw_core::secrets::seal(s).map_err(server))
+        .transpose()
+}
+
 // =============================================================================
 // Account
 // =============================================================================
@@ -365,8 +371,8 @@ pub async fn create_provider(
     )
     .bind(&req.name)
     .bind(&req.kind)
-    .bind(&req.api_token)
-    .bind(&req.aws_secret_key)
+    .bind(seal_opt(req.api_token.as_deref())?)
+    .bind(seal_opt(req.aws_secret_key.as_deref())?)
     .bind(&req.zone)
     .bind(&extra_str)
     .execute(&state.pool)
@@ -412,8 +418,8 @@ pub async fn update_provider(
     )
     .bind(&req.name)
     .bind(&req.kind)
-    .bind(&api_token)
-    .bind(&aws_secret)
+    .bind(seal_opt(api_token.as_deref())?)
+    .bind(seal_opt(aws_secret.as_deref())?)
     .bind(&req.zone)
     .bind(&extra_str)
     .bind(id)

--- a/aifw-api/src/ai_analysis.rs
+++ b/aifw-api/src/ai_analysis.rs
@@ -33,6 +33,7 @@ pub async fn run_analysis(pool: &SqlitePool) -> Result<u32, String> {
 
     let api_key = get_config(pool, &format!("ai_{provider}_api_key"))
         .await
+        .map(|v| aifw_core::secrets::open_lossy(&v))
         .unwrap_or_default();
     let endpoint = get_config(pool, &format!("ai_{provider}_endpoint"))
         .await

--- a/aifw-api/src/auth/oauth.rs
+++ b/aifw-api/src/auth/oauth.rs
@@ -103,7 +103,11 @@ pub async fn save_provider(pool: &SqlitePool, provider: &OAuthProvider) -> Resul
     .bind(&provider.name)
     .bind(provider.provider_type.to_string())
     .bind(&provider.client_id)
-    .bind(&provider.client_secret)
+    // #298: sealed at rest
+    .bind(
+        aifw_core::secrets::seal(&provider.client_secret)
+            .map_err(|e| format!("seal client_secret: {e}"))?,
+    )
     .bind(&provider.auth_url)
     .bind(&provider.token_url)
     .bind(&provider.userinfo_url)
@@ -136,7 +140,7 @@ pub async fn list_providers(pool: &SqlitePool) -> Result<Vec<OAuthProvider>, Str
                     _ => OAuthProviderType::Oidc,
                 },
                 client_id: ci,
-                client_secret: cs,
+                client_secret: aifw_core::secrets::open_lossy(&cs),
                 auth_url: au,
                 token_url: tu,
                 userinfo_url: uu,

--- a/aifw-api/src/auth/totp_store.rs
+++ b/aifw-api/src/auth/totp_store.rs
@@ -12,8 +12,13 @@ pub async fn save_totp_secret(
     user_id: &str,
     secret: &str,
 ) -> Result<(), StatusCode> {
+    // #298: TOTP seeds are sealed at rest.
+    let sealed = aifw_core::secrets::seal(secret).map_err(|e| {
+        tracing::error!(error = %e, "auth: failed to seal TOTP secret");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
     sqlx::query("UPDATE users SET totp_secret = ?1 WHERE id = ?2")
-        .bind(secret)
+        .bind(sealed)
         .bind(user_id)
         .execute(pool)
         .await

--- a/aifw-api/src/auth/users.rs
+++ b/aifw-api/src/auth/users.rs
@@ -65,7 +65,17 @@ pub async fn create_user(
     .bind(&user.username)
     .bind(&user.password_hash)
     .bind(user.totp_enabled)
-    .bind(user.totp_secret.as_deref())
+    .bind(
+        user.totp_secret
+            .as_deref()
+            .map(|s| {
+                aifw_core::secrets::seal(s).map_err(|e| {
+                    tracing::error!(error = %e, "auth: failed to seal TOTP secret");
+                    StatusCode::INTERNAL_SERVER_ERROR
+                })
+            })
+            .transpose()?,
+    )
     .bind(&user.auth_provider)
     .bind(&user.role)
     .bind(user.role_id.as_deref())
@@ -94,7 +104,7 @@ pub async fn list_users(pool: &SqlitePool) -> Result<Vec<User>, StatusCode> {
                 username,
                 password_hash: pw,
                 totp_enabled: totp_on,
-                totp_secret: totp_sec,
+                totp_secret: aifw_core::secrets::open_opt_lossy(totp_sec),
                 auth_provider: provider,
                 role,
                 role_id,
@@ -257,7 +267,7 @@ pub async fn get_user_by_username(
             username,
             password_hash: pw,
             totp_enabled: totp_on,
-            totp_secret: totp_sec,
+            totp_secret: aifw_core::secrets::open_opt_lossy(totp_sec),
             auth_provider: provider,
             role,
             role_id,
@@ -282,7 +292,7 @@ pub async fn get_user_by_id(pool: &SqlitePool, user_id: &str) -> Result<Option<U
             username,
             password_hash: pw,
             totp_enabled: totp_on,
-            totp_secret: totp_sec,
+            totp_secret: aifw_core::secrets::open_opt_lossy(totp_sec),
             auth_provider: provider,
             role,
             role_id,

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -1026,7 +1026,7 @@ async fn build_dhcp_section(pool: &sqlx::SqlitePool) -> aifw_core::config::DhcpS
             "dns_server" => ddns.dns_server = value,
             "tsig_key" => ddns.tsig_key = value,
             "tsig_algorithm" => ddns.tsig_algorithm = value,
-            "tsig_secret" => ddns.tsig_secret = value,
+            "tsig_secret" => ddns.tsig_secret = aifw_core::secrets::open_lossy(&value),
             "ttl" => ddns.ttl = value.parse().unwrap_or(300),
             _ => {}
         }
@@ -2581,7 +2581,11 @@ async fn apply_dhcp_section_db(
         ("dns_server", d.dns_server.clone()),
         ("tsig_key", d.tsig_key.clone()),
         ("tsig_algorithm", d.tsig_algorithm.clone()),
-        ("tsig_secret", d.tsig_secret.clone()),
+        (
+            "tsig_secret",
+            aifw_core::secrets::seal(&d.tsig_secret)
+                .map_err(|e| apply_fail("seal tsig_secret", e))?,
+        ),
         ("ttl", d.ttl.to_string()),
     ] {
         sqlx::query("INSERT OR REPLACE INTO dhcp_ddns_config (key, value) VALUES (?1, ?2)")

--- a/aifw-api/src/dhcp.rs
+++ b/aifw-api/src/dhcp.rs
@@ -569,7 +569,8 @@ async fn load_ddns_config(pool: &SqlitePool) -> DdnsConfig {
             "dns_server" => config.dns_server = value,
             "tsig_key" => config.tsig_key = value,
             "tsig_algorithm" => config.tsig_algorithm = value,
-            "tsig_secret" => config.tsig_secret = value,
+            // #298: sealed at rest; legacy plaintext passes through.
+            "tsig_secret" => config.tsig_secret = aifw_core::secrets::open_lossy(&value),
             "ttl" => config.ttl = value.parse().unwrap_or(300),
             _ => {}
         }
@@ -1405,7 +1406,11 @@ pub async fn update_ddns_config(
     save_ddns_key(&state.pool, "dns_server", &config.dns_server).await;
     save_ddns_key(&state.pool, "tsig_key", &config.tsig_key).await;
     save_ddns_key(&state.pool, "tsig_algorithm", &config.tsig_algorithm).await;
-    save_ddns_key(&state.pool, "tsig_secret", &config.tsig_secret).await;
+    let sealed_tsig = aifw_core::secrets::seal(&config.tsig_secret).map_err(|e| {
+        tracing::error!(error = %e, "dhcp: sealing tsig_secret failed");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    save_ddns_key(&state.pool, "tsig_secret", &sealed_tsig).await;
     save_ddns_key(&state.pool, "ttl", &config.ttl.to_string()).await;
     Ok(Json(MessageResponse {
         message: "DDNS config updated".to_string(),

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -1564,6 +1564,17 @@ async fn main() -> anyhow::Result<()> {
     // JWT secret is loaded from the key file below, then swapped in.
     let auth_settings = auth::AuthSettings::default();
 
+    // #298: the secrets master key lives beside the JWT key
+    // (/var/db/aifw/secrets.key on an appliance; a dev run with a scratch
+    // --jwt-key-file gets a persistent key in the same scratch dir).
+    if let Some(dir) = args.jwt_key_file.parent()
+        && !dir.as_os_str().is_empty()
+    {
+        aifw_core::secrets::set_key_path(dir.join("secrets.key"));
+    } else {
+        aifw_core::secrets::configure_from_db_path(&args.db);
+    }
+
     let mut state = create_app_state(
         &args.db,
         auth_settings,
@@ -1571,6 +1582,10 @@ async fn main() -> anyhow::Result<()> {
         syslog_mgr.clone(),
     )
     .await?;
+
+    // #298: seal any secrets still stored in plaintext by an older
+    // release. One-shot per row; a no-op on every later start.
+    aifw_core::secrets::seal_legacy_rows(&state.pool).await;
 
     // Resolve the JWT secret: explicit override > key file (migrating any
     // legacy DB-stored secret on first run) > freshly generated in file.

--- a/aifw-api/src/routes/ai.rs
+++ b/aifw-api/src/routes/ai.rs
@@ -28,6 +28,7 @@ pub async fn get_ai_settings(
             .unwrap_or(false);
         let api_key = get_val(pool, &format!("ai_{p}_api_key"))
             .await
+            .map(|v| aifw_core::secrets::open_lossy(&v))
             .unwrap_or_default();
         let endpoint = get_val(pool, &format!("ai_{p}_endpoint"))
             .await
@@ -106,7 +107,12 @@ pub async fn update_ai_settings(
             return Err(bad_request());
         }
         if let Some(ref key) = req.api_key {
-            save_val(pool, &format!("ai_{provider}_api_key"), key).await;
+            // #298: sealed at rest.
+            let sealed = aifw_core::secrets::seal(key).map_err(|e| {
+                tracing::error!(error = %e, "ai: failed to seal api key");
+                internal()
+            })?;
+            save_val(pool, &format!("ai_{provider}_api_key"), &sealed).await;
         }
         if let Some(ref endpoint) = req.endpoint {
             save_val(pool, &format!("ai_{provider}_endpoint"), endpoint).await;
@@ -303,7 +309,8 @@ pub async fn test_ai_provider(
             .unwrap_or_default()
     }
 
-    let api_key = get_val(pool, &format!("ai_{provider}_api_key")).await;
+    let api_key =
+        aifw_core::secrets::open_lossy(&get_val(pool, &format!("ai_{provider}_api_key")).await);
     let endpoint = get_val(pool, &format!("ai_{provider}_endpoint")).await;
     let model = get_val(pool, &format!("ai_{provider}_model")).await;
     let stored_insecure = get_val(pool, &format!("ai_{provider}_tls_insecure")).await == "true";
@@ -387,7 +394,8 @@ pub async fn list_ai_models(
             .unwrap_or_default()
     }
 
-    let api_key = get_val(pool, &format!("ai_{provider}_api_key")).await;
+    let api_key =
+        aifw_core::secrets::open_lossy(&get_val(pool, &format!("ai_{provider}_api_key")).await);
     let endpoint = get_val(pool, &format!("ai_{provider}_endpoint")).await;
     let tls_insecure = get_val(pool, &format!("ai_{provider}_tls_insecure")).await == "true";
 

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -736,6 +736,29 @@ mod tests {
         resp.assert_status(StatusCode::UNAUTHORIZED);
     }
 
+    /// #298: OAuth client secrets are sealed in the DB; the loader opens them.
+    #[tokio::test]
+    async fn test_oauth_client_secret_sealed_at_rest() {
+        let state = crate::create_app_state_in_memory(plain_auth_settings())
+            .await
+            .unwrap();
+        let provider = crate::auth::oauth::OAuthProvider::google("cid", "very-secret");
+        crate::auth::oauth::save_provider(&state.pool, &provider)
+            .await
+            .unwrap();
+        let (stored,): (String,) =
+            sqlx::query_as("SELECT client_secret FROM oauth_providers WHERE client_id = 'cid'")
+                .fetch_one(&state.pool)
+                .await
+                .unwrap();
+        assert!(aifw_core::secrets::is_sealed(&stored));
+        assert!(!stored.contains("very-secret"));
+        let listed = crate::auth::oauth::list_providers(&state.pool)
+            .await
+            .unwrap();
+        assert_eq!(listed[0].client_secret, "very-secret");
+    }
+
     #[tokio::test]
     async fn test_oauth_provider_crud() {
         let (server, _) = test_app().await;

--- a/aifw-cli/src/main.rs
+++ b/aifw-cli/src/main.rs
@@ -1080,6 +1080,8 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let cli = Cli::parse();
+    // #298: secrets master key beside the database (shared with aifw-api).
+    aifw_core::secrets::configure_from_db_path(&cli.db);
 
     match cli.command {
         Commands::Init { path } => {

--- a/aifw-core/Cargo.toml
+++ b/aifw-core/Cargo.toml
@@ -18,6 +18,9 @@ uuid = { workspace = true }
 async-trait = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
+aws-lc-rs = { workspace = true }
+base64 = { workspace = true }
+getrandom = { workspace = true }
 cron = "0.17"
 arc-swap = "1"
 ip_network = "0.4"

--- a/aifw-core/src/acme.rs
+++ b/aifw-core/src/acme.rs
@@ -566,8 +566,9 @@ fn row_to_provider(row: &sqlx::sqlite::SqliteRow) -> AcmeDnsProvider {
         name: row.get("name"),
         kind: DnsProviderKind::from_str(&row.get::<String, _>("kind"))
             .unwrap_or(DnsProviderKind::Manual),
-        api_token: row.get("api_token"),
-        aws_secret_key: row.get("aws_secret_key"),
+        // #298: sealed at rest; legacy plaintext passes through.
+        api_token: crate::secrets::open_opt_lossy(row.get("api_token")),
+        aws_secret_key: crate::secrets::open_opt_lossy(row.get("aws_secret_key")),
         zone: row.get("zone"),
         extra,
     }

--- a/aifw-core/src/config_manager.rs
+++ b/aifw-core/src/config_manager.rs
@@ -144,12 +144,15 @@ impl ConfigManager {
         let json = config.to_json();
         let hash = config.hash();
         let now = Utc::now().to_rfc3339();
+        // #298: the snapshot carries every secret in the config (WG keys,
+        // PSKs, credentials) — seal the whole blob at rest.
+        let sealed = crate::secrets::seal(&json).map_err(|e| format!("seal snapshot: {e}"))?;
 
         let result = sqlx::query(
             r#"INSERT INTO config_versions (config_json, hash, applied, created_by, created_at, comment)
                VALUES (?1, ?2, 0, ?3, ?4, ?5)"#,
         )
-        .bind(&json)
+        .bind(&sealed)
         .bind(&hash)
         .bind(created_by)
         .bind(&now)
@@ -258,6 +261,7 @@ impl ConfigManager {
 
         match row {
             Some((version, json)) => {
+                let json = crate::secrets::open(&json).map_err(|e| e.to_string())?;
                 let config = FirewallConfig::from_json(&json)?;
                 Ok(Some((version, config)))
             }
@@ -275,6 +279,7 @@ impl ConfigManager {
         .await
         .map_err(|e| format!("version {version} not found: {e}"))?;
 
+        let json = crate::secrets::open(&json).map_err(|e| e.to_string())?;
         FirewallConfig::from_json(&json)
     }
 
@@ -324,7 +329,8 @@ impl ConfigManager {
             .fetch_one(&self.pool)
             .await
             .ok()
-            .and_then(|(json,)| FirewallConfig::from_json(&json).ok())
+            .and_then(|(json,)| crate::secrets::open(&json).ok())
+            .and_then(|json| FirewallConfig::from_json(&json).ok())
             .map(|c| c.resource_count())
             .unwrap_or(0);
 

--- a/aifw-core/src/ha.rs
+++ b/aifw-core/src/ha.rs
@@ -199,7 +199,7 @@ impl ClusterEngine {
         .bind(vip.virtual_ip.to_string())
         .bind(vip.prefix as i64)
         .bind(&vip.interface.0)
-        .bind(&vip.password)
+        .bind(crate::secrets::seal(&vip.password).map_err(crate::secrets::to_common)?)
         .bind(vip.status.to_string())
         .bind(vip.created_at.to_rfc3339())
         .bind(vip.updated_at.to_rfc3339())
@@ -230,7 +230,7 @@ impl ClusterEngine {
         .bind(v.virtual_ip.to_string())
         .bind(v.prefix as i64)
         .bind(&v.interface.0)
-        .bind(&v.password)
+        .bind(crate::secrets::seal(&v.password).map_err(crate::secrets::to_common)?)
         .bind(v.status.to_string())
         .bind(Utc::now().to_rfc3339())
         .bind(v.id.to_string())
@@ -456,10 +456,12 @@ impl ClusterEngine {
         // Two simple-format UUIDs = 64 hex chars = 256 bits of getrandom-sourced entropy.
         let key = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
         let hash = sha256_hex(&key);
+        // #298: the plaintext copy (needed for outbound calls) is sealed at rest.
+        let sealed = crate::secrets::seal(&key).map_err(crate::secrets::to_common)?;
         sqlx::query(
             "UPDATE cluster_nodes SET peer_api_key = ?1, peer_api_key_hash = ?2 WHERE id = ?3",
         )
-        .bind(&key)
+        .bind(&sealed)
         .bind(&hash)
         .bind(node_id.to_string())
         .execute(&self.pool)
@@ -475,7 +477,7 @@ impl ClusterEngine {
                 .bind(node_id.to_string())
                 .fetch_optional(&self.pool)
                 .await?;
-        Ok(row.and_then(|(k,)| k))
+        crate::secrets::open_opt(row.and_then(|(k,)| k)).map_err(crate::secrets::to_common)
     }
 
     // ============================================================
@@ -789,7 +791,8 @@ impl CarpVipRow {
                 .map_err(|e| AifwError::Database(format!("{e}")))?,
             prefix: self.prefix as u8,
             interface: Interface(self.interface),
-            password: self.password,
+            // #298: sealed at rest; legacy plaintext passes through.
+            password: crate::secrets::open(&self.password).map_err(crate::secrets::to_common)?,
             status: match self.status.as_str() {
                 "master" => CarpStatus::Master,
                 "backup" => CarpStatus::Backup,

--- a/aifw-core/src/ipsec.rs
+++ b/aifw-core/src/ipsec.rs
@@ -543,14 +543,16 @@ impl IpsecTunnelRow {
             local_id: self.local_id,
             remote_id: self.remote_id,
             auth_method: IpsecAuthMethod::parse(&self.auth_method)?,
-            psk: self.psk,
+            // #298: sealed at rest; legacy plaintext passes through.
+            psk: crate::secrets::open(&self.psk).map_err(crate::secrets::to_common)?,
             cert_source: match self.cert_source.as_deref() {
                 None | Some("") => None,
                 Some(s) => Some(IpsecCertSource::parse(s)?),
             },
             acme_cert_id: self.acme_cert_id,
             local_cert_pem: self.local_cert_pem,
-            local_key_pem: self.local_key_pem,
+            local_key_pem: crate::secrets::open(&self.local_key_pem)
+                .map_err(crate::secrets::to_common)?,
             ca_cert_pem: self.ca_cert_pem,
             ike_proposal: self.ike_proposal,
             esp_proposal: self.esp_proposal,
@@ -659,11 +661,11 @@ impl IpsecEngine {
         .bind(&tunnel.local_id)
         .bind(&tunnel.remote_id)
         .bind(tunnel.auth_method.to_string())
-        .bind(&tunnel.psk)
+        .bind(crate::secrets::seal(&tunnel.psk).map_err(crate::secrets::to_common)?)
         .bind(tunnel.cert_source.map(|s| s.to_string()))
         .bind(tunnel.acme_cert_id)
         .bind(&tunnel.local_cert_pem)
-        .bind(&tunnel.local_key_pem)
+        .bind(crate::secrets::seal(&tunnel.local_key_pem).map_err(crate::secrets::to_common)?)
         .bind(&tunnel.ca_cert_pem)
         .bind(&tunnel.ike_proposal)
         .bind(&tunnel.esp_proposal)
@@ -728,11 +730,11 @@ impl IpsecEngine {
         .bind(&tunnel.local_id)
         .bind(&tunnel.remote_id)
         .bind(tunnel.auth_method.to_string())
-        .bind(&tunnel.psk)
+        .bind(crate::secrets::seal(&tunnel.psk).map_err(crate::secrets::to_common)?)
         .bind(tunnel.cert_source.map(|s| s.to_string()))
         .bind(tunnel.acme_cert_id)
         .bind(&tunnel.local_cert_pem)
-        .bind(&tunnel.local_key_pem)
+        .bind(crate::secrets::seal(&tunnel.local_key_pem).map_err(crate::secrets::to_common)?)
         .bind(&tunnel.ca_cert_pem)
         .bind(&tunnel.ike_proposal)
         .bind(&tunnel.esp_proposal)

--- a/aifw-core/src/lib.rs
+++ b/aifw-core/src/lib.rs
@@ -47,6 +47,7 @@ pub use aifw_common::net_safety;
 pub mod path_safety;
 pub mod pf_tuning;
 pub mod s3_backup;
+pub mod secrets;
 /// [`ShapingEngine`] — traffic-shaping queues and connection rate limits
 pub mod shaping;
 pub mod smtp_notify;

--- a/aifw-core/src/s3_backup.rs
+++ b/aifw-core/src/s3_backup.rs
@@ -130,7 +130,8 @@ pub async fn load(pool: &SqlitePool) -> S3Config {
         prefix,
         path_style: path_style != 0,
         access_key_id: ak,
-        secret_access_key: sk,
+        // #298: sealed at rest; legacy plaintext rows pass through.
+        secret_access_key: crate::secrets::open_opt_lossy(sk),
     })
     .unwrap_or_default()
 }
@@ -144,6 +145,12 @@ pub async fn save(pool: &SqlitePool, cfg: &S3Config) -> Result<(), String> {
         Some("") => None,
         Some(v) => Some(v.to_string()),
     };
+    // #298: seal at rest (also re-seals a legacy plaintext value on the
+    // next save).
+    let final_secret = final_secret
+        .map(|v| crate::secrets::seal(&v))
+        .transpose()
+        .map_err(|e| e.to_string())?;
     sqlx::query(
         r#"UPDATE s3_backup_config
               SET enabled=?, bucket=?, region=?, endpoint=?, prefix=?,

--- a/aifw-core/src/secrets.rs
+++ b/aifw-core/src/secrets.rs
@@ -1,0 +1,545 @@
+//! Column-level encryption for secrets stored in SQLite (#298 / SEC-M1).
+//!
+//! Integration secrets (OAuth client secrets, S3/SMTP credentials, TSIG,
+//! WireGuard private/preshared keys, CARP + IPsec PSKs, cluster peer API
+//! keys, ACME DNS tokens, AI provider keys, TOTP seeds) used to sit in the
+//! database in cleartext, so any DB snapshot leak — backup, disk image, an
+//! SQL-read bug elsewhere — handed over every credential the appliance
+//! holds. They are now sealed with AES-256-GCM under a master key that
+//! lives outside the database.
+//!
+//! # Wire format
+//! `enc:v1:<base64(nonce(12) ‖ ciphertext ‖ tag(16))>` — a random 96-bit
+//! nonce per value. Anything without the `enc:v1:` prefix is treated as a
+//! legacy plaintext value by [`open`], so an upgraded appliance keeps
+//! working immediately and every value becomes sealed the next time it is
+//! written (each call site seals on write, opens on read).
+//!
+//! # Master key
+//! 32 random bytes, hex-encoded, in `/var/db/aifw/secrets.key` (0600, next
+//! to `jwt.key`). Loaded lazily on first use by whichever AiFw process
+//! needs it and created — atomically, so two processes racing on first
+//! boot can't end up with two keys — by the first process that has to
+//! *seal* something. Override the path with `AIFW_SECRETS_KEY_FILE`
+//! (tests, dev hosts). #108 (TPM-sealed key) swaps the source of these
+//! 32 bytes; nothing above this module needs to change for that.
+//!
+//! When no key file exists and one cannot be created (read-only dev host,
+//! unit tests), the process falls back to an ephemeral in-memory key and
+//! logs a warning: values round-trip within the process but will not
+//! survive a restart. Production appliances always have a writable
+//! `/var/db/aifw`.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use aws_lc_rs::aead::{AES_256_GCM, Aad, LessSafeKey, NONCE_LEN, Nonce, UnboundKey};
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64;
+use tracing::{info, warn};
+
+use crate::{CoreError, Result};
+
+/// Prefix identifying a sealed value.
+pub const PREFIX: &str = "enc:v1:";
+/// Default location of the master key.
+pub const DEFAULT_KEY_PATH: &str = "/var/db/aifw/secrets.key";
+/// Environment override for the key path (tests / dev hosts).
+pub const KEY_PATH_ENV: &str = "AIFW_SECRETS_KEY_FILE";
+
+const KEY_LEN: usize = 32;
+
+static KEY: OnceLock<LessSafeKey> = OnceLock::new();
+static CONFIGURED_PATH: OnceLock<PathBuf> = OnceLock::new();
+/// Set when the process fell back to an in-memory key (no readable or
+/// creatable key file). Nothing sealed under it survives a restart, so the
+/// legacy-row migration refuses to run in that state.
+static EPHEMERAL: AtomicBool = AtomicBool::new(false);
+
+/// Point this process at a specific key file. Binaries call it once at
+/// startup with `<db dir>/secrets.key` so a dev run with `--db
+/// ./scratch/aifw.db` gets a persistent key beside its database instead of
+/// falling back to an ephemeral one. No effect after the key is loaded or
+/// if `AIFW_SECRETS_KEY_FILE` is set.
+pub fn set_key_path(path: PathBuf) {
+    let _ = CONFIGURED_PATH.set(path);
+}
+
+/// Derive the key path from a database path (`<db dir>/secrets.key`) and
+/// configure it. In-memory / relative-less DB paths leave the default.
+pub fn configure_from_db_path(db_path: &Path) {
+    if let Some(dir) = db_path.parent()
+        && !dir.as_os_str().is_empty()
+    {
+        set_key_path(dir.join("secrets.key"));
+    }
+}
+
+/// Path the master key is read from / written to: env override, then the
+/// path set by [`set_key_path`], then [`DEFAULT_KEY_PATH`].
+pub fn key_path() -> PathBuf {
+    if let Some(p) = std::env::var_os(KEY_PATH_ENV) {
+        return PathBuf::from(p);
+    }
+    CONFIGURED_PATH
+        .get()
+        .cloned()
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_KEY_PATH))
+}
+
+/// True when this process is using an ephemeral (non-persistent) key.
+pub fn is_ephemeral() -> bool {
+    EPHEMERAL.load(Ordering::Relaxed)
+}
+
+/// True for values written by [`seal`].
+pub fn is_sealed(value: &str) -> bool {
+    value.starts_with(PREFIX)
+}
+
+/// Encrypt `plaintext` for storage. Empty input stays empty (an unset
+/// secret is not a secret, and callers test for emptiness).
+pub fn seal(plaintext: &str) -> Result<String> {
+    if plaintext.is_empty() {
+        return Ok(String::new());
+    }
+    let key = load_key(true)?;
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    getrandom::fill(&mut nonce_bytes)
+        .map_err(|e| CoreError::Other(format!("secrets: nonce generation failed: {e}")))?;
+    let nonce = Nonce::assume_unique_for_key(nonce_bytes);
+    let mut buf = plaintext.as_bytes().to_vec();
+    key.seal_in_place_append_tag(nonce, Aad::empty(), &mut buf)
+        .map_err(|_| CoreError::Other("secrets: encryption failed".into()))?;
+    let mut out = Vec::with_capacity(NONCE_LEN + buf.len());
+    out.extend_from_slice(&nonce_bytes);
+    out.extend_from_slice(&buf);
+    Ok(format!("{PREFIX}{}", B64.encode(out)))
+}
+
+/// Decrypt a stored value. Values without the [`PREFIX`] are returned as-is
+/// (legacy plaintext from before #298).
+pub fn open(stored: &str) -> Result<String> {
+    let Some(b64) = stored.strip_prefix(PREFIX) else {
+        return Ok(stored.to_string());
+    };
+    let raw = B64
+        .decode(b64)
+        .map_err(|e| CoreError::Other(format!("secrets: malformed sealed value: {e}")))?;
+    if raw.len() < NONCE_LEN + AES_256_GCM.tag_len() {
+        return Err(CoreError::Other("secrets: sealed value too short".into()));
+    }
+    let key = load_key(false)?;
+    let (nonce_bytes, ct) = raw.split_at(NONCE_LEN);
+    let nonce = Nonce::try_assume_unique_for_key(nonce_bytes)
+        .map_err(|_| CoreError::Other("secrets: bad nonce".into()))?;
+    let mut buf = ct.to_vec();
+    let pt = key
+        .open_in_place(nonce, Aad::empty(), &mut buf)
+        .map_err(|_| {
+            CoreError::Other(
+                "secrets: decryption failed — the master key does not match this value \
+                 (was /var/db/aifw/secrets.key replaced or restored from another box?)"
+                    .into(),
+            )
+        })?;
+    String::from_utf8(pt.to_vec())
+        .map_err(|_| CoreError::Other("secrets: decrypted value is not UTF-8".into()))
+}
+
+/// [`open`] for `Option<String>` columns.
+pub fn open_opt(stored: Option<String>) -> Result<Option<String>> {
+    stored.map(|s| open(&s)).transpose()
+}
+
+/// [`open`] that never fails the caller: on a decryption error it logs and
+/// returns an empty string, so a list/status page still renders and the
+/// operator sees a blank credential rather than a 500. Use for read paths
+/// where the secret is display-masked anyway; use [`open`] where the value
+/// is about to be *used*.
+pub fn open_lossy(stored: &str) -> String {
+    match open(stored) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(error = %e, "secrets: could not open a stored secret; treating as unset");
+            String::new()
+        }
+    }
+}
+
+/// [`open_lossy`] for `Option<String>` columns.
+pub fn open_opt_lossy(stored: Option<String>) -> Option<String> {
+    stored.map(|s| open_lossy(&s))
+}
+
+/// Error adapter for engines that still use `aifw_common::AifwError`
+/// (`ha.rs`, `vpn.rs`): `secrets::seal(v).map_err(secrets::to_common)?`.
+pub fn to_common(e: CoreError) -> aifw_common::AifwError {
+    aifw_common::AifwError::Crypto(e.to_string())
+}
+
+/// Re-seal a value that may still be legacy plaintext, for one-shot
+/// migrations. Returns `None` when the value is already sealed or empty
+/// (nothing to write back).
+pub fn reseal_if_plain(stored: &str) -> Result<Option<String>> {
+    if stored.is_empty() || is_sealed(stored) {
+        return Ok(None);
+    }
+    seal(stored).map(Some)
+}
+
+fn load_key(create: bool) -> Result<&'static LessSafeKey> {
+    if let Some(k) = KEY.get() {
+        return Ok(k);
+    }
+    let path = key_path();
+    let bytes = match read_key_file(&path) {
+        Ok(Some(b)) => b,
+        Ok(None) if create => match create_key_file(&path) {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "secrets: cannot create master key file — using an ephemeral key; \
+                     sealed values will NOT survive a restart"
+                );
+                EPHEMERAL.store(true, Ordering::Relaxed);
+                random_key()?
+            }
+        },
+        Ok(None) => {
+            return Err(CoreError::Config(format!(
+                "secrets: master key {} does not exist yet — a sealed value cannot be \
+                 opened before aifw-api has created the key",
+                path.display()
+            )));
+        }
+        Err(e) => return Err(e),
+    };
+    let unbound = UnboundKey::new(&AES_256_GCM, &bytes)
+        .map_err(|_| CoreError::Config("secrets: master key has the wrong length".into()))?;
+    let _ = KEY.set(LessSafeKey::new(unbound));
+    // Another thread may have won the race; both loaded the same file.
+    Ok(KEY
+        .get()
+        .expect("KEY set just above or by a concurrent loader"))
+}
+
+fn random_key() -> Result<[u8; KEY_LEN]> {
+    let mut k = [0u8; KEY_LEN];
+    getrandom::fill(&mut k)
+        .map_err(|e| CoreError::Other(format!("secrets: key generation failed: {e}")))?;
+    Ok(k)
+}
+
+fn read_key_file(path: &Path) -> Result<Option<[u8; KEY_LEN]>> {
+    match std::fs::read_to_string(path) {
+        Ok(s) => {
+            let raw = hex::decode(s.trim()).map_err(|_| {
+                CoreError::Config(format!("secrets: {} is not hex", path.display()))
+            })?;
+            let arr: [u8; KEY_LEN] = raw.try_into().map_err(|_| {
+                CoreError::Config(format!(
+                    "secrets: {} must hold exactly {KEY_LEN} bytes",
+                    path.display()
+                ))
+            })?;
+            Ok(Some(arr))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(CoreError::Io(e)),
+    }
+}
+
+/// Create the key file atomically (create-new semantics). If another
+/// process created it first, adopt that key instead of ours.
+fn create_key_file(path: &Path) -> Result<[u8; KEY_LEN]> {
+    use std::io::Write;
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    let key = random_key()?;
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    match opts.open(path) {
+        Ok(mut f) => {
+            f.write_all(hex::encode(key).as_bytes())?;
+            f.sync_all()?;
+            drop(f);
+            fix_owner(path);
+            info!(path = %path.display(), "secrets: master key created");
+            Ok(key)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            // Lost the race — read what the winner wrote (it may still be
+            // mid-write for a moment; the file is tiny and fsync'd, retry
+            // briefly).
+            for _ in 0..20 {
+                if let Ok(Some(k)) = read_key_file(path) {
+                    return Ok(k);
+                }
+                std::thread::sleep(std::time::Duration::from_millis(25));
+            }
+            Err(CoreError::Config(format!(
+                "secrets: {} exists but could not be read",
+                path.display()
+            )))
+        }
+        Err(e) => Err(CoreError::Io(e)),
+    }
+}
+
+/// When a root-run process (aifw CLI, aifw-setup) creates the key, hand it
+/// to the `aifw` service user so aifw-api / aifw-daemon can read it.
+/// Best-effort: as a non-root user, or on hosts without an `aifw` user
+/// (dev), chown simply fails and the file keeps its creator's ownership.
+fn fix_owner(path: &Path) {
+    let out = std::process::Command::new("chown")
+        .arg("aifw:aifw")
+        .arg(path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+    if let Ok(st) = out
+        && st.success()
+    {
+        info!(path = %path.display(), "secrets: master key handed to the aifw user");
+    }
+}
+
+/// (table, secret column, primary-key column) for every secret the code
+/// seals. [`seal_legacy_rows`] walks this list; keep it in sync when a new
+/// call site starts sealing a column.
+pub const SEALED_COLUMNS: &[(&str, &str, &str)] = &[
+    ("oauth_providers", "client_secret", "id"),
+    ("s3_backup_config", "secret_access_key", "id"),
+    ("smtp_notify_config", "password", "id"),
+    ("cluster_nodes", "peer_api_key", "id"),
+    ("carp_vips", "password", "id"),
+    ("wg_tunnels", "private_key", "id"),
+    ("wg_peers", "preshared_key", "id"),
+    ("wg_peers", "client_private_key", "id"),
+    ("ipsec_tunnels", "psk", "id"),
+    ("ipsec_tunnels", "local_key_pem", "id"),
+    ("acme_dns_provider", "api_token", "id"),
+    ("acme_dns_provider", "aws_secret_key", "id"),
+    ("users", "totp_secret", "id"),
+    // Config-history snapshots embed every secret above in one JSON blob.
+    ("config_versions", "config_json", "version"),
+];
+
+/// Key/value tables whose *value* is a secret for the listed keys.
+/// (table, key column, value column, key match — `=` literal or `LIKE`).
+pub const SEALED_KV: &[(&str, &str, &str, &str)] = &[
+    ("dhcp_ddns_config", "key", "value", "tsig_secret"),
+    ("auth_config", "key", "value", "ai_%_api_key"),
+];
+
+/// One-shot upgrade pass: seal every legacy plaintext secret still in the
+/// database. Runs at aifw-api startup after the schema migrations; each
+/// later start finds nothing to do. Skipped (with a warning) when the
+/// process only has an ephemeral key — sealing rows under a key that dies
+/// with the process would lock the operator out of their own secrets.
+/// Missing tables/columns (older DBs, other crates' engines not yet
+/// migrated) are ignored. Returns the number of values sealed.
+pub async fn seal_legacy_rows(pool: &sqlx::SqlitePool) -> usize {
+    // Force key load (creating the file if needed) so we know whether we
+    // are persistent before touching a single row.
+    if load_key(true).is_err() || is_ephemeral() {
+        warn!("secrets: no persistent master key — leaving legacy plaintext rows untouched");
+        return 0;
+    }
+    seal_legacy_rows_unchecked(pool).await
+}
+
+/// [`seal_legacy_rows`] without the persistence guard. Exposed for tests
+/// (which run under an ephemeral key); production code must call
+/// [`seal_legacy_rows`].
+#[doc(hidden)]
+pub async fn seal_legacy_rows_unchecked(pool: &sqlx::SqlitePool) -> usize {
+    let mut sealed = 0usize;
+    for (table, col, pk) in SEALED_COLUMNS {
+        // CAST: some PKs are INTEGER (s3/smtp singleton rows, acme
+        // providers), others TEXT uuids; the UPDATE below relies on SQLite
+        // column affinity to match the text back to an integer id.
+        let select = format!(
+            "SELECT CAST({pk} AS TEXT), {col} FROM {table} WHERE {col} IS NOT NULL AND {col} != '' AND {col} NOT LIKE '{PREFIX}%'"
+        );
+        let rows: Vec<(String, String)> = match sqlx::query_as(sqlx::AssertSqlSafe(select))
+            .fetch_all(pool)
+            .await
+        {
+            Ok(r) => r,
+            Err(_) => continue, // table/column absent on this DB
+        };
+        for (id, plain) in rows {
+            let Ok(Some(enc)) = reseal_if_plain(&plain) else {
+                continue;
+            };
+            let update = format!("UPDATE {table} SET {col} = ?1 WHERE {pk} = ?2");
+            match sqlx::query(sqlx::AssertSqlSafe(update))
+                .bind(&enc)
+                .bind(&id)
+                .execute(pool)
+                .await
+            {
+                Ok(_) => sealed += 1,
+                Err(e) => warn!(table, col, error = %e, "secrets: legacy row re-seal failed"),
+            }
+        }
+    }
+    for (table, kcol, vcol, pat) in SEALED_KV {
+        let op = if pat.contains('%') { "LIKE" } else { "=" };
+        let select = format!(
+            "SELECT {kcol}, {vcol} FROM {table} WHERE {kcol} {op} ?1 AND {vcol} != '' AND {vcol} NOT LIKE '{PREFIX}%'"
+        );
+        let rows: Vec<(String, String)> = match sqlx::query_as(sqlx::AssertSqlSafe(select))
+            .bind(pat)
+            .fetch_all(pool)
+            .await
+        {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        for (k, plain) in rows {
+            let Ok(Some(enc)) = reseal_if_plain(&plain) else {
+                continue;
+            };
+            let update = format!("UPDATE {table} SET {vcol} = ?1 WHERE {kcol} = ?2");
+            match sqlx::query(sqlx::AssertSqlSafe(update))
+                .bind(&enc)
+                .bind(&k)
+                .execute(pool)
+                .await
+            {
+                Ok(_) => sealed += 1,
+                Err(e) => warn!(table, key = %k, error = %e, "secrets: legacy row re-seal failed"),
+            }
+        }
+    }
+    if sealed > 0 {
+        info!(
+            sealed,
+            "secrets: legacy plaintext secrets sealed at rest (#298)"
+        );
+    }
+    sealed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seal_open_round_trip_and_legacy_passthrough() {
+        let sealed = seal("hunter2").unwrap();
+        assert!(is_sealed(&sealed));
+        assert_ne!(sealed, "hunter2");
+        assert_eq!(open(&sealed).unwrap(), "hunter2");
+        // Fresh nonce each time
+        assert_ne!(seal("hunter2").unwrap(), sealed);
+        // Legacy plaintext passes through
+        assert_eq!(open("plain-old-secret").unwrap(), "plain-old-secret");
+        assert!(!is_sealed("plain-old-secret"));
+        // Empty stays empty
+        assert_eq!(seal("").unwrap(), "");
+        assert_eq!(open("").unwrap(), "");
+        assert_eq!(open_opt(None).unwrap(), None);
+    }
+
+    #[test]
+    fn tampering_is_detected() {
+        let sealed = seal("payload").unwrap();
+        let mut bytes = B64.decode(&sealed[PREFIX.len()..]).unwrap();
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0x01;
+        let tampered = format!("{PREFIX}{}", B64.encode(bytes));
+        assert!(open(&tampered).is_err());
+        assert_eq!(open_lossy(&tampered), "");
+        assert!(open("enc:v1:not-base64!!").is_err());
+        assert!(open("enc:v1:AAAA").is_err());
+    }
+
+    #[tokio::test]
+    async fn legacy_rows_get_sealed_once() {
+        let db = crate::db::Database::new_in_memory().await.unwrap();
+        let pool = db.pool();
+        // Plaintext rows in a mix of TEXT-pk and INTEGER-pk tables plus a KV table.
+        sqlx::query(
+            "INSERT INTO users (id, username, password_hash, totp_enabled, totp_secret, auth_provider, created_at)
+             VALUES ('u1', 'alice', 'x', 1, 'JBSWY3DPEHPK3PXP', 'local', 'now')",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO auth_config (key, value) VALUES ('ai_openai_api_key', 'sk-plain')",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO auth_config (key, value) VALUES ('ai_openai_model', 'gpt')")
+            .execute(pool)
+            .await
+            .unwrap();
+        crate::acme::migrate(pool).await.unwrap();
+        sqlx::query(
+            "INSERT INTO acme_dns_provider (name, kind, api_token, aws_secret_key, zone, extra)
+             VALUES ('cf', 'cloudflare', 'tok-plain', NULL, 'example.com', '{}')",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        let n = seal_legacy_rows_unchecked(pool).await;
+        assert_eq!(n, 3, "totp_secret + ai api key + acme token");
+
+        let (totp,): (String,) = sqlx::query_as("SELECT totp_secret FROM users WHERE id = 'u1'")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+        assert!(is_sealed(&totp));
+        assert_eq!(open(&totp).unwrap(), "JBSWY3DPEHPK3PXP");
+        let (ai,): (String,) =
+            sqlx::query_as("SELECT value FROM auth_config WHERE key = 'ai_openai_api_key'")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert!(is_sealed(&ai));
+        let (model,): (String,) =
+            sqlx::query_as("SELECT value FROM auth_config WHERE key = 'ai_openai_model'")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert_eq!(model, "gpt", "non-secret KV rows untouched");
+        let (tok,): (String,) =
+            sqlx::query_as("SELECT api_token FROM acme_dns_provider WHERE name = 'cf'")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert!(is_sealed(&tok), "INTEGER-pk table row sealed");
+        assert_eq!(open(&tok).unwrap(), "tok-plain");
+
+        // Idempotent
+        assert_eq!(seal_legacy_rows_unchecked(pool).await, 0);
+    }
+
+    #[test]
+    fn reseal_only_touches_plaintext() {
+        assert!(reseal_if_plain("").unwrap().is_none());
+        let sealed = seal("x").unwrap();
+        assert!(reseal_if_plain(&sealed).unwrap().is_none());
+        let re = reseal_if_plain("x").unwrap().unwrap();
+        assert!(is_sealed(&re));
+        assert_eq!(open(&re).unwrap(), "x");
+    }
+}

--- a/aifw-core/src/smtp_notify.rs
+++ b/aifw-core/src/smtp_notify.rs
@@ -236,7 +236,8 @@ pub async fn load(pool: &SqlitePool) -> SmtpConfig {
         port: port as u16,
         tls: TlsMode::from_str(&tls),
         username: u,
-        password: p,
+        // #298: sealed at rest; legacy plaintext rows pass through.
+        password: crate::secrets::open_opt_lossy(p),
         from_address,
         recipients,
         enabled_events: mask as u32,
@@ -252,6 +253,11 @@ pub async fn save(pool: &SqlitePool, cfg: &SmtpConfig) -> Result<(), String> {
         Some("") => None,
         Some(v) => Some(v.to_string()),
     };
+    // #298: seal at rest.
+    let final_password = final_password
+        .map(|v| crate::secrets::seal(&v))
+        .transpose()
+        .map_err(|e| e.to_string())?;
     sqlx::query(
         r#"UPDATE smtp_notify_config
               SET enabled=?, host=?, port=?, tls=?, username=?, password=?,

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -1059,6 +1059,57 @@ mod tests {
         assert!(engine.list_wg_tunnels().await.unwrap().is_empty());
     }
 
+    /// #298: WireGuard private keys are sealed in the DB but the engine
+    /// hands back plaintext.
+    #[tokio::test]
+    async fn test_wg_private_key_sealed_at_rest() {
+        let db = Database::new_in_memory().await.unwrap();
+        let pf: Arc<dyn PfBackend> = Arc::new(aifw_pf::PfMock::new());
+        let engine = crate::vpn::VpnEngine::new(db.pool().clone(), pf);
+        engine.migrate().await.unwrap();
+        let tunnel = WgTunnel::new(
+            "sealed".to_string(),
+            Interface("wg7".to_string()),
+            51877,
+            Address::Network(
+                std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 77, 0, 1)),
+                24,
+            ),
+        )
+        .unwrap();
+        let id = tunnel.id;
+        let plain_key = tunnel.private_key.clone();
+        engine.add_wg_tunnel(tunnel).await.unwrap();
+
+        let (stored,): (String,) =
+            sqlx::query_as("SELECT private_key FROM wg_tunnels WHERE id = ?1")
+                .bind(id.to_string())
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert!(
+            crate::secrets::is_sealed(&stored),
+            "private_key must be sealed in the DB"
+        );
+        assert_ne!(stored, plain_key);
+        assert_eq!(
+            engine.get_wg_tunnel(id).await.unwrap().private_key,
+            plain_key
+        );
+
+        // A legacy plaintext row (pre-#298 DB) still reads back unchanged.
+        sqlx::query("UPDATE wg_tunnels SET private_key = ?1 WHERE id = ?2")
+            .bind(&plain_key)
+            .bind(id.to_string())
+            .execute(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            engine.get_wg_tunnel(id).await.unwrap().private_key,
+            plain_key
+        );
+    }
+
     #[tokio::test]
     async fn test_wg_tunnel_db_roundtrip() {
         let engine = create_vpn_engine().await;

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -199,7 +199,7 @@ impl VpnEngine {
         .bind(tunnel.id.to_string())
         .bind(&tunnel.name)
         .bind(&tunnel.interface.0)
-        .bind(&tunnel.private_key)
+        .bind(crate::secrets::seal(&tunnel.private_key).map_err(crate::secrets::to_common)?)
         .bind(&tunnel.public_key)
         .bind(tunnel.listen_port as i64)
         .bind(tunnel.address.to_string())
@@ -284,7 +284,7 @@ impl VpnEngine {
         .bind(tunnel.mtu.map(|m| m as i64))
         .bind(tunnel.listen_interface.as_deref())
         .bind(tunnel.split_routes.as_deref())
-        .bind(&tunnel.private_key)
+        .bind(crate::secrets::seal(&tunnel.private_key).map_err(crate::secrets::to_common)?)
         .bind(&tunnel.public_key)
         .bind(tunnel.updated_at.to_rfc3339())
         .bind(tunnel.id.to_string())
@@ -388,8 +388,8 @@ impl VpnEngine {
         .bind(peer.tunnel_id.to_string())
         .bind(&peer.name)
         .bind(&peer.public_key)
-        .bind(peer.preshared_key.as_deref())
-        .bind(peer.client_private_key.as_deref())
+        .bind(seal_opt(peer.preshared_key.as_deref())?)
+        .bind(seal_opt(peer.client_private_key.as_deref())?)
         .bind(peer.endpoint.as_deref())
         .bind(allowed_ips.join(","))
         .bind(peer.persistent_keepalive.map(|k| k as i64))
@@ -457,8 +457,8 @@ impl VpnEngine {
         )
         .bind(&peer.name)
         .bind(&peer.public_key)
-        .bind(peer.preshared_key.as_deref())
-        .bind(peer.client_private_key.as_deref())
+        .bind(seal_opt(peer.preshared_key.as_deref())?)
+        .bind(seal_opt(peer.client_private_key.as_deref())?)
         .bind(peer.endpoint.as_deref())
         .bind(allowed_ips.join(","))
         .bind(peer.persistent_keepalive.map(|k| k as i64))
@@ -1072,7 +1072,9 @@ impl WgTunnelRow {
             id: Uuid::parse_str(&self.id).map_err(|e| AifwError::Database(format!("{e}")))?,
             name: self.name,
             interface: Interface(self.interface),
-            private_key: self.private_key,
+            // #298: sealed at rest; legacy plaintext passes through.
+            private_key: crate::secrets::open(&self.private_key)
+                .map_err(crate::secrets::to_common)?,
             public_key: self.public_key,
             listen_port: self.listen_port as u16,
             address: Address::parse(&self.address)?,
@@ -1086,6 +1088,12 @@ impl WgTunnelRow {
             updated_at: parse_dt(&self.updated_at)?,
         })
     }
+}
+
+/// #298: seal an optional secret column for storage.
+fn seal_opt(v: Option<&str>) -> Result<Option<String>> {
+    v.map(|s| crate::secrets::seal(s).map_err(crate::secrets::to_common))
+        .transpose()
 }
 
 /// Explicit column list for `WgPeerRow` selects (#348). `client_private_key`
@@ -1125,8 +1133,10 @@ impl WgPeerRow {
                 .map_err(|e| AifwError::Database(format!("{e}")))?,
             name: self.name,
             public_key: self.public_key,
-            preshared_key: self.preshared_key,
-            client_private_key: self.client_private_key,
+            preshared_key: crate::secrets::open_opt(self.preshared_key)
+                .map_err(crate::secrets::to_common)?,
+            client_private_key: crate::secrets::open_opt(self.client_private_key)
+                .map_err(crate::secrets::to_common)?,
             endpoint: self.endpoint,
             allowed_ips,
             persistent_keepalive: self.persistent_keepalive.map(|k| k as u16),

--- a/aifw-core/tests/secrets_keyfile.rs
+++ b/aifw-core/tests/secrets_keyfile.rs
@@ -1,0 +1,35 @@
+//! #298: master-key lifecycle. Runs as its own test binary (own process)
+//! so the module's OnceLock starts fresh and the key path can be pointed at
+//! a temp dir before first use.
+
+use aifw_core::secrets;
+
+#[test]
+fn key_file_is_created_restricted_and_reused() {
+    let dir = std::env::temp_dir().join(format!("aifw-secrets-test-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    let key_path = dir.join("secrets.key");
+    // configure_from_db_path derives <db dir>/secrets.key
+    secrets::configure_from_db_path(&dir.join("aifw.db"));
+    assert_eq!(secrets::key_path(), key_path);
+
+    let sealed = secrets::seal("s3cret").expect("seal");
+    assert!(secrets::is_sealed(&sealed));
+    assert!(
+        !secrets::is_ephemeral(),
+        "a creatable path must yield a persistent key"
+    );
+    assert!(key_path.is_file(), "key file created on first seal");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "key file must be 0600");
+    }
+    let hex = std::fs::read_to_string(&key_path).unwrap();
+    assert_eq!(hex.trim().len(), 64, "32 bytes hex");
+
+    assert_eq!(secrets::open(&sealed).unwrap(), "s3cret");
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/aifw-daemon/src/main.rs
+++ b/aifw-daemon/src/main.rs
@@ -89,6 +89,8 @@ async fn main() -> anyhow::Result<()> {
         tokio::fs::create_dir_all(parent).await?;
     }
 
+    // #298: secrets master key beside the database (shared with aifw-api).
+    aifw_core::secrets::configure_from_db_path(&args.db);
     let db = Database::new(&args.db).await?;
     let pool = db.pool().clone();
 

--- a/docs/docs/backup.md
+++ b/docs/docs/backup.md
@@ -48,6 +48,8 @@ curl -X POST https://aifw.local/api/v1/config/import \
   --data @aifw-backup.json
 ```
 
+> **Secrets at rest.** Integration secrets in the database (WireGuard private/preshared keys, IPsec PSKs, CARP passwords, OAuth client secrets, S3/SMTP credentials, TSIG, ACME DNS tokens, AI provider keys, TOTP seeds, cluster peer keys) are sealed with AES-256-GCM under a master key in `/var/db/aifw/secrets.key` (0600, beside `jwt.key`). The JSON export above goes through the engines, so it carries the *decrypted* values and imports cleanly on any box — treat the file accordingly. A **raw copy of `aifw.db`**, on the other hand, is only useful together with its `secrets.key`; move to a new box without the key and every sealed value reads as unset. Back the two up together. (The S3 destination below syncs JSON snapshots, which carry decrypted values and need no key.)
+
 Preview a candidate import without applying via `POST /api/v1/config/import-preview`. The response lists every record that will be created / updated / deleted so you can sanity-check the diff first.
 
 ## S3 backup destination


### PR DESCRIPTION
Closes #298. Unblocks #108 (TPM key source) and #313 (snapshot redaction).

Integration secrets sat in SQLite in cleartext, so any DB snapshot leak — backup, disk image, an SQL-read bug elsewhere — handed over every credential the appliance holds.

**Design (`aifw_core::secrets`)**
- AES-256-GCM (via `aws-lc-rs`, already in the dependency tree through rustls) with a random 96-bit nonce per value; wire format `enc:v1:<base64(nonce‖ct‖tag)>`. Values without the prefix are legacy plaintext and pass through `open()`, so an upgraded box works immediately.
- Master key: 32 random bytes in **`/var/db/aifw/secrets.key`** (0600, beside `jwt.key`). Created atomically (create-new; a racing process adopts the winner's key) by the first process that needs to seal; a root-run creator (`aifw` CLI / setup) hands it to the `aifw` user. Path is derived as `<db dir>/secrets.key` (`configure_from_db_path`) so scratch DBs get their own persistent key; `AIFW_SECRETS_KEY_FILE` overrides. If no key file can be created (read-only dev host, unit tests) the process falls back to an ephemeral key with a loud warning.
- **`seal_legacy_rows()`** runs at aifw-api startup after schema migrations and seals every pre-#298 plaintext row once (TEXT- and INTEGER-pk tables plus KV rows). It refuses to run under an ephemeral key so it can never lock an operator out of their own secrets.

**Sealed** (write → `seal`, read → `open`/`open_opt`/`open_lossy`): OAuth `client_secret`, S3 `secret_access_key`, SMTP `password`, DDNS `tsig_secret`, cluster `peer_api_key`, CARP `password`, WireGuard `private_key` / `preshared_key` / `client_private_key`, IPsec `psk` + `local_key_pem`, ACME DNS `api_token` / `aws_secret_key`, `users.totp_secret`, AI provider API keys, and the **`config_versions` snapshot blobs** (which embed all of the above — without this the history table would have undone the rest).

**Unchanged on purpose**
- `GET /config/export`, JSON import, and cluster snapshots go through the engines and keep carrying decrypted values (each node re-seals under its own key on write). Redacting/encrypting the *export* is #313.
- `aifw-setup` still writes the first admin's TOTP seed in plaintext at first boot; the API's startup pass seals it on first start. (`aifw.conf` on disk also holds it — file, not DB; out of scope here.)

**Operational note (in `docs/docs/backup.md`):** a raw copy of `aifw.db` is only useful together with its `secrets.key`; JSON exports need no key.

**Tests:** round-trip / tamper / legacy passthrough; migration pass over mixed-pk tables and KV rows (idempotent); key-file lifecycle (0600, hex-32, persistent) in its own test binary; WG private key and OAuth client secret asserted sealed in the DB and plaintext through the engine/loader. Full core/api/cli/daemon/setup suites green, `cargo check` zero warnings.

Adds `aws-lc-rs = "1"` and `base64 = "0.22"` as workspace deps (both free, MIT/Apache).
