### PR TITLE
sec(auth): dedicated non-admin 'system' role for the aifw-daemon service user (#318)

### DIFF
--- a/aifw-api/src/auth/migrate.rs
+++ b/aifw-api/src/auth/migrate.rs
@@ -1,6 +1,13 @@
 //! Auth/RBAC schema migration. Creates the users, tokens, OAuth, roles,
 //! schedules, and audit tables and seeds the built-in roles.
 
+/// Role id of the built-in `system` role (#318): what AiFw's own service
+/// identities run as. Not assignable to human users.
+pub const SYSTEM_ROLE_ID: &str = "builtin-system";
+/// Username of the locked service account behind the daemon-loopback and
+/// inbound cluster-peer API keys.
+pub const SYSTEM_USERNAME: &str = "aifw-daemon";
+
 use sqlx::sqlite::SqlitePool;
 
 pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
@@ -184,6 +191,8 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
             PermissionSet::from_permissions(&builtin_role_permissions("operator")).to_bits() as i64;
         let viewer_bits =
             PermissionSet::from_permissions(&builtin_role_permissions("viewer")).to_bits() as i64;
+        let system_bits =
+            PermissionSet::from_permissions(&builtin_role_permissions("system")).to_bits() as i64;
 
         sqlx::query(
             "INSERT OR IGNORE INTO roles (id, name, permissions, builtin, description) VALUES (?1, ?2, ?3, 1, ?4)"
@@ -203,6 +212,14 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
         .bind("builtin-viewer").bind("viewer").bind(viewer_bits).bind("Read-only access")
         .execute(pool).await?;
 
+        // #318: internal service identity (aifw-daemon loopback / cluster peer keys).
+        sqlx::query(
+            "INSERT OR IGNORE INTO roles (id, name, permissions, builtin, description) VALUES (?1, ?2, ?3, 1, ?4)"
+        )
+        .bind(SYSTEM_ROLE_ID).bind("system").bind(system_bits)
+        .bind("AiFw internal services (aifw-daemon loopback, cluster peer) — not for people")
+        .execute(pool).await?;
+
         // Update built-in role permissions in case new permissions were added
         sqlx::query("UPDATE roles SET permissions = ?1 WHERE id = 'builtin-admin'")
             .bind(admin_bits)
@@ -214,6 +231,11 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
             .await?;
         sqlx::query("UPDATE roles SET permissions = ?1 WHERE id = 'builtin-viewer'")
             .bind(viewer_bits)
+            .execute(pool)
+            .await?;
+        sqlx::query("UPDATE roles SET permissions = ?1 WHERE id = ?2")
+            .bind(system_bits)
+            .bind(SYSTEM_ROLE_ID)
             .execute(pool)
             .await?;
     }
@@ -237,6 +259,19 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     sqlx::query(
         "UPDATE users SET role_id = 'builtin-viewer' WHERE role = 'viewer' AND role_id IS NULL",
     )
+    .execute(pool)
+    .await?;
+
+    // #318: the aifw-daemon service user was created without a role and so
+    // inherited the column default ('admin'). Demote every such row to the
+    // system role; the daemon only ever calls HaManage endpoints.
+    sqlx::query(
+        "UPDATE users SET role = 'system', role_id = ?1
+         WHERE username = ?2 AND auth_provider = 'system'
+           AND (role_id IS NULL OR role_id = 'builtin-admin' OR role = 'admin')",
+    )
+    .bind(SYSTEM_ROLE_ID)
+    .bind(SYSTEM_USERNAME)
     .execute(pool)
     .await?;
 

--- a/aifw-api/src/auth/users.rs
+++ b/aifw-api/src/auth/users.rs
@@ -39,6 +39,10 @@ pub async fn create_user(
     validate_password(&req.password, min_length)?;
     let pw_hash = hash_password(&req.password)?;
     let role = req.role.as_deref().unwrap_or("viewer").to_string();
+    // #318: the system role belongs to AiFw's own service identities only.
+    if role == "system" || role == super::migrate::SYSTEM_ROLE_ID {
+        return Err(StatusCode::BAD_REQUEST);
+    }
     let role_id = match role.as_str() {
         "admin" => Some("builtin-admin".to_string()),
         "operator" => Some("builtin-operator".to_string()),
@@ -123,6 +127,10 @@ pub async fn update_user(
         user.password_hash = hash_password(password)?;
     }
     if let Some(ref role) = req.role {
+        // #318: the system role belongs to AiFw's own service identities only.
+        if role == "system" || role == super::migrate::SYSTEM_ROLE_ID {
+            return Err(StatusCode::BAD_REQUEST);
+        }
         user.role = role.clone();
         // Map built-in role names to role_id; custom role_id can be set directly
         user.role_id = match role.as_str() {

--- a/aifw-api/src/cluster.rs
+++ b/aifw-api/src/cluster.rs
@@ -1036,12 +1036,16 @@ async fn register_peer_key(
                 Uuid::new_v4().simple(),
                 Uuid::new_v4().simple()
             ))?;
+            // #318: explicit non-admin service role — the column default
+            // is 'admin', which is exactly the implicit grant this closes.
             sqlx::query(
-                "INSERT INTO users (id, username, password_hash, totp_enabled, auth_provider, created_at) \
-                 VALUES (?1, 'aifw-daemon', ?2, 0, 'system', ?3)",
+                "INSERT INTO users (id, username, password_hash, totp_enabled, auth_provider, role, role_id, created_at) \
+                 VALUES (?1, ?2, ?3, 0, 'system', 'system', ?4, ?5)",
             )
             .bind(&uid)
+            .bind(crate::auth::migrate::SYSTEM_USERNAME)
             .bind(&dummy)
+            .bind(crate::auth::migrate::SYSTEM_ROLE_ID)
             .bind(chrono::Utc::now().to_rfc3339())
             .execute(&s.pool)
             .await
@@ -1110,12 +1114,16 @@ async fn generate_loopback_key(
                 Uuid::new_v4().simple(),
                 Uuid::new_v4().simple()
             ))?;
+            // #318: explicit non-admin service role — the column default
+            // is 'admin', which is exactly the implicit grant this closes.
             sqlx::query(
-                "INSERT INTO users (id, username, password_hash, totp_enabled, auth_provider, created_at) \
-                 VALUES (?1, 'aifw-daemon', ?2, 0, 'system', ?3)",
+                "INSERT INTO users (id, username, password_hash, totp_enabled, auth_provider, role, role_id, created_at) \
+                 VALUES (?1, ?2, ?3, 0, 'system', 'system', ?4, ?5)",
             )
             .bind(&uid)
+            .bind(crate::auth::migrate::SYSTEM_USERNAME)
             .bind(&dummy)
+            .bind(crate::auth::migrate::SYSTEM_ROLE_ID)
             .bind(chrono::Utc::now().to_rfc3339())
             .execute(&s.pool)
             .await

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -1017,6 +1017,109 @@ mod tests {
         resp.assert_status(StatusCode::FORBIDDEN);
     }
 
+    /// #318: the daemon-loopback service user must not be an admin. New rows
+    /// get the built-in `system` role (HaManage only); a legacy row that
+    /// inherited the column default 'admin' is demoted by the auth migration.
+    #[tokio::test]
+    async fn test_daemon_service_user_is_not_admin() {
+        use aifw_common::permission::{Permission, PermissionSet};
+        let state = crate::create_app_state_in_memory(plain_auth_settings())
+            .await
+            .unwrap();
+        let pool = state.pool.clone();
+        let server = TestServer::new(crate::build_router(state, None, "*", false));
+        let token = create_user_and_login(&server).await;
+
+        // Generating the loopback key creates the service user.
+        let resp = server
+            .post("/api/v1/cluster/loopback-key/generate")
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+
+        let (role, role_id): (String, Option<String>) =
+            sqlx::query_as("SELECT role, role_id FROM users WHERE username = 'aifw-daemon'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(role, "system");
+        assert_eq!(
+            role_id.as_deref(),
+            Some(crate::auth::migrate::SYSTEM_ROLE_ID)
+        );
+
+        let (bits, name) =
+            crate::auth::tokens::resolve_token_permissions(&pool, &role, role_id.as_deref())
+                .await
+                .unwrap();
+        let perms = PermissionSet::from_bits(bits);
+        assert_eq!(name, "system");
+        assert!(perms.has(Permission::HaManage));
+        assert!(
+            !perms.has(Permission::UsersWrite),
+            "must not be able to mint admins"
+        );
+        assert!(!perms.has(Permission::SettingsWrite));
+        assert!(!perms.has(Permission::UpdatesInstall));
+
+        // People can't be given the system role.
+        for role in ["system", crate::auth::migrate::SYSTEM_ROLE_ID] {
+            let resp = server
+                .post("/api/v1/auth/users")
+                .authorization_bearer(&token)
+                .json(&json!({"username": format!("u-{role}"), "password": "LongEnough123!", "role": role}))
+                .await;
+            resp.assert_status(StatusCode::BAD_REQUEST);
+        }
+    }
+
+    /// #318: a pre-existing daemon user that got the 'admin' column default is
+    /// demoted to `system` when the auth migration runs.
+    #[tokio::test]
+    async fn test_auth_migration_demotes_legacy_daemon_user() {
+        let state = crate::create_app_state_in_memory(plain_auth_settings())
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO users (id, username, password_hash, totp_enabled, auth_provider, created_at)
+             VALUES ('d1', 'aifw-daemon', 'x', 0, 'system', 'now')",
+        )
+        .execute(&state.pool)
+        .await
+        .unwrap();
+        let (role, role_id): (String, Option<String>) =
+            sqlx::query_as("SELECT role, role_id FROM users WHERE id = 'd1'")
+                .fetch_one(&state.pool)
+                .await
+                .unwrap();
+        assert_eq!(role, "admin", "column default is the bug being fixed");
+        assert!(role_id.is_none());
+
+        crate::auth::migrate::migrate(&state.pool).await.unwrap();
+
+        let (role, role_id): (String, Option<String>) =
+            sqlx::query_as("SELECT role, role_id FROM users WHERE id = 'd1'")
+                .fetch_one(&state.pool)
+                .await
+                .unwrap();
+        assert_eq!(role, "system");
+        assert_eq!(role_id.as_deref(), Some("builtin-system"));
+        // A real admin is untouched.
+        sqlx::query(
+            "INSERT INTO users (id, username, password_hash, totp_enabled, auth_provider, role, role_id, created_at)
+             VALUES ('a1', 'alice', 'x', 0, 'local', 'admin', 'builtin-admin', 'now')",
+        )
+        .execute(&state.pool)
+        .await
+        .unwrap();
+        crate::auth::migrate::migrate(&state.pool).await.unwrap();
+        let (role,): (String,) = sqlx::query_as("SELECT role FROM users WHERE id = 'a1'")
+            .fetch_one(&state.pool)
+            .await
+            .unwrap();
+        assert_eq!(role, "admin");
+    }
+
     /// SEC-H12 (#297): the reserved cluster key names can't be minted through
     /// the normal Users → API Keys path (would otherwise self-grant peer
     /// privilege).

--- a/aifw-common/src/permission.rs
+++ b/aifw-common/src/permission.rs
@@ -295,6 +295,11 @@ impl PermissionSet {
 pub fn builtin_role_permissions(role: &str) -> Vec<Permission> {
     match role {
         "admin" => ALL_PERMISSIONS.to_vec(),
+        // #318: AiFw's own service identities (aifw-daemon loopback key,
+        // inbound cluster peer key). Every endpoint they call sits behind
+        // HaManage; nothing else — in particular no users:write, so a leaked
+        // daemon key can no longer mint an admin.
+        "system" => vec![Permission::HaManage],
         "operator" => ALL_PERMISSIONS
             .iter()
             .filter(|p| {

--- a/aifw-ui/src/app/users/page.tsx
+++ b/aifw-ui/src/app/users/page.tsx
@@ -44,8 +44,12 @@ const roleColors: Record<string, { badge: string; accent: string }> = {
   admin: { badge: "bg-red-500/20 text-red-400 border-red-500/30", accent: "border-red-500/40" },
   operator: { badge: "bg-blue-500/20 text-blue-400 border-blue-500/30", accent: "border-blue-500/40" },
   viewer: { badge: "bg-gray-500/20 text-gray-400 border-gray-500/30", accent: "border-gray-500/40" },
+  system: { badge: "bg-amber-500/20 text-amber-400 border-amber-500/30", accent: "border-amber-500/40" },
 };
 const customRoleStyle = { badge: "bg-purple-500/20 text-purple-400 border-purple-500/30", accent: "border-purple-500/40" };
+// #318: the built-in `system` role belongs to AiFw's own service identities
+// (aifw-daemon loopback / cluster peer keys) — never offer it to people.
+const SYSTEM_ROLE = "system";
 
 function getRoleStyle(name: string, builtin: boolean) {
   if (builtin) return roleColors[name] || customRoleStyle;
@@ -405,7 +409,7 @@ export default function UsersPage() {
                 <div><label className={labelCls}>Password</label><input type="password" value={newPassword} onChange={e => setNewPassword(e.target.value)} placeholder="Password" className={inputCls} required /></div>
                 <div><label className={labelCls}>Role</label>
                   <select value={newRole} onChange={e => setNewRole(e.target.value)} className={inputCls}>
-                    {roles.map(r => <option key={r.id} value={r.name}>{r.name}{!r.builtin ? " (custom)" : ""}</option>)}
+                    {roles.filter(r => r.name !== SYSTEM_ROLE).map(r => <option key={r.id} value={r.name}>{r.name}{!r.builtin ? " (custom)" : ""}</option>)}
                   </select>
                 </div>
               </div>
@@ -438,7 +442,7 @@ export default function UsersPage() {
                         <td className="px-4 py-3"><input type="text" value={editUsername} onChange={e => setEditUsername(e.target.value)} className="w-full px-2 py-1 text-sm bg-[var(--bg-primary)] border border-[var(--border)] rounded text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]" /></td>
                         <td className="px-4 py-3">
                           <select value={editRole} onChange={e => setEditRole(e.target.value)} className="px-2 py-1 text-sm bg-[var(--bg-primary)] border border-[var(--border)] rounded text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]">
-                            {roles.map(r => <option key={r.id} value={r.name}>{r.name}</option>)}
+                            {roles.filter(r => r.name !== SYSTEM_ROLE).map(r => <option key={r.id} value={r.name}>{r.name}</option>)}
                           </select>
                         </td>
                         <td className="px-4 py-3 text-[var(--text-muted)] text-xs">{user.totp_enabled ? "On" : "Off"}</td>
@@ -553,7 +557,7 @@ export default function UsersPage() {
 
         {/* Roles Grid */}
         <div className="space-y-4">
-          {roles.map(role => {
+          {roles.filter(r => r.name !== SYSTEM_ROLE).map(role => {
             const style = getRoleStyle(role.name, role.builtin);
             const userCount = userCountByRole[role.name] || 0;
             const isEditing = editingRoleId === role.id;

--- a/docs/docs/auth.md
+++ b/docs/docs/auth.md
@@ -157,6 +157,7 @@ Tickets are 256 bits of entropy, single-use, and expire in **30 seconds**. They 
 - **admin** &mdash; every permission. Full read + write + system control.
 - **operator** &mdash; everything except `users:write`, `settings:write`, `updates:install`, `system:reboot`, and `ha:manage`. Day-to-day rule / NAT / VPN editing without account or platform-level changes.
 - **viewer** &mdash; read-only. All `*:read` and `*:view` permissions except `users:read`, `settings:read`, and `backup:read` (those leak too much).
+- **system** &mdash; `ha:manage` only. Held by the locked `aifw-daemon` service account behind the daemon-loopback and inbound cluster-peer API keys; it cannot be assigned to people (the API refuses it and the UI hides it). Before this role existed the service account inherited `admin` from a column default, so a leaked daemon key could mint administrators.
 
 Custom roles are arbitrary subsets of the permission set below. Create with `POST /api/v1/auth/roles`.
 


### PR DESCRIPTION
Closes #318 (and the folded-in #326).

The locked `aifw-daemon` account behind the daemon-loopback and inbound cluster-peer API keys was inserted without a role, so it inherited the `users.role` column default **`admin`** — a leaked daemon key (mode 0640, readable by the `aifw` uid) could mint administrators.

**Changes**
- New built-in role **`system`** (`builtin-system`) with `ha:manage` only — every endpoint the daemon (`/cluster/internal/*`, `/cluster/snapshot`) and peers (`snapshot_put`, `cert-push`) call sits behind that permission; the existing key-name checks (SEC-H12) still gate the replication endpoints on top. Seeded and kept current by the auth migration alongside admin/operator/viewer.
- Both service-user inserts in `cluster.rs` set `role`/`role_id` explicitly.
- Migration demotes an existing admin-by-default `aifw-daemon` row (`auth_provider='system'`) to `system`; real admins untouched.
- API refuses `system` / `builtin-system` for human users; UI hides it from role pickers and the roles grid.
- Docs: `auth.md` built-in roles.

**Tests:** new service user resolves to HaManage-only (asserted no `users:write`, `settings:write`, `updates:install`); people can't take the role (400); legacy row demoted while an admin stays admin. api + common suites green, `cargo check` zero warnings, UI lint/build clean.
