### PR TITLE
sec(ha): pin cluster peer and loopback HTTPS calls to certificate fingerprints (#317)

### DIFF
--- a/aifw-api/src/cluster.rs
+++ b/aifw-api/src/cluster.rs
@@ -71,6 +71,7 @@ pub fn write_routes() -> Router<AppState> {
             "/api/v1/cluster/nodes/{id}/generate-key",
             post(generate_node_key),
         )
+        .route("/api/v1/cluster/nodes/{id}/repin", post(repin_node))
         .route("/api/v1/cluster/health", post(create_health))
         .route(
             "/api/v1/cluster/health/{id}",
@@ -467,6 +468,60 @@ async fn generate_node_key(
     Ok(Json(GenerateKeyResponse { key }))
 }
 
+/// Body for `POST /cluster/nodes/{id}/repin` (#317).
+#[derive(Deserialize, Default)]
+struct RepinRequest {
+    /// Explicit SHA-256 fingerprint (hex, colons optional) to pin. Omitted or
+    /// empty = clear the pin and re-learn on next contact.
+    #[serde(default)]
+    fingerprint: Option<String>,
+}
+
+/// Reset or set the pinned TLS certificate fingerprint of a peer (#317).
+/// Use after the peer's API certificate changed by hand (self-signed
+/// regeneration, manual cert import) — replication logs a pin mismatch
+/// until this is done. Cert pushes and first contact manage pins on their own.
+async fn repin_node(
+    State(s): State<AppState>,
+    Path(id): Path<Uuid>,
+    body: Option<Json<RepinRequest>>,
+) -> Result<Json<ClusterNode>, (StatusCode, String)> {
+    let req = body.map(|Json(b)| b).unwrap_or_default();
+    let fp = match req.fingerprint.as_deref().map(str::trim) {
+        None | Some("") => None,
+        Some(raw) => {
+            let cleaned: String = raw
+                .chars()
+                .filter(|c| *c != ':')
+                .map(|c| c.to_ascii_lowercase())
+                .collect();
+            if cleaned.len() != 64 || !cleaned.chars().all(|c| c.is_ascii_hexdigit()) {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "fingerprint must be a SHA-256 hex digest (64 hex chars)".into(),
+                ));
+            }
+            Some(cleaned)
+        }
+    };
+    s.cluster_engine
+        .set_peer_cert_fingerprint(id, fp.as_deref())
+        .await
+        .map_err(|e| match e {
+            aifw_common::AifwError::NotFound(m) => (StatusCode::NOT_FOUND, m),
+            other => (StatusCode::INTERNAL_SERVER_ERROR, other.to_string()),
+        })?;
+    tracing::info!(node = %id, pinned = fp.is_some(), "ha: peer TLS pin updated by operator");
+    let node = s
+        .cluster_engine
+        .list_nodes()
+        .await
+        .ok()
+        .and_then(|ns| ns.into_iter().find(|n| n.id == id))
+        .ok_or((StatusCode::NOT_FOUND, "node vanished".into()))?;
+    Ok(Json(node))
+}
+
 async fn list_health(State(s): State<AppState>) -> Result<Json<Vec<HealthCheck>>, StatusCode> {
     s.cluster_engine
         .list_health_checks()
@@ -750,10 +805,10 @@ async fn snapshot_force(State(s): State<AppState>) -> StatusCode {
         peer.address,
         aifw_common::DEFAULT_LOOPBACK_API_PORT
     );
-    let client = match reqwest::Client::builder()
-        .danger_accept_invalid_certs(true)
-        .timeout(std::time::Duration::from_secs(15))
-        .build()
+    // #317: pinned to the master's certificate (learned on first contact).
+    let client = match s
+        .cluster_engine
+        .peer_client(&peer, std::time::Duration::from_secs(15))
     {
         Ok(c) => c,
         Err(_) => return StatusCode::INTERNAL_SERVER_ERROR,
@@ -765,10 +820,13 @@ async fn snapshot_force(State(s): State<AppState>) -> StatusCode {
         .send()
         .await
     {
-        Ok(r) => match r.text().await {
-            Ok(s) => s,
-            Err(_) => return StatusCode::BAD_GATEWAY,
-        },
+        Ok(r) => {
+            s.cluster_engine.learn_peer_cert(&peer, &r).await;
+            match r.text().await {
+                Ok(s) => s,
+                Err(_) => return StatusCode::BAD_GATEWAY,
+            }
+        }
         Err(_) => return StatusCode::BAD_GATEWAY,
     };
 
@@ -892,6 +950,20 @@ async fn cert_push(
             // Standby tunnels referencing this cert must also rotate to the
             // renewed material (#568) so a failover presents a valid cert.
             aifw_core::ipsec::on_acme_cert_renewed(&s.pool, r.cert_id).await;
+            // #317: the master just renewed — its own API certificate may
+            // change with it. Drop our pin(s) on Primary nodes so the next
+            // call re-learns instead of failing on a stale fingerprint.
+            match s
+                .cluster_engine
+                .clear_pins_for_role(ClusterRole::Primary)
+                .await
+            {
+                Ok(n) if n > 0 => {
+                    tracing::info!(cleared = n, "ha: cleared master TLS pin after cert push")
+                }
+                Ok(_) => {}
+                Err(e) => tracing::warn!(error = %e, "ha: could not clear master TLS pin"),
+            }
             StatusCode::NO_CONTENT
         }
         Err(e) => {

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -988,6 +988,111 @@ mod tests {
         assert_eq!(ollama(&resp.json::<Value>())["tls_insecure"], false);
     }
 
+    /// #317: operator re-pin endpoint — clears or sets the pinned peer
+    /// certificate fingerprint; validates the digest; 404 on unknown nodes.
+    #[tokio::test]
+    async fn test_cluster_node_repin() {
+        let state = crate::create_app_state_in_memory(plain_auth_settings())
+            .await
+            .unwrap();
+        let engine = state.cluster_engine.clone();
+        let server = TestServer::new(crate::build_router(state, None, "*", false));
+        let token = create_user_and_login(&server).await;
+
+        let resp = server
+            .post("/api/v1/cluster/nodes")
+            .authorization_bearer(&token)
+            .json(&json!({"name": "peer-b", "address": "10.9.9.2", "role": "secondary"}))
+            .await;
+        assert!(resp.status_code().is_success(), "{}", resp.text());
+        let node: Value = resp.json();
+        let id = node["id"].as_str().unwrap().to_string();
+        assert!(
+            node["cert_fingerprint"].is_null(),
+            "no pin until first contact"
+        );
+
+        // Explicit pin, colons + uppercase normalised.
+        // "AB:CD:" + 30 × "EF" = 64 hex chars once the colons are stripped.
+        let fp_upper = format!("AB:CD:{}", "EF".repeat(30));
+        let resp = server
+            .post(&format!("/api/v1/cluster/nodes/{id}/repin"))
+            .authorization_bearer(&token)
+            .json(&json!({"fingerprint": fp_upper}))
+            .await;
+        resp.assert_status_ok();
+        let body: Value = resp.json();
+        let pinned = body["cert_fingerprint"].as_str().unwrap();
+        assert_eq!(pinned.len(), 64);
+        assert!(pinned.starts_with("abcd"));
+        assert!(
+            pinned
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+        );
+
+        // Engine sees it and builds a pinned client.
+        let n = engine
+            .list_nodes()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|n| n.id.to_string() == id)
+            .unwrap();
+        assert_eq!(n.cert_fingerprint.as_deref(), Some(pinned));
+        assert!(
+            engine
+                .peer_client(&n, std::time::Duration::from_secs(1))
+                .is_ok()
+        );
+
+        // Bad digest → 400.
+        let resp = server
+            .post(&format!("/api/v1/cluster/nodes/{id}/repin"))
+            .authorization_bearer(&token)
+            .json(&json!({"fingerprint": "not-a-digest"}))
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+
+        // Clear (empty body).
+        let resp = server
+            .post(&format!("/api/v1/cluster/nodes/{id}/repin"))
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        assert!(resp.json::<Value>()["cert_fingerprint"].is_null());
+
+        // Unknown node → 404.
+        let resp = server
+            .post(&format!(
+                "/api/v1/cluster/nodes/{}/repin",
+                uuid::Uuid::new_v4()
+            ))
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status(StatusCode::NOT_FOUND);
+
+        // clear_pins_for_role touches only the given role.
+        engine
+            .set_peer_cert_fingerprint(n.id, Some(&"11".repeat(32)))
+            .await
+            .unwrap();
+        assert_eq!(
+            engine
+                .clear_pins_for_role(aifw_common::ClusterRole::Primary)
+                .await
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            engine
+                .clear_pins_for_role(aifw_common::ClusterRole::Secondary)
+                .await
+                .unwrap(),
+            1
+        );
+    }
+
     /// SEC-H12 (#297): cluster snapshot/cert push must reject a broad HaManage
     /// credential (a JWT, or any non-peer key) — only a registered peer key or
     /// the daemon-loopback key is accepted.

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -3370,6 +3370,20 @@ pub async fn cluster_nodes_add(name: &str, address: &str, role: &str) -> anyhow:
     Ok(())
 }
 
+pub async fn cluster_nodes_repin(id: &str, fingerprint: Option<&str>) -> anyhow::Result<()> {
+    let body = match fingerprint {
+        Some(fp) => serde_json::json!({ "fingerprint": fp }),
+        None => serde_json::json!({}),
+    };
+    let v: serde_json::Value =
+        api_post(&format!("/api/v1/cluster/nodes/{id}/repin"), &body).await?;
+    match v.get("cert_fingerprint").and_then(|f| f.as_str()) {
+        Some(fp) => println!("Node {id} pinned to {fp}"),
+        None => println!("Node {id} pin cleared — it will be re-learned on the next contact."),
+    }
+    Ok(())
+}
+
 pub async fn cluster_nodes_remove(id: &str) -> anyhow::Result<()> {
     api_delete(&format!("/api/v1/cluster/nodes/{id}")).await?;
     println!("Removed node {id}");

--- a/aifw-cli/src/main.rs
+++ b/aifw-cli/src/main.rs
@@ -261,6 +261,18 @@ enum NodesAction {
     },
     /// Remove a cluster node
     Remove { id: String },
+    /// Reset (or set) the pinned TLS certificate fingerprint of a peer.
+    /// Without --fingerprint the pin is cleared and re-learned on next contact.
+    #[command(after_help = "\
+Peer HTTPS calls are pinned to the certificate seen on first contact. If a
+peer's API certificate changed by hand (self-signed regeneration, manual
+import), replication logs 'TLS pin mismatch' until you re-pin it here.")]
+    Repin {
+        id: String,
+        /// SHA-256 fingerprint of the peer's certificate (64 hex chars, colons ok)
+        #[arg(long)]
+        fingerprint: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1642,6 +1654,9 @@ async fn main() -> anyhow::Result<()> {
                     role,
                 } => commands::cluster_nodes_add(&name, &address, &role).await?,
                 NodesAction::Remove { id } => commands::cluster_nodes_remove(&id).await?,
+                NodesAction::Repin { id, fingerprint } => {
+                    commands::cluster_nodes_repin(&id, fingerprint.as_deref()).await?
+                }
             },
             ClusterAction::Health { action } => match action {
                 HealthAction::List => commands::cluster_health_list().await?,

--- a/aifw-common/src/ha.rs
+++ b/aifw-common/src/ha.rs
@@ -359,6 +359,11 @@ pub struct ClusterNode {
     pub software_version: Option<String>,
     /// When this node last successfully pushed a TLS cert to its peer.
     pub last_pushed_cert_at: Option<DateTime<Utc>>,
+    /// SHA-256 fingerprint (lowercase hex) of the API certificate this peer
+    /// presents; every HTTPS call to the peer is pinned to it (#317). `None`
+    /// until first contact learns it (or after an operator re-pin).
+    #[serde(default)]
+    pub cert_fingerprint: Option<String>,
 }
 
 /// Health status of a cluster node (wire values are lowercase)
@@ -402,6 +407,7 @@ impl ClusterNode {
             created_at: now,
             software_version: None,
             last_pushed_cert_at: None,
+            cert_fingerprint: None,
         }
     }
 

--- a/aifw-core/Cargo.toml
+++ b/aifw-core/Cargo.toml
@@ -26,6 +26,8 @@ aws-credential-types = "1"
 instant-acme = "0.8"
 rcgen = { workspace = true }
 reqwest = { workspace = true }
+rustls = { workspace = true }
+rustls-pemfile = { workspace = true }
 lettre = { version = "0.11", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "builder", "hostname"] }
 rusty-s3 = "0.10"
 aws-sigv4 = { version = "1", default-features = false, features = ["sign-http", "http1"] }
@@ -34,6 +36,7 @@ url = "2"
 
 [dev-dependencies]
 anyhow = { workspace = true }
+tokio-rustls = { workspace = true }
 
 [lints]
 workspace = true

--- a/aifw-core/src/acme_engine.rs
+++ b/aifw-core/src/acme_engine.rs
@@ -201,12 +201,6 @@ async fn push_cert_to_peers(
         return Ok(());
     }
 
-    let client = reqwest::Client::builder()
-        .danger_accept_invalid_certs(true)
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .map_err(|e| aifw_common::AifwError::Other(format!("acme: reqwest build: {e}")))?;
-
     for n in nodes
         .iter()
         .filter(|n| matches!(n.role, ClusterRole::Secondary))
@@ -218,6 +212,8 @@ async fn push_cert_to_peers(
                 continue;
             }
         };
+        // Pinned to the peer's current certificate (#317).
+        let client = cluster_engine.peer_client(n, std::time::Duration::from_secs(30))?;
         let url = format!(
             "https://{}:{}/api/v1/cluster/cert-push",
             n.address,
@@ -243,6 +239,13 @@ async fn push_cert_to_peers(
                         .bind(n.id.to_string())
                         .execute(pool)
                         .await;
+                // #317: the peer's API certificate is likely about to change
+                // (it may export the pushed chain to its own TLS store) —
+                // clear our pin so the next contact re-learns it instead of
+                // failing on a stale fingerprint.
+                if let Err(e) = cluster_engine.set_peer_cert_fingerprint(n.id, None).await {
+                    tracing::warn!(peer = %n.address, error = %e, "acme: could not clear peer pin");
+                }
             }
             Ok(r) => tracing::warn!(
                 cert_id,

--- a/aifw-core/src/ha.rs
+++ b/aifw-core/src/ha.rs
@@ -82,6 +82,7 @@ impl ClusterEngine {
             "ALTER TABLE cluster_nodes ADD COLUMN peer_api_key_hash TEXT",
             "ALTER TABLE cluster_nodes ADD COLUMN software_version TEXT",
             "ALTER TABLE cluster_nodes ADD COLUMN last_pushed_cert_at TEXT",
+            "ALTER TABLE cluster_nodes ADD COLUMN cert_fingerprint TEXT",
         ] {
             let _ = sqlx::query(stmt).execute(&self.pool).await;
         }
@@ -479,6 +480,80 @@ impl ClusterEngine {
     }
 
     // ============================================================
+    // Peer TLS pinning (#317)
+    // ============================================================
+
+    /// HTTPS client for calling `node`, pinned to its stored certificate
+    /// fingerprint. With no pin yet the client accepts any certificate and
+    /// exposes the observed one so [`Self::learn_peer_cert`] can pin it.
+    pub fn peer_client(
+        &self,
+        node: &ClusterNode,
+        timeout: std::time::Duration,
+    ) -> Result<reqwest::Client> {
+        crate::peer_tls::client_for(
+            node.cert_fingerprint.as_deref(),
+            &node.address.to_string(),
+            timeout,
+        )
+        .map_err(|e| AifwError::Other(e.to_string()))
+    }
+
+    /// Trust-on-first-use: if `node` has no pin yet, record the certificate
+    /// fingerprint observed on `resp` (a successful call made through
+    /// [`Self::peer_client`]). No-op when already pinned. Best-effort — the
+    /// call that produced `resp` already succeeded.
+    pub async fn learn_peer_cert(&self, node: &ClusterNode, resp: &reqwest::Response) {
+        if node.cert_fingerprint.is_some() {
+            return;
+        }
+        let Some(fp) = crate::peer_tls::observed_fingerprint(resp) else {
+            return;
+        };
+        match self.set_peer_cert_fingerprint(node.id, Some(&fp)).await {
+            Ok(()) => tracing::info!(
+                peer = %node.address,
+                pin = %crate::peer_tls::short(&fp),
+                "ha: pinned peer certificate on first contact"
+            ),
+            Err(e) => {
+                tracing::warn!(peer = %node.address, error = %e, "ha: could not store peer pin")
+            }
+        }
+    }
+
+    /// Set (or clear, with `None`) the pinned certificate fingerprint for a
+    /// node. Clearing = "re-pin on next contact".
+    pub async fn set_peer_cert_fingerprint(&self, id: Uuid, fp: Option<&str>) -> Result<()> {
+        let result = sqlx::query("UPDATE cluster_nodes SET cert_fingerprint = ?1 WHERE id = ?2")
+            .bind(fp.map(|f| f.to_ascii_lowercase()))
+            .bind(id.to_string())
+            .execute(&self.pool)
+            .await?;
+        if result.rows_affected() == 0 {
+            return Err(AifwError::NotFound(format!("cluster node {id} not found")));
+        }
+        Ok(())
+    }
+
+    /// Clear the pins of every node with `role` so the next contact
+    /// re-learns them. Used around a certificate distribution (cert push):
+    /// the peer's API certificate is about to change, and whether it will
+    /// serve exactly the pushed chain depends on its own ACME-export
+    /// settings, so a fresh TOFU is safer than guessing. Returns the number
+    /// of nodes cleared.
+    pub async fn clear_pins_for_role(&self, role: ClusterRole) -> Result<usize> {
+        let mut n = 0;
+        for node in self.list_nodes().await? {
+            if node.role == role && node.cert_fingerprint.is_some() {
+                self.set_peer_cert_fingerprint(node.id, None).await?;
+                n += 1;
+            }
+        }
+        Ok(n)
+    }
+
+    // ============================================================
     // Health checks
     // ============================================================
 
@@ -851,7 +926,7 @@ impl PfsyncRow {
 /// Note: `peer_api_key`/`peer_api_key_hash` exist on the table but are NOT part
 /// of `ClusterNodeRow`, so they are intentionally omitted here.
 const CLUSTER_NODES_COLUMNS: &str = "id, name, address, role, health, last_seen, \
-    config_version, created_at, software_version, last_pushed_cert_at";
+    config_version, created_at, software_version, last_pushed_cert_at, cert_fingerprint";
 
 #[derive(sqlx::FromRow)]
 struct ClusterNodeRow {
@@ -865,6 +940,7 @@ struct ClusterNodeRow {
     created_at: String,
     software_version: Option<String>,
     last_pushed_cert_at: Option<String>,
+    cert_fingerprint: Option<String>,
 }
 
 impl ClusterNodeRow {
@@ -893,6 +969,7 @@ impl ClusterNodeRow {
             created_at: parse_dt(&self.created_at)?,
             software_version: self.software_version,
             last_pushed_cert_at,
+            cert_fingerprint: self.cert_fingerprint,
         })
     }
 }

--- a/aifw-core/src/lib.rs
+++ b/aifw-core/src/lib.rs
@@ -45,6 +45,7 @@ pub mod os_upgrade_state;
 /// re-exported here so existing `crate::net_safety::…` call sites keep working.
 pub use aifw_common::net_safety;
 pub mod path_safety;
+pub mod peer_tls;
 pub mod pf_tuning;
 pub mod s3_backup;
 /// [`ShapingEngine`] — traffic-shaping queues and connection rate limits

--- a/aifw-core/src/peer_tls.rs
+++ b/aifw-core/src/peer_tls.rs
@@ -1,0 +1,379 @@
+//! TLS trust for AiFw-to-AiFw HTTPS calls (#317 / SEC-L2).
+//!
+//! Cluster peers and the daemon's loopback calls used to accept any
+//! certificate (`danger_accept_invalid_certs`) — the peer API key was the
+//! only thing standing between an on-path attacker and the replication
+//! stream (which carries the whole config, secrets included). Calls now
+//! pin the leaf certificate by SHA-256 fingerprint:
+//!
+//! * **Peers** — the pin lives in `cluster_nodes.cert_fingerprint`. It is
+//!   learned on first successful contact (trust-on-first-use, like an SSH
+//!   `known_hosts` entry) and enforced from then on. Cert distribution via
+//!   `cluster/cert-push` updates the pins on both sides, and an operator
+//!   can clear a pin (`POST /cluster/nodes/{id}/repin`, `aifw cluster
+//!   repin`) after a manual certificate change.
+//! * **Loopback** (aifw-daemon → local aifw-api) — pinned to the certificate
+//!   file the API serves (`/usr/local/etc/aifw/tls/cert.pem`); the client is
+//!   rebuilt when that file changes, so ACME renewals and self-signed
+//!   regeneration are picked up without a restart.
+//!
+//! A pin mismatch fails the handshake and logs both fingerprints.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, SignatureScheme};
+use sha2::{Digest, Sha256};
+use tracing::{debug, info, warn};
+
+/// Where aifw-api reads its serving certificate from (see `--tls-cert`).
+pub const LOCAL_API_CERT_PATH: &str = "/usr/local/etc/aifw/tls/cert.pem";
+
+/// Lowercase hex SHA-256 of a DER certificate — the pin format everywhere.
+pub fn fingerprint_der(der: &[u8]) -> String {
+    hex::encode(Sha256::digest(der))
+}
+
+/// Fingerprint of the first certificate in a PEM file, if readable.
+pub fn fingerprint_pem_file(path: &Path) -> Option<String> {
+    let pem = std::fs::read(path).ok()?;
+    let mut reader = std::io::Cursor::new(pem);
+    let cert = rustls_pemfile::certs(&mut reader).next()?.ok()?;
+    Some(fingerprint_der(cert.as_ref()))
+}
+
+/// Fingerprint of the first certificate in PEM text (cert push payloads).
+pub fn fingerprint_pem_str(pem: &str) -> Option<String> {
+    let mut reader = std::io::Cursor::new(pem.as_bytes());
+    let cert = rustls_pemfile::certs(&mut reader).next()?.ok()?;
+    Some(fingerprint_der(cert.as_ref()))
+}
+
+/// Short form for logs / UI (`ab12cd34…`).
+pub fn short(fp: &str) -> String {
+    fp.chars().take(16).collect::<String>() + "…"
+}
+
+/// Peer certificate fingerprint observed on a response (requires the client
+/// to have been built with `tls_info`).
+pub fn observed_fingerprint(resp: &reqwest::Response) -> Option<String> {
+    resp.extensions()
+        .get::<reqwest::tls::TlsInfo>()
+        .and_then(|t| t.peer_certificate())
+        .map(fingerprint_der)
+}
+
+/// Verifier that accepts exactly one leaf certificate (by fingerprint) and
+/// nothing else — no chain building, no hostname check (peers are addressed
+/// by IP and mostly self-signed). Handshake signatures are still verified
+/// with the default provider so the pinned key must actually be in use.
+#[derive(Debug)]
+struct PinnedCert {
+    expected: String,
+    label: String,
+    provider: Arc<rustls::crypto::CryptoProvider>,
+}
+
+impl ServerCertVerifier for PinnedCert {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        let got = fingerprint_der(end_entity.as_ref());
+        if got == self.expected {
+            return Ok(ServerCertVerified::assertion());
+        }
+        warn!(
+            peer = %self.label,
+            expected = %short(&self.expected),
+            observed = %short(&got),
+            "TLS pin mismatch — the peer's certificate changed; re-pin it if this was expected"
+        );
+        Err(rustls::Error::InvalidCertificate(
+            rustls::CertificateError::ApplicationVerificationFailure,
+        ))
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.provider
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+fn provider() -> Arc<rustls::crypto::CryptoProvider> {
+    rustls::crypto::CryptoProvider::get_default()
+        .cloned()
+        .unwrap_or_else(|| Arc::new(rustls::crypto::aws_lc_rs::default_provider()))
+}
+
+/// Build an HTTPS client for one peer.
+///
+/// * `pin = Some(fp)` — only that leaf certificate is accepted.
+/// * `pin = None` — first contact: any certificate is accepted **and the
+///   response carries `TlsInfo`** so the caller can record the observed
+///   fingerprint with [`observed_fingerprint`] and pin it from then on.
+pub fn client_for(
+    pin: Option<&str>,
+    label: &str,
+    timeout: Duration,
+) -> crate::Result<reqwest::Client> {
+    let build = |b: reqwest::ClientBuilder| {
+        b.tls_info(true)
+            .timeout(timeout)
+            .build()
+            .map_err(|e| crate::CoreError::Other(format!("peer_tls: http client: {e}")))
+    };
+    match pin {
+        Some(fp) => {
+            let verifier = Arc::new(PinnedCert {
+                expected: fp.to_ascii_lowercase(),
+                label: label.to_string(),
+                provider: provider(),
+            });
+            let cfg = rustls::ClientConfig::builder_with_provider(provider())
+                .with_safe_default_protocol_versions()
+                .map_err(|e| crate::CoreError::Other(format!("peer_tls: rustls config: {e}")))?
+                .dangerous()
+                .with_custom_certificate_verifier(verifier)
+                .with_no_client_auth();
+            build(reqwest::Client::builder().tls_backend_preconfigured(cfg))
+        }
+        None => {
+            debug!(
+                peer = label,
+                "peer_tls: no pin yet — first contact will pin the observed certificate"
+            );
+            build(reqwest::Client::builder().danger_accept_invalid_certs(true))
+        }
+    }
+}
+
+/// HTTPS client for the local aifw-api (daemon loopback), pinned to the
+/// certificate file the API serves. Rebuilt transparently when the file's
+/// fingerprint changes (ACME renewal, self-signed regeneration). If the
+/// file cannot be read the client falls back to accept-any with a warning
+/// — loopback traffic never leaves the box, but the pin is still preferred.
+pub struct LocalApiClient {
+    cert_path: std::path::PathBuf,
+    timeout: Duration,
+    state: Mutex<Option<(Option<String>, reqwest::Client)>>,
+    warned: std::sync::atomic::AtomicBool,
+}
+
+impl LocalApiClient {
+    /// Client pinned to [`LOCAL_API_CERT_PATH`].
+    pub fn new(timeout: Duration) -> Self {
+        Self::with_cert_path(std::path::PathBuf::from(LOCAL_API_CERT_PATH), timeout)
+    }
+
+    /// Client pinned to an explicit certificate file.
+    pub fn with_cert_path(cert_path: std::path::PathBuf, timeout: Duration) -> Self {
+        Self {
+            cert_path,
+            timeout,
+            state: Mutex::new(None),
+            warned: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    /// Current client, rebuilt if the local certificate changed.
+    pub fn get(&self) -> crate::Result<reqwest::Client> {
+        let fp = fingerprint_pem_file(&self.cert_path);
+        if fp.is_none() && !self.warned.swap(true, std::sync::atomic::Ordering::Relaxed) {
+            warn!(
+                path = %self.cert_path.display(),
+                "peer_tls: local API certificate not readable — loopback calls fall back to accept-any"
+            );
+        }
+        let mut guard = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some((cached_fp, client)) = guard.as_ref()
+            && *cached_fp == fp
+        {
+            return Ok(client.clone());
+        }
+        let client = client_for(fp.as_deref(), "loopback", self.timeout)?;
+        if let Some(f) = &fp {
+            info!(pin = %short(f), "peer_tls: loopback client pinned to local API certificate");
+        }
+        *guard = Some((fp, client.clone()));
+        Ok(client)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_is_sha256_hex() {
+        let fp = fingerprint_der(b"hello");
+        assert_eq!(fp.len(), 64);
+        assert_eq!(
+            fp,
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+        assert_eq!(short(&fp), "2cf24dba5fb0a30e…");
+    }
+
+    #[test]
+    fn pem_fingerprint_round_trip() {
+        let key = rcgen::KeyPair::generate().unwrap();
+        let params = rcgen::CertificateParams::new(vec!["peer.test".into()]).unwrap();
+        let cert = params.self_signed(&key).unwrap();
+        let pem = cert.pem();
+        let expected = fingerprint_der(cert.der());
+        assert_eq!(
+            fingerprint_pem_str(&pem).as_deref(),
+            Some(expected.as_str())
+        );
+        let dir = std::env::temp_dir().join(format!("aifw-peer-tls-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("cert.pem");
+        std::fs::write(&path, &pem).unwrap();
+        assert_eq!(
+            fingerprint_pem_file(&path).as_deref(),
+            Some(expected.as_str())
+        );
+        assert!(fingerprint_pem_file(&dir.join("missing.pem")).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pinned_verifier_accepts_only_the_pinned_leaf() {
+        let key = rcgen::KeyPair::generate().unwrap();
+        let params = rcgen::CertificateParams::new(vec!["peer.test".into()]).unwrap();
+        let cert = params.self_signed(&key).unwrap();
+        let other_key = rcgen::KeyPair::generate().unwrap();
+        let other = rcgen::CertificateParams::new(vec!["peer.test".into()])
+            .unwrap()
+            .self_signed(&other_key)
+            .unwrap();
+        let v = PinnedCert {
+            expected: fingerprint_der(cert.der()),
+            label: "t".into(),
+            provider: provider(),
+        };
+        let name = ServerName::try_from("peer.test").unwrap();
+        let now = UnixTime::now();
+        assert!(
+            v.verify_server_cert(cert.der(), &[], &name, &[], now)
+                .is_ok()
+        );
+        assert!(
+            v.verify_server_cert(other.der(), &[], &name, &[], now)
+                .is_err()
+        );
+    }
+
+    /// Spin up a one-shot HTTPS server on 127.0.0.1 with a fresh self-signed
+    /// cert; returns (port, leaf fingerprint). Serves any number of requests
+    /// with a tiny 200 response.
+    async fn tls_server() -> (u16, String) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let key = rcgen::KeyPair::generate().unwrap();
+        let params = rcgen::CertificateParams::new(vec!["localhost".into()]).unwrap();
+        let cert = params.self_signed(&key).unwrap();
+        let fp = fingerprint_der(cert.der());
+        let certs = vec![CertificateDer::from(cert.der().to_vec())];
+        let key_der = rustls::pki_types::PrivateKeyDer::try_from(key.serialize_der()).unwrap();
+        let cfg = rustls::ServerConfig::builder_with_provider(provider())
+            .with_safe_default_protocol_versions()
+            .unwrap()
+            .with_no_client_auth()
+            .with_single_cert(certs, key_der)
+            .unwrap();
+        let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(cfg));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            loop {
+                let Ok((sock, _)) = listener.accept().await else {
+                    break;
+                };
+                let acceptor = acceptor.clone();
+                tokio::spawn(async move {
+                    let Ok(mut tls) = acceptor.accept(sock).await else {
+                        return;
+                    };
+                    let mut buf = [0u8; 2048];
+                    let _ = tls.read(&mut buf).await;
+                    let _ = tls
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+                        )
+                        .await;
+                    let _ = tls.shutdown().await;
+                });
+            }
+        });
+        (port, fp)
+    }
+
+    #[tokio::test]
+    async fn pinned_client_end_to_end() {
+        let (port, fp) = tls_server().await;
+        let url = format!("https://127.0.0.1:{port}/");
+
+        // Unpinned first contact: connects, and the observed fingerprint is exposed.
+        let c = client_for(None, "t", Duration::from_secs(5)).unwrap();
+        let resp = c.get(&url).send().await.expect("first contact");
+        assert_eq!(resp.status(), 200);
+        assert_eq!(observed_fingerprint(&resp).as_deref(), Some(fp.as_str()));
+
+        // Correct pin: OK.
+        let c = client_for(Some(&fp), "t", Duration::from_secs(5)).unwrap();
+        assert_eq!(c.get(&url).send().await.expect("pinned").status(), 200);
+
+        // Wrong pin: handshake refused.
+        let wrong = "00".repeat(32);
+        let c = client_for(Some(&wrong), "t", Duration::from_secs(5)).unwrap();
+        let err = c.get(&url).send().await.expect_err("mismatch must fail");
+        assert!(err.is_connect() || err.is_request(), "{err}");
+    }
+
+    #[test]
+    fn clients_build_for_both_modes() {
+        assert!(client_for(None, "x", Duration::from_secs(1)).is_ok());
+        let r = client_for(Some(&"ab".repeat(32)), "x", Duration::from_secs(1));
+        assert!(r.is_ok(), "{:?}", r.err());
+    }
+}

--- a/aifw-daemon/src/cluster_replicator.rs
+++ b/aifw-daemon/src/cluster_replicator.rs
@@ -36,28 +36,16 @@ impl ClusterReplicator {
     }
 
     pub async fn run(self) {
-        // Build the client once — TLS context and connection pool are reused
-        // across all peer pushes and across all ticks.
-        let client = match reqwest::Client::builder()
-            .danger_accept_invalid_certs(true)
-            .timeout(Duration::from_secs(15))
-            .build()
-        {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "ha: replicator failed to build http client; aborting"
-                );
-                return;
-            }
-        };
+        // #317: loopback calls are pinned to the local API certificate;
+        // per-peer clients are pinned to each peer's stored fingerprint and
+        // built per tick (they are cheap, and a peer's pin can change).
+        let loopback = aifw_core::peer_tls::LocalApiClient::new(Duration::from_secs(15));
 
         let mut tick = interval(Duration::from_secs(10));
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         loop {
             tick.tick().await;
-            if let Err(e) = self.tick_once(&client).await {
+            if let Err(e) = self.tick_once(&loopback).await {
                 // Warn ONCE on the first 401 so a missing/unregistered
                 // AIFW_LOOPBACK_API_KEY is visible without flooding logs.
                 let status = e
@@ -79,7 +67,10 @@ impl ClusterReplicator {
         }
     }
 
-    async fn tick_once(&self, client: &reqwest::Client) -> anyhow::Result<()> {
+    async fn tick_once(
+        &self,
+        loopback: &aifw_core::peer_tls::LocalApiClient,
+    ) -> anyhow::Result<()> {
         let role = aifw_core::current_local_role().await;
         if !matches!(role, ClusterRole::Primary) {
             return Ok(());
@@ -87,7 +78,8 @@ impl ClusterReplicator {
 
         // Pull our snapshot ONCE — body and hash are both derived from this
         // single read, so they are always consistent with each other.
-        let local_data = client
+        let local_data = loopback
+            .get()?
             .get(format!("{}/api/v1/cluster/snapshot", self.api_base))
             .header("Authorization", format!("ApiKey {}", self.self_api_key))
             .send()
@@ -106,6 +98,8 @@ impl ClusterReplicator {
                 Some(k) => k,
                 None => continue,
             };
+            // Pinned to this peer's certificate (#317).
+            let client = self.engine.peer_client(peer, Duration::from_secs(15))?;
 
             // Cheap hash probe — we don't need the full snapshot from the peer,
             // only whether it matches what we already have.
@@ -120,7 +114,10 @@ impl ClusterReplicator {
                 .send()
                 .await
             {
-                Ok(r) => r.text().await.unwrap_or_default().trim().to_string(),
+                Ok(r) => {
+                    self.engine.learn_peer_cert(peer, &r).await;
+                    r.text().await.unwrap_or_default().trim().to_string()
+                }
                 Err(e) => {
                     tracing::debug!(
                         error = %e,

--- a/aifw-daemon/src/health_prober.rs
+++ b/aifw-daemon/src/health_prober.rs
@@ -35,7 +35,11 @@ impl HealthProber {
         let mut demoted = false;
         let mut recovery_started: Option<Instant> = None;
 
-        let client = match reqwest::Client::builder()
+        // Client for operator-defined HTTP GET probes. These target
+        // arbitrary services (often internal, often self-signed) and carry
+        // no credentials, so certificate validity is not part of the
+        // "is it up" question — accept-any is deliberate here.
+        let probe_client = match reqwest::Client::builder()
             .danger_accept_invalid_certs(true)
             .timeout(Duration::from_secs(5))
             .build()
@@ -49,6 +53,8 @@ impl HealthProber {
                 return;
             }
         };
+        // #317: notifications to the local API are pinned to its certificate.
+        let loopback = aifw_core::peer_tls::LocalApiClient::new(Duration::from_secs(5));
 
         loop {
             tick.tick().await;
@@ -80,17 +86,17 @@ impl HealthProber {
                 }
                 st.last_run = Some(Instant::now());
 
-                let ok = run_probe(c, &client).await;
+                let ok = run_probe(c, &probe_client).await;
                 let outcome = apply_probe_result(st, ok, c.failures_before_down);
                 if outcome.became_healthy {
                     // Notification is best-effort — a failed POST must not
                     // stall the probe loop; the next tick retries the state.
-                    let _ = self.notify_health(&client, &c.name, true, None).await;
+                    let _ = self.notify_health(&loopback, &c.name, true, None).await;
                 } else if outcome.became_unhealthy {
                     // Same best-effort rationale as above.
                     let _ = self
                         .notify_health(
-                            &client,
+                            &loopback,
                             &c.name,
                             false,
                             Some(format!("{} consecutive failures", outcome.failures_after)),
@@ -157,14 +163,15 @@ impl HealthProber {
 
     async fn notify_health(
         &self,
-        client: &reqwest::Client,
+        loopback: &aifw_core::peer_tls::LocalApiClient,
         name: &str,
         healthy: bool,
         detail: Option<String>,
     ) -> anyhow::Result<()> {
         let body = serde_json::json!({"check": name, "healthy": healthy, "detail": detail});
         let url = format!("{}/api/v1/cluster/internal/health-changed", self.api_base);
-        let resp = client
+        let resp = loopback
+            .get()?
             .post(&url)
             .header("Authorization", format!("ApiKey {}", self.api_key))
             .json(&body)

--- a/aifw-daemon/src/role_watcher.rs
+++ b/aifw-daemon/src/role_watcher.rs
@@ -25,17 +25,8 @@ impl RoleWatcher {
         let mut tick = tokio::time::interval(Duration::from_secs(1));
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
-        let client = match reqwest::Client::builder()
-            .danger_accept_invalid_certs(true)
-            .timeout(Duration::from_secs(5))
-            .build()
-        {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!(error = %e, "ha: role_watcher failed to build http client; aborting");
-                return;
-            }
-        };
+        // #317: loopback calls are pinned to the local API certificate.
+        let loopback = aifw_core::peer_tls::LocalApiClient::new(Duration::from_secs(5));
 
         loop {
             tick.tick().await;
@@ -53,6 +44,13 @@ impl RoleWatcher {
                         .unwrap_or_else(|_| role.clone());
                     let body = serde_json::json!({"from": from_canon, "to": to_canon, "vhid": 0u8});
                     let url = format!("{}/api/v1/cluster/internal/role-changed", self.api_base);
+                    let client = match loopback.get() {
+                        Ok(c) => c,
+                        Err(e) => {
+                            tracing::warn!(error = %e, "ha: role_watcher http client");
+                            continue;
+                        }
+                    };
                     match client
                         .post(&url)
                         .header("Authorization", format!("ApiKey {}", self.api_key))

--- a/aifw-ui/src/app/cluster/components/NodesSection.tsx
+++ b/aifw-ui/src/app/cluster/components/NodesSection.tsx
@@ -23,6 +23,7 @@ export function NodesSection({
   onSave,
   onDelete,
   onGeneratePeerKey,
+  onRepin,
 }: {
   nodes: Node[];
   saving: boolean;
@@ -35,6 +36,8 @@ export function NodesSection({
   /// `onDeleted` is invoked only when the delete succeeded (before reload).
   onDelete: (n: Node, onDeleted: () => void) => void;
   onGeneratePeerKey: (nodeId: string, nodeName: string) => void;
+  /// #317: clear the peer's pinned TLS fingerprint so it is re-learned on next contact.
+  onRepin: (nodeId: string) => void;
 }) {
   const [showNodeForm, setShowNodeForm] = useState(false);
   const [nodeForm, setNodeForm] = useState<NodeFormState>(defaultNodeForm);
@@ -147,6 +150,12 @@ export function NodesSection({
                 <th className="text-left py-3 px-4 text-xs font-medium text-gray-400 uppercase tracking-wider">
                   Last seen
                 </th>
+                <th
+                  className="text-left py-3 px-4 text-xs font-medium text-gray-400 uppercase tracking-wider"
+                  title="SHA-256 of the peer's API certificate that our HTTPS calls are pinned to. Learned on first contact; reset it if the peer's certificate changed by hand."
+                >
+                  TLS pin
+                </th>
                 <th className="w-40"></th>
               </tr>
             </thead>
@@ -162,6 +171,27 @@ export function NodesSection({
                   <td className="py-2.5 px-4">{n.health}</td>
                   <td className="py-2.5 px-4">
                     {new Date(n.last_seen).toLocaleString()}
+                  </td>
+                  <td className="py-2.5 px-4">
+                    {n.cert_fingerprint ? (
+                      <span
+                        className="font-mono text-xs text-[var(--text-muted)]"
+                        title={n.cert_fingerprint}
+                      >
+                        {n.cert_fingerprint.slice(0, 16)}…
+                        <button
+                          onClick={() => onRepin(n.id)}
+                          className="ml-2 text-[var(--accent)] hover:underline"
+                          title="Forget this pin; the next contact re-learns the peer's current certificate"
+                        >
+                          Re-pin
+                        </button>
+                      </span>
+                    ) : (
+                      <span className="text-xs text-[var(--text-muted)]" title="Not pinned yet — pinned automatically on the first successful contact">
+                        learn on first contact
+                      </span>
+                    )}
                   </td>
                   <td className="py-2.5 px-2">
                     <div className="flex items-center gap-1">

--- a/aifw-ui/src/app/cluster/page.tsx
+++ b/aifw-ui/src/app/cluster/page.tsx
@@ -34,6 +34,7 @@ export default function ClusterPage() {
     promote,
     demote,
     generatePeerKey,
+    repinPeer,
     generateLoopbackKey,
     registerPeerKey,
     saveVip,
@@ -180,6 +181,7 @@ export default function ClusterPage() {
         onSave={saveNode}
         onDelete={deleteNode}
         onGeneratePeerKey={generatePeerKey}
+        onRepin={repinPeer}
       />
     </div>
   );

--- a/aifw-ui/src/hooks/useCluster.ts
+++ b/aifw-ui/src/hooks/useCluster.ts
@@ -22,6 +22,7 @@ import {
   forceSnapshotSync,
   generateLoopbackKey as apiGenerateLoopbackKey,
   generateNodePeerKey,
+  repinNode,
   getHealthSummary,
   getPfsync,
   listCarpVips,
@@ -116,6 +117,18 @@ export function useCluster() {
     try {
       await demoteCluster();
       await reload();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const repinPeer = async (nodeId: string) => {
+    setBusy(true);
+    try {
+      await repinNode(nodeId);
+      await reload();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to reset peer TLS pin");
     } finally {
       setBusy(false);
     }
@@ -391,6 +404,7 @@ export function useCluster() {
     promote,
     demote,
     generatePeerKey,
+    repinPeer,
     generateLoopbackKey,
     registerPeerKey,
     saveVip,

--- a/aifw-ui/src/lib/api/cluster.ts
+++ b/aifw-ui/src/lib/api/cluster.ts
@@ -36,6 +36,8 @@ export type Node = {
   role: string;
   health: string;
   last_seen: string;
+  /** SHA-256 of the peer's API certificate that our calls are pinned to (#317); null until first contact. */
+  cert_fingerprint?: string | null;
 };
 
 export type HealthCheck = {
@@ -200,6 +202,13 @@ export const demoteCluster = () => api.post<unknown>("/api/v1/cluster/demote");
 
 export const generateNodePeerKey = (nodeId: string) =>
   api.post<{ key: string }>(`/api/v1/cluster/nodes/${nodeId}/generate-key`);
+
+/** Clear (no fingerprint) or set the pinned TLS certificate of a peer (#317). */
+export const repinNode = (nodeId: string, fingerprint?: string) =>
+  api.post<Node>(
+    `/api/v1/cluster/nodes/${nodeId}/repin`,
+    fingerprint ? { fingerprint } : {},
+  );
 
 export const generateLoopbackKey = () =>
   api.post<{ ok: boolean; message: string }>(

--- a/docs/ha.md
+++ b/docs/ha.md
@@ -52,11 +52,12 @@ of any failure on the master.
 The replication channel between cluster nodes is treated as TRUSTED. Specifically:
 
 - **Snapshot pushes carry secrets in plaintext.** The full firewall config is replicated across nodes, including VPN (WireGuard) private keys, preshared keys, DDNS TSIG keys, rDHCP HA TLS material, and the CARP shared password.
-- **TLS verification is disabled on inter-node calls.** Each node accepts self-signed certificates from peers. Anyone with network-layer access to the pfsync segment can MITM these calls and recover the secrets above.
-- **Mitigation: use a dedicated, physically-secured pfsync NIC.** A back-to-back cable between the two nodes, or a VLAN that no other host can reach, is the recommended configuration.
-- **Per-peer API keys.** Each node holds an API key for the peer it pushes to. These are stored in plaintext in the local SQLite DB; treat the DB file as a credential store.
+- **Inter-node calls are pinned to the peer's certificate** (SHA-256 of the API certificate, stored per node in `cluster_nodes.cert_fingerprint`; #317). The pin is learned on the first successful contact — trust-on-first-use, like an SSH `known_hosts` entry — and enforced from then on; a changed certificate fails the handshake and logs `TLS pin mismatch`. Daemon → local API loopback calls are pinned to `/usr/local/etc/aifw/tls/cert.pem` and follow that file when it changes.
+  - Cert pushes (`cluster/cert-push`) clear the affected pins on both sides so the next contact re-learns them; a manual certificate change on a peer (self-signed regeneration, hand import) needs an operator re-pin: `aifw cluster nodes repin <id>` (optionally `--fingerprint <sha256>`), `POST /api/v1/cluster/nodes/{id}/repin`, or the **Re-pin** action on the HA → Nodes table.
+  - The first contact and any re-pin are the residual MITM windows. Register nodes over a segment you trust, or pass the peer's fingerprint explicitly (`--fingerprint`, or the request body) instead of learning it.
+- **Mitigation: use a dedicated, physically-secured pfsync NIC.** A back-to-back cable between the two nodes, or a VLAN that no other host can reach, is still the recommended configuration.
+- **Per-peer API keys.** Each node holds an API key for the peer it pushes to (sealed at rest since #298); treat the DB file plus `secrets.key` as a credential store.
 - **`/usr/local/etc/aifw/daemon.key`** holds the loopback API key used by daemon background tasks. File mode `640`, owned `root:aifw`. The aifw user must have read access; no other local user should.
-- **Future cert pinning** would close the MITM gap. If a follow-up issue has not yet been filed, open one to track this work.
 
 If your network does not satisfy "trusted pfsync segment," do not enable HA replication.
 


### PR DESCRIPTION
Closes #317.

All five inter-node / loopback reqwest clients (`acme_engine.rs`, `cluster.rs`, `cluster_replicator.rs`, `health_prober.rs`, `role_watcher.rs`) accepted any certificate (`danger_accept_invalid_certs`), leaving the peer API key as the only thing between an on-path attacker and the replication stream (which carries the whole config, secrets included).

**Design (`aifw_core::peer_tls`)**
- Custom rustls `ServerCertVerifier` that accepts exactly one leaf certificate by SHA-256 fingerprint (no chain / hostname — peers are IP-addressed and self-signed; handshake signatures are still verified with the default provider so the pinned key must actually be in use).
- `client_for(pin)` → pinned client; `client_for(None)` → first-contact client (accept-any + `tls_info`) so the caller can record the observed fingerprint. Trust-on-first-use, like an SSH `known_hosts` entry; enforced from then on. Mismatch fails the handshake and logs both fingerprints.
- **Peers:** pin in `cluster_nodes.cert_fingerprint`; `ClusterEngine::{peer_client, learn_peer_cert, set_peer_cert_fingerprint, clear_pins_for_role}`.
- **Loopback (daemon → local API):** `LocalApiClient` pins to `/usr/local/etc/aifw/tls/cert.pem` and rebuilds when the file changes, so ACME renewals / self-signed regeneration are picked up without a restart.
- **Cert pushes** clear the affected pins on both sides (master clears the pushed-to peer; the receiver clears its Primary pins) so the next contact re-learns rather than failing on a stale fingerprint — the peer's *API* cert may or may not become the pushed chain, depending on its ACME-export settings, so a fresh TOFU is safer than guessing.
- Operator HTTP-GET **health probes** keep accept-any deliberately: they target arbitrary internal services with no credentials, and certificate validity isn't part of the "is it up" question. Everything that carries a credential is pinned.

**Operator surface:** `POST /api/v1/cluster/nodes/{id}/repin` (empty = clear; `{fingerprint}` = set explicitly, colons/case normalised, 400 on a bad digest, 404 unknown node), `aifw cluster nodes repin <id> [--fingerprint <sha256>]`, and a **TLS pin** column with *Re-pin* on the HA → Nodes table (`cert_fingerprint` is on the node JSON).

**Residual risk (documented in `docs/ha.md`):** first contact and any re-pin are TOFU windows; register nodes over a segment you trust or pass the fingerprint explicitly.

**Tests:** verifier accept/reject; PEM/DER fingerprinting; end-to-end against a local tokio-rustls server (unpinned learns the fingerprint, correct pin OK, wrong pin refused); repin route + role-scoped clearing. core/api/daemon/common suites green, `cargo check` zero warnings, UI lint/build clean.

Note: this branch is independent of #666 (secrets-at-rest); the two touch adjacent lines in `ha.rs` and will need a trivial merge in whichever lands second.
