### PR TITLE
sec(auth): trust X-Forwarded-For only from configured proxies (#308)

### DIFF
--- a/aifw-api/Cargo.toml
+++ b/aifw-api/Cargo.toml
@@ -51,6 +51,7 @@ time = { workspace = true }
 tokio-rustls = { workspace = true }
 rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
+ip_network = "0.4"
 quick-xml = "0.41"
 thiserror = { workspace = true }
 

--- a/aifw-api/src/auth/middleware.rs
+++ b/aifw-api/src/auth/middleware.rs
@@ -201,7 +201,11 @@ pub async fn auth_middleware(
                 data: aifw_plugins::hooks::HookEventData::Api {
                     method,
                     path,
-                    remote_addr: None,
+                    // #308: resolved peer / trusted-proxy client address.
+                    remote_addr: request
+                        .extensions()
+                        .get::<crate::client_ip::ClientIp>()
+                        .and_then(|c| c.key()),
                 },
             };
             let actions = plugins.dispatch(&event).await;

--- a/aifw-api/src/client_ip.rs
+++ b/aifw-api/src/client_ip.rs
@@ -1,0 +1,264 @@
+//! Client-IP resolution with a trusted-proxy allowlist (#308 / SEC-M11).
+//!
+//! `X-Forwarded-For` used to be believed unconditionally, so anyone could
+//! dodge login / refresh rate limiting by rotating the header. Now the
+//! peer address (from `ConnectInfo`) is the client unless that peer is in
+//! the operator's trusted-proxy list — only then is XFF consulted, and
+//! walked from the right so that hops appended by *our* proxies are
+//! skipped and the first address a trusted proxy saw wins.
+//!
+//! Sources of the allowlist, merged: `--trusted-proxies` /
+//! `AIFW_TRUSTED_PROXIES` (comma-separated IPs or CIDRs) and the
+//! `api_server_trusted_proxies` key in `auth_config` (Settings → API
+//! Server), read at startup.
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use axum::extract::{ConnectInfo, Request, State};
+use axum::http::HeaderMap;
+use axum::middleware::Next;
+use axum::response::Response;
+use ip_network::IpNetwork;
+
+/// Parsed trusted-proxy allowlist.
+#[derive(Debug, Default, Clone)]
+pub struct TrustedProxies {
+    nets: Vec<IpNetwork>,
+}
+
+impl TrustedProxies {
+    /// Parse a comma/space-separated list of IPs and CIDRs. Bad entries are
+    /// returned so the caller can log them; good ones are kept.
+    pub fn parse(spec: &str) -> (Self, Vec<String>) {
+        let mut nets = Vec::new();
+        let mut bad = Vec::new();
+        for raw in spec.split([',', ' ', '\n']) {
+            let item = raw.trim();
+            if item.is_empty() {
+                continue;
+            }
+            match parse_entry(item) {
+                Some(n) => nets.push(n),
+                None => bad.push(item.to_string()),
+            }
+        }
+        (Self { nets }, bad)
+    }
+
+    /// Merge another list into this one.
+    pub fn extend(&mut self, other: TrustedProxies) {
+        self.nets.extend(other.nets);
+    }
+
+    /// True if `ip` belongs to a trusted proxy.
+    pub fn contains(&self, ip: IpAddr) -> bool {
+        // Compare v4-mapped v6 peers (::ffff:a.b.c.d) as their v4 form so an
+        // allowlist written in v4 works on a dual-stack listener.
+        let ip = match ip {
+            IpAddr::V6(v6) => v6.to_ipv4_mapped().map(IpAddr::V4).unwrap_or(ip),
+            v4 => v4,
+        };
+        self.nets.iter().any(|n| n.contains(ip))
+    }
+
+    /// True if no proxies are configured (XFF is never trusted).
+    pub fn is_empty(&self) -> bool {
+        self.nets.is_empty()
+    }
+}
+
+fn parse_entry(item: &str) -> Option<IpNetwork> {
+    if let Ok(n) = item.parse::<IpNetwork>() {
+        return Some(n);
+    }
+    let ip: IpAddr = item.parse().ok()?;
+    let bits = if ip.is_ipv4() { 32 } else { 128 };
+    IpNetwork::new(ip, bits).ok()
+}
+
+/// The resolved client address for a request, as a request extension.
+/// `None` when the server has no `ConnectInfo` (in-process test servers).
+#[derive(Debug, Clone, Copy)]
+pub struct ClientIp(pub Option<IpAddr>);
+
+impl ClientIp {
+    /// String form for rate-limiter keys and logs.
+    pub fn key(&self) -> Option<String> {
+        self.0.map(|ip| ip.to_string())
+    }
+}
+
+/// Pure resolution: `peer` is the TCP peer; XFF is honoured only when the
+/// peer is a trusted proxy, walking right-to-left past trusted hops.
+pub fn resolve(
+    peer: Option<IpAddr>,
+    headers: &HeaderMap,
+    trusted: &TrustedProxies,
+) -> Option<IpAddr> {
+    let peer = peer?;
+    if trusted.is_empty() || !trusted.contains(peer) {
+        return Some(peer);
+    }
+    let Some(xff) = headers.get("x-forwarded-for").and_then(|v| v.to_str().ok()) else {
+        return Some(peer);
+    };
+    // Rightmost entry not itself a trusted proxy = the real client. All
+    // entries left of it were supplied by untrusted parties (or the client)
+    // and are ignored.
+    for hop in xff.rsplit(',') {
+        let hop = hop.trim();
+        // Tolerate "ip:port" and bracketed v6 forms some proxies emit.
+        let candidate = hop
+            .parse::<IpAddr>()
+            .ok()
+            .or_else(|| hop.parse::<SocketAddr>().ok().map(|s| s.ip()))
+            .or_else(|| hop.trim_matches(['[', ']']).parse::<IpAddr>().ok());
+        match candidate {
+            Some(ip) if trusted.contains(ip) => continue,
+            Some(ip) => return Some(ip),
+            None => return Some(peer), // garbage header — fall back to the peer
+        }
+    }
+    // Every hop was one of our proxies: the connection originated inside
+    // the proxy tier; attribute to the peer.
+    Some(peer)
+}
+
+/// Middleware: attach [`ClientIp`] to every request.
+pub async fn attach_client_ip(
+    State(trusted): State<Arc<TrustedProxies>>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    let peer = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|c| c.0.ip());
+    let ip = resolve(peer, request.headers(), &trusted);
+    request.extensions_mut().insert(ClientIp(ip));
+    next.run(request).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn hdrs(xff: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert("x-forwarded-for", HeaderValue::from_str(xff).unwrap());
+        h
+    }
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn parses_ips_and_cidrs_and_reports_bad() {
+        let (t, bad) = TrustedProxies::parse("10.0.0.5, 192.168.0.0/16 fd00::/8,nope");
+        assert_eq!(bad, vec!["nope"]);
+        assert!(t.contains(ip("10.0.0.5")));
+        assert!(t.contains(ip("192.168.44.1")));
+        assert!(t.contains(ip("fd00::1")));
+        assert!(!t.contains(ip("10.0.0.6")));
+        // v4-mapped v6 peer matches a v4 allowlist entry
+        assert!(t.contains(ip("::ffff:10.0.0.5")));
+    }
+
+    #[test]
+    fn untrusted_peer_ignores_xff() {
+        let (t, _) = TrustedProxies::parse("10.0.0.5");
+        let r = resolve(Some(ip("203.0.113.9")), &hdrs("1.2.3.4"), &t);
+        assert_eq!(r, Some(ip("203.0.113.9")));
+        // and with no allowlist at all
+        let r = resolve(
+            Some(ip("203.0.113.9")),
+            &hdrs("1.2.3.4"),
+            &TrustedProxies::default(),
+        );
+        assert_eq!(r, Some(ip("203.0.113.9")));
+    }
+
+    #[test]
+    fn trusted_peer_uses_rightmost_untrusted_hop() {
+        let (t, _) = TrustedProxies::parse("10.0.0.0/8");
+        // client -> proxy A (10.0.0.5) -> proxy B (10.0.0.6, our peer)
+        let r = resolve(Some(ip("10.0.0.6")), &hdrs("198.51.100.7, 10.0.0.5"), &t);
+        assert_eq!(r, Some(ip("198.51.100.7")));
+        // Attacker prepends junk: only the entry the trusted proxy appended counts.
+        let r = resolve(Some(ip("10.0.0.6")), &hdrs("1.1.1.1, 198.51.100.7"), &t);
+        assert_eq!(r, Some(ip("198.51.100.7")));
+        // ip:port form
+        let r = resolve(Some(ip("10.0.0.6")), &hdrs("198.51.100.7:5555"), &t);
+        assert_eq!(r, Some(ip("198.51.100.7")));
+        // All hops trusted / header missing / garbage → peer
+        assert_eq!(
+            resolve(Some(ip("10.0.0.6")), &hdrs("10.0.0.5"), &t),
+            Some(ip("10.0.0.6"))
+        );
+        assert_eq!(
+            resolve(Some(ip("10.0.0.6")), &HeaderMap::new(), &t),
+            Some(ip("10.0.0.6"))
+        );
+        assert_eq!(
+            resolve(Some(ip("10.0.0.6")), &hdrs("what"), &t),
+            Some(ip("10.0.0.6"))
+        );
+    }
+
+    /// The middleware end to end: peer from ConnectInfo, XFF honoured only
+    /// behind a trusted proxy, handlers read `Extension<ClientIp>`.
+    #[tokio::test]
+    async fn middleware_attaches_resolved_ip() {
+        use axum::{Router, body::Body, routing::get};
+        use tower::ServiceExt;
+
+        async fn who(axum::Extension(c): axum::Extension<ClientIp>) -> String {
+            c.key().unwrap_or_else(|| "none".into())
+        }
+        let (trusted, _) = TrustedProxies::parse("10.0.0.0/8");
+        let app = Router::new()
+            .route("/", get(who))
+            .layer(axum::middleware::from_fn_with_state(
+                Arc::new(trusted),
+                attach_client_ip,
+            ));
+
+        let call = |peer: Option<&str>, xff: Option<&str>| {
+            let app = app.clone();
+            let peer = peer.map(|p| p.parse::<SocketAddr>().unwrap());
+            let xff = xff.map(str::to_string);
+            async move {
+                let mut req = axum::http::Request::builder().uri("/");
+                if let Some(x) = &xff {
+                    req = req.header("x-forwarded-for", x);
+                }
+                let mut req = req.body(Body::empty()).unwrap();
+                if let Some(p) = peer {
+                    req.extensions_mut().insert(ConnectInfo(p));
+                }
+                let resp = app.oneshot(req).await.unwrap();
+                let bytes = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+                String::from_utf8(bytes.to_vec()).unwrap()
+            }
+        };
+
+        assert_eq!(
+            call(Some("203.0.113.9:4000"), Some("1.2.3.4")).await,
+            "203.0.113.9"
+        );
+        assert_eq!(
+            call(Some("10.0.0.6:4000"), Some("198.51.100.7")).await,
+            "198.51.100.7"
+        );
+        assert_eq!(call(Some("10.0.0.6:4000"), None).await, "10.0.0.6");
+        assert_eq!(call(None, Some("1.2.3.4")).await, "none");
+    }
+
+    #[test]
+    fn no_peer_means_unknown() {
+        let (t, _) = TrustedProxies::parse("10.0.0.0/8");
+        assert_eq!(resolve(None, &hdrs("1.2.3.4"), &t), None);
+    }
+}

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -5,6 +5,7 @@ mod auth;
 mod backup;
 mod backup_s3;
 mod ca;
+mod client_ip;
 mod cluster;
 mod dhcp;
 mod dns_blocklists;
@@ -200,6 +201,8 @@ pub struct AppState {
     /// Watch channel that fires whenever `pending` changes — drives SSE.
     pub pending_tx: watch::Sender<PendingChanges>,
     pub login_limiter: LoginRateLimiter,
+    /// #308: proxies whose X-Forwarded-For we believe. Empty = never.
+    pub trusted_proxies: Arc<client_ip::TrustedProxies>,
     pub ws_tickets: Arc<auth::ws_ticket::WsTicketStore>,
     /// Broadcast channel that carries the prepared per-tick dashboard JSON
     /// payload. A single producer task (`ws::run_dashboard_producer`) builds
@@ -331,6 +334,13 @@ struct Args {
     /// CORS allowed origins (comma-separated, or * for any)
     #[arg(long, default_value = "*")]
     cors_origins: String,
+
+    /// Reverse proxies / load balancers whose X-Forwarded-For header is
+    /// trusted for the client IP (comma-separated IPs or CIDRs). Merged with
+    /// the `api_server_trusted_proxies` setting. Empty (default) = the TCP
+    /// peer is always the client and XFF is ignored (#308).
+    #[arg(long, env = "AIFW_TRUSTED_PROXIES", default_value = "")]
+    trusted_proxies: String,
 
     /// Path to static UI build directory (serves web UI if set)
     #[arg(long, env = "AIFW_UI_DIR")]
@@ -631,6 +641,12 @@ pub fn build_router(
                 )
                 .layer(cors),
         )
+        // #308: resolve the client address (peer, or XFF behind a trusted
+        // proxy) once per request; handlers read `Extension<ClientIp>`.
+        .layer(middleware::from_fn_with_state(
+            state.trusted_proxies.clone(),
+            client_ip::attach_client_ip,
+        ))
         .with_state(state);
 
     // Serve static UI if directory is provided.
@@ -1169,6 +1185,7 @@ async fn create_state_from_db(
         pending: Arc::new(RwLock::new(PendingChanges::default())),
         pending_tx: watch::channel(PendingChanges::default()).0,
         login_limiter: LoginRateLimiter::default(),
+        trusted_proxies: Arc::new(client_ip::TrustedProxies::default()),
         ws_tickets: auth::ws_ticket::WsTicketStore::new(),
         // Broadcast capacity is per-subscriber lag tolerance, not aggregate.
         // 256 slots of Arc<String> (~16 KiB pointers + bookkeeping) absorb
@@ -1582,6 +1599,29 @@ async fn main() -> anyhow::Result<()> {
             auth::jwt_key::load_or_create(&args.jwt_key_file, &state.pool)
                 .await
                 .map_err(|e| anyhow::anyhow!("JWT key file: {e}"))?;
+    }
+
+    // #308: trusted proxies = CLI/env list + Settings → API Server value.
+    {
+        let (mut trusted, mut bad) = client_ip::TrustedProxies::parse(&args.trusted_proxies);
+        let stored: Option<(String,)> = sqlx::query_as(
+            "SELECT value FROM auth_config WHERE key = 'api_server_trusted_proxies'",
+        )
+        .fetch_optional(&state.pool)
+        .await
+        .unwrap_or(None);
+        if let Some((v,)) = stored {
+            let (t, b) = client_ip::TrustedProxies::parse(&v);
+            trusted.extend(t);
+            bad.extend(b);
+        }
+        for b in &bad {
+            warn!(entry = %b, "trusted-proxies: ignoring unparseable entry");
+        }
+        if !trusted.is_empty() {
+            info!("X-Forwarded-For trusted from configured proxies");
+        }
+        state.trusted_proxies = Arc::new(trusted);
     }
 
     // Load non-secret auth settings from DB.
@@ -2042,9 +2082,12 @@ async fn main() -> anyhow::Result<()> {
         }
         let listener = tokio::net::TcpListener::bind(&args.listen).await?;
         info!("AiFw API listening on http://{}", args.listen);
-        axum::serve(listener, app)
-            .with_graceful_shutdown(shutdown_signal())
-            .await?;
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
     } else {
         ensure_tls_cert(&args.tls_cert, &args.tls_key)?;
         let tls_config =
@@ -2064,7 +2107,7 @@ async fn main() -> anyhow::Result<()> {
         });
         axum_server::bind_rustls(addr, tls_config)
             .handle(handle)
-            .serve(app.into_make_service())
+            .serve(app.into_make_service_with_connect_info::<std::net::SocketAddr>())
             .await?;
     }
 

--- a/aifw-api/src/routes/auth.rs
+++ b/aifw-api/src/routes/auth.rs
@@ -22,19 +22,16 @@ fn session_cookie_headers(state: &AppState, tokens: &auth::TokenPair) -> HeaderM
 
 pub async fn login(
     State(state): State<AppState>,
-    headers: HeaderMap,
+    client: Option<axum::Extension<crate::client_ip::ClientIp>>,
     Json(req): Json<auth::LoginRequest>,
 ) -> Result<(HeaderMap, Json<auth::LoginResponse>), StatusCode> {
-    // Rate-limit on two axes: the X-Forwarded-For-ish client IP (best
-    // effort — spoofable without a trusted-proxies allow-list, tracked
-    // as a follow-up) AND the username. The username axis guarantees a
-    // password-spray against one account still gets limited even if
-    // the attacker rotates XFF per request.
-    let client_ip = headers
-        .get("x-forwarded-for")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.split(',').next())
-        .map(|s| s.trim().to_string())
+    // Rate-limit on two axes: the client IP AND the username. The IP is
+    // the TCP peer, or X-Forwarded-For only when the peer is a configured
+    // trusted proxy (#308) — so it can no longer be rotated per request by
+    // the attacker. The username axis guarantees a password-spray against
+    // one account still gets limited regardless.
+    let client_ip = client
+        .and_then(|c| c.0.key())
         .unwrap_or_else(|| format!("user:{}", req.username));
     let rl_user = req.username.to_ascii_lowercase();
 
@@ -200,6 +197,7 @@ pub async fn totp_login(
 pub async fn refresh_token(
     State(state): State<AppState>,
     headers: HeaderMap,
+    client: Option<axum::Extension<crate::client_ip::ClientIp>>,
     body: Option<Json<auth::tokens::RefreshRequest>>,
 ) -> Result<(HeaderMap, Json<auth::TokenPair>), StatusCode> {
     // Token comes from the JSON body (header-auth clients) or, for the
@@ -208,17 +206,14 @@ pub async fn refresh_token(
         .map(|Json(r)| r.refresh_token)
         .or_else(|| auth::cookies::cookie_value(&headers, auth::cookies::REFRESH_COOKIE))
         .ok_or(bad_request())?;
-    // SEC-H8: rate-limit refresh like login. Key on the client IP (best
-    // effort, spoofable without a trusted-proxy allow-list) and on the
-    // token prefix so a spray of forged tokens from one source is capped.
-    // Falling back to the prefix as the IP key when there's no XFF avoids a
-    // single shared global bucket that would block unrelated clients.
+    // SEC-H8: rate-limit refresh like login. Key on the client IP (peer, or
+    // XFF behind a trusted proxy — #308) and on the token prefix so a spray
+    // of forged tokens from one source is capped. Falling back to the prefix
+    // as the IP key when the peer is unknown avoids a single shared global
+    // bucket that would block unrelated clients.
     let token_prefix = auth::tokens::refresh_prefix(&refresh_token).to_string();
-    let client_ip = headers
-        .get("x-forwarded-for")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.split(',').next())
-        .map(|s| s.trim().to_string())
+    let client_ip = client
+        .and_then(|c| c.0.key())
         .unwrap_or_else(|| format!("rfx:{token_prefix}"));
 
     if state

--- a/aifw-ui/src/app/settings/components/ApiServerSection.tsx
+++ b/aifw-ui/src/app/settings/components/ApiServerSection.tsx
@@ -11,8 +11,8 @@ export interface ApiServerSectionProps {
   setPort: Dispatch<SetStateAction<string>>;
   corsOrigins: string;
   setCorsOrigins: Dispatch<SetStateAction<string>>;
-  jwtSecret: string;
-  setJwtSecret: Dispatch<SetStateAction<string>>;
+  trustedProxies: string;
+  setTrustedProxies: Dispatch<SetStateAction<string>>;
   saving: boolean;
   feedback: Feedback | null;
   save: () => void;
@@ -24,8 +24,8 @@ export function ApiServerSection({
   setPort,
   corsOrigins,
   setCorsOrigins,
-  jwtSecret,
-  setJwtSecret,
+  trustedProxies,
+  setTrustedProxies,
   saving,
   feedback,
   save,
@@ -58,14 +58,26 @@ export function ApiServerSection({
           </div>
         </div>
         <div>
-          <label className={labelCls}>JWT Secret</label>
+          <label className={labelCls}>Trusted Proxies</label>
           <input
-            type="password"
-            value={jwtSecret}
-            onChange={(e) => setJwtSecret(e.target.value)}
+            type="text"
+            value={trustedProxies}
+            onChange={(e) => setTrustedProxies(e.target.value)}
+            placeholder="e.g. 10.0.0.5, 192.168.10.0/24 — empty = none"
             className={inputCls}
           />
+          <p className="text-[11px] text-[var(--text-muted)] mt-1">
+            Only when a request arrives from one of these addresses is its
+            <code className="mx-1">X-Forwarded-For</code>header used as the client IP
+            (login / refresh rate limiting, plugin hooks). Leave empty unless AiFw sits
+            behind your own reverse proxy or load balancer. Applied at the next API restart;
+            <code className="mx-1">--trusted-proxies</code>/
+            <code className="mx-1">AIFW_TRUSTED_PROXIES</code>are merged in.
+          </p>
         </div>
+        <p className="text-[11px] text-[var(--text-muted)]">
+          The JWT signing secret lives in <code>/var/db/aifw/jwt.key</code> (not editable here).
+        </p>
 
         <div className="flex justify-end">
           <button onClick={save} disabled={saving} className={saveBtnCls}>

--- a/aifw-ui/src/hooks/useSettings.ts
+++ b/aifw-ui/src/hooks/useSettings.ts
@@ -49,6 +49,7 @@ import {
   rebootSystem,
   saveAiSettings,
   saveApiServerSettings,
+  getApiServerSettings,
   saveAuthSettings,
   saveConfigRetention,
   saveDashboardHistorySettings,
@@ -193,9 +194,22 @@ export function useMetricsSettings() {
 export function useApiServerSettings() {
   const [port, setPort] = useState("8080");
   const [corsOrigins, setCorsOrigins] = useState("*");
-  const [jwtSecret, setJwtSecret] = useState("auto-generated");
+  const [trustedProxies, setTrustedProxies] = useState("");
   const [saving, setSaving] = useState(false);
   const { feedback, showFeedback, clearFeedback } = useFeedback(4000);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const s = await getApiServerSettings();
+        if (s.port) setPort(String(s.port));
+        if (s.cors_origins) setCorsOrigins(s.cors_origins);
+        if (s.trusted_proxies !== undefined) setTrustedProxies(s.trusted_proxies);
+      } catch {
+        // endpoint may not exist yet
+      }
+    })();
+  }, []);
 
   const save = async () => {
     setSaving(true);
@@ -204,9 +218,9 @@ export function useApiServerSettings() {
       await saveApiServerSettings({
         port: Number(port),
         cors_origins: corsOrigins,
-        jwt_secret: jwtSecret,
+        trusted_proxies: trustedProxies,
       });
-      showFeedback("success", "API settings saved.");
+      showFeedback("success", "API settings saved — applied at the next aifw-api restart.");
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Unknown error";
       showFeedback("error", `Save failed: ${msg}`);
@@ -215,7 +229,7 @@ export function useApiServerSettings() {
     }
   };
 
-  return { port, setPort, corsOrigins, setCorsOrigins, jwtSecret, setJwtSecret, saving, feedback, save };
+  return { port, setPort, corsOrigins, setCorsOrigins, trustedProxies, setTrustedProxies, saving, feedback, save };
 }
 
 // --- TLS Policy ---

--- a/aifw-ui/src/lib/api/settings.ts
+++ b/aifw-ui/src/lib/api/settings.ts
@@ -35,11 +35,17 @@ export function saveMetricsSettings(body: MetricsSettingsPayload): Promise<unkno
 export interface ApiServerSettingsPayload {
   port: number;
   cors_origins: string;
-  jwt_secret: string;
+  /** Proxies whose X-Forwarded-For is trusted for the client IP (#308); IPs/CIDRs, comma-separated. */
+  trusted_proxies: string;
 }
 
+/** Stored under the generic `api_server` section; applied at the next aifw-api restart. */
 export function saveApiServerSettings(body: ApiServerSettingsPayload): Promise<unknown> {
-  return api.put("/api/v1/settings/api", body);
+  return api.put("/api/v1/settings/api_server", body);
+}
+
+export function getApiServerSettings(): Promise<Partial<Record<keyof ApiServerSettingsPayload, string>>> {
+  return api.get("/api/v1/settings/api_server");
 }
 
 // ---- TLS Policy ----

--- a/docs/docs/auth.md
+++ b/docs/docs/auth.md
@@ -53,6 +53,8 @@ curl -X POST https://aifw.local/api/v1/auth/login \
   -d '{"username": "alice", "password": "..."}'
 ```
 
+Login and refresh are rate-limited per client IP and per username / token prefix. The client IP is the TCP peer; `X-Forwarded-For` is only believed when the peer is a configured **trusted proxy** (`--trusted-proxies` / `AIFW_TRUSTED_PROXIES`, or Settings &rarr; API Server &rarr; Trusted Proxies; comma-separated IPs or CIDRs, applied at the next API restart). With no trusted proxies configured &mdash; the default &mdash; the header is ignored, so a client can't dodge the limiter by rotating it. Behind a trusted proxy the rightmost hop that isn't itself a trusted proxy is used.
+
 ## TOTP 2FA
 
 Each user can enrol a TOTP authenticator (Google Authenticator, Authy, 1Password, Bitwarden, &hellip;).


### PR DESCRIPTION
Closes #308.

Login and refresh rate limiting keyed on `X-Forwarded-For` unconditionally (`routes/auth.rs:29`, `:218` — the "tracked as a follow-up" comment), so any client could dodge the limiter by rotating the header.

**Changes**
- New `client_ip` module: `TrustedProxies` allowlist (IPs / CIDRs) built from `--trusted-proxies` / `AIFW_TRUSTED_PROXIES` **merged with** the `api_server_trusted_proxies` setting; `resolve()` uses the TCP peer unless that peer is a trusted proxy — then the rightmost XFF hop that isn't itself a trusted proxy (`ip:port` / bracketed v6 tolerated, garbage → peer); a root middleware attaches `ClientIp` to every request. Both serve paths now run with `into_make_service_with_connect_info`. With no trusted proxies configured (the default) XFF is simply ignored.
- `login` / `refresh` key the limiter on `ClientIp` (falling back to the per-user / per-token-prefix key when the peer is unknown, e.g. in-process test servers); the plugin `ApiRequest` hook now gets `remote_addr` filled in.
- UI Settings → API Server gets a **Trusted Proxies** field. While there: the section posted to `/settings/api`, which the generic handler rejects (`api_server` is the valid section), so "Save API" has been a silent no-op — fixed, and it now loads its current values. The misleading "JWT Secret" input is gone (the secret is file-based since #56).
- Docs: `auth.md`.

**Tests:** allowlist parsing/matching incl. v4-mapped v6 peers; untrusted peer ignores XFF; trusted peer walks hops right-to-left (attacker-prepended entries ignored); all-hops-trusted / missing / garbage header → peer; middleware end to end via `tower::oneshot` with a synthetic `ConnectInfo`. api suite green (223), `cargo check` zero warnings, UI lint/build clean.
