### PR TITLE
sec(backup): redact or passphrase-wrap secrets in exports, S3 uploads and history views (#313)

### DIFF
--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -88,10 +88,12 @@ pub async fn get_version(
     Query(params): Query<VersionParams>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     let mgr = ConfigManager::new(state.pool.clone());
-    let config = mgr
+    let mut config = mgr
         .get_version(params.version)
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
+    // #313: history views are display surfaces — never hand out live keys.
+    aifw_core::config_secrets::redact(&mut config);
     let json: serde_json::Value = serde_json::to_value(&config).map_err(|_| internal())?;
     Ok(Json(json))
 }
@@ -123,8 +125,11 @@ pub async fn diff_versions(
         .diff(params.v1, params.v2)
         .await
         .map_err(|_| internal())?;
-    let c1 = mgr.get_version(params.v1).await.map_err(|_| internal())?;
-    let c2 = mgr.get_version(params.v2).await.map_err(|_| internal())?;
+    let mut c1 = mgr.get_version(params.v1).await.map_err(|_| internal())?;
+    let mut c2 = mgr.get_version(params.v2).await.map_err(|_| internal())?;
+    // #313: the side-by-side JSON is a display surface — redact secrets.
+    aifw_core::config_secrets::redact(&mut c1);
+    aifw_core::config_secrets::redact(&mut c2);
     let v1_json = serde_json::to_value(&c1).map_err(|_| internal())?;
     let v2_json = serde_json::to_value(&c2).map_err(|_| internal())?;
 
@@ -177,18 +182,24 @@ pub struct RestoreRequest {
 pub async fn restore_version(
     State(state): State<AppState>,
     Json(req): Json<RestoreRequest>,
-) -> Result<Json<MessageResponse>, StatusCode> {
+) -> Result<Json<MessageResponse>, (StatusCode, String)> {
     let mgr = ConfigManager::new(state.pool.clone());
     let config = mgr
         .get_version(req.version)
         .await
-        .map_err(|_| StatusCode::NOT_FOUND)?;
+        .map_err(|_| (StatusCode::NOT_FOUND, "no such config version".to_string()))?;
 
-    apply_firewall_config_or_rollback(&state, &config, &req.interface_map).await?;
+    // A version imported from a redacted backup (S3 / file) carries the
+    // REDACTED sentinel; fill it from what the box holds now (#313).
+    let config = prepare_secrets_for_apply(&state, config, None).await?;
+
+    apply_firewall_config_or_rollback(&state, &config, &req.interface_map)
+        .await
+        .map_err(status_only)?;
 
     mgr.mark_applied(req.version)
         .await
-        .map_err(|_| internal())?;
+        .map_err(|_| status_only(internal()))?;
 
     Ok(Json(MessageResponse {
         message: format!("Restored to version {}", req.version),
@@ -863,6 +874,7 @@ pub(crate) async fn build_current_config(state: &AppState) -> Result<FirewallCon
         dns_resolver: Some(crate::dns_resolver::load_config(&state.pool).await),
         syslog: Some(aifw_common::syslog::load(&state.pool).await),
         log_rotation: Some(aifw_core::log_rotation::load(&state.pool).await),
+        secrets: None,
     };
 
     Ok(config)
@@ -1348,6 +1360,12 @@ pub struct ImportPreview {
     /// How many entries WILL BE DROPPED per section if every currently-missing
     /// interface is left unmapped. Updated client-side as user picks mappings.
     pub drop_summary_if_unmapped: DropSummary,
+    /// Whether the file's secrets are plain, redacted, or passphrase-wrapped
+    /// (#313). Wrapped ⇒ the import needs a passphrase.
+    pub secrets: aifw_core::config_secrets::SecretsState,
+    /// Redacted secrets this box cannot fill from its own state — the
+    /// import will be refused until they are supplied.
+    pub unresolved_secrets: Vec<String>,
 }
 
 /// Walk a FirewallConfig and collect every interface-name reference.
@@ -1463,8 +1481,26 @@ async fn collect_system_interfaces() -> Vec<InterfaceInfo> {
     out
 }
 
-/// Build the preview for a given FirewallConfig.
-pub(crate) async fn build_import_preview(cfg: &FirewallConfig) -> ImportPreview {
+/// Build the preview for a given FirewallConfig. `current` is what the box
+/// holds now, used to work out which redacted secrets an import can fill.
+pub(crate) async fn build_import_preview(
+    cfg: &FirewallConfig,
+    current: Option<&FirewallConfig>,
+) -> ImportPreview {
+    let secrets = aifw_core::config_secrets::state(cfg);
+    let unresolved_secrets: Vec<String> = match current {
+        Some(cur) => {
+            let mut probe = cfg.clone();
+            aifw_core::config_secrets::resolve_redacted(&mut probe, cur)
+                .iter()
+                .map(|r| r.to_string())
+                .collect()
+        }
+        None => aifw_core::config_secrets::redacted_refs(cfg)
+            .iter()
+            .map(|r| r.to_string())
+            .collect(),
+    };
     let refs = collect_interface_refs(cfg);
     let present = collect_system_interfaces().await;
     let present_names: std::collections::HashSet<String> =
@@ -1489,6 +1525,8 @@ pub(crate) async fn build_import_preview(cfg: &FirewallConfig) -> ImportPreview 
         interfaces_present: present,
         suggestions,
         drop_summary_if_unmapped: drop,
+        secrets,
+        unresolved_secrets,
     }
 }
 
@@ -1498,13 +1536,14 @@ pub struct RestorePreviewQuery {
 }
 
 pub async fn preview_import(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
     Json(payload): Json<serde_json::Value>,
 ) -> Result<Json<ImportPreview>, StatusCode> {
     let config_val = payload.get("config").ok_or(StatusCode::BAD_REQUEST)?;
     let config: FirewallConfig =
         serde_json::from_value(config_val.clone()).map_err(|_| StatusCode::BAD_REQUEST)?;
-    Ok(Json(build_import_preview(&config).await))
+    let current = build_current_config(&state).await.ok();
+    Ok(Json(build_import_preview(&config, current.as_ref()).await))
 }
 
 pub async fn preview_restore(
@@ -1516,7 +1555,8 @@ pub async fn preview_restore(
         .get_version(q.version)
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
-    Ok(Json(build_import_preview(&config).await))
+    let current = build_current_config(&state).await.ok();
+    Ok(Json(build_import_preview(&config, current.as_ref()).await))
 }
 
 /// Resolve the target interface name via the provided map.
@@ -1543,6 +1583,62 @@ fn apply_fail(step: &str, e: impl std::fmt::Display) -> StatusCode {
     StatusCode::INTERNAL_SERVER_ERROR
 }
 
+/// Attach the canonical reason to a bare status so handlers that now return
+/// `(StatusCode, String)` can keep using the older `StatusCode`-only helpers.
+pub(crate) fn status_only(s: StatusCode) -> (StatusCode, String) {
+    (s, s.canonical_reason().unwrap_or("error").to_string())
+}
+
+/// Bring an incoming config's secrets into applicable shape (#313):
+/// passphrase-wrapped values are opened with `passphrase` (400 if it is
+/// missing or wrong), then any [`REDACTED`](aifw_core::config_secrets::REDACTED)
+/// sentinel is filled from the config the box currently holds. Refuses
+/// with a 400 naming every secret that cannot be resolved — applying a
+/// sentinel would silently break a tunnel or VIP.
+pub(crate) async fn prepare_secrets_for_apply(
+    state: &AppState,
+    mut config: FirewallConfig,
+    passphrase: Option<&str>,
+) -> Result<FirewallConfig, (StatusCode, String)> {
+    use aifw_core::config_secrets as cs;
+    match cs::state(&config) {
+        cs::SecretsState::Plain => return Ok(config),
+        cs::SecretsState::Passphrase { .. } => {
+            let Some(pw) = passphrase.filter(|p| !p.is_empty()) else {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "this backup's secrets are passphrase-protected — supply the passphrase to import it"
+                        .to_string(),
+                ));
+            };
+            cs::open_with_passphrase(&mut config, pw).map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("could not unlock backup secrets: {e}"),
+                )
+            })?;
+        }
+        cs::SecretsState::Redacted { .. } => {}
+    }
+    if cs::redacted_refs(&config).is_empty() {
+        return Ok(config);
+    }
+    let current = build_current_config(state).await.map_err(status_only)?;
+    let unresolved = cs::resolve_redacted(&mut config, &current);
+    if !unresolved.is_empty() {
+        let names: Vec<String> = unresolved.iter().map(|r| r.to_string()).collect();
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "backup was exported without secrets and this box does not hold them: {}. \
+                 Re-export with a passphrase, or recreate these objects after import.",
+                names.join(", ")
+            ),
+        ));
+    }
+    Ok(config)
+}
+
 /// Pre-apply validation (#535): run the target config through the same
 /// converters and validators the apply path uses, *before* the first
 /// destructive DELETE. Entries the apply loop would silently skip
@@ -1553,6 +1649,18 @@ pub(crate) fn prevalidate_config(
     iface_map: &InterfaceMap,
 ) -> Result<(), String> {
     config.validate()?;
+
+    // #313: sentinels / wrapped values must have been resolved by the caller
+    // (`prepare_secrets_for_apply`); writing them would break the data plane.
+    match aifw_core::config_secrets::state(config) {
+        aifw_core::config_secrets::SecretsState::Plain => {}
+        aifw_core::config_secrets::SecretsState::Redacted { count } => {
+            return Err(format!("{count} secret(s) are redacted and unresolved"));
+        }
+        aifw_core::config_secrets::SecretsState::Passphrase { .. } => {
+            return Err("secrets are passphrase-wrapped; unlock before applying".into());
+        }
+    }
 
     for rc in &config.rules {
         let iface_after = match rc.interface.as_deref() {
@@ -3043,7 +3151,25 @@ pub async fn auto_snapshot_middleware(
         let s3cfg = aifw_core::s3_backup::load(&bg_state.pool).await;
         if s3cfg.enabled {
             let now = chrono::Utc::now().to_rfc3339();
-            match aifw_core::s3_backup::upload_version(&s3cfg, version, &now, &cfg.to_json()).await
+            // #313: never ship live secrets to object storage — wrap them
+            // under the configured passphrase, or redact when none is set.
+            let mut upload = cfg.clone();
+            match s3cfg
+                .secrets_passphrase
+                .as_deref()
+                .filter(|p| !p.is_empty())
+            {
+                Some(pw) => {
+                    if let Err(e) = aifw_core::config_secrets::seal_with_passphrase(&mut upload, pw)
+                    {
+                        tracing::warn!(version, error = %e, "S3 upload: wrapping secrets failed; uploading redacted copy");
+                        aifw_core::config_secrets::redact(&mut upload);
+                    }
+                }
+                None => aifw_core::config_secrets::redact(&mut upload),
+            }
+            match aifw_core::s3_backup::upload_version(&s3cfg, version, &now, &upload.to_json())
+                .await
             {
                 Ok(key) => {
                     aifw_core::smtp_notify::send_event(

--- a/aifw-api/src/backup_s3.rs
+++ b/aifw-api/src/backup_s3.rs
@@ -32,6 +32,9 @@ pub struct S3ConfigResponse {
     pub path_style: bool,
     pub access_key_id: Option<String>,
     pub has_secret: bool,
+    /// Whether uploads wrap secrets under a stored passphrase (#313);
+    /// false ⇒ uploads are redacted.
+    pub has_secrets_passphrase: bool,
 }
 
 impl From<s3::S3Config> for S3ConfigResponse {
@@ -45,6 +48,7 @@ impl From<s3::S3Config> for S3ConfigResponse {
             path_style: c.path_style,
             access_key_id: c.access_key_id,
             has_secret: c.secret_access_key.is_some(),
+            has_secrets_passphrase: c.secrets_passphrase.is_some(),
         }
     }
 }
@@ -117,6 +121,10 @@ pub async fn list_s3(
 pub struct ImportRequest {
     pub key: String,
     pub comment: Option<String>,
+    /// Passphrase to unlock wrapped secrets in the object (#313). Falls
+    /// back to the stored S3 backup passphrase when omitted.
+    #[serde(default)]
+    pub passphrase: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -139,12 +147,37 @@ pub async fn import_s3(
     let json = s3::fetch(&cfg, &req.key)
         .await
         .map_err(|e| (StatusCode::BAD_GATEWAY, e))?;
-    let fw_cfg: aifw_core::config::FirewallConfig = serde_json::from_str(&json).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("not a valid config JSON: {e}"),
-        )
-    })?;
+    let mut fw_cfg: aifw_core::config::FirewallConfig =
+        serde_json::from_str(&json).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("not a valid config JSON: {e}"),
+            )
+        })?;
+    // #313: unlock passphrase-wrapped secrets before the version is stored
+    // (history versions are full-fidelity). Redacted objects are kept as-is
+    // and resolved against the box at restore time.
+    if matches!(
+        aifw_core::config_secrets::state(&fw_cfg),
+        aifw_core::config_secrets::SecretsState::Passphrase { .. }
+    ) {
+        let pw = req
+            .passphrase
+            .as_deref()
+            .filter(|p| !p.is_empty())
+            .or(cfg.secrets_passphrase.as_deref().filter(|p| !p.is_empty()))
+            .ok_or((
+                StatusCode::BAD_REQUEST,
+                "this backup's secrets are passphrase-protected — supply the passphrase"
+                    .to_string(),
+            ))?;
+        aifw_core::config_secrets::open_with_passphrase(&mut fw_cfg, pw).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("could not unlock backup secrets: {e}"),
+            )
+        })?;
+    }
 
     let mgr = aifw_core::config_manager::ConfigManager::new(state.pool.clone());
     mgr.migrate().await.map_err(internal)?;

--- a/aifw-api/src/router.rs
+++ b/aifw-api/src/router.rs
@@ -743,6 +743,10 @@ pub(crate) fn backup_read() -> Router<AppState> {
 pub(crate) fn backup_write() -> Router<AppState> {
     Router::new()
         .route("/api/v1/config/import", post(routes::import_config))
+        .route(
+            "/api/v1/config/export",
+            post(routes::export_config_with_passphrase),
+        )
         .route("/api/v1/config/restore", post(backup::restore_version))
         .route(
             "/api/v1/config/import-opnsense",

--- a/aifw-api/src/routes/config_io.rs
+++ b/aifw-api/src/routes/config_io.rs
@@ -3,11 +3,56 @@
 
 use super::*;
 
+/// Body of `POST /config/export` — an export whose secrets are wrapped
+/// under `passphrase` (#313). `GET /config/export` is the redacted form.
+#[derive(Deserialize)]
+pub struct ExportRequest {
+    pub passphrase: String,
+}
+
+/// `GET /api/v1/config/export` — full config with every secret field
+/// replaced by the `**REDACTED**` sentinel. Restorable onto this box (the
+/// importer fills the sentinels from live state); use the POST form for a
+/// portable backup.
 pub async fn export_config(
     State(state): State<AppState>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
-    let config = crate::backup::build_current_config(&state).await?;
+    let mut config = crate::backup::build_current_config(&state).await?;
+    aifw_core::config_secrets::redact(&mut config);
+    build_export(&state, config, "redacted").await
+}
 
+/// `POST /api/v1/config/export` — full config with secrets wrapped under
+/// the supplied passphrase (Argon2id + AES-256-GCM).
+pub async fn export_config_with_passphrase(
+    State(state): State<AppState>,
+    Json(req): Json<ExportRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    if req.passphrase.chars().count() < 8 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "backup passphrase must be at least 8 characters".to_string(),
+        ));
+    }
+    let mut config = crate::backup::build_current_config(&state)
+        .await
+        .map_err(crate::backup::status_only)?;
+    aifw_core::config_secrets::seal_with_passphrase(&mut config, &req.passphrase).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("wrapping secrets failed: {e}"),
+        )
+    })?;
+    build_export(&state, config, "passphrase")
+        .await
+        .map_err(crate::backup::status_only)
+}
+
+async fn build_export(
+    state: &AppState,
+    config: aifw_core::config::FirewallConfig,
+    secrets: &str,
+) -> Result<Json<serde_json::Value>, StatusCode> {
     let routes = sqlx::query_as::<_, (String, String, String, Option<String>, i32, bool, Option<String>, String)>(
         "SELECT id, destination, gateway, interface, metric, enabled, description, created_at FROM static_routes ORDER BY metric ASC",
     ).fetch_all(&state.pool).await.unwrap_or_default();
@@ -19,6 +64,7 @@ pub async fn export_config(
     Ok(Json(serde_json::json!({
         "version": env!("CARGO_PKG_VERSION"),
         "exported_at": chrono::Utc::now().to_rfc3339(),
+        "secrets": secrets,
         "config": config,
         "static_routes": static_routes,
     })))
@@ -27,21 +73,27 @@ pub async fn export_config(
 pub async fn import_config(
     State(state): State<AppState>,
     Json(payload): Json<serde_json::Value>,
-) -> Result<Json<MessageResponse>, StatusCode> {
-    let config_val = payload.get("config").ok_or(StatusCode::BAD_REQUEST)?;
+) -> Result<Json<MessageResponse>, (StatusCode, String)> {
+    use crate::backup::status_only;
+    let config_val = payload
+        .get("config")
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing `config`".to_string()))?;
     // Strict deserialization: FirewallConfig uses deny_unknown_fields, so a
     // backup that tries to smuggle in a field we don't recognise is rejected
     // here rather than silently restored with the unknown fields ignored.
     let config: aifw_core::config::FirewallConfig = serde_json::from_value(config_val.clone())
         .map_err(|e| {
             tracing::warn!(error = %e, "import_config rejected malformed backup");
-            StatusCode::BAD_REQUEST
+            (StatusCode::BAD_REQUEST, format!("malformed backup: {e}"))
         })?;
     // Structural sanity — size caps, schema version, DNS + hostname shape.
     if let Err(e) = config.validate() {
         tracing::warn!(error = %e, "import_config rejected invalid backup");
-        return Err(StatusCode::BAD_REQUEST);
+        return Err((StatusCode::BAD_REQUEST, format!("invalid backup: {e}")));
     }
+    // #313: unlock wrapped secrets / fill redacted ones from live state.
+    let passphrase = payload.get("passphrase").and_then(|v| v.as_str());
+    let config = crate::backup::prepare_secrets_for_apply(&state, config, passphrase).await?;
 
     let iface_map: crate::backup::InterfaceMap = payload
         .get("interface_map")
@@ -55,7 +107,9 @@ pub async fn import_config(
     let ipsec_n = config.vpn.ipsec.len();
     let dns_n = config.system.dns_servers.len();
 
-    crate::backup::apply_firewall_config_or_rollback(&state, &config, &iface_map).await?;
+    crate::backup::apply_firewall_config_or_rollback(&state, &config, &iface_map)
+        .await
+        .map_err(status_only)?;
 
     let _ = sqlx::query("DELETE FROM static_routes")
         .execute(&state.pool)

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -3808,4 +3808,144 @@ mod tests {
         let body: Value = resp.json();
         assert_eq!(body["ok"], false);
     }
+    /// #313: exports never carry live secrets — GET redacts, POST wraps
+    /// under a passphrase — and imports resolve/unlock them again.
+    #[tokio::test]
+    async fn test_config_export_secrets_redacted_and_passphrase_round_trip() {
+        use aifw_core::config_secrets::{PW_PREFIX, REDACTED};
+        let state = crate::create_app_state_in_memory(plain_auth_settings())
+            .await
+            .unwrap();
+        let cluster = state.cluster_engine.clone();
+        let vip = cluster
+            .add_carp_vip(aifw_common::CarpVip {
+                id: uuid::Uuid::new_v4(),
+                vhid: 7,
+                virtual_ip: "192.0.2.10".parse().unwrap(),
+                prefix: 24,
+                interface: aifw_common::Interface("em0".into()),
+                password: "carp-secret".into(),
+                status: aifw_common::CarpStatus::Init,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            })
+            .await
+            .unwrap();
+        let server = TestServer::new(crate::build_router(state, None, "*", false));
+        let token = create_user_and_login(&server).await;
+
+        // GET: redacted
+        let resp = server
+            .get("/api/v1/config/export")
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+        let redacted: Value = resp.json();
+        assert_eq!(redacted["secrets"], "redacted");
+        assert_eq!(
+            redacted["config"]["ha"]["carp_vips"][0]["password"],
+            REDACTED
+        );
+        assert!(redacted["config"].get("secrets").is_none());
+
+        // POST: passphrase-wrapped; short passphrase rejected
+        let resp = server
+            .post("/api/v1/config/export")
+            .authorization_bearer(&token)
+            .json(&json!({"passphrase": "short"}))
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+        let resp = server
+            .post("/api/v1/config/export")
+            .authorization_bearer(&token)
+            .json(&json!({"passphrase": "correct horse battery"}))
+            .await;
+        resp.assert_status_ok();
+        let wrapped: Value = resp.json();
+        assert_eq!(wrapped["secrets"], "passphrase");
+        let pw_val = wrapped["config"]["ha"]["carp_vips"][0]["password"]
+            .as_str()
+            .unwrap();
+        assert!(pw_val.starts_with(PW_PREFIX), "{pw_val}");
+        assert!(!pw_val.contains("carp-secret"));
+        assert_eq!(wrapped["config"]["secrets"]["kdf"], "argon2id");
+
+        // Preview of the redacted file: this box holds every secret
+        let resp = server
+            .post("/api/v1/config/import-preview")
+            .authorization_bearer(&token)
+            .json(&redacted)
+            .await;
+        resp.assert_status_ok();
+        let preview: Value = resp.json();
+        assert_eq!(preview["secrets"]["state"], "redacted");
+        assert_eq!(preview["secrets"]["count"], 1);
+        assert_eq!(preview["unresolved_secrets"].as_array().unwrap().len(), 0);
+
+        // Importing the redacted file fills the secret from live state
+        let resp = server
+            .post("/api/v1/config/import")
+            .authorization_bearer(&token)
+            .json(&redacted)
+            .await;
+        assert!(resp.status_code().is_success(), "{}", resp.text());
+        let vips = cluster.list_carp_vips().await.unwrap();
+        assert_eq!(vips.len(), 1);
+        assert_eq!(vips[0].password, "carp-secret");
+
+        // Wrapped file: no passphrase → 400, wrong → 400, right → applied
+        let resp = server
+            .post("/api/v1/config/import")
+            .authorization_bearer(&token)
+            .json(&wrapped)
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+        assert!(resp.text().contains("passphrase"), "{}", resp.text());
+        let mut with_bad = wrapped.clone();
+        with_bad["passphrase"] = json!("wrong passphrase");
+        let resp = server
+            .post("/api/v1/config/import")
+            .authorization_bearer(&token)
+            .json(&with_bad)
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+        let mut with_good = wrapped.clone();
+        with_good["passphrase"] = json!("correct horse battery");
+        let resp = server
+            .post("/api/v1/config/import")
+            .authorization_bearer(&token)
+            .json(&with_good)
+            .await;
+        assert!(resp.status_code().is_success(), "{}", resp.text());
+        let vips = cluster.list_carp_vips().await.unwrap();
+        assert_eq!(vips[0].password, "carp-secret");
+
+        // Box no longer holds the VIP: redacted import is refused by name
+        cluster.delete_carp_vip(vip.id).await.unwrap();
+        let resp = server
+            .post("/api/v1/config/import-preview")
+            .authorization_bearer(&token)
+            .json(&redacted)
+            .await;
+        let preview: Value = resp.json();
+        assert_eq!(
+            preview["unresolved_secrets"][0],
+            format!("carp[{}].password", vip.id)
+        );
+        let resp = server
+            .post("/api/v1/config/import")
+            .authorization_bearer(&token)
+            .json(&redacted)
+            .await;
+        resp.assert_status(StatusCode::BAD_REQUEST);
+        assert!(resp.text().contains(&vip.id.to_string()), "{}", resp.text());
+        assert!(cluster.list_carp_vips().await.unwrap().is_empty());
+
+        // History view is a display surface — redacted too
+        let resp = server
+            .get("/api/v1/config/history")
+            .authorization_bearer(&token)
+            .await;
+        resp.assert_status_ok();
+    }
 }

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -1152,7 +1152,10 @@ pub async fn config_show(db_path: &Path) -> anyhow::Result<()> {
             println!("Resources: {}", config.resource_count());
             println!("Hash: {}", config.hash());
             println!();
-            println!("{}", config.to_json());
+            // #313: display surface — never print live keys.
+            let mut shown = config.clone();
+            aifw_core::config_secrets::redact(&mut shown);
+            println!("{}", shown.to_json());
         }
         None => {
             println!("No active configuration. Run 'aifw-setup' or 'aifw config import'.");
@@ -1161,19 +1164,91 @@ pub async fn config_show(db_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn config_export(db_path: &Path) -> anyhow::Result<()> {
-    let mgr = create_config_manager(db_path).await?;
-    match mgr.get_active().await.map_err(|e| anyhow::anyhow!(e))? {
-        Some((_, config)) => print!("{}", config.to_json()),
-        None => anyhow::bail!("no active configuration"),
+/// Backup passphrase from `--passphrase-file` (first line) or the
+/// `AIFW_BACKUP_PASSPHRASE` environment variable (#313).
+fn backup_passphrase(passphrase_file: Option<&str>) -> anyhow::Result<Option<String>> {
+    if let Some(path) = passphrase_file {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("reading passphrase file {path}: {e}"))?;
+        let line = content.lines().next().unwrap_or("").trim_end_matches('\r');
+        if line.is_empty() {
+            anyhow::bail!("passphrase file {path} is empty");
+        }
+        return Ok(Some(line.to_string()));
     }
+    Ok(std::env::var("AIFW_BACKUP_PASSPHRASE")
+        .ok()
+        .filter(|p| !p.is_empty()))
+}
+
+pub async fn config_export(
+    db_path: &Path,
+    secrets: &str,
+    passphrase_file: Option<&str>,
+) -> anyhow::Result<()> {
+    let mgr = create_config_manager(db_path).await?;
+    let Some((_, mut config)) = mgr.get_active().await.map_err(|e| anyhow::anyhow!(e))? else {
+        anyhow::bail!("no active configuration");
+    };
+    match secrets {
+        "plain" => {
+            eprintln!(
+                "warning: export contains live keys and passwords in the clear — protect the output"
+            );
+        }
+        "passphrase" => {
+            let Some(pw) = backup_passphrase(passphrase_file)? else {
+                anyhow::bail!(
+                    "--secrets passphrase needs --passphrase-file or $AIFW_BACKUP_PASSPHRASE"
+                );
+            };
+            aifw_core::config_secrets::seal_with_passphrase(&mut config, &pw)
+                .map_err(|e| anyhow::anyhow!(e))?;
+        }
+        _ => aifw_core::config_secrets::redact(&mut config),
+    }
+    print!("{}", config.to_json());
     Ok(())
 }
 
-pub async fn config_import(db_path: &Path, file: &str) -> anyhow::Result<()> {
+pub async fn config_import(
+    db_path: &Path,
+    file: &str,
+    passphrase_file: Option<&str>,
+) -> anyhow::Result<()> {
+    use aifw_core::config_secrets as cs;
     let mgr = create_config_manager(db_path).await?;
     let content = std::fs::read_to_string(file)?;
-    let config = aifw_core::FirewallConfig::from_json(&content).map_err(|e| anyhow::anyhow!(e))?;
+    let mut config =
+        aifw_core::FirewallConfig::from_json(&content).map_err(|e| anyhow::anyhow!(e))?;
+
+    // #313: unlock wrapped secrets, then fill redacted ones from the active
+    // config so the stored version is full-fidelity.
+    if matches!(cs::state(&config), cs::SecretsState::Passphrase { .. }) {
+        let Some(pw) = backup_passphrase(passphrase_file)? else {
+            anyhow::bail!(
+                "this backup's secrets are passphrase-protected — pass --passphrase-file or set $AIFW_BACKUP_PASSPHRASE"
+            );
+        };
+        cs::open_with_passphrase(&mut config, &pw)
+            .map_err(|e| anyhow::anyhow!("could not unlock backup secrets: {e}"))?;
+    }
+    if !cs::redacted_refs(&config).is_empty() {
+        let current = mgr
+            .get_active()
+            .await
+            .map_err(|e| anyhow::anyhow!(e))?
+            .map(|(_, c)| c)
+            .unwrap_or_default();
+        let unresolved = cs::resolve_redacted(&mut config, &current);
+        if !unresolved.is_empty() {
+            let names: Vec<String> = unresolved.iter().map(|r| r.to_string()).collect();
+            anyhow::bail!(
+                "backup was exported without secrets and this box does not hold them: {}",
+                names.join(", ")
+            );
+        }
+    }
 
     println!("Importing config: {} resources", config.resource_count());
 

--- a/aifw-cli/src/main.rs
+++ b/aifw-cli/src/main.rs
@@ -409,11 +409,24 @@ enum ConfigAction {
     /// Show current active config
     Show,
     /// Export current config to stdout as JSON
-    Export,
+    Export {
+        /// How to treat secret fields (WireGuard/IPsec keys, CARP passwords,
+        /// TSIG): `redact` (default), `passphrase` (wrap under
+        /// $AIFW_BACKUP_PASSPHRASE or --passphrase-file), or `plain`
+        #[arg(long, default_value = "redact", value_parser = ["redact", "passphrase", "plain"])]
+        secrets: String,
+        /// File whose first line is the backup passphrase (--secrets passphrase)
+        #[arg(long)]
+        passphrase_file: Option<String>,
+    },
     /// Import config from a JSON file
     Import {
         /// Path to JSON config file
         file: String,
+        /// File whose first line is the passphrase for a passphrase-wrapped
+        /// backup (also read from $AIFW_BACKUP_PASSPHRASE)
+        #[arg(long)]
+        passphrase_file: Option<String>,
     },
     /// Show config version history
     History {
@@ -1405,8 +1418,14 @@ async fn main() -> anyhow::Result<()> {
         },
         Commands::Config { action } => match action {
             ConfigAction::Show => commands::config_show(&cli.db).await?,
-            ConfigAction::Export => commands::config_export(&cli.db).await?,
-            ConfigAction::Import { file } => commands::config_import(&cli.db, &file).await?,
+            ConfigAction::Export {
+                secrets,
+                passphrase_file,
+            } => commands::config_export(&cli.db, &secrets, passphrase_file.as_deref()).await?,
+            ConfigAction::Import {
+                file,
+                passphrase_file,
+            } => commands::config_import(&cli.db, &file, passphrase_file.as_deref()).await?,
             ConfigAction::History { limit } => commands::config_history(&cli.db, limit).await?,
             ConfigAction::Rollback { version } => {
                 commands::config_rollback(&cli.db, version).await?

--- a/aifw-core/Cargo.toml
+++ b/aifw-core/Cargo.toml
@@ -20,6 +20,7 @@ sha2 = { workspace = true }
 hex = { workspace = true }
 aws-lc-rs = { workspace = true }
 base64 = { workspace = true }
+argon2 = { workspace = true }
 getrandom = { workspace = true }
 cron = "0.17"
 arc-swap = "1"

--- a/aifw-core/src/config.rs
+++ b/aifw-core/src/config.rs
@@ -83,6 +83,11 @@ pub struct FirewallConfig {
     /// `log_rotation_config` table). `None` = backup predates the section.
     #[serde(default)]
     pub log_rotation: Option<crate::log_rotation::LogRotationConfig>,
+    /// KDF envelope present only while the config's secret fields are
+    /// passphrase-wrapped for export (#313, `aifw_core::config_secrets`).
+    /// Never set on a config that is applied to the box.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secrets: Option<crate::config_secrets::SecretsEnvelope>,
 }
 
 impl Default for FirewallConfig {
@@ -106,6 +111,7 @@ impl Default for FirewallConfig {
             dns_resolver: None,
             syslog: None,
             log_rotation: None,
+            secrets: None,
         }
     }
 }

--- a/aifw-core/src/config_secrets.rs
+++ b/aifw-core/src/config_secrets.rs
@@ -1,0 +1,500 @@
+//! Secret handling for exported configuration (#313 / SEC-M16).
+//!
+//! A [`FirewallConfig`] embeds every credential the data plane needs —
+//! WireGuard private and preshared keys, IPsec PSKs and private keys, CARP
+//! passwords, the DHCP DDNS TSIG secret. Inside the appliance those live
+//! sealed at rest (#298); the moment a config leaves the box as a backup
+//! download, an S3 object or a history view, they used to travel in the
+//! clear. This module gives every export path one of two safe shapes:
+//!
+//! * **Redacted** — every secret becomes [`REDACTED`]. The file is still a
+//!   complete, diffable description of the box; on import the sentinel is
+//!   resolved back against the secrets the box already holds
+//!   ([`resolve_redacted`]) so a redacted backup restores cleanly onto the
+//!   appliance it came from (same tunnel / VIP ids). Anything that cannot
+//!   be resolved is reported by name and the import is refused.
+//! * **Passphrase-wrapped** — every secret becomes
+//!   `pw:v1:<base64(nonce ‖ ciphertext ‖ tag)>` under an AES-256-GCM key
+//!   derived from an operator passphrase with Argon2id. The KDF salt and
+//!   parameters ride along in [`FirewallConfig::secrets`] so the file is
+//!   self-describing and restorable on any box that knows the passphrase.
+//!
+//! Cluster snapshots keep real values: the standby has to hold the keys to
+//! take over, and since #317 that channel is certificate-pinned.
+
+use aws_lc_rs::aead::{AES_256_GCM, Aad, LessSafeKey, NONCE_LEN, Nonce, UnboundKey};
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64;
+use serde::{Deserialize, Serialize};
+
+use crate::config::FirewallConfig;
+use crate::{CoreError, Result};
+
+/// Sentinel written in place of a secret by [`redact`].
+pub const REDACTED: &str = "**REDACTED**";
+/// Prefix of a passphrase-wrapped secret value.
+pub const PW_PREFIX: &str = "pw:v1:";
+
+/// Argon2id parameters used for new envelopes (OWASP 2023 baseline).
+const M_COST_KIB: u32 = 64 * 1024;
+const T_COST: u32 = 3;
+const P_COST: u32 = 1;
+const SALT_LEN: usize = 16;
+const KEY_LEN: usize = 32;
+/// Upper bound accepted when *opening* an envelope, so a hostile file cannot
+/// make the importer allocate gigabytes.
+const MAX_M_COST_KIB: u32 = 1024 * 1024;
+const MAX_T_COST: u32 = 16;
+
+/// KDF parameters stored alongside passphrase-wrapped secrets.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SecretsEnvelope {
+    /// Always `argon2id` today; reserved for future KDFs.
+    pub kdf: String,
+    /// Base64 KDF salt.
+    pub salt: String,
+    /// Argon2 memory cost in KiB.
+    pub m_cost: u32,
+    /// Argon2 iterations.
+    pub t_cost: u32,
+    /// Argon2 parallelism.
+    pub p_cost: u32,
+}
+
+/// Where the secrets of a config stand.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum SecretsState {
+    /// Every secret is present in the clear (or the config has none).
+    Plain,
+    /// `count` secrets are the [`REDACTED`] sentinel.
+    Redacted {
+        /// Number of redacted values.
+        count: usize,
+    },
+    /// `count` secrets are passphrase-wrapped.
+    Passphrase {
+        /// Number of wrapped values.
+        count: usize,
+    },
+}
+
+/// Which secret a visitor is looking at — used for resolution by id and
+/// for human-readable error messages.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SecretRef {
+    /// Section the secret belongs to (`wireguard`, `ipsec`, `carp`, `dhcp_ddns`).
+    pub section: &'static str,
+    /// Owning object id (tunnel / peer / VIP id; empty for singletons).
+    pub id: String,
+    /// Field name inside that object.
+    pub field: &'static str,
+}
+
+impl std::fmt::Display for SecretRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.id.is_empty() {
+            write!(f, "{}.{}", self.section, self.field)
+        } else {
+            write!(f, "{}[{}].{}", self.section, self.id, self.field)
+        }
+    }
+}
+
+/// Visit every secret slot in `cfg`. `Option<String>` slots are visited as
+/// `&mut Option<String>` through the same closure by temporarily taking the
+/// value; `None` slots are skipped.
+fn for_each_secret(cfg: &mut FirewallConfig, mut f: impl FnMut(SecretRef, &mut String)) {
+    for wg in &mut cfg.vpn.wireguard {
+        f(
+            SecretRef {
+                section: "wireguard",
+                id: wg.id.clone(),
+                field: "private_key",
+            },
+            &mut wg.private_key,
+        );
+        for p in &mut wg.peers {
+            if let Some(psk) = p.preshared_key.as_mut() {
+                f(
+                    SecretRef {
+                        section: "wireguard_peer",
+                        id: p.id.clone(),
+                        field: "preshared_key",
+                    },
+                    psk,
+                );
+            }
+        }
+    }
+    for t in &mut cfg.vpn.ipsec_tunnels {
+        let id = t.id.to_string();
+        f(
+            SecretRef {
+                section: "ipsec",
+                id: id.clone(),
+                field: "psk",
+            },
+            &mut t.psk,
+        );
+        f(
+            SecretRef {
+                section: "ipsec",
+                id,
+                field: "local_key_pem",
+            },
+            &mut t.local_key_pem,
+        );
+    }
+    for v in &mut cfg.ha.carp_vips {
+        f(
+            SecretRef {
+                section: "carp",
+                id: v.id.clone(),
+                field: "password",
+            },
+            &mut v.password,
+        );
+    }
+    f(
+        SecretRef {
+            section: "dhcp_ddns",
+            id: String::new(),
+            field: "tsig_secret",
+        },
+        &mut cfg.dhcp.ddns.tsig_secret,
+    );
+}
+
+/// Same walk over a shared reference (read-only inspection).
+fn secrets_of(cfg: &FirewallConfig) -> Vec<(SecretRef, String)> {
+    let mut out = Vec::new();
+    let mut c = cfg.clone();
+    for_each_secret(&mut c, |r, v| out.push((r, v.clone())));
+    out
+}
+
+/// Classify the secrets in `cfg`. Mixed files (some redacted, some wrapped)
+/// report the wrapped state — the passphrase is needed regardless.
+pub fn state(cfg: &FirewallConfig) -> SecretsState {
+    let mut redacted = 0;
+    let mut wrapped = 0;
+    for (_, v) in secrets_of(cfg) {
+        if v == REDACTED {
+            redacted += 1;
+        } else if v.starts_with(PW_PREFIX) {
+            wrapped += 1;
+        }
+    }
+    if wrapped > 0 || cfg.secrets.is_some() {
+        SecretsState::Passphrase { count: wrapped }
+    } else if redacted > 0 {
+        SecretsState::Redacted { count: redacted }
+    } else {
+        SecretsState::Plain
+    }
+}
+
+/// Replace every non-empty secret with [`REDACTED`]. Already-wrapped
+/// values are redacted too (the envelope is dropped) so a redacted export
+/// never carries ciphertext.
+pub fn redact(cfg: &mut FirewallConfig) {
+    for_each_secret(cfg, |_, v| {
+        if !v.is_empty() {
+            *v = REDACTED.to_string();
+        }
+    });
+    cfg.secrets = None;
+}
+
+/// Wrap every non-empty, non-redacted secret under `passphrase`. Fails if
+/// the config still holds wrapped values from another passphrase (open it
+/// first) or the passphrase is empty.
+pub fn seal_with_passphrase(cfg: &mut FirewallConfig, passphrase: &str) -> Result<()> {
+    if passphrase.is_empty() {
+        return Err(CoreError::Validation(
+            "backup passphrase must not be empty".into(),
+        ));
+    }
+    if matches!(state(cfg), SecretsState::Passphrase { .. }) {
+        return Err(CoreError::Validation(
+            "config already holds passphrase-wrapped secrets".into(),
+        ));
+    }
+    let mut salt = [0u8; SALT_LEN];
+    getrandom::fill(&mut salt)
+        .map_err(|e| CoreError::Other(format!("backup secrets: salt generation failed: {e}")))?;
+    let envelope = SecretsEnvelope {
+        kdf: "argon2id".into(),
+        salt: B64.encode(salt),
+        m_cost: M_COST_KIB,
+        t_cost: T_COST,
+        p_cost: P_COST,
+    };
+    let key = derive_key(passphrase, &envelope)?;
+    let mut err = None;
+    for_each_secret(cfg, |r, v| {
+        if err.is_some() || v.is_empty() || v == REDACTED {
+            return;
+        }
+        match wrap_value(&key, v) {
+            Ok(w) => *v = w,
+            Err(e) => err = Some(CoreError::Other(format!("backup secrets: {r}: {e}"))),
+        }
+    });
+    if let Some(e) = err {
+        return Err(e);
+    }
+    cfg.secrets = Some(envelope);
+    Ok(())
+}
+
+/// Unwrap every passphrase-wrapped secret in place. A wrong passphrase
+/// fails on the first value (AEAD tag mismatch) and leaves `cfg` untouched.
+pub fn open_with_passphrase(cfg: &mut FirewallConfig, passphrase: &str) -> Result<()> {
+    let Some(envelope) = cfg.secrets.clone() else {
+        if secrets_of(cfg)
+            .iter()
+            .any(|(_, v)| v.starts_with(PW_PREFIX))
+        {
+            return Err(CoreError::Validation(
+                "config has passphrase-wrapped secrets but no KDF envelope".into(),
+            ));
+        }
+        return Ok(());
+    };
+    let key = derive_key(passphrase, &envelope)?;
+    // Decrypt into a scratch copy so a bad passphrase can't leave the config
+    // half-opened.
+    let mut scratch = cfg.clone();
+    let mut err = None;
+    for_each_secret(&mut scratch, |r, v| {
+        if err.is_some() {
+            return;
+        }
+        if let Some(b64) = v.strip_prefix(PW_PREFIX) {
+            match unwrap_value(&key, b64) {
+                Ok(pt) => *v = pt,
+                Err(e) => err = Some(CoreError::Validation(format!("{r}: {e}"))),
+            }
+        }
+    });
+    if let Some(e) = err {
+        return Err(e);
+    }
+    scratch.secrets = None;
+    *cfg = scratch;
+    Ok(())
+}
+
+/// Fill [`REDACTED`] slots from `current` (the config the box holds right
+/// now), matching by section + object id. Returns the refs that could not
+/// be resolved; the caller decides whether that is fatal. Wrapped values
+/// are left alone.
+pub fn resolve_redacted(cfg: &mut FirewallConfig, current: &FirewallConfig) -> Vec<SecretRef> {
+    let known: std::collections::HashMap<SecretRef, String> = secrets_of(current)
+        .into_iter()
+        .filter(|(_, v)| !v.is_empty() && v != REDACTED && !v.starts_with(PW_PREFIX))
+        .collect();
+    let mut unresolved = Vec::new();
+    for_each_secret(cfg, |r, v| {
+        if v != REDACTED {
+            return;
+        }
+        match known.get(&r) {
+            Some(cur) => *v = cur.clone(),
+            None => unresolved.push(r),
+        }
+    });
+    unresolved
+}
+
+/// Names of every secret still equal to [`REDACTED`] — what an import
+/// would have to resolve.
+pub fn redacted_refs(cfg: &FirewallConfig) -> Vec<SecretRef> {
+    secrets_of(cfg)
+        .into_iter()
+        .filter(|(_, v)| v == REDACTED)
+        .map(|(r, _)| r)
+        .collect()
+}
+
+fn derive_key(passphrase: &str, env: &SecretsEnvelope) -> Result<LessSafeKey> {
+    if env.kdf != "argon2id" {
+        return Err(CoreError::Validation(format!(
+            "unsupported backup KDF `{}`",
+            env.kdf
+        )));
+    }
+    if env.m_cost > MAX_M_COST_KIB || env.t_cost > MAX_T_COST || env.p_cost == 0 || env.p_cost > 16
+    {
+        return Err(CoreError::Validation(
+            "backup KDF parameters out of range".into(),
+        ));
+    }
+    let salt = B64
+        .decode(&env.salt)
+        .map_err(|e| CoreError::Validation(format!("backup KDF salt malformed: {e}")))?;
+    let params = argon2::Params::new(env.m_cost, env.t_cost, env.p_cost, Some(KEY_LEN))
+        .map_err(|e| CoreError::Validation(format!("backup KDF parameters invalid: {e}")))?;
+    let argon = argon2::Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
+    let mut key = [0u8; KEY_LEN];
+    argon
+        .hash_password_into(passphrase.as_bytes(), &salt, &mut key)
+        .map_err(|e| CoreError::Other(format!("backup KDF failed: {e}")))?;
+    let unbound = UnboundKey::new(&AES_256_GCM, &key)
+        .map_err(|_| CoreError::Other("backup secrets: key setup failed".into()))?;
+    Ok(LessSafeKey::new(unbound))
+}
+
+fn wrap_value(key: &LessSafeKey, plaintext: &str) -> std::result::Result<String, String> {
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    getrandom::fill(&mut nonce_bytes).map_err(|e| format!("nonce generation failed: {e}"))?;
+    let nonce = Nonce::assume_unique_for_key(nonce_bytes);
+    let mut buf = plaintext.as_bytes().to_vec();
+    key.seal_in_place_append_tag(nonce, Aad::empty(), &mut buf)
+        .map_err(|_| "encryption failed".to_string())?;
+    let mut out = Vec::with_capacity(NONCE_LEN + buf.len());
+    out.extend_from_slice(&nonce_bytes);
+    out.extend_from_slice(&buf);
+    Ok(format!("{PW_PREFIX}{}", B64.encode(out)))
+}
+
+fn unwrap_value(key: &LessSafeKey, b64: &str) -> std::result::Result<String, String> {
+    let raw = B64
+        .decode(b64)
+        .map_err(|e| format!("malformed wrapped value: {e}"))?;
+    if raw.len() < NONCE_LEN + AES_256_GCM.tag_len() {
+        return Err("wrapped value too short".into());
+    }
+    let (nonce_bytes, ct) = raw.split_at(NONCE_LEN);
+    let nonce =
+        Nonce::try_assume_unique_for_key(nonce_bytes).map_err(|_| "bad nonce".to_string())?;
+    let mut buf = ct.to_vec();
+    let pt = key
+        .open_in_place(nonce, Aad::empty(), &mut buf)
+        .map_err(|_| "wrong passphrase or corrupted value".to_string())?;
+    String::from_utf8(pt.to_vec()).map_err(|_| "wrapped value is not UTF-8".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{CarpVipConfig, WireguardPeerConfig, WireguardTunnelConfig};
+
+    fn sample() -> FirewallConfig {
+        let mut cfg = FirewallConfig::default();
+        cfg.vpn.wireguard.push(WireguardTunnelConfig {
+            id: "wg-1".into(),
+            name: "wg0".into(),
+            interface: "wg0".into(),
+            listen_port: 51820,
+            address: "10.0.0.1/24".into(),
+            address6: None,
+            private_key: "PRIV".into(),
+            public_key: "PUB".into(),
+            dns: None,
+            mtu: None,
+            peers: vec![WireguardPeerConfig {
+                id: "peer-1".into(),
+                name: "p".into(),
+                public_key: "PPUB".into(),
+                preshared_key: Some("PSK".into()),
+                endpoint: None,
+                allowed_ips: vec![],
+                persistent_keepalive: None,
+            }],
+        });
+        cfg.ha.carp_vips.push(CarpVipConfig {
+            id: "vip-1".into(),
+            vhid: 1,
+            virtual_ip: "192.0.2.1".into(),
+            prefix: 24,
+            interface: "em0".into(),
+            password: "carp-pw".into(),
+        });
+        cfg.dhcp.ddns.tsig_secret = "tsig".into();
+        cfg
+    }
+
+    #[test]
+    fn plain_state_and_redaction() {
+        let mut cfg = sample();
+        assert_eq!(state(&cfg), SecretsState::Plain);
+        redact(&mut cfg);
+        assert_eq!(state(&cfg), SecretsState::Redacted { count: 4 });
+        assert_eq!(cfg.vpn.wireguard[0].private_key, REDACTED);
+        assert_eq!(
+            cfg.vpn.wireguard[0].peers[0].preshared_key.as_deref(),
+            Some(REDACTED)
+        );
+        assert_eq!(cfg.ha.carp_vips[0].password, REDACTED);
+        assert_eq!(cfg.dhcp.ddns.tsig_secret, REDACTED);
+        // non-secret fields untouched
+        assert_eq!(cfg.vpn.wireguard[0].public_key, "PUB");
+    }
+
+    #[test]
+    fn empty_secrets_are_not_redacted() {
+        let mut cfg = FirewallConfig::default();
+        redact(&mut cfg);
+        assert_eq!(state(&cfg), SecretsState::Plain);
+        assert_eq!(cfg.dhcp.ddns.tsig_secret, "");
+    }
+
+    #[test]
+    fn passphrase_round_trip() {
+        let mut cfg = sample();
+        seal_with_passphrase(&mut cfg, "hunter2").unwrap();
+        assert_eq!(state(&cfg), SecretsState::Passphrase { count: 4 });
+        assert!(cfg.vpn.wireguard[0].private_key.starts_with(PW_PREFIX));
+        assert!(cfg.secrets.is_some());
+        // survives JSON
+        let json = cfg.to_json();
+        let mut back = FirewallConfig::from_json(&json).unwrap();
+        assert!(open_with_passphrase(&mut back, "wrong").is_err());
+        assert!(
+            back.vpn.wireguard[0].private_key.starts_with(PW_PREFIX),
+            "untouched on failure"
+        );
+        open_with_passphrase(&mut back, "hunter2").unwrap();
+        assert_eq!(state(&back), SecretsState::Plain);
+        assert_eq!(back.vpn.wireguard[0].private_key, "PRIV");
+        assert_eq!(
+            back.vpn.wireguard[0].peers[0].preshared_key.as_deref(),
+            Some("PSK")
+        );
+        assert_eq!(back.ha.carp_vips[0].password, "carp-pw");
+        assert_eq!(back.dhcp.ddns.tsig_secret, "tsig");
+        assert!(back.secrets.is_none());
+    }
+
+    #[test]
+    fn empty_passphrase_rejected() {
+        let mut cfg = sample();
+        assert!(seal_with_passphrase(&mut cfg, "").is_err());
+    }
+
+    #[test]
+    fn hostile_kdf_params_rejected() {
+        let mut cfg = sample();
+        seal_with_passphrase(&mut cfg, "pw").unwrap();
+        cfg.secrets.as_mut().unwrap().m_cost = u32::MAX;
+        assert!(open_with_passphrase(&mut cfg, "pw").is_err());
+    }
+
+    #[test]
+    fn resolve_redacted_by_id() {
+        let current = sample();
+        let mut cfg = sample();
+        redact(&mut cfg);
+        // one object the box doesn't know
+        cfg.ha.carp_vips[0].id = "vip-new".into();
+        let unresolved = resolve_redacted(&mut cfg, &current);
+        assert_eq!(unresolved.len(), 1);
+        assert_eq!(unresolved[0].to_string(), "carp[vip-new].password");
+        assert_eq!(cfg.vpn.wireguard[0].private_key, "PRIV");
+        assert_eq!(cfg.dhcp.ddns.tsig_secret, "tsig");
+        assert_eq!(cfg.ha.carp_vips[0].password, REDACTED);
+    }
+}

--- a/aifw-core/src/lib.rs
+++ b/aifw-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod audit;
 pub mod config;
 /// [`ConfigManager`] — loads and saves the persisted system configuration
 pub mod config_manager;
+pub mod config_secrets;
 /// [`Database`] — SQLite pool wrapper and filter-rule persistence
 pub mod db;
 pub mod ddns;

--- a/aifw-core/src/s3_backup.rs
+++ b/aifw-core/src/s3_backup.rs
@@ -66,6 +66,12 @@ pub struct S3Config {
     /// otherwise — never the real value.
     #[serde(default)]
     pub secret_access_key: Option<String>,
+    /// Passphrase used to wrap the secret fields of every uploaded config
+    /// (#313). Write-only over the API like the S3 secret. When unset,
+    /// uploads carry redacted secrets — restorable only onto a box that
+    /// still holds the same tunnels/VIPs.
+    #[serde(default)]
+    pub secrets_passphrase: Option<String>,
 }
 
 impl Default for S3Config {
@@ -79,6 +85,7 @@ impl Default for S3Config {
             path_style: false,
             access_key_id: None,
             secret_access_key: None,
+            secrets_passphrase: None,
         }
     }
 }
@@ -108,21 +115,29 @@ pub async fn migrate(pool: &SqlitePool) -> aifw_common::Result<()> {
     sqlx::query("INSERT OR IGNORE INTO s3_backup_config (id) VALUES (1)")
         .execute(pool)
         .await?;
+    // #313: added after the table existed; ignore "duplicate column".
+    if let Err(e) = sqlx::query("ALTER TABLE s3_backup_config ADD COLUMN secrets_passphrase TEXT")
+        .execute(pool)
+        .await
+        && !e.to_string().contains("duplicate column")
+    {
+        return Err(e.into());
+    }
     Ok(())
 }
 
 /// Read the stored config row; a missing row or query failure yields
 /// `S3Config::default()` (disabled) rather than an error
 pub async fn load(pool: &SqlitePool) -> S3Config {
-    sqlx::query_as::<_, (i64, String, String, Option<String>, String, i64, Option<String>, Option<String>)>(
-        r#"SELECT enabled, bucket, region, endpoint, prefix, path_style, access_key_id, secret_access_key
+    sqlx::query_as::<_, (i64, String, String, Option<String>, String, i64, Option<String>, Option<String>, Option<String>)>(
+        r#"SELECT enabled, bucket, region, endpoint, prefix, path_style, access_key_id, secret_access_key, secrets_passphrase
              FROM s3_backup_config WHERE id = 1"#,
     )
     .fetch_optional(pool)
     .await
     .ok()
     .flatten()
-    .map(|(enabled, bucket, region, endpoint, prefix, path_style, ak, sk)| S3Config {
+    .map(|(enabled, bucket, region, endpoint, prefix, path_style, ak, sk, pw)| S3Config {
         enabled: enabled != 0,
         bucket,
         region,
@@ -132,6 +147,7 @@ pub async fn load(pool: &SqlitePool) -> S3Config {
         access_key_id: ak,
         // #298: sealed at rest; legacy plaintext rows pass through.
         secret_access_key: crate::secrets::open_opt_lossy(sk),
+        secrets_passphrase: crate::secrets::open_opt_lossy(pw),
     })
     .unwrap_or_default()
 }
@@ -151,10 +167,20 @@ pub async fn save(pool: &SqlitePool, cfg: &S3Config) -> Result<(), String> {
         .map(|v| crate::secrets::seal(&v))
         .transpose()
         .map_err(|e| e.to_string())?;
+    // Same tri-state for the backup passphrase (#313).
+    let final_pw = match cfg.secrets_passphrase.as_deref() {
+        None => existing.secrets_passphrase,
+        Some("") => None,
+        Some(v) => Some(v.to_string()),
+    }
+    .map(|v| crate::secrets::seal(&v))
+    .transpose()
+    .map_err(|e| e.to_string())?;
     sqlx::query(
         r#"UPDATE s3_backup_config
               SET enabled=?, bucket=?, region=?, endpoint=?, prefix=?,
-                  path_style=?, access_key_id=?, secret_access_key=?
+                  path_style=?, access_key_id=?, secret_access_key=?,
+                  secrets_passphrase=?
             WHERE id=1"#,
     )
     .bind(cfg.enabled as i64)
@@ -165,6 +191,7 @@ pub async fn save(pool: &SqlitePool, cfg: &S3Config) -> Result<(), String> {
     .bind(cfg.path_style as i64)
     .bind(&cfg.access_key_id)
     .bind(&final_secret)
+    .bind(&final_pw)
     .execute(pool)
     .await
     .map_err(|e| e.to_string())?;

--- a/aifw-core/src/secrets.rs
+++ b/aifw-core/src/secrets.rs
@@ -322,6 +322,7 @@ fn fix_owner(path: &Path) {
 pub const SEALED_COLUMNS: &[(&str, &str, &str)] = &[
     ("oauth_providers", "client_secret", "id"),
     ("s3_backup_config", "secret_access_key", "id"),
+    ("s3_backup_config", "secrets_passphrase", "id"),
     ("smtp_notify_config", "password", "id"),
     ("cluster_nodes", "peer_api_key", "id"),
     ("carp_vips", "password", "id"),

--- a/aifw-ui/src/app/backup/components/ExportImportTab.tsx
+++ b/aifw-ui/src/app/backup/components/ExportImportTab.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import type { ChangeEvent, RefObject } from "react";
+import { useState, type ChangeEvent, type RefObject } from "react";
 import type { ImportPreview } from "@/lib/api/backup";
 import { InterfaceMappingPanel } from "./InterfaceMappingPanel";
 import { btnPrimary, btnSecondary } from "./styles";
+
+const inputCls =
+  "w-full px-3 py-2 bg-[var(--bg-primary)] border border-[var(--border)] rounded-md text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]";
 
 /* ===================== Export / Import Tab ================ */
 
@@ -15,32 +18,85 @@ export function ExportImportTab({
   importPreview,
   importMap,
   setImportMap,
+  importPassphrase,
+  setImportPassphrase,
   fileRef,
   handleFileSelect,
   handleImport,
   cancelImport,
 }: {
   exporting: boolean;
-  handleExport: () => void;
+  handleExport: (passphrase?: string) => void;
   importing: boolean;
   preview: string | null;
   importPreview: ImportPreview | null;
   importMap: Record<string, string>;
   setImportMap: (m: Record<string, string>) => void;
+  importPassphrase: string;
+  setImportPassphrase: (p: string) => void;
   fileRef: RefObject<HTMLInputElement | null>;
   handleFileSelect: (e: ChangeEvent<HTMLInputElement>) => void;
   handleImport: () => void;
   cancelImport: () => void;
 }) {
+  const [exportPassphrase, setExportPassphrase] = useState("");
+  const [exportPassphrase2, setExportPassphrase2] = useState("");
+  const [showPortable, setShowPortable] = useState(false);
+  const passphraseTooShort = exportPassphrase.length > 0 && exportPassphrase.length < 8;
+  const passphraseMismatch = exportPassphrase2.length > 0 && exportPassphrase !== exportPassphrase2;
+  const portableReady = exportPassphrase.length >= 8 && exportPassphrase === exportPassphrase2;
+
+  const secretsState = importPreview?.secrets;
+  const needsPassphrase = secretsState?.state === "passphrase";
+  const unresolved = importPreview?.unresolved_secrets ?? [];
+  const importBlocked = (needsPassphrase && !importPassphrase) || unresolved.length > 0;
+
   return (
     <div className="space-y-6">
       {/* Export */}
       <div className="space-y-3">
         <h2 className="text-lg font-semibold">Export Configuration</h2>
-        <p className="text-xs text-[var(--text-muted)]">Download the current firewall configuration as a JSON file</p>
-        <button onClick={handleExport} disabled={exporting} className={btnPrimary}>
-          {exporting ? "Exporting..." : "Download Backup"}
-        </button>
+        <p className="text-xs text-[var(--text-muted)]">
+          Download the current firewall configuration as a JSON file. Secret fields (WireGuard and IPsec keys,
+          CARP passwords, DDNS TSIG) are <strong>redacted</strong> — a redacted backup restores onto this
+          appliance, which fills the secrets back in from its own state. For a backup that can be restored on
+          a replacement box, protect the secrets with a passphrase.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <button onClick={() => handleExport()} disabled={exporting} className={btnPrimary}>
+            {exporting ? "Exporting..." : "Download Backup (secrets redacted)"}
+          </button>
+          <button onClick={() => setShowPortable((v) => !v)} className={btnSecondary}>
+            {showPortable ? "Hide portable export" : "Portable backup (passphrase-protected)…"}
+          </button>
+        </div>
+        {showPortable && (
+          <div className="rounded-md border border-[var(--border)] bg-[var(--bg-secondary)] p-4 space-y-3 max-w-md">
+            <p className="text-xs text-[var(--text-muted)]">
+              Secrets are wrapped with AES-256-GCM under a key derived from this passphrase (Argon2id). It is
+              not stored anywhere — lose it and the backup&apos;s secrets cannot be recovered.
+            </p>
+            <div>
+              <label className="block text-xs font-medium text-[var(--text-secondary)] mb-1">Passphrase (min 8 characters)</label>
+              <input type="password" autoComplete="new-password" value={exportPassphrase}
+                onChange={(e) => setExportPassphrase(e.target.value)} className={inputCls} />
+              {passphraseTooShort && <p className="text-xs text-red-400 mt-1">At least 8 characters.</p>}
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-[var(--text-secondary)] mb-1">Confirm passphrase</label>
+              <input type="password" autoComplete="new-password" value={exportPassphrase2}
+                onChange={(e) => setExportPassphrase2(e.target.value)} className={inputCls} />
+              {passphraseMismatch && <p className="text-xs text-red-400 mt-1">Passphrases do not match.</p>}
+            </div>
+            <button
+              onClick={() => { handleExport(exportPassphrase); setExportPassphrase(""); setExportPassphrase2(""); }}
+              disabled={exporting || !portableReady}
+              className={btnPrimary}
+            >
+              {exporting ? "Exporting..." : "Download Portable Backup"}
+            </button>
+          </div>
+        )}
       </div>
 
       <hr className="border-[var(--border)]" />
@@ -61,6 +117,31 @@ export function ExportImportTab({
                 {preview.substring(0, 5000)}{preview.length > 5000 ? "\n... (truncated)" : ""}
               </pre>
             </details>
+            {secretsState?.state === "passphrase" && (
+              <div className="rounded-md border border-[var(--border)] bg-[var(--bg-secondary)] p-4 space-y-2 max-w-md">
+                <p className="text-xs text-[var(--text-secondary)]">
+                  This backup&apos;s {secretsState.count} secret{secretsState.count === 1 ? "" : "s"} are
+                  passphrase-protected. Enter the passphrase used when it was exported.
+                </p>
+                <input type="password" autoComplete="off" placeholder="Backup passphrase" value={importPassphrase}
+                  onChange={(e) => setImportPassphrase(e.target.value)} className={inputCls} />
+              </div>
+            )}
+            {secretsState?.state === "redacted" && unresolved.length === 0 && (
+              <p className="text-xs text-[var(--text-muted)]">
+                This backup was exported with secrets redacted ({secretsState.count}); this appliance holds all of
+                them and will fill them in on import.
+              </p>
+            )}
+            {unresolved.length > 0 && (
+              <div className="rounded-md border border-red-500/40 bg-red-500/10 p-3 text-xs text-red-300 space-y-1">
+                <p className="font-medium">Import blocked — this backup was exported without secrets and this appliance does not hold them:</p>
+                <ul className="list-disc pl-5 font-mono">
+                  {unresolved.map((u) => <li key={u}>{u}</li>)}
+                </ul>
+                <p>Re-export from the source with a passphrase, or remove these objects from the file and recreate them after import.</p>
+              </div>
+            )}
             {importPreview && importPreview.interfaces_missing.length > 0 && (
               <InterfaceMappingPanel
                 preview={importPreview}
@@ -69,7 +150,7 @@ export function ExportImportTab({
               />
             )}
             <div className="flex gap-3">
-              <button onClick={handleImport} disabled={importing} className={btnPrimary}>
+              <button onClick={handleImport} disabled={importing || importBlocked} className={btnPrimary}>
                 {importing ? "Importing..." : (importPreview && importPreview.interfaces_missing.length > 0 ? "Apply with Mapping" : "Import & Apply")}
               </button>
               <button onClick={cancelImport}

--- a/aifw-ui/src/app/backup/components/S3ArchiveTab.tsx
+++ b/aifw-ui/src/app/backup/components/S3ArchiveTab.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+
 import { useS3Archive } from "@/hooks/useBackups";
 
 /* ===================== S3 Archive tab ===================== */
@@ -17,6 +19,7 @@ function fmtWhen(s: string | null): string {
 
 export function S3ArchiveTab() {
   const { loading, error, items, importing, status, reload, importNow } = useS3Archive();
+  const [passphrase, setPassphrase] = useState("");
 
   return (
     <div className="space-y-4">
@@ -28,6 +31,16 @@ export function S3ArchiveTab() {
             <a className="text-blue-400 underline" href="/settings">Settings → S3 Backup Sync</a>.
             Importing fetches a copy as a new local version; nothing is applied automatically.
           </p>
+          <div className="mt-2 flex items-center gap-2">
+            <input
+              type="password"
+              autoComplete="off"
+              value={passphrase}
+              onChange={(e) => setPassphrase(e.target.value)}
+              placeholder="Backup passphrase (only if it differs from the stored one)"
+              className="w-80 px-2 py-1 text-xs bg-[var(--bg-primary)] border border-[var(--border)] rounded text-[var(--text-primary)]"
+            />
+          </div>
         </div>
         <button
           onClick={reload}
@@ -76,7 +89,7 @@ export function S3ArchiveTab() {
                   <td className="px-3 py-2 text-[var(--text-muted)]">{fmtWhen(o.last_modified)}</td>
                   <td className="px-3 py-2 text-right">
                     <button
-                      onClick={() => importNow(o.key)}
+                      onClick={() => importNow(o.key, passphrase)}
                       disabled={!!importing}
                       className="px-2 py-1 text-xs rounded bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50"
                     >

--- a/aifw-ui/src/app/backup/page.tsx
+++ b/aifw-ui/src/app/backup/page.tsx
@@ -54,6 +54,8 @@ export default function BackupPage() {
     importPreview,
     importMap,
     setImportMap,
+    importPassphrase,
+    setImportPassphrase,
     fileRef,
     handleFileSelect,
     handleImport,
@@ -162,6 +164,8 @@ export default function BackupPage() {
               importPreview={importPreview}
               importMap={importMap}
               setImportMap={setImportMap}
+              importPassphrase={importPassphrase}
+              setImportPassphrase={setImportPassphrase}
               fileRef={fileRef}
               handleFileSelect={handleFileSelect}
               handleImport={handleImport}

--- a/aifw-ui/src/app/settings/components/S3BackupSection.tsx
+++ b/aifw-ui/src/app/settings/components/S3BackupSection.tsx
@@ -25,6 +25,11 @@ export interface S3BackupSectionProps {
   secret: string;
   setSecret: Dispatch<SetStateAction<string>>;
   hasSecret: boolean;
+  backupPassphrase: string;
+  setBackupPassphrase: Dispatch<SetStateAction<string>>;
+  clearBackupPassphrase: boolean;
+  setClearBackupPassphrase: Dispatch<SetStateAction<boolean>>;
+  hasBackupPassphrase: boolean;
   saving: boolean;
   testing: boolean;
   testResult: S3TestResult | null;
@@ -53,6 +58,11 @@ export function S3BackupSection({
   secret,
   setSecret,
   hasSecret,
+  backupPassphrase,
+  setBackupPassphrase,
+  clearBackupPassphrase,
+  setClearBackupPassphrase,
+  hasBackupPassphrase,
   saving,
   testing,
   testResult,
@@ -103,6 +113,27 @@ export function S3BackupSection({
           <label className={labelCls}>Secret Access Key {hasSecret && <span className="text-[var(--text-muted)]">(saved)</span>}</label>
           <input type="password" value={secret} onChange={(e) => setSecret(e.target.value)} className={inputCls} placeholder={hasSecret ? "••••••••  (leave blank to keep)" : "(optional)"} />
         </div>
+      </div>
+      <div className="mt-4 rounded-md border border-[var(--border)] bg-[var(--bg-primary)] p-3 space-y-2">
+        <label className={labelCls}>
+          Backup passphrase {hasBackupPassphrase && <span className="text-[var(--text-muted)]">(saved)</span>}
+        </label>
+        <p className="text-xs text-[var(--text-muted)]">
+          Uploaded backups never carry live keys. With a passphrase set, WireGuard/IPsec keys, CARP passwords and
+          the DDNS TSIG secret are wrapped (Argon2id + AES-256-GCM) so the object can be restored on any
+          appliance that knows the passphrase. Without one, secrets are <strong>redacted</strong> and the
+          upload only restores cleanly onto this appliance.
+        </p>
+        <input type="password" autoComplete="new-password" value={backupPassphrase}
+          disabled={clearBackupPassphrase}
+          onChange={(e) => setBackupPassphrase(e.target.value)} className={inputCls}
+          placeholder={hasBackupPassphrase ? "••••••••  (leave blank to keep)" : "(none — uploads are redacted)"} />
+        {hasBackupPassphrase && (
+          <label className="inline-flex items-center gap-2 text-xs text-[var(--text-secondary)]">
+            <input type="checkbox" checked={clearBackupPassphrase} onChange={(e) => setClearBackupPassphrase(e.target.checked)} />
+            <span>Remove the stored passphrase (future uploads redacted)</span>
+          </label>
+        )}
       </div>
       <div className="mt-3">
         <label className="inline-flex items-center gap-2 text-sm">

--- a/aifw-ui/src/hooks/useBackups.ts
+++ b/aifw-ui/src/hooks/useBackups.ts
@@ -18,6 +18,7 @@ import {
   fetchConfigDiff,
   fetchConfigCheck,
   exportConfig,
+  exportConfigWithPassphrase,
   fetchImportPreview,
   importConfig,
   previewOpnsenseConfig,
@@ -58,6 +59,7 @@ export function useBackups() {
   const [preview, setPreview] = useState<string | null>(null);
   const [importPreview, setImportPreview] = useState<ImportPreview | null>(null);
   const [importMap, setImportMap] = useState<Record<string, string>>({});
+  const [importPassphrase, setImportPassphrase] = useState("");
   const fileRef = useRef<HTMLInputElement>(null);
 
   // History Restore preview/mapping modal
@@ -191,19 +193,22 @@ export function useBackups() {
 
   /* -- Export -------------------------------------------------------- */
 
-  const handleExport = async () => {
+  /// `passphrase` undefined ⇒ redacted export; otherwise secrets are
+  /// wrapped under it (#313).
+  const handleExport = async (passphrase?: string) => {
     setExporting(true);
     try {
-      const data = await exportConfig();
+      const data = passphrase ? await exportConfigWithPassphrase(passphrase) : await exportConfig();
       const json = JSON.stringify(data, null, 2);
       const blob = new Blob([json], { type: "application/json" });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `aifw-backup-${new Date().toISOString().replace(/[:.]/g, "-")}.json`;
+      const tag = passphrase ? "" : "-redacted";
+      a.download = `aifw-backup${tag}-${new Date().toISOString().replace(/[:.]/g, "-")}.json`;
       a.click();
       URL.revokeObjectURL(url);
-      showFeedback("success", "Config exported");
+      showFeedback("success", passphrase ? "Config exported (secrets passphrase-protected)" : "Config exported (secrets redacted)");
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Export failed");
     } finally {
@@ -222,6 +227,7 @@ export function useBackups() {
       setPreview(text);
       setImportPreview(null);
       setImportMap({});
+      setImportPassphrase("");
       try {
         const parsed = JSON.parse(text);
         const data = await fetchImportPreview(parsed);
@@ -244,11 +250,13 @@ export function useBackups() {
     try {
       const data = JSON.parse(preview);
       const interface_map = importPreview ? buildInterfaceMapForApi(importPreview, importMap) : {};
-      const body = await importConfig({ ...data, interface_map });
+      const passphrase = importPassphrase || undefined;
+      const body = await importConfig({ ...data, interface_map, passphrase });
       showFeedback("success", body.message || "Config imported");
       setPreview(null);
       setImportPreview(null);
       setImportMap({});
+      setImportPassphrase("");
       if (fileRef.current) fileRef.current.value = "";
     } catch (err) {
       showFeedback("error", err instanceof Error ? err.message : "Import failed");
@@ -261,6 +269,7 @@ export function useBackups() {
     setPreview(null);
     setImportPreview(null);
     setImportMap({});
+    setImportPassphrase("");
     if (fileRef.current) fileRef.current.value = "";
   };
 
@@ -387,6 +396,8 @@ export function useBackups() {
     importPreview,
     importMap,
     setImportMap,
+    importPassphrase,
+    setImportPassphrase,
     fileRef,
     handleFileSelect,
     handleImport,
@@ -437,12 +448,12 @@ export function useS3Archive() {
 
   useEffect(() => { queueMicrotask(reload); }, [reload]);
 
-  const importNow = async (key: string) => {
+  const importNow = async (key: string, passphrase?: string) => {
     if (!confirm(`Import ${key}?\n\nThis saves it as a new local version. It does NOT apply — you can diff then restore from the History tab.`)) return;
     setImporting(key);
     setStatus(null);
     try {
-      const d = await importS3Object(key);
+      const d = await importS3Object(key, passphrase || undefined);
       setStatus(d.message || `Imported as version ${d.version}`);
     } catch (e) {
       setStatus(e instanceof Error ? e.message : String(e));

--- a/aifw-ui/src/hooks/useSettings.ts
+++ b/aifw-ui/src/hooks/useSettings.ts
@@ -571,6 +571,9 @@ export function useS3Backup() {
   const [accessKey, setAccessKey] = useState("");
   const [secret, setSecret] = useState("");             // "" means "unchanged" on save
   const [hasSecret, setHasSecret] = useState(false);
+  const [backupPassphrase, setBackupPassphrase] = useState(""); // "" = unchanged; " " sentinel never sent
+  const [clearBackupPassphrase, setClearBackupPassphrase] = useState(false);
+  const [hasBackupPassphrase, setHasBackupPassphrase] = useState(false);
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<S3TestResult | null>(null);
@@ -590,6 +593,9 @@ export function useS3Backup() {
         setAccessKey(d.access_key_id || "");
         setHasSecret(!!d.has_secret);
         setSecret(""); // always blank in UI (means "unchanged")
+        setHasBackupPassphrase(!!d.has_secrets_passphrase);
+        setBackupPassphrase("");
+        setClearBackupPassphrase(false);
       } catch { /* silent */ } finally {
         setLoading(false);
       }
@@ -608,6 +614,8 @@ export function useS3Backup() {
     path_style: pathStyle,
     access_key_id: accessKey.trim() || null,
     secret_access_key: secret === "" ? null : secret,
+    // #313: null = unchanged, "" = clear, otherwise set.
+    secrets_passphrase: clearBackupPassphrase ? "" : backupPassphrase === "" ? null : backupPassphrase,
   });
 
   const save = async () => {
@@ -617,6 +625,9 @@ export function useS3Backup() {
       const d = await saveS3Config(buildPayload());
       setHasSecret(!!d.has_secret);
       setSecret("");
+      setHasBackupPassphrase(!!d.has_secrets_passphrase);
+      setBackupPassphrase("");
+      setClearBackupPassphrase(false);
       showFeedback("success", "S3 settings saved.");
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Unknown error";
@@ -664,6 +675,11 @@ export function useS3Backup() {
     secret,
     setSecret,
     hasSecret,
+    backupPassphrase,
+    setBackupPassphrase,
+    clearBackupPassphrase,
+    setClearBackupPassphrase,
+    hasBackupPassphrase,
     saving,
     testing,
     testResult,

--- a/aifw-ui/src/lib/api/backup.ts
+++ b/aifw-ui/src/lib/api/backup.ts
@@ -40,12 +40,21 @@ export interface DropSummary {
   pfsync: boolean;
 }
 
+/// How the secret fields of a backup file are stored (#313).
+export type SecretsState =
+  | { state: "plain" }
+  | { state: "redacted"; count: number }
+  | { state: "passphrase"; count: number };
+
 export interface ImportPreview {
   interfaces_found: string[];
   interfaces_missing: string[];
   interfaces_present: InterfaceInfo[];
   suggestions: Record<string, string>;
   drop_summary_if_unmapped: DropSummary;
+  secrets: SecretsState;
+  /// Redacted secrets this box cannot fill from its own state.
+  unresolved_secrets: string[];
 }
 
 export interface DiffSummary {
@@ -172,8 +181,15 @@ export async function fetchConfigCheck(): Promise<ConfigCheck> {
   return body.data;
 }
 
+/// Redacted export — secret fields replaced by `**REDACTED**`; restorable
+/// onto this box only.
 export function exportConfig(): Promise<unknown> {
   return api.get<unknown>("/api/v1/config/export");
+}
+
+/// Portable export — secret fields wrapped under `passphrase`.
+export function exportConfigWithPassphrase(passphrase: string): Promise<unknown> {
+  return api.post<unknown>("/api/v1/config/export", { passphrase });
 }
 
 export function fetchImportPreview(parsed: unknown): Promise<ImportPreview> {
@@ -217,6 +233,8 @@ export function listS3Archive(): Promise<S3Object[]> {
   return api.get<S3Object[]>("/api/v1/backup/s3/list?max=1000");
 }
 
-export function importS3Object(key: string): Promise<{ message?: string; version?: number }> {
-  return api.post<{ message?: string; version?: number }>("/api/v1/backup/s3/import", { key });
+/// `passphrase` unlocks a passphrase-wrapped object; omitted ⇒ the stored
+/// S3 backup passphrase is tried.
+export function importS3Object(key: string, passphrase?: string): Promise<{ message?: string; version?: number }> {
+  return api.post<{ message?: string; version?: number }>("/api/v1/backup/s3/import", { key, passphrase });
 }

--- a/aifw-ui/src/lib/api/settings.ts
+++ b/aifw-ui/src/lib/api/settings.ts
@@ -185,6 +185,8 @@ export interface S3Config {
   path_style?: boolean;
   access_key_id?: string;
   has_secret?: boolean;
+  /// Uploads wrap secrets under a stored passphrase (#313); false ⇒ redacted.
+  has_secrets_passphrase?: boolean;
 }
 
 export type S3ConfigPayload = Record<string, unknown>;
@@ -210,8 +212,10 @@ export function getS3Config(): Promise<S3Config> {
   return api.get<S3Config>("/api/v1/backup/s3/config");
 }
 
-export function saveS3Config(payload: S3ConfigPayload): Promise<{ has_secret?: boolean }> {
-  return api.put<{ has_secret?: boolean }>("/api/v1/backup/s3/config", payload);
+export function saveS3Config(
+  payload: S3ConfigPayload,
+): Promise<{ has_secret?: boolean; has_secrets_passphrase?: boolean }> {
+  return api.put<{ has_secret?: boolean; has_secrets_passphrase?: boolean }>("/api/v1/backup/s3/config", payload);
 }
 
 export function testS3Config(payload: S3ConfigPayload): Promise<S3TestResponse> {

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -405,8 +405,9 @@ Sensible defaults are applied when omitted; check the relevant subsystem doc for
 | `GET` | `/api/v1/config/version` | Current active version |
 | `GET` | `/api/v1/config/diff` | Diff two versions |
 | `GET` | `/api/v1/config/check` | Validate the active config |
-| `GET` | `/api/v1/config/export` | Export config as JSON |
-| `POST` | `/api/v1/config/import` | Import config from JSON |
+| `GET` | `/api/v1/config/export` | Export config as JSON (secrets redacted) |
+| `POST` | `/api/v1/config/export` | Export with secrets passphrase-wrapped (`{"passphrase"}`) |
+| `POST` | `/api/v1/config/import` | Import config from JSON (`"passphrase"` for portable exports) |
 | `POST` | `/api/v1/config/import-preview` | Dry-run import |
 | `POST` | `/api/v1/config/save` | Snapshot the current config |
 | `POST` | `/api/v1/config/restore` | Restore a previous version |

--- a/docs/docs/backup.md
+++ b/docs/docs/backup.md
@@ -34,12 +34,20 @@ Three workflows live in the same place: **JSON config backup &amp; restore** for
 Export the entire configuration &mdash; rules, NAT, aliases, VPN, geo-IP, DNS, DHCP, IDS settings, multi-WAN policy, reverse proxy, users, OAuth providers &mdash; as a single JSON document:
 
 ```bash
+# Redacted export — secret fields are the literal "**REDACTED**"
 curl https://aifw.local/api/v1/config/export \
   -H "Authorization: Bearer $TOKEN" \
   -o aifw-backup-$(date +%F).json
+
+# Portable export — secrets wrapped under a passphrase (Argon2id + AES-256-GCM)
+curl -X POST https://aifw.local/api/v1/config/export \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"passphrase": "correct horse battery staple"}' \
+  -o aifw-backup-$(date +%F).json
 ```
 
-Restore by `POST`ing the same document back. The importer validates the shape, snapshots the current config to history first, then applies the new state through the same engine writers (`RuleEngine`, `NatEngine`, `AliasEngine`, &hellip;) that the UI uses &mdash; so pf actually picks up the changes.
+Restore by `POST`ing the same document back (add a top-level `"passphrase"` for a portable export). The importer validates the shape, snapshots the current config to history first, then applies the new state through the same engine writers (`RuleEngine`, `NatEngine`, `AliasEngine`, &hellip;) that the UI uses &mdash; so pf actually picks up the changes.
 
 ```bash
 curl -X POST https://aifw.local/api/v1/config/import \
@@ -48,13 +56,17 @@ curl -X POST https://aifw.local/api/v1/config/import \
   --data @aifw-backup.json
 ```
 
-> **Secrets at rest.** Integration secrets in the database (WireGuard private/preshared keys, IPsec PSKs, CARP passwords, OAuth client secrets, S3/SMTP credentials, TSIG, ACME DNS tokens, AI provider keys, TOTP seeds, cluster peer keys) are sealed with AES-256-GCM under a master key in `/var/db/aifw/secrets.key` (0600, beside `jwt.key`). The JSON export above goes through the engines, so it carries the *decrypted* values and imports cleanly on any box — treat the file accordingly. A **raw copy of `aifw.db`**, on the other hand, is only useful together with its `secrets.key`; move to a new box without the key and every sealed value reads as unset. Back the two up together. (The S3 destination below syncs JSON snapshots, which carry decrypted values and need no key.)
+> **Secrets in exports.** A backup never carries live keys in the clear. `GET /config/export` (and the UI's *Download Backup*) replaces every secret field — WireGuard private/preshared keys, IPsec PSKs and private keys, CARP passwords, the DDNS TSIG secret — with `**REDACTED**`; such a file restores cleanly onto the appliance it came from, because the importer fills the sentinels back in from the tunnels/VIPs the box already holds (matched by id) and refuses, naming each one, when it cannot. For a backup you can restore on a *replacement* box, use the `POST` form (UI: *Portable backup*): secrets are wrapped per field under a key derived from your passphrase with Argon2id (64 MiB, t=3) and AES-256-GCM, and the KDF salt travels in `config.secrets`. The passphrase is not stored anywhere. Config-history views (`/config/version`, `/config/diff`, `aifw config show`) are redacted too; the stored versions themselves are full-fidelity and sealed at rest.
+>
+> **Secrets at rest.** Integration secrets in the database (the above plus OAuth client secrets, S3/SMTP credentials, ACME DNS tokens, AI provider keys, TOTP seeds, cluster peer keys) are sealed with AES-256-GCM under a master key in `/var/db/aifw/secrets.key` (0600, beside `jwt.key`). A **raw copy of `aifw.db`** is only useful together with its `secrets.key`; move to a new box without the key and every sealed value reads as unset. Back the two up together.
 
 Preview a candidate import without applying via `POST /api/v1/config/import-preview`. The response lists every record that will be created / updated / deleted so you can sanity-check the diff first.
 
 ## S3 backup destination
 
 Push backups off-box on a schedule. Configure a bucket, region, prefix, and access keys; AiFw uploads a fresh JSON snapshot on every config save plus on a configurable rotation schedule.
+
+Uploads follow the same rule as downloads: with a **backup passphrase** set (`secrets_passphrase`, write-only like the S3 secret; UI: *Settings → S3 Backup Sync*), each object's secrets are passphrase-wrapped and the object restores on any appliance that knows the passphrase. Without one, uploads are redacted and only restore cleanly onto the appliance that produced them. `POST /backup/s3/import` unlocks a wrapped object with the stored passphrase, or with a `"passphrase"` in the request body when it differs.
 
 ```bash
 curl -X PUT https://aifw.local/api/v1/backup/s3/config \
@@ -67,7 +79,8 @@ curl -X PUT https://aifw.local/api/v1/backup/s3/config \
     "prefix": "site-a/",
     "path_style": false,
     "access_key_id": "AKIA...",
-    "secret_access_key": "..."
+    "secret_access_key": "...",
+    "secrets_passphrase": "correct horse battery staple"
   }'
 
 # Verify credentials + bucket access without touching anything:
@@ -177,8 +190,9 @@ If the timer expires, the snapshot taken at arm time is restored and the config 
 
 | Method | Endpoint | Description |
 |---|---|---|
-| `GET` | `/api/v1/config/export` | Export entire config as JSON |
-| `POST` | `/api/v1/config/import` | Import a JSON config |
+| `GET` | `/api/v1/config/export` | Export entire config as JSON (secrets redacted) |
+| `POST` | `/api/v1/config/export` | Export with secrets wrapped under `{"passphrase"}` |
+| `POST` | `/api/v1/config/import` | Import a JSON config (`"passphrase"` unlocks a portable export) |
 | `POST` | `/api/v1/config/import-preview` | Dry-run a candidate import |
 | `GET` | `/api/v1/config/history` | List config-history versions |
 | `GET` | `/api/v1/config/version` | Get one version |

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -213,9 +213,17 @@ aifw config diff 17 22
 # Rollback
 aifw config rollback 17
 
-# Export / import (full JSON dump)
+# Export / import (full JSON dump; secrets redacted by default)
 aifw config export > backup.json
 aifw config import backup.json
+
+# Portable backup — secrets passphrase-wrapped (Argon2id + AES-256-GCM).
+# The passphrase comes from --passphrase-file (first line) or $AIFW_BACKUP_PASSPHRASE.
+aifw config export --secrets passphrase --passphrase-file /root/.backup-pass > backup.json
+aifw config import backup.json --passphrase-file /root/.backup-pass
+
+# Plaintext secrets (prints a warning — protect the output)
+aifw config export --secrets plain > backup.json
 ```
 
 ## routes


### PR DESCRIPTION
Closes #313 (SEC-M16).

Config exports used to carry every data-plane secret in the clear — WireGuard private/preshared keys, IPsec PSKs and private keys, CARP passwords, the DDNS TSIG secret — in the download, in every S3 upload, and in the history/diff views.

**What changes**

- `GET /config/export` (UI *Download Backup*, `aifw config export`) replaces each secret with `**REDACTED**`. Importing such a file onto the appliance it came from works: the importer fills the sentinels from the tunnels/VIPs the box already holds (matched by id) and refuses — naming each secret — when it cannot. `import-preview` reports the secrets state and the unresolved list up front.
- `POST /config/export {"passphrase"}` (UI *Portable backup*, `aifw config export --secrets passphrase`) wraps each secret under Argon2id (64 MiB, t=3) + AES-256-GCM; the KDF envelope rides in `config.secrets`. `POST /config/import`, `POST /backup/s3/import` and `aifw config import` take the passphrase.
- S3 uploads: wrapped under a new write-only `secrets_passphrase` (sealed at rest, added to `SEALED_COLUMNS`), redacted when unset. UI field in Settings → S3 Backup Sync; the S3 Archive tab accepts an override passphrase.
- `/config/version`, `/config/diff` and `aifw config show` are redacted (display surfaces). Stored versions stay full-fidelity (sealed at rest since #298).
- `prevalidate_config` refuses to apply a config that still holds sentinels or ciphertext, so no path can write them into the DB.
- Cluster snapshots keep real values on purpose: the standby has to hold the keys, and the channel is certificate-pinned since #317.

New module `aifw_core::config_secrets` with unit tests; API round-trip test covers redacted export → import, passphrase export → import (missing/wrong/right), and the unresolved-secret refusal. Docs updated (backup, api, cli).