### PR TITLE
sec: P3 sweep — BPF header parse, 80-bit recovery codes, register docs, checked sudo outcomes (#306 #319 #324 #325)

### DIFF
--- a/aifw-api/src/auth/totp.rs
+++ b/aifw-api/src/auth/totp.rs
@@ -97,21 +97,32 @@ fn generate_code_at_step(secret: &[u8], step: u64) -> u32 {
 // Recovery codes
 // ============================================================
 
-/// Generate a set of one-time recovery codes
+/// Bytes of entropy per recovery code: 80 bits (OWASP ASVS 2.8.x floor),
+/// up from the 48 bits the pre-#319 UUID-derived codes carried.
+const RECOVERY_CODE_BYTES: usize = 10;
+
+/// Generate a set of one-time recovery codes, each 80 random bits from
+/// the OS RNG formatted as five groups of four upper-case hex digits
+/// (`XXXX-XXXX-XXXX-XXXX-XXXX`, 24 characters).
 pub fn generate_recovery_codes(count: usize) -> Vec<String> {
+    use argon2::password_hash::rand_core::{OsRng, RngCore};
     (0..count)
         .map(|_| {
-            let u = uuid::Uuid::new_v4();
-            let bytes = u.as_bytes();
-            // Format as XXXX-XXXX-XXXX (alphanumeric)
-            format!(
-                "{:04X}-{:04X}-{:04X}",
-                u16::from_be_bytes([bytes[0], bytes[1]]),
-                u16::from_be_bytes([bytes[2], bytes[3]]),
-                u16::from_be_bytes([bytes[4], bytes[5]]),
-            )
+            let mut bytes = [0u8; RECOVERY_CODE_BYTES];
+            OsRng.fill_bytes(&mut bytes);
+            bytes
+                .chunks(2)
+                .map(|pair| format!("{:02X}{:02X}", pair[0], pair[1]))
+                .collect::<Vec<_>>()
+                .join("-")
         })
         .collect()
+}
+
+/// Canonical form a typed recovery code is compared in: trimmed and
+/// upper-cased, so `abcd-1234-…` matches the code the user was shown.
+pub fn normalize_recovery_code(input: &str) -> String {
+    input.trim().to_ascii_uppercase()
 }
 
 // ============================================================
@@ -362,12 +373,21 @@ mod tests {
         unique.sort();
         unique.dedup();
         assert_eq!(unique.len(), 8);
-        // Format: XXXX-XXXX-XXXX
+        // Format: XXXX-XXXX-XXXX-XXXX-XXXX (80 bits, #319)
         for code in &codes {
-            assert_eq!(code.len(), 14);
-            assert_eq!(&code[4..5], "-");
-            assert_eq!(&code[9..10], "-");
+            assert_eq!(code.len(), 24);
+            for (i, ch) in code.chars().enumerate() {
+                if i % 5 == 4 {
+                    assert_eq!(ch, '-', "{code}");
+                } else {
+                    assert!(ch.is_ascii_hexdigit() && !ch.is_ascii_lowercase(), "{code}");
+                }
+            }
         }
+        assert_eq!(
+            normalize_recovery_code("  ab12-cd34-ef56-0789-1a2b\n"),
+            "AB12-CD34-EF56-0789-1A2B"
+        );
     }
 
     #[test]

--- a/aifw-api/src/auth/totp_store.rs
+++ b/aifw-api/src/auth/totp_store.rs
@@ -97,6 +97,7 @@ pub async fn save_recovery_codes(
 
 /// Try to use a recovery code. Returns true if valid and unused.
 pub async fn use_recovery_code(pool: &SqlitePool, user_id: &str, code: &str) -> bool {
+    let code = super::totp::normalize_recovery_code(code);
     let rows = sqlx::query_as::<_, (String, String)>(
         "SELECT id, code_hash FROM recovery_codes WHERE user_id = ?1 AND used = 0",
     )
@@ -106,7 +107,7 @@ pub async fn use_recovery_code(pool: &SqlitePool, user_id: &str, code: &str) -> 
     .unwrap_or_default();
 
     for (id, code_hash) in rows {
-        if verify_password(code, &code_hash) {
+        if verify_password(&code, &code_hash) {
             let _ = sqlx::query("UPDATE recovery_codes SET used = 1 WHERE id = ?1")
                 .bind(&id)
                 .execute(pool)

--- a/aifw-api/src/dns_resolver.rs
+++ b/aifw-api/src/dns_resolver.rs
@@ -1585,7 +1585,7 @@ async fn write_backend_config_files(state: &AppState, backend: &str) -> Result<(
             Ok(())
         }
         "rdns" => {
-            let _ = Command::new("/usr/local/bin/sudo")
+            let res = Command::new("/usr/local/bin/sudo")
                 .args([
                     "mkdir",
                     "-p",
@@ -1596,6 +1596,7 @@ async fn write_backend_config_files(state: &AppState, backend: &str) -> Result<(
                 ])
                 .output()
                 .await;
+            aifw_core::sudo::warn_on_fail("rdns: create config directories", &res);
 
             let conf = generate_rdns_conf(&state.pool).await;
             let tmp = "/tmp/aifw_rdns.toml";
@@ -1604,7 +1605,7 @@ async fn write_backend_config_files(state: &AppState, backend: &str) -> Result<(
             let _ = tokio::fs::remove_file(tmp).await;
 
             let zones = generate_rdns_zones(&state.pool).await;
-            let _ = Command::new("/usr/local/bin/sudo")
+            let res = Command::new("/usr/local/bin/sudo")
                 .args([
                     "/usr/bin/find",
                     "/usr/local/etc/rdns/zones",
@@ -1614,6 +1615,7 @@ async fn write_backend_config_files(state: &AppState, backend: &str) -> Result<(
                 ])
                 .output()
                 .await;
+            aifw_core::sudo::warn_on_fail("rdns: clear stale zone files", &res);
             for (filename, content) in &zones {
                 let safe_name = sanitize_zone_filename(filename);
                 if safe_name.is_empty() {
@@ -1637,10 +1639,11 @@ async fn write_backend_config_files(state: &AppState, backend: &str) -> Result<(
                 sudo_copy(tmp_rpz, hosts_rpz_path).await;
                 let _ = tokio::fs::remove_file(tmp_rpz).await;
             } else {
-                let _ = Command::new("/usr/local/bin/sudo")
+                let res = Command::new("/usr/local/bin/sudo")
                     .args(["/bin/rm", "-f", hosts_rpz_path])
                     .output()
                     .await;
+                aifw_core::sudo::warn_on_fail("rdns: remove hosts RPZ", &res);
             }
 
             if let Some(rpz_content) = generate_rdns_rpz(&state.pool).await {

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -1494,11 +1494,17 @@ async fn ensure_rdr_anchor() {
         .await
         .is_ok()
     {
-        let _ = tokio::process::Command::new("/usr/local/bin/sudo")
+        let res = tokio::process::Command::new("/usr/local/bin/sudo")
             .args(["/sbin/pfctl", "-f", pf_path])
             .output()
             .await;
-        info!("Patched pf.conf with missing AiFw anchors and reloaded");
+        if aifw_core::sudo::warn_on_fail("pfctl -f after anchor patch", &res) {
+            info!("Patched pf.conf with missing AiFw anchors and reloaded");
+        } else {
+            tracing::warn!(
+                "Patched pf.conf with missing AiFw anchors but reload failed — anchors take effect at next pf reload"
+            );
+        }
     } else {
         tracing::warn!("aifw-sudo-write failed to commit patched pf.conf");
     }

--- a/aifw-api/src/multiwan.rs
+++ b/aifw-api/src/multiwan.rs
@@ -344,7 +344,7 @@ pub async fn enable_fibs(
     let already_enabled = false;
 
     let reboot_scheduled = if req.reboot && !already_enabled {
-        let _ = tokio::process::Command::new("/usr/local/bin/sudo")
+        let res = tokio::process::Command::new("/usr/local/bin/sudo")
             .args([
                 "/sbin/shutdown",
                 "-r",
@@ -353,7 +353,8 @@ pub async fn enable_fibs(
             ])
             .output()
             .await;
-        true
+        // #325: report what actually happened rather than assuming.
+        aifw_core::sudo::warn_on_fail("multiwan: schedule reboot", &res)
     } else {
         false
     };

--- a/aifw-api/src/routes/auth.rs
+++ b/aifw-api/src/routes/auth.rs
@@ -546,9 +546,15 @@ pub async fn oauth_callback(
     Err(StatusCode::NOT_IMPLEMENTED)
 }
 
-/// Public registration — only allowed when no users exist (first-user bootstrap).
-/// First user is always created as admin regardless of request.
-/// Uses a DB-level check to prevent TOCTOU race conditions.
+/// Public registration — only allowed when no human users exist
+/// (first-user bootstrap). First user is always created as admin regardless
+/// of request. Uses a DB-level check to prevent TOCTOU race conditions.
+///
+/// This is also the documented recovery path (#324): if every account is
+/// deleted, the next anonymous `POST /auth/register` re-creates the admin.
+/// The `aifw-daemon` service account (#318, `auth_provider = 'system'`)
+/// does not count — a cluster node whose human accounts are gone must
+/// still be recoverable.
 pub async fn register(
     State(state): State<AppState>,
     Json(req): Json<auth::CreateUserRequest>,
@@ -565,11 +571,11 @@ pub async fn register(
     let user_id = uuid::Uuid::new_v4();
     let now = chrono::Utc::now().to_rfc3339();
 
-    // Atomic: INSERT ... WHERE (SELECT COUNT(*) FROM users) = 0
+    // Atomic: INSERT ... WHERE no non-system user exists
     let result = sqlx::query(
         r#"INSERT INTO users (id, username, password_hash, totp_enabled, totp_secret, auth_provider, role, role_id, enabled, created_at)
            SELECT ?1, ?2, ?3, 0, NULL, 'local', 'admin', 'builtin-admin', 1, ?4
-           WHERE (SELECT COUNT(*) FROM users) = 0"#,
+           WHERE NOT EXISTS (SELECT 1 FROM users WHERE auth_provider != 'system')"#,
     )
     .bind(user_id.to_string())
     .bind(&admin_req.username)

--- a/aifw-api/src/updates.rs
+++ b/aifw-api/src/updates.rs
@@ -898,7 +898,7 @@ async fn finalize_os_upgrade(pool: SqlitePool, mut job: OsUpgradeState) {
 
 pub async fn reboot_system() -> Result<Json<MessageResponse>, StatusCode> {
     // Schedule reboot in 10 seconds
-    let _ = Command::new("/usr/local/bin/sudo")
+    let res = Command::new("/usr/local/bin/sudo")
         .args([
             "/sbin/shutdown",
             "-r",
@@ -907,6 +907,11 @@ pub async fn reboot_system() -> Result<Json<MessageResponse>, StatusCode> {
         ])
         .output()
         .await;
+    // #325: don't tell the operator the box is rebooting when shutdown(8)
+    // refused (sudoers drift, already pending shutdown, …).
+    if !aifw_core::sudo::warn_on_fail("schedule reboot", &res) {
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
     Ok(Json(MessageResponse {
         message: "System rebooting in 10 seconds".to_string(),
     }))
@@ -914,7 +919,7 @@ pub async fn reboot_system() -> Result<Json<MessageResponse>, StatusCode> {
 
 pub async fn shutdown_system() -> Result<Json<MessageResponse>, StatusCode> {
     // Schedule power-off in 10 seconds
-    let _ = Command::new("/usr/local/bin/sudo")
+    let res = Command::new("/usr/local/bin/sudo")
         .args([
             "/sbin/shutdown",
             "-p",
@@ -923,6 +928,9 @@ pub async fn shutdown_system() -> Result<Json<MessageResponse>, StatusCode> {
         ])
         .output()
         .await;
+    if !aifw_core::sudo::warn_on_fail("schedule shutdown", &res) {
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
     Ok(Json(MessageResponse {
         message: "System shutting down in 10 seconds".to_string(),
     }))

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -1144,6 +1144,23 @@ async fn create_config_manager(db_path: &Path) -> anyhow::Result<aifw_core::Conf
     Ok(mgr)
 }
 
+/// Run `service <name> <action>` and fail with its stderr on a non-zero
+/// exit (#325) instead of printing a success line regardless.
+pub fn service_ctl(name: &str, action: &str) -> anyhow::Result<()> {
+    let out = std::process::Command::new("service")
+        .args([name, action])
+        .output()
+        .map_err(|e| anyhow::anyhow!("service {name} {action}: failed to run: {e}"))?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "service {name} {action} exited {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
 pub async fn config_show(db_path: &Path) -> anyhow::Result<()> {
     let mgr = create_config_manager(db_path).await?;
     match mgr.get_active().await.map_err(|e| anyhow::anyhow!(e))? {
@@ -1331,9 +1348,20 @@ pub async fn routes_remove(db_path: &Path, id: &str) -> anyhow::Result<()> {
 
     if let Some((dest, gw, enabled)) = row {
         if enabled {
-            let _ = std::process::Command::new("route")
+            // #325: a failed kernel-route delete leaves a stale route the
+            // DB no longer knows about — say so instead of hiding it.
+            match std::process::Command::new("route")
                 .args(["delete", &dest, &gw])
-                .output();
+                .output()
+            {
+                Ok(o) if o.status.success() => {}
+                Ok(o) => eprintln!(
+                    "warning: route delete {dest} {gw} exited {}: {}",
+                    o.status,
+                    String::from_utf8_lossy(&o.stderr).trim()
+                ),
+                Err(e) => eprintln!("warning: route delete {dest} {gw} failed to run: {e}"),
+            }
         }
         sqlx::query("DELETE FROM static_routes WHERE id = ?1")
             .bind(id)

--- a/aifw-cli/src/main.rs
+++ b/aifw-cli/src/main.rs
@@ -1444,21 +1444,15 @@ async fn main() -> anyhow::Result<()> {
         Commands::Dhcp { action } => match action {
             DhcpAction::Status => commands::dhcp_status(&cli.db).await?,
             DhcpAction::Start => {
-                let _ = std::process::Command::new("service")
-                    .args(["rdhcpd", "start"])
-                    .output();
+                commands::service_ctl("rdhcpd", "start")?;
                 println!("DHCP started");
             }
             DhcpAction::Stop => {
-                let _ = std::process::Command::new("service")
-                    .args(["rdhcpd", "stop"])
-                    .output();
+                commands::service_ctl("rdhcpd", "stop")?;
                 println!("DHCP stopped");
             }
             DhcpAction::Restart => {
-                let _ = std::process::Command::new("service")
-                    .args(["rdhcpd", "restart"])
-                    .output();
+                commands::service_ctl("rdhcpd", "restart")?;
                 println!("DHCP restarted");
             }
             DhcpAction::Subnets { json } => commands::dhcp_subnets(&cli.db, json).await?,

--- a/aifw-core/src/acme_export.rs
+++ b/aifw-core/src/acme_export.rs
@@ -128,10 +128,12 @@ async fn sudo_install_string(
     let tmp = format!("/tmp/aifw_acme_export_{basename}.tmp");
 
     if let Some(parent) = std::path::Path::new(dest).parent() {
-        let _ = Command::new(SUDO)
+        let res = Command::new(SUDO)
             .args(["/bin/mkdir", "-p", parent.to_str().unwrap_or("")])
             .output()
             .await;
+        // Non-fatal: the install below fails loudly if the dir is missing.
+        crate::sudo::warn_on_fail("acme export: create destination directory", &res);
     }
 
     tokio::fs::write(&tmp, body)

--- a/aifw-core/src/dns_blocklists.rs
+++ b/aifw-core/src/dns_blocklists.rs
@@ -954,10 +954,11 @@ async fn atomic_write(path: &std::path::Path, body: &str) -> std::io::Result<()>
 async fn remove_blocklist_file(path: &std::path::Path) {
     use tokio::process::Command;
     if let Some(p) = path.to_str() {
-        let _ = Command::new("/usr/local/bin/sudo")
+        let res = Command::new("/usr/local/bin/sudo")
             .args(["/bin/rm", "-f", p])
             .output()
             .await;
+        crate::sudo::warn_on_fail("dns blocklists: remove RPZ file", &res);
     }
 }
 

--- a/aifw-core/src/sudo.rs
+++ b/aifw-core/src/sudo.rs
@@ -82,6 +82,28 @@ const HELPER_TCPDUMP: &str = "/usr/local/libexec/aifw-sudo-tcpdump";
 const HELPER_SWANCTL: &str = "/usr/local/libexec/aifw-sudo-swanctl";
 const HELPER_DUMMYNET: &str = "/usr/local/libexec/aifw-sudo-dummynet";
 const HELPER_NEWSYSLOG: &str = "/usr/local/libexec/aifw-sudo-newsyslog";
+/// Log (at warn) when a privileged command failed to spawn or exited
+/// non-zero, with its stderr. For best-effort steps whose failure must be
+/// visible in the logs but is not fatal to the caller (#325 / SEC-I3).
+/// Returns `true` when the command succeeded.
+pub fn warn_on_fail(what: &str, res: &std::io::Result<std::process::Output>) -> bool {
+    match res {
+        Ok(o) if o.status.success() => true,
+        Ok(o) => {
+            tracing::warn!(
+                status = %o.status,
+                stderr = %String::from_utf8_lossy(&o.stderr).trim(),
+                "{what} failed"
+            );
+            false
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "{what} failed to run");
+            false
+        }
+    }
+}
+
 /// Apply dummynet/FQ-CoDel commands through the closed helper.
 pub async fn dummynet_apply(commands: &[String]) -> std::io::Result<()> {
     let payload = commands.join("\n");

--- a/aifw-ids/src/capture/bpf.rs
+++ b/aifw-ids/src/capture/bpf.rs
@@ -14,18 +14,50 @@ const BIOCPROMISC: libc::c_ulong = 0x20004269; // _IO('B', 105)
 const BIOCSRTIMEOUT: libc::c_ulong = 0x8010426D; // _IOW('B', 109, struct timeval)
 const BIOCGBLEN: libc::c_ulong = 0x40044266; // _IOR('B', 102, u_int)
 
-/// BPF packet header (prepended to each packet in the buffer).
-/// On 64-bit FreeBSD, bh_tstamp is struct timeval = 16 bytes (two longs).
-/// Total header size is 32 bytes on 64-bit, 20 bytes on 32-bit.
-#[repr(C)]
+/// BPF packet header (prepended to each packet in the buffer), decoded
+/// field-by-field from the kernel-filled bytes. `struct bpf_hdr` is
+/// `{ struct timeval bh_tstamp; u_int32_t bh_caplen; u_int32_t
+/// bh_datalen; u_short bh_hdrlen; }` — the timeval is two `c_long`s (16
+/// bytes on 64-bit, 8 on 32-bit). Packets in the buffer are only
+/// `BPF_WORDALIGN`ed (4/8 bytes), which the old pointer cast to a
+/// `#[repr(C)]` struct silently relied on to also satisfy the timeval's
+/// alignment; reading the fields out of the byte slice needs no
+/// alignment at all and no `unsafe` (#306 / SEC-M9).
 struct BpfHeader {
-    bh_tstamp_sec: libc::c_long,  // 8 bytes on 64-bit
-    bh_tstamp_usec: libc::c_long, // 8 bytes on 64-bit
+    bh_tstamp_sec: libc::c_long,
+    bh_tstamp_usec: libc::c_long,
     bh_caplen: u32,
     bh_datalen: u32,
     bh_hdrlen: u16,
-    _padding: u16,
-    _padding2: u32, // alignment to 32 bytes on 64-bit
+}
+
+impl BpfHeader {
+    /// Bytes the fixed part of the header occupies (`bh_hdrlen` in the
+    /// header itself is authoritative for where the payload starts).
+    const LEN: usize = 2 * std::mem::size_of::<libc::c_long>() + 4 + 4 + 2;
+
+    /// Decode from the first [`Self::LEN`] bytes of `b` (native endian).
+    /// Returns `None` if the slice is too short.
+    fn parse(b: &[u8]) -> Option<Self> {
+        const L: usize = std::mem::size_of::<libc::c_long>();
+        if b.len() < Self::LEN {
+            return None;
+        }
+        let long_at = |off: usize| -> libc::c_long {
+            let mut buf = [0u8; L];
+            buf.copy_from_slice(&b[off..off + L]);
+            libc::c_long::from_ne_bytes(buf)
+        };
+        let u32_at = |off: usize| u32::from_ne_bytes([b[off], b[off + 1], b[off + 2], b[off + 3]]);
+        let u16_at = |off: usize| u16::from_ne_bytes([b[off], b[off + 1]]);
+        Some(Self {
+            bh_tstamp_sec: long_at(0),
+            bh_tstamp_usec: long_at(L),
+            bh_caplen: u32_at(2 * L),
+            bh_datalen: u32_at(2 * L + 4),
+            bh_hdrlen: u16_at(2 * L + 8),
+        })
+    }
 }
 
 /// ifreq struct for BIOCSETIF
@@ -174,16 +206,10 @@ impl CaptureBackend for BpfCapture {
         }
 
         // Parse BPF header at current position
-        if self.buf_pos + std::mem::size_of::<BpfHeader>() > self.buf_read {
+        let Some(hdr) = BpfHeader::parse(&self.buffer[self.buf_pos..self.buf_read]) else {
             self.buf_pos = self.buf_read; // Consumed
             return None;
-        }
-
-        // SAFETY: the bounds check above guarantees at least
-        // `size_of::<BpfHeader>()` bytes remain at `buf_pos`. BpfHeader is
-        // `#[repr(C)]` POD, so reinterpreting the kernel-filled bytes is valid;
-        // the borrow lives only as long as `self.buffer` is untouched below.
-        let hdr = unsafe { &*(self.buffer.as_ptr().add(self.buf_pos) as *const BpfHeader) };
+        };
 
         let caplen = hdr.bh_caplen as usize;
         let hdrlen = hdr.bh_hdrlen as usize;
@@ -282,4 +308,29 @@ fn open_bpf_device() -> Result<RawFd> {
     Err(crate::IdsError::Capture(
         "no available /dev/bpf device (tried bpf0..bpf255)".to_string(),
     ))
+}
+
+#[cfg(test)]
+mod header_tests {
+    use super::BpfHeader;
+
+    #[test]
+    fn parses_fields_from_unaligned_bytes() {
+        const L: usize = std::mem::size_of::<libc::c_long>();
+        let mut raw = vec![0xAAu8]; // one leading byte → misaligned start
+        raw.extend_from_slice(&(1_700_000_000 as libc::c_long).to_ne_bytes());
+        raw.extend_from_slice(&(123_456 as libc::c_long).to_ne_bytes());
+        raw.extend_from_slice(&64u32.to_ne_bytes());
+        raw.extend_from_slice(&1500u32.to_ne_bytes());
+        raw.extend_from_slice(&((2 * L + 10 + 6) as u16).to_ne_bytes());
+        raw.extend_from_slice(&[0u8; 8]);
+        let hdr = BpfHeader::parse(&raw[1..]).expect("enough bytes");
+        assert_eq!(hdr.bh_tstamp_sec, 1_700_000_000);
+        assert_eq!(hdr.bh_tstamp_usec, 123_456);
+        assert_eq!(hdr.bh_caplen, 64);
+        assert_eq!(hdr.bh_datalen, 1500);
+        assert_eq!(hdr.bh_hdrlen as usize, 2 * L + 16);
+        assert!(BpfHeader::parse(&raw[1..BpfHeader::LEN]).is_some());
+        assert!(BpfHeader::parse(&raw[1..BpfHeader::LEN - 1]).is_none());
+    }
 }

--- a/aifw-ui/src/app/login/page.tsx
+++ b/aifw-ui/src/app/login/page.tsx
@@ -111,7 +111,7 @@ export default function LoginPage() {
               <label className="text-xs text-[var(--text-muted)] uppercase tracking-wider block mb-1">TOTP Code</label>
               <input type="text" value={totpCode} onChange={(e) => setTotpCode(e.target.value)}
                 className={inputClass} required autoFocus autoComplete="one-time-code"
-                placeholder="000000" maxLength={20} />
+                placeholder="000000" maxLength={24} />
             </div>
 
             <button type="submit" disabled={loading}

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -132,7 +132,7 @@ Sensible defaults are applied when omitted; check the relevant subsystem doc for
 | `POST` | `/api/v1/auth/totp/disable` | Disable TOTP for the current user |
 | `POST` | `/api/v1/auth/refresh` | Exchange refresh token for a new JWT |
 | `POST` | `/api/v1/auth/logout` | Revoke the current session |
-| `POST` | `/api/v1/auth/register` | Self-service registration (if enabled) |
+| `POST` | `/api/v1/auth/register` | Bootstrap the first admin — unauthenticated, only succeeds while no user account exists |
 | `GET` | `/api/v1/auth/me` | Current user identity, role, perms |
 | `POST` | `/api/v1/auth/ws-ticket` | Mint a 30-second WebSocket ticket |
 | `GET`,&nbsp;`POST` | `/api/v1/auth/users` | List / create users |

--- a/docs/docs/auth.md
+++ b/docs/docs/auth.md
@@ -45,6 +45,8 @@ curl -X POST https://aifw.local/api/v1/auth/users \
   }'
 ```
 
+The very first account is created by the setup wizard, or by an unauthenticated `POST /api/v1/auth/register` &mdash; that endpoint only succeeds while **no** user account exists (the `aifw-daemon` service account doesn't count) and always creates an admin; every later call gets `403`. That is also the recovery story if the last admin is ever deleted: with no accounts left, the next `register` re-creates one, so treat the box as open until it is called (do it immediately, from the console). Deleting yourself as the only admin therefore doesn't lock you out; it just returns the box to first-boot state for whoever reaches the API next.
+
 Login returns a JWT plus a refresh token:
 
 ```bash
@@ -252,7 +254,7 @@ The canonical list lives in [`aifw-common/src/permission.rs`](https://github.com
 | `POST` | `/api/v1/auth/totp/login` | Submit TOTP code after `/login` |
 | `POST` | `/api/v1/auth/refresh` | Exchange a refresh token for a new JWT |
 | `POST` | `/api/v1/auth/logout` | Revoke the current session |
-| `POST` | `/api/v1/auth/register` | Self-service registration (if enabled) |
+| `POST` | `/api/v1/auth/register` | Bootstrap the first admin — unauthenticated, only succeeds while no user account exists |
 | `GET` | `/api/v1/auth/me` | Current user identity, role, perms |
 | `POST` | `/api/v1/auth/totp/setup` | Begin TOTP enrolment |
 | `POST` | `/api/v1/auth/totp/verify` | Verify and activate TOTP |


### PR DESCRIPTION
Closes #306, closes #319, closes #324, closes #325.

- **#306 (SEC-M9)** — `aifw-ids` BPF capture decoded each packet header by casting an arbitrary offset of the `Vec<u8>` buffer to `&BpfHeader` (`#[repr(C)]` with a `timeval`), a misaligned read. The header is now parsed field-by-field from the byte slice (`BpfHeader::parse`, native endian, `c_long`-sized timeval), which needs no alignment and no `unsafe`. Unit test with a deliberately misaligned buffer; checked with `--target x86_64-unknown-freebsd`.
- **#319 (SEC-L4)** — recovery codes are 80 random bits from `OsRng` (`XXXX-XXXX-XXXX-XXXX-XXXX`), up from 48 UUID-derived bits. Typed codes are trimmed and upper-cased before the argon2 check; login input `maxLength` widened to fit.
- **#324 (SEC-I2)** — auth docs now describe `POST /auth/register` as the first-admin bootstrap and the recovery story when the last admin is deleted. The `aifw-daemon` system account (#318) is excluded from the "no users exist" check so a cluster node stays recoverable.
- **#325 (SEC-I3)** — new `aifw_core::sudo::warn_on_fail(what, &res) -> bool` logs spawn failures / non-zero exits with stderr; applied to every `let _ = Command::new(sudo)…` site: reboot/shutdown now return 500 when `shutdown(8)` refuses instead of claiming the box is going down, multi-WAN reboot scheduling reports truthfully, pf anchor-patch reload, rdns config dirs / stale zone cleanup / RPZ removal, ACME export mkdir, blocklist file removal. CLI `aifw dhcp start|stop|restart` and `aifw routes remove` report command failures instead of printing success.