### PR TITLE
chore(ai): gate the unwired aifw-ai prototype crate; docs describe what actually ships (#171)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,26 @@ members = [
     "aifw-cli",
     "aifw-setup",
 ]
+# `aifw-ai` (heuristic ML-detector prototypes, #171) is not wired into any
+# binary and is excluded from the default build set: plain `cargo build` /
+# `cargo test` skip it, `cargo build --workspace` or `-p aifw-ai` still
+# builds it. Move it back into the default set when it gets a data path.
+default-members = [
+    "aifw-common",
+    "aifw-pf",
+    "aifw-core",
+    "aifw-conntrack",
+    "aifw-plugins",
+    "aifw-ids",
+    "aifw-ids-bin",
+    "aifw-ids-ipc",
+    "aifw-metrics",
+    "aifw-api",
+    "aifw-tui",
+    "aifw-daemon",
+    "aifw-cli",
+    "aifw-setup",
+]
 resolver = "2"
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AiFw
 
-High-performance firewall for FreeBSD built in Rust on top of pf. Optional AI/ML threat detection. All features free and open source.
+High-performance firewall for FreeBSD built in Rust on top of pf. Optional AI-assisted IDS alert triage. All features free and open source.
 
 > **AI is not required.** AiFw is a full-featured firewall, router, DHCP server, DNS resolver, IDS/IPS, reverse proxy, and NTP server that works perfectly without any AI features enabled. You get stateful packet filtering, NAT, VPN, Geo-IP blocking, Suricata-compatible intrusion detection, traffic shaping, and a complete web UI — all without AI. There is no cloud dependency and no telemetry.
 
-> **AI/ML features are a work in progress.** The `aifw-ai` crate contains experimental detectors for port scans, DDoS, brute force, C2 beacons, and DNS tunneling. These are not yet production-ready and are disabled by default. The AI module is an opt-in add-on that will be developed further in future releases. The Threats page in the UI reflects the current WIP status of this module.
+> **What "AI" means here today.** The shipping AI feature is **LLM-assisted alert triage**: point Settings → AI at a provider (OpenAI, Anthropic, Ollama, …) and critical/high IDS alerts get reviewed and classified on the Threats page; leave it unset and nothing is called. The `aifw-ai` crate — heuristic prototypes for port-scan / DDoS / brute-force / C2-beacon / DNS-tunnel detection — is **not wired into the daemon or API**: nothing on the appliance runs those detectors and there is no setting that enables them (#171). It is kept out of the default build (`cargo build --workspace` or `-p aifw-ai` compiles it) until it has a real data path.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![FreeBSD](https://img.shields.io/badge/FreeBSD-15.x-red.svg)](https://www.freebsd.org/)
@@ -77,7 +77,7 @@ High-performance firewall for FreeBSD built in Rust on top of pf. Optional AI/ML
 - **NAT** — SNAT, DNAT/RDR, masquerade, binat, NAT bypass (`no nat`), `static-port` on outbound rules, NAT64/NAT46 (real cross-family translation via pf af-to, FreeBSD 15+, with DNS64 in the resolver)
 - **Connection tracking** — real-time state table monitoring, top talkers, protocol breakdown
 - **Rate limiting & traffic shaping** — HFSC/PriQ queues, per-IP overload tables, SYN flood protection (CoDel via dummynet FQ-CoDel in development, #532)
-- **AI/ML threat detection** *(optional, WIP)* — experimental port scan, DDoS, brute force, C2 beacon, DNS tunnel detection with auto-response (disabled by default, not yet production-ready)
+- **AI-assisted alert triage** *(optional)* — an LLM provider you configure reviews critical/high IDS alerts and classifies them (Threats page); off unless a provider is set. Behavioural ML detectors (`aifw-ai`) exist only as unwired prototypes — see the note above.
 - **VPN integration** — WireGuard tunnels + peers, and IKEv2 site-to-site IPsec (tunnel mode, PSK or X.509 auth, NAT-T) powered by strongSwan
 - **Geo-IP filtering** — country-based block/allow with GeoLite2 CSV, CIDR aggregation
 - **TLS inspection** — JA3/JA3S fingerprinting, SNI filtering, cert validation, version enforcement
@@ -100,7 +100,7 @@ AiFw/
 ├── aifw-core/          # Engines: rules, NAT, VPN, TLS, geo-IP, HA, shaping, audit
 ├── aifw-conntrack/     # Connection tracking, pflog parsing, stats
 ├── aifw-plugins/       # Plugin framework (native + WASM) + 3 example plugins
-├── aifw-ai/            # ML threat detection (5 detectors) + auto-response [WIP]
+├── aifw-ai/            # Heuristic ML-detector prototypes — NOT wired into any binary (#171)
 ├── aifw-metrics/       # RRD ring buffer metrics engine
 ├── aifw-api/           # Axum REST API server (JWT + API key auth)
 ├── aifw-tui/           # ratatui terminal UI

--- a/aifw-ai/src/lib.rs
+++ b/aifw-ai/src/lib.rs
@@ -1,8 +1,14 @@
 #![warn(missing_docs)]
 //! # aifw-ai
 //!
-//! **WIP** — AI/ML threat-detection engine. This crate is a work in progress;
-//! see the crate README for current status and caveats.
+//! **Prototype, not wired in.** Heuristic behavioural detectors (port
+//! scan, DDoS, brute force, C2 beacon, DNS tunnel), a feature extractor,
+//! an inference-backend trait with a development stub, and an auto-response
+//! model. No AiFw binary depends on this crate: nothing on the appliance
+//! runs these detectors and there is no setting that enables them (#171).
+//! It is excluded from the workspace's `default-members` — build it with
+//! `cargo build -p aifw-ai` or `--workspace`. The AI feature that ships is
+//! the LLM-assisted alert triage in `aifw-api::ai_analysis`.
 
 /// Heuristic threat detectors (port scan, DDoS, brute force, C2, DNS tunnel)
 pub mod detectors;

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -81,7 +81,8 @@ A fair, honest comparison. Where a competitor is stronger, we say so. This matri
 <tr><td>YARA rules</td><td class="partial">subset</td><td class="no">—</td><td class="no">—</td></tr>
 <tr><td>Inline IPS (drops the triggering packet)</td><td class="partial">planned</td><td class="yes">✓</td><td class="yes">✓</td></tr>
 <tr><td>Reactive source blocking after detection</td><td class="yes">✓</td><td class="yes">✓</td><td class="yes">✓</td></tr>
-<tr><td>AI/ML threat detection</td><td class="yes">✓</td><td class="no">—</td><td class="no">—</td></tr>
+<tr><td>AI-assisted alert triage (LLM)</td><td class="yes">✓</td><td class="no">—</td><td class="no">—</td></tr>
+<tr><td>Behavioural ML threat detection</td><td class="partial">prototype, not wired in</td><td class="no">—</td><td class="no">—</td></tr>
 
 <tr class="section-row"><td colspan="4">DNS</td></tr>
 <tr><td>DNS resolver</td><td class="yes">rDNS</td><td class="yes">Unbound</td><td class="yes">Unbound</td></tr>
@@ -153,7 +154,7 @@ A fair, honest comparison. Where a competitor is stronger, we say so. This matri
 - **Multi-WAN with FIB isolation** — each WAN lives in its own FreeBSD FIB (just like a Juniper routing-instance). Gateway groups with failover, weighted load-balance, and MOS-weighted adaptive policies. Blast-radius preview shows which existing flows would migrate before you apply. No other open-source FreeBSD firewall does this.
 - **OPNsense config import** — drop-in migration. Parse the XML, preview the diff, apply atomically with rollback. Recently rewritten end-to-end (#230, #248–#252).
 - **Built-in reverse proxy + ACME** — TrafficCop runs HTTP, TCP, and UDP. ACME issuance pushes certs straight to the TLS store, file, or webhook. No HAProxy plugin install dance.
-- **AI/ML threat detection** — 5 built-in behavioural detectors (port scan, DDoS, brute force, C2 beacon, DNS tunneling) with auto-response and TTL blocks. Implemented in `aifw-ai/src/detectors/`.
+- **AI-assisted alert triage** — an LLM provider you configure reviews critical/high IDS alerts and classifies them with reasoning and an audit log. (Behavioural ML detectors are prototypes only — not wired in.)
 - **Sigma + YARA rule support** — modern rule formats neither OPNsense nor pfSense support (practical subsets mapped to network flows, not full engine parity). Parsers in `aifw-ids/src/rules/`.
 - **Commit confirm** — auto-rollback if you lock yourself out. Default 300-second timeout, cancellable via oneshot channel. Both competitors have this as a years-open feature request.
 - **Modern React/Next.js UI** — static export, no Node.js runtime on the appliance. Not PHP.

--- a/docs/docs/ids.md
+++ b/docs/docs/ids.md
@@ -84,25 +84,15 @@ Auto-update runs every **24 hours** by default (configurable per ruleset via `up
 
 Add additional rulesets (Abuse.ch, ET Pro, custom feeds) via `POST /api/v1/ids/rulesets`. Each ruleset gets its own URL, format (`suricata` / `sigma` / `yara`), enable flag, and update cadence.
 
-## AI threat detection
+## AI-assisted alert triage
 
-> **Status: opt-in / experimental.** The `aifw-ai` crate is a work in progress, disabled by default, and not yet production-ready. The Threats page in the UI marks this as WIP. See the README for the current framing.
+With an LLM provider configured under **Settings &rarr; AI**, AiFw periodically reviews unreviewed critical/high alerts (`POST /api/v1/ai/analyze` triggers a pass by hand) and records a classification plus reasoning on the **Threats** page; every call is logged at `GET /api/v1/ai/audit-log`. Without a provider nothing is called and the Threats page is a plain alert view.
 
-Five behavioural detectors run on flow features extracted from conntrack:
-
-| Detector | Trigger heuristic |
-|---|---|
-| **Port scan** | &geq; 15 unique destination ports with &geq; 60% failed connection ratio |
-| **DDoS / SYN flood** | &gt; 100 SYNs with &gt; 80% failure ratio, or sustained &gt; 50 conn/sec |
-| **Brute force** | &geq; 10 connections to &leq; 5 ports with &geq; 70% failure ratio |
-| **C2 beacon** | &geq; 5 connections to &leq; 2 destinations with low duration variance and small payloads |
-| **DNS tunneling** | &gt; 50 DNS queries with DNS / total connection ratio &gt; 80% |
-
-Thresholds are tuneable per-detector at construction time. Detectors emit `Threat` records with a 0..1 score, evidence string, and per-metric breakdown that the API surfaces alongside Suricata alerts.
+> **Behavioural ML detectors are not shipped.** The `aifw-ai` crate holds heuristic prototypes for port-scan, DDoS, brute-force, C2-beacon and DNS-tunnel detection, but it is not wired into the daemon or API &mdash; nothing on the appliance runs them and there is no setting that enables them ([#171](https://github.com/ZerosAndOnesLLC/AiFw/issues/171)). Reactive blocking on the box today comes from IDS rules and rate limits, not from these detectors.
 
 ## Alert management
 
-Every match &mdash; rule-driven or AI-detected &mdash; lands in the alerts table with severity, signature, source / destination, payload excerpt, and timestamp.
+Every match lands in the alerts table with severity, signature, source / destination, payload excerpt, and timestamp.
 
 ```bash
 curl https://aifw.local/api/v1/ids/alerts?limit=50 \
@@ -166,7 +156,6 @@ Suppressions are paginated: `GET /api/v1/ids/suppressions?limit=50&offset=0`.
 - [Firewall rules &rarr;]({{ '/docs/firewall/' | relative_url }})
 - [Auth &amp; RBAC &rarr;]({{ '/docs/auth/' | relative_url }})
 - Source: [`aifw-ids/src/`](https://github.com/ZerosAndOnesLLC/AiFw/tree/main/aifw-ids/src)
-- Source: [`aifw-ai/src/detectors/`](https://github.com/ZerosAndOnesLLC/AiFw/tree/main/aifw-ai/src/detectors)
 
 </article>
 </div>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,7 +26,7 @@ breadcrumb:
       "name": "Does AiFw require AI features to work?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "No. AiFw is a complete firewall, router, DHCP server, DNS resolver, IDS/IPS, reverse proxy, and NTP server without any AI features enabled. The five behavioural detectors in aifw-ai (port scan, DDoS, brute force, C2 beacon, DNS tunneling) are opt-in, experimental, and disabled by default."
+        "text": "No. AiFw is a complete firewall, router, DHCP server, DNS resolver, IDS/IPS, reverse proxy, and NTP server without any AI features enabled. The one AI feature that ships, LLM-assisted triage of critical/high IDS alerts, only runs when you configure a provider. Behavioural ML detectors exist only as unwired prototypes in the aifw-ai crate."
       }
     },
     { "@type": "Question", "name": "Can I import my existing OPNsense config?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. AiFw ships an OPNsense XML importer that parses your config, previews a diff of what will change, and applies atomically with rollback on failure. The importer was rewritten end-to-end in 2026 (PRs #230 and #248–#252)." } },
@@ -57,7 +57,7 @@ No. AiFw is a ground-up rewrite in Rust. It runs on FreeBSD and uses pf for pack
 
 ## Does AiFw require AI features to work?
 
-No. AiFw is a complete firewall, router, DHCP server, DNS resolver, IDS/IPS, reverse proxy, and NTP server without any AI features enabled. The five behavioural detectors in `aifw-ai` (port scan, DDoS, brute force, C2 beacon, DNS tunneling) are **opt-in, experimental, and disabled by default**. They will be developed further in future releases.
+No. AiFw is a complete firewall, router, DHCP server, DNS resolver, IDS/IPS, reverse proxy, and NTP server without any AI features enabled. The one AI feature that ships &mdash; LLM-assisted triage of critical/high IDS alerts &mdash; only runs when you configure a provider under Settings &rarr; AI. Behavioural ML detectors (port scan, DDoS, brute force, C2 beacon, DNS tunnelling) exist only as unwired prototypes in the `aifw-ai` crate; nothing on the appliance runs them.
 
 ## Can I import my existing OPNsense config?
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -102,17 +102,11 @@ IKEv2 **site-to-site** tunnels (tunnel mode) powered by strongSwan: charon negot
 - **Payload inspection** with multi-pattern detection
 - **Threshold-based detection**
 
-## AI threat detection
+## AI-assisted alert triage
 
-Five behavioural detectors run alongside signature-based IDS, implemented in `aifw-ai/src/detectors/`:
+Configure an LLM provider under **Settings → AI** (OpenAI, Anthropic, Ollama or any compatible endpoint; the key is sealed at rest) and AiFw periodically sends unreviewed critical/high IDS alerts for review. Each verdict — true positive, false positive, needs attention — lands on the **Threats** page with the model's reasoning, and every call is written to an audit log. Nothing leaves the box unless a provider is set.
 
-1. **Port scan** — flags sources with >15 unique ports hit and >60% failed-connection ratio
-2. **DDoS** — detects SYN floods and high connection rates (>50 conn/sec)
-3. **Brute force** — concentrated auth attacks: 10+ connections across 1–5 ports with >70% failure rate
-4. **C2 beacon** — low-variance periodic connections to single or few hosts
-5. **DNS tunneling** — anomalous DNS traffic patterns consistent with tunneled data
-
-Each detector produces a threat score (0.0–1.0 confidence) and severity classification. Auto-response actions include temporary IP blocks with configurable TTL, alert generation, and full audit trail of every decision.
+Behavioural ML detectors (port scan, DDoS, brute force, C2 beacon, DNS tunnelling) exist only as heuristic **prototypes** in the `aifw-ai` crate. They are not wired into the daemon or API, nothing on the appliance runs them, and there is no setting that enables them ([#171](https://github.com/ZerosAndOnesLLC/AiFw/issues/171)).
 
 ## DNS
 

--- a/docs/maturity.md
+++ b/docs/maturity.md
@@ -46,7 +46,8 @@ AiFw is in **active development (beta)**. This matrix is the honest, per-feature
 <tr><td>Backup / restore / OPNsense import</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="partial">⏳</td><td>Beta — pre-validated apply, single DB transaction, post-apply pf verification, snapshot rollback for kernel state (since v5.99.7; hardened for #535); kernel applies are still not transactional</td></tr>
 <tr><td>DHCP / DNS / NTP (companions)</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="partial">⏳</td><td>Beta — builds pinned to reviewed revisions since v5.99.8</td></tr>
 <tr><td>Reverse proxy + ACME (TrafficCop)</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="partial">⏳</td><td>Beta</td></tr>
-<tr><td>AI/ML threat detection</td><td class="yes">✓</td><td class="partial">⏳</td><td class="no">✗</td><td class="no">✗</td><td>Experimental, opt-in, disabled by default</td></tr>
+<tr><td>AI-assisted alert triage (LLM)</td><td class="yes">✓</td><td class="yes">✓</td><td class="partial">⏳</td><td class="no">✗</td><td>Off unless a provider is configured</td></tr>
+<tr><td>Behavioural ML threat detection</td><td class="partial">⏳</td><td class="no">✗</td><td class="no">✗</td><td class="no">✗</td><td>Prototype crate only — not wired into daemon/API (#171)</td></tr>
 <tr><td>Plugin system</td><td class="yes">✓</td><td class="partial">⏳</td><td class="no">✗</td><td class="no">✗</td><td>Beta — WASM planned</td></tr>
 </tbody>
 </table>


### PR DESCRIPTION
Closes #171 — takes the **gate it** option.

`aifw-ai` has zero dependents: no binary links it, nothing on the appliance runs the five heuristic detectors, and there is no setting that turns them on. Meanwhile README, features, IDS docs, the comparison table, the maturity matrix and the FAQ all advertised "five behavioural detectors with auto-response, disabled by default".

- `Cargo.toml`: `default-members` now excludes `aifw-ai`, so plain `cargo build` / `cargo test` skip it. `--workspace` and `-p aifw-ai` still build it, and CI (`clippy --workspace`, `test --workspace`) keeps it compiling and its 14 unit tests green, so the prototype doesn't rot.
- Crate docs state plainly that it is a prototype not wired into any binary.
- README / `docs/features.md` / `docs/docs/ids.md` / `docs/compare.md` / `docs/maturity.md` / `docs/faq.md`: the AI feature that ships is **LLM-assisted alert triage** (Settings → AI provider, Threats page, `/api/v1/ai/analyze` + `/ai/audit-log`); the ML detectors are described as unwired prototypes wherever they were previously listed as a feature. Comparison/maturity rows split into "AI-assisted alert triage ✓" and "Behavioural ML detection — prototype, not wired in".

Ship-MVP (wiring conntrack features → detectors → alerts) remains a future feature; when it lands, move the crate back into `default-members`.