### PR TITLE
feat(nat): explicit translated destination for nat46/nat64 (`af-to … to <dst>`) (#596)

### DIFF
--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -441,6 +441,7 @@ pub(crate) async fn capture_runtime_snapshot(state: &AppState) -> Result<String,
                 label: n.label.clone(),
                 status: n.status,
                 static_port: n.static_port,
+                af_to_dst: n.af_to_dst.as_ref().map(|a| a.to_string()),
             })
             .collect(),
         aliases,
@@ -746,6 +747,7 @@ pub(crate) async fn build_current_config(state: &AppState) -> Result<FirewallCon
                 label: n.label.clone(),
                 status: n.status,
                 static_port: n.static_port,
+                af_to_dst: n.af_to_dst.as_ref().map(|a| a.to_string()),
             })
             .collect(),
         queues: queues
@@ -2755,6 +2757,11 @@ fn nat_from_config(nc: &aifw_core::config::NatRuleConfig) -> Option<aifw_common:
         label: nc.label.clone(),
         status,
         static_port: nc.static_port,
+        af_to_dst: nc
+            .af_to_dst
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .and_then(|s| Address::parse(s).ok()),
         created_at: now,
         updated_at: now,
     })

--- a/aifw-api/src/opnsense/importer.rs
+++ b/aifw-api/src/opnsense/importer.rs
@@ -1290,6 +1290,7 @@ fn build_port_forward(
             label: n.descr.clone(),
             status: NatStatus::Active,
             static_port: false,
+            af_to_dst: None,
             created_at: now,
             updated_at: now,
         },
@@ -1348,6 +1349,7 @@ fn build_outbound(
         label: n.descr.clone(),
         status: NatStatus::Active,
         static_port,
+        af_to_dst: None,
         created_at: now,
         updated_at: now,
     })
@@ -1382,6 +1384,7 @@ fn build_one_to_one(
         label: n.descr.clone(),
         status: NatStatus::Active,
         static_port: false,
+        af_to_dst: None,
         created_at: now,
         updated_at: now,
     })

--- a/aifw-api/src/routes/nat.rs
+++ b/aifw-api/src/routes/nat.rs
@@ -27,6 +27,10 @@ pub struct CreateNatRuleRequest {
     /// only; #253). Defaults false.
     #[serde(default)]
     pub static_port: bool,
+    /// Explicit translated destination for nat46/nat64 (`af-to … to
+    /// <dst>`, #596). Empty/omitted keeps RFC 6052 embedding.
+    #[serde(default)]
+    pub af_to_dst: Option<String>,
 }
 
 pub async fn list_nat_rules(
@@ -119,6 +123,13 @@ pub async fn create_nat_rule(
     rule.dst_port = port_range(req.dst_port_start, req.dst_port_end);
     rule.label = req.label;
     rule.static_port = req.static_port;
+    rule.af_to_dst = match req.af_to_dst.as_deref().map(str::trim) {
+        Some(a) if !a.is_empty() => Some(
+            Address::parse(a)
+                .map_err(|e| nat_bad_request(format!("invalid translated destination: {e}")))?,
+        ),
+        _ => None,
+    };
 
     let rule = state
         .nat_engine
@@ -176,6 +187,13 @@ pub async fn update_nat_rule(
     };
     rule.label = req.label;
     rule.static_port = req.static_port;
+    rule.af_to_dst = match req.af_to_dst.as_deref().map(str::trim) {
+        Some(a) if !a.is_empty() => Some(
+            Address::parse(a)
+                .map_err(|e| nat_bad_request(format!("invalid translated destination: {e}")))?,
+        ),
+        _ => None,
+    };
     if let Some(ref s) = req.status {
         rule.status = match s.as_str() {
             "active" => NatStatus::Active,

--- a/aifw-cli/src/commands.rs
+++ b/aifw-cli/src/commands.rs
@@ -415,6 +415,7 @@ pub async fn nat_add(
     redirect_port: Option<&str>,
     label: Option<&str>,
     static_port: bool,
+    af_to_dst: Option<&str>,
 ) -> anyhow::Result<()> {
     let nat = create_nat_engine(db_path).await?;
 
@@ -433,6 +434,11 @@ pub async fn nat_add(
     rule.dst_port = dst_port.map(parse_port).transpose()?;
     rule.label = label.map(String::from);
     rule.static_port = static_port;
+    rule.af_to_dst = af_to_dst
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(Address::parse)
+        .transpose()?;
 
     let rule = nat.add_rule(rule).await.map_err(|e| {
         let msg = e.to_string();
@@ -470,6 +476,12 @@ fn nat_flag_hint(msg: &str) -> Option<&'static str> {
         Some("fix --src: it must match the rule's ingress family (IPv6 for nat64, IPv4 for nat46)")
     } else if msg.contains("static_port is only valid") {
         Some("drop --static-port — it only applies to --type snat / masquerade")
+    } else if msg.contains("af_to_dst (translated destination) is only valid") {
+        Some("drop --af-to-dst — it only applies to --type nat46 / nat64")
+    } else if msg.contains("translated destination must be a single") {
+        Some(
+            "--af-to-dst must be one host address in the translated family (IPv6 for nat46, IPv4 for nat64)",
+        )
     } else if msg.contains("no-nat rules") {
         Some("drop --redirect / --redirect-port — nonat exempts traffic and has no target")
     } else {
@@ -538,9 +550,14 @@ pub async fn nat_list(db_path: &Path, json: bool) -> anyhow::Result<()> {
                 .unwrap_or_default()
         );
         // Cross-family rules read as a direction, not an address rewrite.
+        let af_dst = rule
+            .af_to_dst
+            .as_ref()
+            .map(|d| format!(" to {d}"))
+            .unwrap_or_default();
         let redir = match rule.nat_type {
-            NatType::Nat64 => format!("v6->v4 via {}", rule.redirect.address),
-            NatType::Nat46 => format!("v4->v6 via {}", rule.redirect.address),
+            NatType::Nat64 => format!("v6->v4 via {}{af_dst}", rule.redirect.address),
+            NatType::Nat46 => format!("v4->v6 via {}{af_dst}", rule.redirect.address),
             NatType::NoNat => "(bypass — no NAT)".to_string(),
             NatType::Masquerade => format!("({})", rule.interface),
             _ => format!("{}", rule.redirect),

--- a/aifw-cli/src/main.rs
+++ b/aifw-cli/src/main.rs
@@ -918,6 +918,8 @@ EXAMPLES:
     },
 }
 
+// `Add` carries a dozen optional strings; same rationale as `IdsAction`.
+#[allow(clippy::large_enum_variant)]
 #[derive(Subcommand)]
 enum NatAction {
     /// Add a NAT rule
@@ -995,6 +997,12 @@ EXAMPLES:
         /// source port is rewritten.
         #[arg(long)]
         static_port: bool,
+
+        /// nat46/nat64 only: explicit translated destination (pf `af-to …
+        /// to <addr>`), e.g. the IPv6 address a nat46 target server really
+        /// listens on. Omit to use the RFC 6052 embedded address.
+        #[arg(long, value_name = "ADDR")]
+        af_to_dst: Option<String>,
     },
     /// Remove a NAT rule by ID
     Remove {
@@ -1213,6 +1221,7 @@ async fn main() -> anyhow::Result<()> {
                 redirect_port,
                 label,
                 static_port,
+                af_to_dst,
             } => {
                 // Smart default: nat64 practically always matches the
                 // well-known prefix; every other type keeps "any".
@@ -1249,6 +1258,7 @@ async fn main() -> anyhow::Result<()> {
                     redirect_port.as_deref(),
                     label.as_deref(),
                     static_port,
+                    af_to_dst.as_deref(),
                 )
                 .await?;
             }

--- a/aifw-common/src/nat.rs
+++ b/aifw-common/src/nat.rs
@@ -120,6 +120,14 @@ pub struct NatRule {
     /// the source port is rewritten. Ignored for other NAT types (#253).
     #[serde(default)]
     pub static_port: bool,
+    /// Explicit translated destination for cross-family rules (pf `af-to
+    /// <af> from <src> to <dst>`). NAT46: the IPv6 host the IPv4 destination
+    /// is rewritten to, so a rule can reach a server that does not hold the
+    /// RFC 6052 embedded address; NAT64: the IPv4 host instead of the one
+    /// embedded in the matched /96. `None` keeps pf's default embedding.
+    /// Ignored for other NAT types (#596).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub af_to_dst: Option<Address>,
     /// Creation timestamp (UTC)
     pub created_at: DateTime<Utc>,
     /// Last modification timestamp (UTC)
@@ -151,6 +159,7 @@ impl NatRule {
             label: None,
             status: NatStatus::Active,
             static_port: false,
+            af_to_dst: None,
             created_at: now,
             updated_at: now,
         }
@@ -264,12 +273,13 @@ impl NatRule {
     /// is required because the main ruleset's default policy follows the
     /// anchor hooks and would otherwise override the pass (last-match wins).
     /// The translated destination is the IPv4 embedded in the low 32 bits of
-    /// the matched /96 prefix (RFC 6052).
+    /// the matched /96 prefix (RFC 6052), or [`Self::af_to_dst`] when set.
     fn to_pf_nat64(&self) -> String {
         let mut parts = vec![format!("pass in quick on {} inet6", self.interface)];
         self.push_af_proto(&mut parts, true);
         self.push_from_to(&mut parts);
         parts.push(format!("af-to inet from {}", self.redirect.address));
+        self.push_af_to_dst(&mut parts);
         self.push_filter_label(&mut parts);
         parts.join(" ")
     }
@@ -278,14 +288,24 @@ impl NatRule {
     /// `pass in quick on <iface> inet [proto <p>] from <src> to <v4-dst> af-to inet6 from <v6-src> [label "..."]`
     ///
     /// The translated destination defaults to the RFC 6052 embedding of the
-    /// original IPv4 destination in the /96 subnet of the new IPv6 source.
+    /// original IPv4 destination in the /96 subnet of the new IPv6 source;
+    /// [`Self::af_to_dst`] overrides it with an explicit `to <v6-dst>` (#596).
     fn to_pf_nat46(&self) -> String {
         let mut parts = vec![format!("pass in quick on {} inet", self.interface)];
         self.push_af_proto(&mut parts, false);
         self.push_from_to(&mut parts);
         parts.push(format!("af-to inet6 from {}", self.redirect.address));
+        self.push_af_to_dst(&mut parts);
         self.push_filter_label(&mut parts);
         parts.join(" ")
+    }
+
+    /// `to <dst>` clause of an `af-to` translation when an explicit
+    /// translated destination is set.
+    fn push_af_to_dst(&self, parts: &mut Vec<String>) {
+        if let Some(dst) = &self.af_to_dst {
+            parts.push(format!("to {dst}"));
+        }
     }
 
     fn push_proto(&self, parts: &mut Vec<String>) {

--- a/aifw-common/src/tests.rs
+++ b/aifw-common/src/tests.rs
@@ -501,6 +501,20 @@ mod tests {
             rule.to_pf_rule(),
             "pass in quick on em1 inet from any to 10.99.1.1 af-to inet6 from 2001:db8:2::1"
         );
+        // #596: explicit translated destination renders as `to <v6>`
+        rule.af_to_dst = Some(Address::Single(IpAddr::V6(
+            "2001:db8:2::80".parse().unwrap(),
+        )));
+        assert_eq!(
+            rule.to_pf_rule(),
+            "pass in quick on em1 inet from any to 10.99.1.1 af-to inet6 from 2001:db8:2::1 to 2001:db8:2::80"
+        );
+        rule.label = Some("v4-to-v6-web".into());
+        assert!(
+            rule.to_pf_rule().ends_with(
+                "af-to inet6 from 2001:db8:2::1 to 2001:db8:2::80 label \"v4-to-v6-web\""
+            )
+        );
     }
 
     #[test]

--- a/aifw-core/src/config.rs
+++ b/aifw-core/src/config.rs
@@ -522,6 +522,10 @@ pub struct NatRuleConfig {
     /// snapshots taken before the field existed still load.
     #[serde(default)]
     pub static_port: bool,
+    /// Explicit `af-to … to <dst>` translated destination on nat46/nat64
+    /// rules (#596); `None` = RFC 6052 embedding.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub af_to_dst: Option<String>,
 }
 
 /// A traffic-shaping queue as stored in a config snapshot

--- a/aifw-core/src/nat.rs
+++ b/aifw-core/src/nat.rs
@@ -90,6 +90,18 @@ impl NatEngine {
                 .execute(&self.pool)
                 .await?;
         }
+        // #596: explicit af-to translated destination (NAT46/NAT64).
+        let has_af_to_dst: bool = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM pragma_table_info('nat_rules') WHERE name = 'af_to_dst'",
+        )
+        .fetch_one(&self.pool)
+        .await?
+            > 0;
+        if !has_af_to_dst {
+            sqlx::query("ALTER TABLE nat_rules ADD COLUMN af_to_dst TEXT")
+                .execute(&self.pool)
+                .await?;
+        }
 
         Ok(())
     }
@@ -168,7 +180,8 @@ impl NatEngine {
                 src_addr = ?5, src_port_start = ?6, src_port_end = ?7,
                 dst_addr = ?8, dst_port_start = ?9, dst_port_end = ?10,
                 redirect_addr = ?11, redirect_port_start = ?12, redirect_port_end = ?13,
-                label = ?14, status = ?15, updated_at = ?16, static_port = ?17
+                label = ?14, status = ?15, updated_at = ?16, static_port = ?17,
+                af_to_dst = ?18
             WHERE id = ?1
             "#,
         )
@@ -192,6 +205,7 @@ impl NatEngine {
         })
         .bind(chrono::Utc::now().to_rfc3339())
         .bind(rule.static_port as i64)
+        .bind(rule.af_to_dst.as_ref().map(|a| a.to_string()))
         .execute(&mut *tx)
         .await?;
 
@@ -391,8 +405,8 @@ impl NatEngine {
             INSERT INTO nat_rules (id, nat_type, interface, protocol, src_addr,
                 src_port_start, src_port_end, dst_addr, dst_port_start, dst_port_end,
                 redirect_addr, redirect_port_start, redirect_port_end,
-                label, status, created_at, updated_at, static_port)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
+                label, status, created_at, updated_at, static_port, af_to_dst)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)
             "#,
         )
         .bind(rule.id.to_string())
@@ -416,6 +430,7 @@ impl NatEngine {
         .bind(rule.created_at.to_rfc3339())
         .bind(rule.updated_at.to_rfc3339())
         .bind(rule.static_port as i64)
+        .bind(rule.af_to_dst.as_ref().map(|a| a.to_string()))
         .execute(exec)
         .await?;
 
@@ -467,6 +482,12 @@ pub fn validate_nat_rule(rule: &NatRule) -> Result<()> {
     if rule.static_port && !matches!(rule.nat_type, NatType::Snat | NatType::Masquerade) {
         return Err(AifwError::Validation(
             "static_port is only valid for SNAT and masquerade rules".to_string(),
+        ));
+    }
+    if rule.af_to_dst.is_some() && !matches!(rule.nat_type, NatType::Nat46 | NatType::Nat64) {
+        return Err(AifwError::Validation(
+            "af_to_dst (translated destination) is only valid for nat46 and nat64 rules"
+                .to_string(),
         ));
     }
     // #253: `no nat` has no translation target.
@@ -548,6 +569,19 @@ fn validate_af_to(rule: &NatRule, inet6_match: bool) -> Result<()> {
         }
     }
 
+    // Optional explicit translated destination (#596): a single concrete
+    // host in the translated family (pf: `af-to <af> from <src> to <dst>`).
+    if let Some(dst) = &rule.af_to_dst {
+        match (dst, dst.is_ipv6()) {
+            (Address::Single(_), Some(v6)) if v6 != inet6_match => {}
+            _ => {
+                return Err(AifwError::Validation(format!(
+                    "{kind} translated destination must be a single {translated} address (or empty for RFC 6052 embedding)"
+                )));
+            }
+        }
+    }
+
     // af-to has no port-rewrite syntax.
     if rule.redirect.port.is_some() {
         return Err(AifwError::Validation(format!(
@@ -564,7 +598,7 @@ fn validate_af_to(rule: &NatRule, inet6_match: bool) -> Result<()> {
 const NAT_RULE_COLUMNS: &str = "id, nat_type, interface, protocol, src_addr, \
     src_port_start, src_port_end, dst_addr, dst_port_start, dst_port_end, \
     redirect_addr, redirect_port_start, redirect_port_end, label, status, \
-    created_at, updated_at, static_port";
+    created_at, updated_at, static_port, af_to_dst";
 
 #[derive(sqlx::FromRow)]
 struct NatRuleRow {
@@ -586,6 +620,7 @@ struct NatRuleRow {
     created_at: String,
     updated_at: String,
     static_port: i64,
+    af_to_dst: Option<String>,
 }
 
 impl NatRuleRow {
@@ -620,6 +655,12 @@ impl NatRuleRow {
                 _ => NatStatus::Disabled,
             },
             static_port: self.static_port != 0,
+            af_to_dst: self
+                .af_to_dst
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .map(Address::parse)
+                .transpose()?,
             created_at: DateTime::parse_from_rfc3339(&self.created_at)
                 .map_err(|e| AifwError::Database(format!("invalid date: {e}")))?
                 .with_timezone(&Utc),

--- a/aifw-core/src/tests.rs
+++ b/aifw-core/src/tests.rs
@@ -819,6 +819,62 @@ mod tests {
             203, 0, 113, 1,
         )));
         assert!(engine.add_rule(rule).await.is_err());
+
+        // #596: explicit translated destination must be a single IPv6 host
+        let mut rule = make();
+        rule.af_to_dst = Some(Address::Single(std::net::IpAddr::V4(
+            std::net::Ipv4Addr::new(192, 0, 2, 80),
+        )));
+        assert!(engine.add_rule(rule).await.is_err());
+        let mut rule = make();
+        rule.af_to_dst = Some(Address::Network(
+            std::net::IpAddr::V6("2001:db8:2::".parse().unwrap()),
+            64,
+        ));
+        assert!(engine.add_rule(rule).await.is_err());
+        let mut rule = make();
+        rule.af_to_dst = Some(Address::Single(std::net::IpAddr::V6(
+            "2001:db8:2::80".parse().unwrap(),
+        )));
+        let added = engine.add_rule(rule).await.unwrap();
+        // round-trips through SQLite
+        let stored = engine
+            .list_rules()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|r| r.id == added.id)
+            .unwrap();
+        assert_eq!(
+            stored.af_to_dst,
+            Some(Address::Single(std::net::IpAddr::V6(
+                "2001:db8:2::80".parse().unwrap()
+            )))
+        );
+        assert!(
+            stored
+                .to_pf_rule()
+                .ends_with("af-to inet6 from 2001:db8:2::1 to 2001:db8:2::80")
+        );
+
+        // af_to_dst is meaningless on other NAT types
+        let mut snat = NatRule::new(
+            NatType::Snat,
+            Interface("em0".to_string()),
+            Protocol::Any,
+            Address::Any,
+            Address::Any,
+            NatRedirect {
+                address: Address::Single(std::net::IpAddr::V4(std::net::Ipv4Addr::new(
+                    203, 0, 113, 1,
+                ))),
+                port: None,
+            },
+        );
+        snat.af_to_dst = Some(Address::Single(std::net::IpAddr::V6(
+            "2001:db8:2::80".parse().unwrap(),
+        )));
+        assert!(engine.add_rule(snat).await.is_err());
     }
 
     // --- Shaping engine tests ---

--- a/aifw-ui/src/app/nat/page.tsx
+++ b/aifw-ui/src/app/nat/page.tsx
@@ -27,6 +27,7 @@ const defaultForm = {
   label: "",
   status: "active",
   static_port: false,
+  af_to_dst: "",
 };
 
 type FormState = typeof defaultForm;
@@ -117,6 +118,7 @@ export default function NatPage() {
       label: rule.label || "",
       status: rule.status,
       static_port: Boolean(rule.static_port),
+      af_to_dst: rule.af_to_dst || "",
     });
     setEditingId(rule.id);
     setShowForm(true);
@@ -132,6 +134,7 @@ export default function NatPage() {
       redirect_addr: NO_TARGET_TYPES.has(form.nat_type) ? "any" : form.redirect_addr,
       static_port: STATIC_PORT_TYPES.has(form.nat_type) && form.static_port,
     };
+    if (isCrossFamily(form.nat_type) && form.af_to_dst.trim()) body.af_to_dst = form.af_to_dst.trim();
 
     if (form.src_port_start) body.src_port_start = parseInt(form.src_port_start, 10);
     if (form.dst_port_start) body.dst_port_start = parseInt(form.dst_port_start, 10);
@@ -185,6 +188,7 @@ export default function NatPage() {
         redirect_port_start: rule.redirect?.port?.start,
         label: rule.label || undefined,
         static_port: rule.static_port,
+        af_to_dst: rule.af_to_dst || undefined,
         status: newStatus,
       } as UpdateNatRequest);
       setNatRules((prev) =>
@@ -391,6 +395,26 @@ export default function NatPage() {
                 {!fieldErrors.redirect && meta.redirectHelp && (
                   <p className="mt-1 text-[11px] text-gray-500">{meta.redirectHelp}</p>
                 )}
+                {/* Explicit translated destination — af-to "to <dst>" (#596) */}
+                {isCrossFamily(form.nat_type) && (
+                  <div className="mt-3">
+                    <label className={labelCls}>
+                      Translated destination <span className="text-gray-500 font-normal">(optional)</span>
+                    </label>
+                    <input
+                      type="text"
+                      value={form.af_to_dst}
+                      onChange={(e) => updateField("af_to_dst", e.target.value)}
+                      placeholder={form.nat_type === "nat46" ? "e.g. 2001:db8:2::80" : "e.g. 192.0.2.80"}
+                      className={inputCls}
+                    />
+                    <p className="mt-1 text-[11px] text-gray-500">
+                      {form.nat_type === "nat46"
+                        ? "IPv6 host the IPv4 destination is rewritten to. Leave empty to embed the IPv4 destination in the translation source's /96 (RFC 6052) — the server must then answer on that embedded address."
+                        : "IPv4 host to send to instead of the address embedded in the matched /96 prefix. Leave empty for RFC 6052 embedding."}
+                    </p>
+                  </div>
+                )}
               </div>
             ) : (
               <div>
@@ -533,6 +557,12 @@ export default function NatPage() {
                             {directionSummary(rule.nat_type)}{" "}
                             <span className="text-gray-500">via</span>{" "}
                             <span className="text-green-400">{rule.redirect?.address || "-"}</span>
+                            {rule.af_to_dst && (
+                              <>
+                                {" "}<span className="text-gray-500">to</span>{" "}
+                                <span className="text-green-400">{rule.af_to_dst}</span>
+                              </>
+                            )}
                           </span>
                         ) : rule.nat_type === "nonat" ? (
                           <span className="font-mono text-xs text-gray-400 italic">no NAT (bypass)</span>

--- a/aifw-ui/src/lib/api.ts
+++ b/aifw-ui/src/lib/api.ts
@@ -348,6 +348,8 @@ export interface NatRule {
   status: string;
   /** pf static-port: keep the original source port (snat/masquerade only). */
   static_port: boolean;
+  /** nat46/nat64: explicit `af-to … to <dst>` translated destination; absent = RFC 6052 embedding. */
+  af_to_dst?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -369,6 +371,8 @@ export interface CreateNatRequest {
   label?: string;
   status?: string;
   static_port?: boolean;
+  /** nat46/nat64 only: explicit translated destination. */
+  af_to_dst?: string;
 }
 
 export interface UpdateNatRequest extends CreateNatRequest {

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -133,6 +133,11 @@ aifw nat add \
 # NAT64 — IPv6-only clients reach IPv4 hosts (dst defaults to 64:ff9b::/96)
 aifw nat add --nat-type nat64 --interface em1 --redirect 203.0.113.1
 
+# NAT46 — IPv4 clients reach an IPv6 server on the address it already has
+# (omit --af-to-dst to use the RFC 6052 embedded address instead)
+aifw nat add --nat-type nat46 --interface em0 --dst 192.0.2.80 \
+  --redirect 2001:db8:2::1 --af-to-dst 2001:db8:2::80
+
 # Print the RFC 6052 embedded address clients use for an IPv4 host
 aifw nat embed 64:ff9b::/96 10.1.2.3     # -> 64:ff9b::a01:203
 ```

--- a/docs/docs/nat.md
+++ b/docs/docs/nat.md
@@ -164,13 +164,22 @@ Let IPv4-only clients reach an IPv6 service. Compiles to the opposite `af-to` di
 pass in quick on em0 inet from any to 192.0.2.80 af-to inet6 from 2001:db8:2::1
 ```
 
-Field mapping: `src_addr`/`dst_addr` are IPv4 (a concrete destination is required); `redirect.address` is a single IPv6 host the firewall owns. The translated destination is the IPv4 destination embedded in the /96 subnet of that IPv6 source (RFC 6052) &mdash; so the IPv6 server must answer on the embedded address (`192.0.2.80` under `2001:db8:2::/96` &rarr; `2001:db8:2::c000:250`; check with `aifw nat embed`). An explicit arbitrary-destination field is tracked as a follow-up. NAT46 is uncommon on most firewall distros &mdash; AiFw exposes it as a first-class rule type.
+Field mapping: `src_addr`/`dst_addr` are IPv4 (a concrete destination is required); `redirect.address` is a single IPv6 host the firewall owns. By default the translated destination is the IPv4 destination embedded in the /96 subnet of that IPv6 source (RFC 6052) &mdash; so the IPv6 server must answer on the embedded address (`192.0.2.80` under `2001:db8:2::/96` &rarr; `2001:db8:2::c000:250`; check with `aifw nat embed`).
+
+To reach an IPv6 server on an address it already has, set **`af_to_dst`** (UI: *Translated destination*, CLI: `--af-to-dst`) to that single IPv6 host; pf then rewrites the destination explicitly:
+
+```
+pass in quick on em0 inet from any to 192.0.2.80 af-to inet6 from 2001:db8:2::1 to 2001:db8:2::80
+```
 
 ```json
 { "nat_type": "nat46", "interface": "em0",
   "src_addr": "any", "dst_addr": "192.0.2.80",
-  "redirect": { "address": "2001:db8:2::1" } }
+  "redirect": { "address": "2001:db8:2::1" },
+  "af_to_dst": "2001:db8:2::80" }
 ```
+
+`af_to_dst` works the same way on NAT64 rules (a single IPv4 host instead of the address embedded in the /96), and is rejected on every other NAT type. NAT46 is uncommon on most firewall distros &mdash; AiFw exposes it as a first-class rule type.
 
 Cross-family notes (both types): `af-to` translates addresses, not ports (`redirect.port` is rejected); rules apply to inbound traffic on the selected interface; pf tables aren't allowed on the matched side (family must be concrete); requires FreeBSD 15+ (every AiFw appliance image ships on 15.x).
 

--- a/freebsd/tests/lib.sh
+++ b/freebsd/tests/lib.sh
@@ -149,6 +149,22 @@ client_send_udp() { # $1 = host, $2 = port
     printf 'aifw-functional-udp\n' | jx_client nc -u -w 2 "$1" "$2" >/dev/null 2>&1
 }
 
+# Wait until something in the server jail is listening on a TCP port. The
+# one-shot `nc -l` listeners above start in the background; connecting
+# before they bind gets an RST and a spurious "cannot reach" (seen on the
+# nat46 leg of t09).
+wait_for_listener() { # $1 = port, $2 = seconds
+    _i=0
+    while [ "$_i" -lt "$(( $2 * 5 ))" ]; do
+        # LOCAL ADDRESS column reads `*:8093` / `[::1]:8093`, followed by
+        # the FOREIGN ADDRESS column.
+        jx_server sockstat -l -P tcp 2>/dev/null | grep -qE ":$1[[:space:]]" && return 0
+        sleep 0.2
+        _i=$((_i + 1))
+    done
+    return 1
+}
+
 wait_for_file() { # $1 = jail (client|server), $2 = file, $3 = seconds
     _i=0
     while [ "$_i" -lt "$3" ]; do

--- a/freebsd/tests/lib.sh
+++ b/freebsd/tests/lib.sh
@@ -137,6 +137,9 @@ client_can_reach() { # $1 = host, $2 = port
 # marker file when a connection arrives.
 server_listen_once() { # $1 = port, $2 = marker file
     jx_server sh -c "rm -f '$2'; (nc -l '$1' >/dev/null 2>&1 && touch '$2') &"
+    # Don't return before the port is actually bound — a SYN that beats the
+    # bind is RST'd and the caller reports a bogus "cannot reach".
+    wait_for_listener "$1" 5 || log "warning: listener on :$1 not visible after 5s"
 }
 
 # One-shot UDP listener for packet-path tests. UDP has no connection refusal,

--- a/freebsd/tests/t09-nat64.sh
+++ b/freebsd/tests/t09-nat64.sh
@@ -24,6 +24,7 @@ jx_client route -q add -inet6 "$NAT64_PREFIX" "$CLIENT6_NET_HOST" >/dev/null 2>&
 PORT=8091
 MARKER=/tmp/aifwfx-t09-tcp-marker
 server_listen_once $PORT $MARKER
+wait_for_listener $PORT 5 || fail "nat64 tcp: server listener on :$PORT never came up"
 if client_can_reach "$SERVER_IP_EMBEDDED" $PORT; then
     wait_for_file server $MARKER 5 || fail "nat64 tcp: connected but server never saw it"
 else
@@ -67,6 +68,7 @@ MARKER46=/tmp/aifwfx-t09-nat46-marker
 # Explicit -6: plain `nc -l` binds the IPv4 wildcard only, so the translated
 # IPv6 SYN would be RST'd and the test would fail with no listener at fault.
 jx_server sh -c "rm -f '$MARKER46'; (nc -6 -l '$PORT46' >/dev/null 2>&1 && touch '$MARKER46') &"
+wait_for_listener $PORT46 5 || fail "nat46 tcp: server listener on :$PORT46 never came up"
 if client_can_reach "$NAT46_V4" $PORT46; then
     wait_for_file server $MARKER46 5 || fail "nat46 tcp: connected but server never saw it"
 else

--- a/freebsd/tests/t09-nat64.sh
+++ b/freebsd/tests/t09-nat64.sh
@@ -24,7 +24,6 @@ jx_client route -q add -inet6 "$NAT64_PREFIX" "$CLIENT6_NET_HOST" >/dev/null 2>&
 PORT=8091
 MARKER=/tmp/aifwfx-t09-tcp-marker
 server_listen_once $PORT $MARKER
-wait_for_listener $PORT 5 || fail "nat64 tcp: server listener on :$PORT never came up"
 if client_can_reach "$SERVER_IP_EMBEDDED" $PORT; then
     wait_for_file server $MARKER 5 || fail "nat64 tcp: connected but server never saw it"
 else


### PR DESCRIPTION
Closes #596.

A nat46 rule translated the IPv4 destination into the /96 of the IPv6 translation source (RFC 6052), so the target server had to hold that embedded address. pf's `af-to` supports an explicit destination (`af-to inet6 from <src> to <dst>`); the rule model now exposes it.

- `NatRule.af_to_dst: Option<Address>` (serde default / skipped when unset; `nat_rules.af_to_dst` column added with the same probe-then-ALTER pattern as `static_port`; `NatRuleConfig.af_to_dst` in exports/snapshots).
- Render: `pass in quick on em0 inet from any to 192.0.2.80 af-to inet6 from 2001:db8:2::1 to 2001:db8:2::80`. Works symmetrically on nat64 (explicit IPv4 host instead of the /96-embedded one).
- Validation: must be a single host in the translated family (IPv6 for nat46, IPv4 for nat64); rejected on every other NAT type.
- API `POST/PUT /nat` accept `af_to_dst`; CLI `aifw nat add --af-to-dst <ADDR>` (+ hint text on validation errors, shown in `aifw nat list`); UI NAT form shows a *Translated destination* field for cross-family types with per-type help, table shows `v4->v6 via <src> to <dst>`.
- Tests: pf render (with/without label), validation (wrong family, network, wrong NAT type), SQLite round-trip. Docs: nat.md, cli.md.