### PR TITLE
feat(auth): finish OAuth2/OIDC login — code exchange, PKCE, account linking, TOTP step, SSO UI (#170)

### DIFF
--- a/aifw-api/Cargo.toml
+++ b/aifw-api/Cargo.toml
@@ -37,6 +37,8 @@ dashmap = "6"
 nix = { workspace = true }
 libc = { workspace = true }
 reqwest = { workspace = true }
+url = { workspace = true }
+base64 = { workspace = true }
 async-stream = "0.3"
 futures-util = "0.3"
 redis = { version = "1.6", features = ["tokio-comp", "connection-manager"] }

--- a/aifw-api/src/auth/migrate.rs
+++ b/aifw-api/src/auth/migrate.rs
@@ -104,6 +104,9 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
         .execute(pool)
         .await?;
 
+    // #170: PKCE/redirect columns on oauth_states + TOTP-pending tickets.
+    super::oauth_flow::migrate(pool).await?;
+
     // Add role and enabled columns if they don't exist
     let _ = sqlx::query("ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'admin'")
         .execute(pool)

--- a/aifw-api/src/auth/mod.rs
+++ b/aifw-api/src/auth/mod.rs
@@ -12,6 +12,7 @@ pub mod jwt_key;
 pub mod middleware;
 pub mod migrate;
 pub mod oauth;
+pub mod oauth_flow;
 pub mod password;
 pub mod revocation;
 pub mod tokens;

--- a/aifw-api/src/auth/oauth.rs
+++ b/aifw-api/src/auth/oauth.rs
@@ -75,18 +75,6 @@ impl OAuthProvider {
             created_at: Utc::now().to_rfc3339(),
         }
     }
-
-    /// Build the authorization URL with state parameter
-    pub fn authorize_url(&self, redirect_uri: &str, state: &str) -> String {
-        format!(
-            "{}?client_id={}&redirect_uri={}&response_type=code&scope={}&state={}",
-            self.auth_url,
-            url_encode(&self.client_id),
-            url_encode(redirect_uri),
-            url_encode(&self.scopes),
-            url_encode(state),
-        )
-    }
 }
 
 // ============================================================
@@ -180,14 +168,31 @@ pub async fn delete_provider(pool: &SqlitePool, id: Uuid) -> Result<(), String> 
 /// while keeping the store self-cleaning.
 const OAUTH_STATE_TTL_SECS: i64 = 600;
 
-/// Persist a freshly-issued `state` nonce bound to a provider.
-pub async fn save_state(pool: &SqlitePool, state: &str, provider: &str) -> Result<(), String> {
+/// What was stored alongside a `state` nonce at authorize time (#170).
+#[derive(Debug, Clone)]
+pub struct PendingAuthorize {
+    /// PKCE code verifier to send with the token exchange.
+    pub code_verifier: String,
+    /// Exact redirect URI used in the authorize request (must repeat).
+    pub redirect_uri: String,
+}
+
+/// Persist a freshly-issued `state` nonce bound to a provider, together
+/// with the PKCE verifier and redirect URI the callback must reuse.
+pub async fn save_state(
+    pool: &SqlitePool,
+    state: &str,
+    provider: &str,
+    pending: &PendingAuthorize,
+) -> Result<(), String> {
     sqlx::query(
-        "INSERT OR REPLACE INTO oauth_states (state, provider, created_at) VALUES (?1, ?2, ?3)",
+        "INSERT OR REPLACE INTO oauth_states (state, provider, created_at, code_verifier, redirect_uri) VALUES (?1, ?2, ?3, ?4, ?5)",
     )
     .bind(state)
     .bind(provider)
     .bind(Utc::now().to_rfc3339())
+    .bind(&pending.code_verifier)
+    .bind(&pending.redirect_uri)
     .execute(pool)
     .await
     .map_err(|e| format!("db error: {e}"))?;
@@ -196,9 +201,13 @@ pub async fn save_state(pool: &SqlitePool, state: &str, provider: &str) -> Resul
 
 /// Consume a `state` nonce at the callback: it must exist, match the
 /// provider, and be unexpired. The row is deleted so a nonce is single-use
-/// (replay-proof). Returns true iff the state was valid. Expired rows are
-/// swept opportunistically.
-pub async fn consume_state(pool: &SqlitePool, state: &str, provider: &str) -> bool {
+/// (replay-proof). Returns what was stored at authorize time iff the state
+/// was valid. Expired rows are swept opportunistically.
+pub async fn consume_state(
+    pool: &SqlitePool,
+    state: &str,
+    provider: &str,
+) -> Option<PendingAuthorize> {
     // Best-effort GC of stale nonces.
     let cutoff = (Utc::now() - chrono::Duration::seconds(OAUTH_STATE_TTL_SECS)).to_rfc3339();
     let _ = sqlx::query("DELETE FROM oauth_states WHERE created_at < ?1")
@@ -206,32 +215,25 @@ pub async fn consume_state(pool: &SqlitePool, state: &str, provider: &str) -> bo
         .execute(pool)
         .await;
 
-    let row = sqlx::query_as::<_, (String, String)>(
-        "DELETE FROM oauth_states WHERE state = ?1 RETURNING provider, created_at",
+    let row = sqlx::query_as::<_, (String, String, Option<String>, Option<String>)>(
+        "DELETE FROM oauth_states WHERE state = ?1 RETURNING provider, created_at, code_verifier, redirect_uri",
     )
     .bind(state)
     .fetch_optional(pool)
     .await
     .unwrap_or(None);
 
-    match row {
-        Some((row_provider, created_at)) => {
-            let fresh = chrono::DateTime::parse_from_rfc3339(&created_at)
-                .map(|c| (Utc::now() - c.with_timezone(&Utc)).num_seconds() <= OAUTH_STATE_TTL_SECS)
-                .unwrap_or(false);
-            fresh && row_provider.eq_ignore_ascii_case(provider)
-        }
-        None => false,
+    let (row_provider, created_at, verifier, redirect_uri) = row?;
+    let fresh = chrono::DateTime::parse_from_rfc3339(&created_at)
+        .map(|c| (Utc::now() - c.with_timezone(&Utc)).num_seconds() <= OAUTH_STATE_TTL_SECS)
+        .unwrap_or(false);
+    if !(fresh && row_provider.eq_ignore_ascii_case(provider)) {
+        return None;
     }
-}
-
-fn url_encode(s: &str) -> String {
-    s.replace(' ', "+")
-        .replace(':', "%3A")
-        .replace('/', "%2F")
-        .replace('@', "%40")
-        .replace('&', "%26")
-        .replace('=', "%3D")
+    Some(PendingAuthorize {
+        code_verifier: verifier.unwrap_or_default(),
+        redirect_uri: redirect_uri.unwrap_or_default(),
+    })
 }
 
 // ============================================================
@@ -258,6 +260,34 @@ pub struct AuthorizeResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct CallbackQuery {
+    #[serde(default)]
     pub code: String,
+    #[serde(default)]
     pub state: String,
+    /// Provider-side denial (`access_denied`, …).
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// Body of `POST /auth/oauth/totp` — finish a TOTP-gated OAuth login.
+#[derive(Debug, Deserialize)]
+pub struct OAuthTotpRequest {
+    pub ticket: String,
+    pub totp_code: String,
+}
+
+/// Public login options for the sign-in page (no secrets).
+#[derive(Debug, Serialize)]
+pub struct LoginOption {
+    pub name: String,
+    pub provider_type: OAuthProviderType,
+}
+
+/// `GET/PUT /auth/oauth/settings`.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OAuthSettings {
+    /// Externally reachable base URL used to build the callback redirect
+    /// URI; empty ⇒ derived from the request `Host`.
+    #[serde(default)]
+    pub public_url: String,
 }

--- a/aifw-api/src/auth/oauth_flow.rs
+++ b/aifw-api/src/auth/oauth_flow.rs
@@ -1,0 +1,670 @@
+//! OAuth 2.0 / OIDC login flow (#170): authorization-code exchange with
+//! PKCE, userinfo lookup, local-account resolution and the optional TOTP
+//! second step.
+//!
+//! Provider *configuration* and the CSRF `state` store live in
+//! [`super::oauth`]; this module is the runtime that turns a provider
+//! callback into an AiFw session.
+//!
+//! # Flow
+//! 1. `GET /auth/oauth/{provider}/authorize` — mint `state` + PKCE
+//!    verifier, persist both, return the provider's authorization URL.
+//! 2. Browser → provider consent → `GET /auth/oauth/{provider}/callback
+//!    ?code=&state=`.
+//! 3. [`exchange_code`] posts the code (+ verifier) to the token endpoint,
+//!    [`fetch_identity`] reads the userinfo endpoint (GitHub: plus
+//!    `/user/emails` when the profile hides the address).
+//! 4. [`resolve_user`] maps the identity to a local account: an existing
+//!    `oauth_identities` link wins; otherwise a *verified* email matching a
+//!    local username links that account; otherwise `auto_create_oauth_users`
+//!    provisions a `viewer` with an unusable password.
+//! 5. If `require_totp_for_oauth` and the account has TOTP enrolled, a
+//!    single-use pending ticket sends the browser to the TOTP prompt
+//!    (`POST /auth/oauth/totp`); else the session is issued straight away.
+
+use std::time::Duration;
+
+use axum::http::HeaderMap;
+use base64::Engine as _;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use sqlx::SqlitePool;
+use uuid::Uuid;
+
+use super::oauth::{OAuthProvider, OAuthProviderType};
+use super::types::User;
+
+/// How long a TOTP-pending ticket stays valid.
+const PENDING_TTL_SECS: i64 = 300;
+/// Timeout for each provider HTTP call.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(15);
+/// `auth_config` key holding the externally reachable base URL used to
+/// build the callback redirect URI (e.g. `https://fw.example.com:8080`).
+pub const PUBLIC_URL_KEY: &str = "oauth_public_url";
+
+/// Where an OAuth login attempt failed; rendered into the UI redirect as
+/// `?oauth_error=<code>` and logged with detail server-side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlowError {
+    /// Provider disabled or unknown.
+    Provider,
+    /// `state` missing, expired, replayed or for another provider.
+    State,
+    /// Token endpoint refused the code.
+    Exchange,
+    /// Userinfo endpoint failed or returned no usable subject.
+    Userinfo,
+    /// No linked account, no verified email to link by, or auto-create off.
+    NoAccount,
+    /// The account exists but is disabled.
+    Disabled,
+    /// Internal/database failure.
+    Internal,
+}
+
+impl FlowError {
+    /// Stable machine-readable code for the UI.
+    pub fn code(self) -> &'static str {
+        match self {
+            FlowError::Provider => "provider",
+            FlowError::State => "state",
+            FlowError::Exchange => "exchange",
+            FlowError::Userinfo => "userinfo",
+            FlowError::NoAccount => "no_account",
+            FlowError::Disabled => "disabled",
+            FlowError::Internal => "internal",
+        }
+    }
+}
+
+// ============================================================
+// PKCE
+// ============================================================
+
+/// A fresh PKCE verifier (43 base64url chars from 32 random bytes).
+pub fn new_code_verifier() -> String {
+    let mut bytes = [0u8; 32];
+    use argon2::password_hash::rand_core::{OsRng, RngCore};
+    OsRng.fill_bytes(&mut bytes);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// S256 challenge for a verifier.
+pub fn code_challenge(verifier: &str) -> String {
+    let digest = Sha256::digest(verifier.as_bytes());
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest)
+}
+
+// ============================================================
+// Redirect URI
+// ============================================================
+
+/// Base URL the provider must send the browser back to. The operator can
+/// pin it (`oauth_public_url` in `auth_config`, e.g. behind a reverse
+/// proxy); otherwise it is derived from the request `Host` and the API's
+/// own TLS mode.
+pub async fn public_base_url(pool: &SqlitePool, headers: &HeaderMap, tls: bool) -> Option<String> {
+    let configured: Option<String> =
+        sqlx::query_scalar("SELECT value FROM auth_config WHERE key = ?1")
+            .bind(PUBLIC_URL_KEY)
+            .fetch_optional(pool)
+            .await
+            .ok()
+            .flatten();
+    if let Some(u) = configured.map(|s| s.trim().trim_end_matches('/').to_string())
+        && !u.is_empty()
+    {
+        return Some(u);
+    }
+    let host = headers
+        .get(axum::http::header::HOST)
+        .and_then(|h| h.to_str().ok())?
+        .trim();
+    if host.is_empty() {
+        return None;
+    }
+    let scheme = if tls { "https" } else { "http" };
+    Some(format!("{scheme}://{host}"))
+}
+
+/// Callback path for a provider name (relative to the public base URL).
+pub fn callback_path(provider_name: &str) -> String {
+    format!(
+        "/api/v1/auth/oauth/{}/callback",
+        url::form_urlencoded::byte_serialize(provider_name.as_bytes()).collect::<String>()
+    )
+}
+
+/// Full authorization URL with `state` and PKCE challenge, properly encoded.
+pub fn authorize_url(
+    provider: &OAuthProvider,
+    redirect_uri: &str,
+    state: &str,
+    verifier: &str,
+) -> String {
+    let mut params = url::form_urlencoded::Serializer::new(String::new());
+    params
+        .append_pair("client_id", &provider.client_id)
+        .append_pair("redirect_uri", redirect_uri)
+        .append_pair("response_type", "code")
+        .append_pair("scope", &provider.scopes)
+        .append_pair("state", state)
+        .append_pair("code_challenge", &code_challenge(verifier))
+        .append_pair("code_challenge_method", "S256");
+    if provider.provider_type == OAuthProviderType::Google {
+        // Ask Google for a fresh consent only when needed; keeps the
+        // repeated-login UX quiet.
+        params.append_pair("access_type", "online");
+    }
+    let sep = if provider.auth_url.contains('?') {
+        "&"
+    } else {
+        "?"
+    };
+    format!("{}{sep}{}", provider.auth_url, params.finish())
+}
+
+// ============================================================
+// Token exchange + userinfo
+// ============================================================
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: Option<String>,
+    #[serde(default)]
+    id_token: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    error_description: Option<String>,
+}
+
+/// What the provider told us about the person who just consented.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Identity {
+    /// Provider-scoped stable subject (`sub`, GitHub numeric `id`).
+    pub subject: String,
+    /// Email if the provider disclosed one.
+    pub email: Option<String>,
+    /// Whether the provider vouches for the email (`email_verified`, GitHub
+    /// primary+verified). Unverified emails never link existing accounts.
+    pub email_verified: bool,
+    /// Display/login name for a provisioned username when there is no email.
+    pub login: Option<String>,
+}
+
+fn http() -> Result<reqwest::Client, FlowError> {
+    reqwest::Client::builder()
+        .timeout(HTTP_TIMEOUT)
+        .user_agent(concat!("AiFw/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| {
+            tracing::error!(error = %e, "oauth: http client build failed");
+            FlowError::Internal
+        })
+}
+
+/// Redeem the authorization code for an access token.
+pub async fn exchange_code(
+    provider: &OAuthProvider,
+    code: &str,
+    redirect_uri: &str,
+    verifier: &str,
+) -> Result<String, FlowError> {
+    let client = http()?;
+    let body = url::form_urlencoded::Serializer::new(String::new())
+        .append_pair("grant_type", "authorization_code")
+        .append_pair("code", code)
+        .append_pair("redirect_uri", redirect_uri)
+        .append_pair("client_id", &provider.client_id)
+        .append_pair("client_secret", &provider.client_secret)
+        .append_pair("code_verifier", verifier)
+        .finish();
+    let resp = client
+        .post(&provider.token_url)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .header(reqwest::header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::warn!(provider = %provider.name, error = %e, "oauth: token endpoint unreachable");
+            FlowError::Exchange
+        })?;
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    let parsed: TokenResponse = serde_json::from_str(&body).map_err(|e| {
+        tracing::warn!(provider = %provider.name, %status, error = %e, "oauth: token response not JSON");
+        FlowError::Exchange
+    })?;
+    if let Some(err) = parsed.error {
+        tracing::warn!(provider = %provider.name, %status, error = %err,
+            description = parsed.error_description.as_deref().unwrap_or(""),
+            "oauth: token endpoint refused the code");
+        return Err(FlowError::Exchange);
+    }
+    if !status.is_success() {
+        tracing::warn!(provider = %provider.name, %status, "oauth: token endpoint error");
+        return Err(FlowError::Exchange);
+    }
+    let _ = parsed.id_token; // userinfo is the source of truth for every provider type
+    parsed
+        .access_token
+        .filter(|t| !t.is_empty())
+        .ok_or_else(|| {
+            tracing::warn!(provider = %provider.name, "oauth: token response without access_token");
+            FlowError::Exchange
+        })
+}
+
+/// Read the userinfo endpoint and normalise it into an [`Identity`].
+pub async fn fetch_identity(
+    provider: &OAuthProvider,
+    access_token: &str,
+) -> Result<Identity, FlowError> {
+    let client = http()?;
+    let info: serde_json::Value = client
+        .get(&provider.userinfo_url)
+        .bearer_auth(access_token)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .send()
+        .await
+        .and_then(|r| r.error_for_status())
+        .map_err(|e| {
+            tracing::warn!(provider = %provider.name, error = %e, "oauth: userinfo request failed");
+            FlowError::Userinfo
+        })?
+        .json()
+        .await
+        .map_err(|e| {
+            tracing::warn!(provider = %provider.name, error = %e, "oauth: userinfo not JSON");
+            FlowError::Userinfo
+        })?;
+
+    let mut identity = identity_from_userinfo(provider.provider_type, &info).ok_or_else(|| {
+        tracing::warn!(provider = %provider.name, "oauth: userinfo has no subject");
+        FlowError::Userinfo
+    })?;
+
+    // GitHub hides the address unless it is public; the emails API returns
+    // the verified primary for the `user:email` scope.
+    if provider.provider_type == OAuthProviderType::Github && identity.email.is_none() {
+        let emails_url = if provider.userinfo_url.ends_with("/user") {
+            format!("{}/emails", provider.userinfo_url)
+        } else {
+            "https://api.github.com/user/emails".to_string()
+        };
+        if let Ok(resp) = client
+            .get(&emails_url)
+            .bearer_auth(access_token)
+            .header(reqwest::header::ACCEPT, "application/json")
+            .send()
+            .await
+            && let Ok(list) = resp.json::<Vec<serde_json::Value>>().await
+        {
+            let pick = list
+                .iter()
+                .find(|e| {
+                    e["primary"].as_bool() == Some(true) && e["verified"].as_bool() == Some(true)
+                })
+                .or_else(|| list.iter().find(|e| e["verified"].as_bool() == Some(true)));
+            if let Some(e) = pick.and_then(|e| e["email"].as_str()) {
+                identity.email = Some(e.to_string());
+                identity.email_verified = true;
+            }
+        }
+    }
+    Ok(identity)
+}
+
+/// Pure normalisation of a userinfo document (testable without HTTP).
+pub fn identity_from_userinfo(
+    kind: OAuthProviderType,
+    info: &serde_json::Value,
+) -> Option<Identity> {
+    let str_of = |k: &str| {
+        info.get(k)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    };
+    match kind {
+        OAuthProviderType::Github => {
+            let subject = info.get("id").and_then(|v| {
+                v.as_i64()
+                    .map(|n| n.to_string())
+                    .or_else(|| v.as_str().map(str::to_string))
+            })?;
+            Some(Identity {
+                subject,
+                // Public profile email; verification comes via /user/emails.
+                email: str_of("email"),
+                email_verified: false,
+                login: str_of("login").or_else(|| str_of("name")),
+            })
+        }
+        OAuthProviderType::Google | OAuthProviderType::Oidc => {
+            let subject = str_of("sub")?;
+            let verified = info
+                .get("email_verified")
+                .map(|v| v.as_bool() == Some(true) || v.as_str() == Some("true"))
+                .unwrap_or(false);
+            Some(Identity {
+                subject,
+                email: str_of("email"),
+                email_verified: verified,
+                login: str_of("preferred_username").or_else(|| str_of("name")),
+            })
+        }
+    }
+}
+
+// ============================================================
+// Account resolution
+// ============================================================
+
+/// Map an identity to a local user, linking or provisioning as policy allows.
+pub async fn resolve_user(
+    pool: &SqlitePool,
+    provider: &OAuthProvider,
+    identity: &Identity,
+    auto_create: bool,
+) -> Result<User, FlowError> {
+    // 1. Existing link.
+    let linked: Option<String> = sqlx::query_scalar(
+        "SELECT user_id FROM oauth_identities WHERE provider_id = ?1 AND provider_user_id = ?2",
+    )
+    .bind(provider.id.to_string())
+    .bind(&identity.subject)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        tracing::error!(error = %e, "oauth: identity lookup failed");
+        FlowError::Internal
+    })?;
+    if let Some(uid) = linked {
+        return match super::users::get_user_by_id(pool, &uid).await {
+            Ok(Some(u)) => Ok(u),
+            Ok(None) => {
+                // Dangling link (user deleted) — drop it and fall through.
+                let _ = sqlx::query("DELETE FROM oauth_identities WHERE user_id = ?1")
+                    .bind(&uid)
+                    .execute(pool)
+                    .await;
+                resolve_unlinked(pool, provider, identity, auto_create).await
+            }
+            Err(_) => Err(FlowError::Internal),
+        };
+    }
+    resolve_unlinked(pool, provider, identity, auto_create).await
+}
+
+async fn resolve_unlinked(
+    pool: &SqlitePool,
+    provider: &OAuthProvider,
+    identity: &Identity,
+    auto_create: bool,
+) -> Result<User, FlowError> {
+    let email = identity
+        .email
+        .as_deref()
+        .map(|e| e.trim().to_ascii_lowercase());
+
+    // 2. Verified email that matches an existing local username → link.
+    if identity.email_verified
+        && let Some(email) = email.as_deref()
+        && let Ok(Some(user)) = super::users::get_user_by_username(pool, email).await
+    {
+        link_identity(pool, &user, provider, identity).await?;
+        return Ok(user);
+    }
+
+    // 3. Provision.
+    if !auto_create {
+        return Err(FlowError::NoAccount);
+    }
+    let base = match (&email, identity.email_verified, &identity.login) {
+        (Some(e), true, _) => e.clone(),
+        (_, _, Some(login)) => format!(
+            "{}:{}",
+            provider.name.to_ascii_lowercase(),
+            login.to_ascii_lowercase()
+        ),
+        (Some(e), false, None) => e.clone(),
+        _ => format!(
+            "{}:{}",
+            provider.name.to_ascii_lowercase(),
+            identity.subject
+        ),
+    };
+    let username = unique_username(pool, &base).await?;
+    // Unusable password: OAuth accounts authenticate only through the
+    // provider. Long random secret hashed with the normal Argon2 path.
+    let random = format!("{}{}", Uuid::new_v4(), Uuid::new_v4());
+    let pw_hash = super::password::hash_password(&random).map_err(|_| FlowError::Internal)?;
+    let id = Uuid::new_v4();
+    let now = chrono::Utc::now().to_rfc3339();
+    sqlx::query(
+        r#"INSERT INTO users (id, username, password_hash, totp_enabled, totp_secret, auth_provider, role, role_id, enabled, created_at)
+           VALUES (?1, ?2, ?3, 0, NULL, ?4, 'viewer', 'builtin-viewer', 1, ?5)"#,
+    )
+    .bind(id.to_string())
+    .bind(&username)
+    .bind(&pw_hash)
+    .bind(&provider.name)
+    .bind(&now)
+    .execute(pool)
+    .await
+    .map_err(|e| {
+        tracing::error!(error = %e, "oauth: user provisioning failed");
+        FlowError::Internal
+    })?;
+    let user = User {
+        id,
+        username,
+        password_hash: pw_hash,
+        totp_enabled: false,
+        totp_secret: None,
+        auth_provider: provider.name.clone(),
+        role: "viewer".to_string(),
+        role_id: Some("builtin-viewer".to_string()),
+        enabled: true,
+        created_at: now,
+    };
+    link_identity(pool, &user, provider, identity).await?;
+    super::users::log_user_audit(
+        pool,
+        &user.id.to_string(),
+        Some(&user.id.to_string()),
+        "oauth_user_provisioned",
+        Some(&format!("{} via {}", user.username, provider.name)),
+    )
+    .await;
+    Ok(user)
+}
+
+async fn unique_username(pool: &SqlitePool, base: &str) -> Result<String, FlowError> {
+    let base: String = base
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '@' | '.' | '_' | '-' | ':' | '+'))
+        .take(120)
+        .collect();
+    let base = if base.is_empty() {
+        "oauth-user".to_string()
+    } else {
+        base
+    };
+    for n in 0..100u32 {
+        let candidate = if n == 0 {
+            base.clone()
+        } else {
+            format!("{base}-{n}")
+        };
+        let taken: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM users WHERE username = ?1")
+            .bind(&candidate)
+            .fetch_one(pool)
+            .await
+            .map_err(|_| FlowError::Internal)?;
+        if taken == 0 {
+            return Ok(candidate);
+        }
+    }
+    Err(FlowError::Internal)
+}
+
+async fn link_identity(
+    pool: &SqlitePool,
+    user: &User,
+    provider: &OAuthProvider,
+    identity: &Identity,
+) -> Result<(), FlowError> {
+    sqlx::query(
+        "INSERT INTO oauth_identities (id, user_id, provider_id, provider_user_id, email, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .bind(user.id.to_string())
+    .bind(provider.id.to_string())
+    .bind(&identity.subject)
+    .bind(identity.email.as_deref().unwrap_or(""))
+    .bind(chrono::Utc::now().to_rfc3339())
+    .execute(pool)
+    .await
+    .map_err(|e| {
+        tracing::error!(error = %e, "oauth: identity link failed");
+        FlowError::Internal
+    })?;
+    Ok(())
+}
+
+// ============================================================
+// TOTP-pending tickets
+// ============================================================
+
+/// Create the pending-login table (idempotent).
+pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"CREATE TABLE IF NOT EXISTS oauth_pending_logins (
+            ticket TEXT PRIMARY KEY,
+            user_id TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )"#,
+    )
+    .execute(pool)
+    .await?;
+    for stmt in [
+        "ALTER TABLE oauth_states ADD COLUMN code_verifier TEXT",
+        "ALTER TABLE oauth_states ADD COLUMN redirect_uri TEXT",
+    ] {
+        if let Err(e) = sqlx::query(stmt).execute(pool).await
+            && !e.to_string().contains("duplicate column")
+        {
+            return Err(e);
+        }
+    }
+    Ok(())
+}
+
+/// Issue a single-use ticket that lets the browser finish an OAuth login
+/// with a TOTP code.
+pub async fn issue_pending(
+    pool: &SqlitePool,
+    user_id: &str,
+    provider: &str,
+) -> Result<String, FlowError> {
+    let ticket = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
+    sqlx::query(
+        "INSERT INTO oauth_pending_logins (ticket, user_id, provider, created_at) VALUES (?1, ?2, ?3, ?4)",
+    )
+    .bind(&ticket)
+    .bind(user_id)
+    .bind(provider)
+    .bind(chrono::Utc::now().to_rfc3339())
+    .execute(pool)
+    .await
+    .map_err(|_| FlowError::Internal)?;
+    Ok(ticket)
+}
+
+/// Consume a pending ticket; returns the user id if it was valid and fresh.
+pub async fn consume_pending(pool: &SqlitePool, ticket: &str) -> Option<String> {
+    let cutoff = (chrono::Utc::now() - chrono::Duration::seconds(PENDING_TTL_SECS)).to_rfc3339();
+    let _ = sqlx::query("DELETE FROM oauth_pending_logins WHERE created_at < ?1")
+        .bind(&cutoff)
+        .execute(pool)
+        .await;
+    sqlx::query_scalar::<_, String>(
+        "DELETE FROM oauth_pending_logins WHERE ticket = ?1 RETURNING user_id",
+    )
+    .bind(ticket)
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn pkce_challenge_is_s256_of_verifier() {
+        // RFC 7636 appendix B vector
+        let v = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        assert_eq!(
+            code_challenge(v),
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        );
+        let fresh = new_code_verifier();
+        assert!(
+            fresh.len() >= 43
+                && fresh
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        );
+    }
+
+    #[test]
+    fn authorize_url_is_encoded_and_carries_pkce() {
+        let p = OAuthProvider::google("cid", "sec");
+        let u = authorize_url(
+            &p,
+            "https://fw.example.com:8080/api/v1/auth/oauth/Google/callback",
+            "st ate",
+            "ver",
+        );
+        assert!(u.starts_with("https://accounts.google.com/o/oauth2/v2/auth?client_id=cid&"));
+        assert!(u.contains("redirect_uri=https%3A%2F%2Ffw.example.com%3A8080%2Fapi%2Fv1%2Fauth%2Foauth%2FGoogle%2Fcallback"));
+        assert!(u.contains("scope=openid+email+profile"));
+        assert!(u.contains("state=st+ate"));
+        assert!(u.contains(&format!("code_challenge={}", code_challenge("ver"))));
+        assert!(u.contains("code_challenge_method=S256"));
+    }
+
+    #[test]
+    fn userinfo_normalisation() {
+        let g = identity_from_userinfo(
+            OAuthProviderType::Google,
+            &json!({"sub":"123","email":"A@Example.com","email_verified":true,"name":"A"}),
+        )
+        .unwrap();
+        assert_eq!(g.subject, "123");
+        assert!(g.email_verified);
+        let o = identity_from_userinfo(OAuthProviderType::Oidc, &json!({"sub":"x","email":"a@b"}))
+            .unwrap();
+        assert!(
+            !o.email_verified,
+            "missing email_verified claim ⇒ unverified"
+        );
+        let gh = identity_from_userinfo(
+            OAuthProviderType::Github,
+            &json!({"id": 42, "login":"octo", "email": null}),
+        )
+        .unwrap();
+        assert_eq!(gh.subject, "42");
+        assert_eq!(gh.login.as_deref(), Some("octo"));
+        assert!(gh.email.is_none());
+        assert!(identity_from_userinfo(OAuthProviderType::Oidc, &json!({"email":"a@b"})).is_none());
+    }
+}

--- a/aifw-api/src/router.rs
+++ b/aifw-api/src/router.rs
@@ -35,6 +35,11 @@ pub(crate) fn public_routes() -> Router<AppState> {
             "/api/v1/auth/oauth/{provider}/callback",
             get(routes::oauth_callback),
         )
+        .route("/api/v1/auth/oauth/totp", post(routes::oauth_totp))
+        .route(
+            "/api/v1/auth/oauth/login-options",
+            get(routes::oauth_login_options),
+        )
         .route("/api/v1/auth/register", post(routes::register))
 }
 
@@ -476,6 +481,10 @@ pub(crate) fn settings_read() -> Router<AppState> {
             "/api/v1/auth/oauth/providers",
             get(routes::list_oauth_providers),
         )
+        .route(
+            "/api/v1/auth/oauth/settings",
+            get(routes::get_oauth_settings),
+        )
         .route("/api/v1/settings/tls", get(routes::get_tls_settings))
         .route("/api/v1/settings/valkey", get(routes::get_valkey_settings))
         .route(
@@ -536,6 +545,10 @@ pub(crate) fn settings_write() -> Router<AppState> {
         .route(
             "/api/v1/auth/oauth/providers/{id}",
             delete(routes::delete_oauth_provider),
+        )
+        .route(
+            "/api/v1/auth/oauth/settings",
+            put(routes::put_oauth_settings),
         )
         .route("/api/v1/settings/tls", put(routes::update_tls_settings))
         .route(

--- a/aifw-api/src/routes/auth.rs
+++ b/aifw-api/src/routes/auth.rs
@@ -460,7 +460,16 @@ pub async fn create_oauth_provider(
     State(state): State<AppState>,
     Json(req): Json<auth::oauth::CreateProviderRequest>,
 ) -> Result<(StatusCode, Json<ApiResponse<auth::oauth::OAuthProvider>>), StatusCode> {
-    let provider = match req.provider_type.as_str() {
+    let name = req.name.trim().to_string();
+    if name.is_empty()
+        || name.len() > 64
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, ' ' | '-' | '_' | '.'))
+    {
+        return Err(bad_request());
+    }
+    let mut provider = match req.provider_type.as_str() {
         "google" => auth::oauth::OAuthProvider::google(&req.client_id, &req.client_secret),
         "github" => auth::oauth::OAuthProvider::github(&req.client_id, &req.client_secret),
         _ => auth::oauth::OAuthProvider {
@@ -479,11 +488,77 @@ pub async fn create_oauth_provider(
             created_at: chrono::Utc::now().to_rfc3339(),
         },
     };
+    provider.name = name;
+    if provider.provider_type == auth::oauth::OAuthProviderType::Oidc {
+        // Generic OIDC needs all three endpoints, all https.
+        for u in [
+            &provider.auth_url,
+            &provider.token_url,
+            &provider.userinfo_url,
+        ] {
+            if !(u.starts_with("https://")
+                || u.starts_with("http://localhost")
+                || u.starts_with("http://127."))
+            {
+                return Err(bad_request());
+            }
+        }
+    }
 
     auth::oauth::save_provider(&state.pool, &provider)
         .await
-        .map_err(|_| internal())?;
+        .map_err(|e| {
+            tracing::warn!(error = %e, "oauth: save provider failed");
+            StatusCode::CONFLICT
+        })?;
     Ok((StatusCode::CREATED, Json(ApiResponse { data: provider })))
+}
+
+/// Public: enabled providers the sign-in page may offer (names + types only).
+pub async fn oauth_login_options(
+    State(state): State<AppState>,
+) -> Result<Json<ApiResponse<Vec<auth::oauth::LoginOption>>>, StatusCode> {
+    let providers = auth::oauth::list_providers(&state.pool)
+        .await
+        .map_err(|_| internal())?;
+    Ok(Json(ApiResponse {
+        data: providers
+            .into_iter()
+            .filter(|p| p.enabled)
+            .map(|p| auth::oauth::LoginOption {
+                name: p.name,
+                provider_type: p.provider_type,
+            })
+            .collect(),
+    }))
+}
+
+pub async fn get_oauth_settings(
+    State(state): State<AppState>,
+) -> Result<Json<auth::oauth::OAuthSettings>, StatusCode> {
+    let public_url: Option<String> =
+        sqlx::query_scalar("SELECT value FROM auth_config WHERE key = ?1")
+            .bind(auth::oauth_flow::PUBLIC_URL_KEY)
+            .fetch_optional(&state.pool)
+            .await
+            .map_err(|_| internal())?;
+    Ok(Json(auth::oauth::OAuthSettings {
+        public_url: public_url.unwrap_or_default(),
+    }))
+}
+
+pub async fn put_oauth_settings(
+    State(state): State<AppState>,
+    Json(req): Json<auth::oauth::OAuthSettings>,
+) -> Result<Json<auth::oauth::OAuthSettings>, StatusCode> {
+    let url = req.public_url.trim().trim_end_matches('/').to_string();
+    if !url.is_empty() && !(url.starts_with("https://") || url.starts_with("http://")) {
+        return Err(bad_request());
+    }
+    auth::config::AuthSettings::save_setting(&state.pool, auth::oauth_flow::PUBLIC_URL_KEY, &url)
+        .await
+        .map_err(|_| internal())?;
+    Ok(Json(auth::oauth::OAuthSettings { public_url: url }))
 }
 
 pub async fn delete_oauth_provider(
@@ -502,20 +577,36 @@ pub async fn delete_oauth_provider(
 pub async fn oauth_authorize(
     State(state): State<AppState>,
     Path(provider_name): Path<String>,
+    headers: HeaderMap,
 ) -> Result<Json<auth::oauth::AuthorizeResponse>, StatusCode> {
+    use crate::auth::oauth_flow as flow;
     let provider = auth::oauth::get_provider_by_name(&state.pool, &provider_name)
         .await
         .map_err(|_| internal())?
+        .filter(|p| p.enabled)
         .ok_or(StatusCode::NOT_FOUND)?;
 
-    let oauth_state = Uuid::new_v4().to_string();
-    // SEC-H9: bind this state nonce so the callback can prove it originated
-    // from an authorize request this server issued.
-    auth::oauth::save_state(&state.pool, &oauth_state, &provider_name)
+    let base = flow::public_base_url(&state.pool, &headers, state.tls_enabled)
         .await
-        .map_err(|_| internal())?;
-    let redirect_uri = format!("/api/v1/auth/oauth/{}/callback", provider_name);
-    let url = provider.authorize_url(&redirect_uri, &oauth_state);
+        .ok_or(bad_request())?;
+    let redirect_uri = format!("{base}{}", flow::callback_path(&provider.name));
+    let oauth_state = Uuid::new_v4().to_string();
+    let verifier = flow::new_code_verifier();
+    // SEC-H9: bind this state nonce so the callback can prove it originated
+    // from an authorize request this server issued; the PKCE verifier and
+    // redirect URI ride along so the exchange repeats them exactly.
+    auth::oauth::save_state(
+        &state.pool,
+        &oauth_state,
+        &provider.name,
+        &auth::oauth::PendingAuthorize {
+            code_verifier: verifier.clone(),
+            redirect_uri: redirect_uri.clone(),
+        },
+    )
+    .await
+    .map_err(|_| internal())?;
+    let url = flow::authorize_url(&provider, &redirect_uri, &oauth_state, &verifier);
 
     Ok(Json(auth::oauth::AuthorizeResponse {
         authorize_url: url,
@@ -523,27 +614,199 @@ pub async fn oauth_authorize(
     }))
 }
 
+/// Where the browser lands after the callback: the login page carries the
+/// outcome in the query string (static UI, no server-side templating).
+fn oauth_ui_redirect(query: &str) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    axum::response::Redirect::to(&format!("/login/?{query}")).into_response()
+}
+
+fn oauth_fail(provider: &str, err: crate::auth::oauth_flow::FlowError) -> axum::response::Response {
+    tracing::warn!(provider, error = err.code(), "oauth: login failed");
+    oauth_ui_redirect(&format!("oauth_error={}", err.code()))
+}
+
+/// Provider redirect target: exchange the code, resolve the account, and
+/// either install the session cookies or hand off to the TOTP step (#170).
 pub async fn oauth_callback(
     State(state): State<AppState>,
     Path(provider_name): Path<String>,
     axum::extract::Query(query): axum::extract::Query<auth::oauth::CallbackQuery>,
-) -> Result<Json<MessageResponse>, StatusCode> {
-    // Validate required parameters are present
-    if query.code.is_empty() {
-        return Err(bad_request());
+) -> axum::response::Response {
+    use crate::auth::oauth_flow::{self as flow, FlowError};
+    use axum::response::IntoResponse;
+
+    if let Some(err) = query.error.as_deref() {
+        // The user (or provider) declined; the state stays consumable but
+        // expires on its own.
+        tracing::info!(provider = %provider_name, error = err, "oauth: provider returned error");
+        return oauth_ui_redirect("oauth_error=denied");
     }
-    if query.state.is_empty() {
-        return Err(bad_request());
+    if query.code.is_empty() || query.state.is_empty() {
+        return oauth_fail(&provider_name, FlowError::State);
     }
     // SEC-H9: the state nonce must match one we issued at /authorize for this
     // provider and be unexpired. consume_state deletes it (single-use), so a
     // replayed or forged callback is rejected before any token exchange.
-    if !auth::oauth::consume_state(&state.pool, &query.state, &provider_name).await {
+    let Some(pending) = auth::oauth::consume_state(&state.pool, &query.state, &provider_name).await
+    else {
+        return oauth_fail(&provider_name, FlowError::State);
+    };
+    let provider = match auth::oauth::get_provider_by_name(&state.pool, &provider_name).await {
+        Ok(Some(p)) if p.enabled => p,
+        _ => return oauth_fail(&provider_name, FlowError::Provider),
+    };
+
+    let access_token = match flow::exchange_code(
+        &provider,
+        &query.code,
+        &pending.redirect_uri,
+        &pending.code_verifier,
+    )
+    .await
+    {
+        Ok(t) => t,
+        Err(e) => return oauth_fail(&provider_name, e),
+    };
+    let identity = match flow::fetch_identity(&provider, &access_token).await {
+        Ok(i) => i,
+        Err(e) => return oauth_fail(&provider_name, e),
+    };
+
+    // Policy flags are read live so a settings change applies without a
+    // restart.
+    let live = auth::AuthSettings::load(&state.pool).await;
+    let user = match flow::resolve_user(
+        &state.pool,
+        &provider,
+        &identity,
+        live.auto_create_oauth_users,
+    )
+    .await
+    {
+        Ok(u) => u,
+        Err(e) => return oauth_fail(&provider_name, e),
+    };
+    if !user.enabled {
+        auth::log_user_audit(
+            &state.pool,
+            &user.id.to_string(),
+            Some(&user.id.to_string()),
+            "login_denied_disabled",
+            Some(&format!("oauth:{}", provider.name)),
+        )
+        .await;
+        return oauth_fail(&provider_name, FlowError::Disabled);
+    }
+
+    // Second factor: with `require_totp_for_oauth` on, an account that has
+    // TOTP enrolled must present it; off ⇒ the IdP is trusted for MFA.
+    if live.require_totp_for_oauth && user.totp_enabled {
+        return match flow::issue_pending(&state.pool, &user.id.to_string(), &provider.name).await {
+            Ok(ticket) => oauth_ui_redirect(&format!(
+                "oauth_totp={ticket}&user={}",
+                url::form_urlencoded::byte_serialize(user.username.as_bytes()).collect::<String>()
+            )),
+            Err(e) => oauth_fail(&provider_name, e),
+        };
+    }
+
+    match issue_oauth_session(&state, &user, &provider.name).await {
+        Ok(cookies) => (cookies, oauth_ui_redirect("oauth=ok")).into_response(),
+        Err(_) => oauth_fail(&provider_name, FlowError::Internal),
+    }
+}
+
+/// Mint the token pair for an OAuth-authenticated user, write the audit row
+/// and return the session cookie headers.
+async fn issue_oauth_session(
+    state: &AppState,
+    user: &auth::User,
+    provider_name: &str,
+) -> Result<HeaderMap, StatusCode> {
+    let (perm_bits, role_name) =
+        auth::tokens::resolve_token_permissions(&state.pool, &user.role, user.role_id.as_deref())
+            .await
+            .map_err(|_| internal())?;
+    let tokens = auth::tokens::issue_token_pair(
+        &state.pool,
+        &user.id.to_string(),
+        &user.username,
+        perm_bits,
+        &role_name,
+        &state.auth_settings,
+    )
+    .await
+    .map_err(|_| internal())?;
+    auth::log_user_audit(
+        &state.pool,
+        &user.id.to_string(),
+        Some(&user.id.to_string()),
+        "login_success",
+        Some(&format!("{} via oauth:{provider_name}", user.username)),
+    )
+    .await;
+    Ok(session_cookie_headers(state, &tokens))
+}
+
+/// Finish a TOTP-gated OAuth login: the single-use ticket from the callback
+/// plus a TOTP or recovery code → session (cookies + token pair).
+pub async fn oauth_totp(
+    State(state): State<AppState>,
+    Json(req): Json<auth::oauth::OAuthTotpRequest>,
+) -> Result<(HeaderMap, Json<auth::TokenPair>), StatusCode> {
+    let Some(user_id) = auth::oauth_flow::consume_pending(&state.pool, &req.ticket).await else {
+        return Err(StatusCode::UNAUTHORIZED);
+    };
+    let user = auth::get_user_by_id(&state.pool, &user_id)
+        .await?
+        .filter(|u| u.enabled)
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+    let totp_valid = user
+        .totp_secret
+        .as_deref()
+        .map(|s| auth::totp::verify(s, &req.totp_code))
+        .unwrap_or(false);
+    let recovery_valid = if !totp_valid {
+        auth::use_recovery_code(&state.pool, &user.id.to_string(), &req.totp_code).await
+    } else {
+        false
+    };
+    if !totp_valid && !recovery_valid {
+        auth::log_user_audit(
+            &state.pool,
+            &user.id.to_string(),
+            Some(&user.id.to_string()),
+            "login_failed",
+            Some("oauth totp step"),
+        )
+        .await;
         return Err(StatusCode::UNAUTHORIZED);
     }
-    // State is valid, but the token exchange itself is not yet implemented
-    // (tracked in #170) — return 501 until that lands.
-    Err(StatusCode::NOT_IMPLEMENTED)
+    let (perm_bits, role_name) =
+        auth::tokens::resolve_token_permissions(&state.pool, &user.role, user.role_id.as_deref())
+            .await
+            .map_err(|_| internal())?;
+    let tokens = auth::tokens::issue_token_pair(
+        &state.pool,
+        &user.id.to_string(),
+        &user.username,
+        perm_bits,
+        &role_name,
+        &state.auth_settings,
+    )
+    .await
+    .map_err(|_| internal())?;
+    auth::log_user_audit(
+        &state.pool,
+        &user.id.to_string(),
+        Some(&user.id.to_string()),
+        "login_success",
+        Some(&format!("{} via oauth+totp", user.username)),
+    )
+    .await;
+    let cookies = session_cookie_headers(&state, &tokens);
+    Ok((cookies, Json(tokens)))
 }
 
 /// Public registration — only allowed when no human users exist

--- a/aifw-api/src/tests.rs
+++ b/aifw-api/src/tests.rs
@@ -908,11 +908,17 @@ mod tests {
         let (server, _) = test_app().await;
         let token = create_user_and_login(&server).await;
 
-        // A forged state is rejected before any token exchange.
+        // A forged state is rejected before any token exchange — the
+        // browser is bounced to the login page with the `state` error (#170
+        // made the callback a redirecting endpoint).
         let resp = server
             .get("/api/v1/auth/oauth/Google/callback?code=abc&state=forged-nonce")
             .await;
-        resp.assert_status(StatusCode::UNAUTHORIZED);
+        assert!(resp.status_code().is_redirection());
+        assert_eq!(
+            resp.headers().get("location").unwrap(),
+            "/login/?oauth_error=state"
+        );
 
         // Create the provider, then obtain a real state from /authorize.
         server
@@ -934,14 +940,18 @@ mod tests {
             .unwrap()
             .to_string();
 
-        // A valid state passes the CSRF check — the 501 confirms it reached
-        // the (still-unimplemented, #170) token-exchange step.
+        // A valid state passes the CSRF check and reaches the token
+        // exchange — which fails here (no real Google), so the error is
+        // `exchange`, not `state`.
         let resp = server
             .get(&format!(
                 "/api/v1/auth/oauth/Google/callback?code=abc&state={state}"
             ))
             .await;
-        resp.assert_status(StatusCode::NOT_IMPLEMENTED);
+        assert_eq!(
+            resp.headers().get("location").unwrap(),
+            "/login/?oauth_error=exchange"
+        );
 
         // Replaying the same (now-consumed) state is rejected.
         let resp = server
@@ -949,7 +959,10 @@ mod tests {
                 "/api/v1/auth/oauth/Google/callback?code=abc&state={state}"
             ))
             .await;
-        resp.assert_status(StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            resp.headers().get("location").unwrap(),
+            "/login/?oauth_error=state"
+        );
     }
 
     /// SEC-H4 (#289): the per-provider `tls_insecure` opt-in must persist and
@@ -3947,5 +3960,345 @@ mod tests {
             .authorization_bearer(&token)
             .await;
         resp.assert_status_ok();
+    }
+    /// #170: full OAuth/OIDC round-trip against an in-process mock IdP —
+    /// PKCE + state, token exchange, userinfo, auto-provisioning, session
+    /// cookies, replay rejection, auto-create off, and the TOTP second step.
+    #[tokio::test]
+    async fn test_oauth_login_round_trip_with_mock_idp() {
+        use axum::{
+            Json, Router,
+            routing::{get, post},
+        };
+        use std::sync::{Arc, Mutex};
+
+        // ---- mock identity provider ------------------------------------
+        #[derive(Clone, Default)]
+        struct Idp {
+            token_forms: Arc<Mutex<Vec<String>>>,
+            userinfo: Arc<Mutex<Value>>,
+        }
+        let idp = Idp {
+            userinfo: Arc::new(Mutex::new(json!({
+                "sub": "sub-123", "email": "Alice@Example.com", "email_verified": true, "name": "Alice"
+            }))),
+            ..Default::default()
+        };
+        let idp_for_token = idp.clone();
+        let idp_for_info = idp.clone();
+        let idp_app = Router::new()
+            .route(
+                "/token",
+                post(move |body: String| {
+                    let idp = idp_for_token.clone();
+                    async move {
+                        idp.token_forms.lock().unwrap().push(body.clone());
+                        if body.contains("code=goodcode") {
+                            Json(json!({"access_token": "at-xyz", "token_type": "Bearer"}))
+                        } else {
+                            Json(json!({"error": "invalid_grant"}))
+                        }
+                    }
+                }),
+            )
+            .route(
+                "/userinfo",
+                get(move |headers: axum::http::HeaderMap| {
+                    let idp = idp_for_info.clone();
+                    async move {
+                        let ok = headers.get("authorization").and_then(|h| h.to_str().ok())
+                            == Some("Bearer at-xyz");
+                        if ok {
+                            (StatusCode::OK, Json(idp.userinfo.lock().unwrap().clone()))
+                        } else {
+                            (StatusCode::UNAUTHORIZED, Json(json!({})))
+                        }
+                    }
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let idp_addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, idp_app).await.unwrap();
+        });
+        let idp_base = format!("http://127.0.0.1:{}", idp_addr.port());
+
+        // ---- AiFw side ---------------------------------------------------
+        let state = crate::create_app_state_in_memory(plain_auth_settings())
+            .await
+            .unwrap();
+        let pool = state.pool.clone();
+        let server = TestServer::new(crate::build_router(state, None, "*", false));
+        let token = create_user_and_login(&server).await;
+
+        // No providers yet → empty public login options.
+        let resp = server.get("/api/v1/auth/oauth/login-options").await;
+        resp.assert_status_ok();
+        assert_eq!(resp.json::<Value>()["data"].as_array().unwrap().len(), 0);
+
+        // Register a generic OIDC provider pointing at the mock.
+        let resp = server
+            .post("/api/v1/auth/oauth/providers")
+            .authorization_bearer(&token)
+            .json(&json!({
+                "name": "MockIdP", "provider_type": "oidc",
+                "client_id": "cid", "client_secret": "csecret",
+                "auth_url": format!("{idp_base}/authorize"),
+                "token_url": format!("{idp_base}/token"),
+                "userinfo_url": format!("{idp_base}/userinfo"),
+                "scopes": "openid email"
+            }))
+            .await;
+        assert_eq!(resp.status_code(), StatusCode::CREATED, "{}", resp.text());
+        let resp = server.get("/api/v1/auth/oauth/login-options").await;
+        let opts: Value = resp.json();
+        assert_eq!(opts["data"][0]["name"], "MockIdP");
+        assert!(opts["data"][0].get("client_secret").is_none());
+
+        // Pin the public URL (what the redirect URI is built from).
+        server
+            .put("/api/v1/auth/oauth/settings")
+            .authorization_bearer(&token)
+            .json(&json!({"public_url": "https://fw.example.test:8080/"}))
+            .await
+            .assert_status_ok();
+
+        // authorize → URL with state + PKCE
+        async fn start(server: &TestServer, idp_base: &str) -> String {
+            let resp = server.get("/api/v1/auth/oauth/MockIdP/authorize").await;
+            resp.assert_status_ok();
+            let body: Value = resp.json();
+            let url = body["authorize_url"].as_str().unwrap().to_string();
+            assert!(url.starts_with(&format!("{idp_base}/authorize?")), "{url}");
+            assert!(url.contains("redirect_uri=https%3A%2F%2Ffw.example.test%3A8080%2Fapi%2Fv1%2Fauth%2Foauth%2FMockIdP%2Fcallback"), "{url}");
+            assert!(url.contains("code_challenge_method=S256"), "{url}");
+            body["state"].as_str().unwrap().to_string()
+        }
+
+        // Happy path: new identity, auto-created viewer, session cookies set.
+        let st = start(&server, &idp_base).await;
+        let resp = server
+            .get(&format!(
+                "/api/v1/auth/oauth/MockIdP/callback?code=goodcode&state={st}"
+            ))
+            .await;
+        assert!(resp.status_code().is_redirection(), "{}", resp.text());
+        let loc = resp
+            .headers()
+            .get("location")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(loc, "/login/?oauth=ok", "{loc}");
+        let cookies: Vec<String> = resp
+            .headers()
+            .get_all("set-cookie")
+            .iter()
+            .map(|v| v.to_str().unwrap().to_string())
+            .collect();
+        assert!(
+            cookies.iter().any(|c| c.starts_with("aifw_at=")),
+            "{cookies:?}"
+        );
+        let access = cookies
+            .iter()
+            .find(|c| c.starts_with("aifw_at="))
+            .and_then(|c| c.split(';').next())
+            .and_then(|kv| kv.strip_prefix("aifw_at="))
+            .unwrap()
+            .to_string();
+        // Exchange carried the PKCE verifier and the exact redirect URI.
+        let forms = idp.token_forms.lock().unwrap().clone();
+        assert_eq!(forms.len(), 1);
+        assert!(forms[0].contains("code_verifier="), "{}", forms[0]);
+        assert!(forms[0].contains("client_secret=csecret"), "{}", forms[0]);
+        assert!(forms[0].contains("redirect_uri=https%3A%2F%2Ffw.example.test%3A8080%2Fapi%2Fv1%2Fauth%2Foauth%2FMockIdP%2Fcallback"), "{}", forms[0]);
+        // The cookie session works, and the account is the provisioned viewer.
+        let resp = server
+            .get("/api/v1/auth/me")
+            .add_header("cookie", format!("aifw_at={access}"))
+            .await;
+        resp.assert_status_ok();
+        let me: Value = resp.json();
+        assert_eq!(me["username"], "alice@example.com", "{me}");
+        assert_eq!(me["role"], "viewer");
+        assert_eq!(me["auth_provider"], "MockIdP");
+
+        // Replaying the same state is refused before any exchange.
+        let resp = server
+            .get(&format!(
+                "/api/v1/auth/oauth/MockIdP/callback?code=goodcode&state={st}"
+            ))
+            .await;
+        assert_eq!(
+            resp.headers().get("location").unwrap().to_str().unwrap(),
+            "/login/?oauth_error=state"
+        );
+        assert_eq!(idp.token_forms.lock().unwrap().len(), 1);
+
+        // Bad code → exchange error.
+        let st = start(&server, &idp_base).await;
+        let resp = server
+            .get(&format!(
+                "/api/v1/auth/oauth/MockIdP/callback?code=badcode&state={st}"
+            ))
+            .await;
+        assert_eq!(
+            resp.headers().get("location").unwrap().to_str().unwrap(),
+            "/login/?oauth_error=exchange"
+        );
+
+        // Second login of the same subject links to the same account (no dup user).
+        let st = start(&server, &idp_base).await;
+        let resp = server
+            .get(&format!(
+                "/api/v1/auth/oauth/MockIdP/callback?code=goodcode&state={st}"
+            ))
+            .await;
+        assert_eq!(
+            resp.headers().get("location").unwrap().to_str().unwrap(),
+            "/login/?oauth=ok"
+        );
+        let n: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM users WHERE username = 'alice@example.com'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(n, 1);
+
+        // Auto-create off: an unknown subject is refused.
+        server
+            .put("/api/v1/auth/settings")
+            .authorization_bearer(&token)
+            .json(&json!({"auto_create_oauth_users": false}))
+            .await
+            .assert_status_ok();
+        *idp.userinfo.lock().unwrap() =
+            json!({"sub": "sub-999", "email": "bob@example.com", "email_verified": true});
+        let st = start(&server, &idp_base).await;
+        let resp = server
+            .get(&format!(
+                "/api/v1/auth/oauth/MockIdP/callback?code=goodcode&state={st}"
+            ))
+            .await;
+        assert_eq!(
+            resp.headers().get("location").unwrap().to_str().unwrap(),
+            "/login/?oauth_error=no_account"
+        );
+
+        // Verified email matching an existing local username links it —
+        // here the bootstrap admin, whose username is "admin".
+        *idp.userinfo.lock().unwrap() =
+            json!({"sub": "sub-admin", "email": "admin", "email_verified": true});
+        let st = start(&server, &idp_base).await;
+        let resp = server
+            .get(&format!(
+                "/api/v1/auth/oauth/MockIdP/callback?code=goodcode&state={st}"
+            ))
+            .await;
+        assert_eq!(
+            resp.headers().get("location").unwrap().to_str().unwrap(),
+            "/login/?oauth=ok"
+        );
+        // …but an unverified email must not.
+        *idp.userinfo.lock().unwrap() =
+            json!({"sub": "sub-evil", "email": "admin", "email_verified": false});
+        let st = start(&server, &idp_base).await;
+        let resp = server
+            .get(&format!(
+                "/api/v1/auth/oauth/MockIdP/callback?code=goodcode&state={st}"
+            ))
+            .await;
+        assert_eq!(
+            resp.headers().get("location").unwrap().to_str().unwrap(),
+            "/login/?oauth_error=no_account"
+        );
+
+        // TOTP second step: admin enrols TOTP and require_totp_for_oauth is on.
+        let resp = server
+            .post("/api/v1/auth/totp/setup")
+            .authorization_bearer(&token)
+            .await;
+        let secret = resp.json::<Value>()["secret"].as_str().unwrap().to_string();
+        let code = crate::auth::totp::generate_current(&secret).unwrap();
+        server
+            .post("/api/v1/auth/totp/verify")
+            .authorization_bearer(&token)
+            .json(&json!({"code": &code}))
+            .await
+            .assert_status_ok();
+        server
+            .put("/api/v1/auth/settings")
+            .authorization_bearer(&token)
+            .json(&json!({"require_totp_for_oauth": true}))
+            .await
+            .assert_status_ok();
+        *idp.userinfo.lock().unwrap() =
+            json!({"sub": "sub-admin", "email": "admin", "email_verified": true});
+        let st = start(&server, &idp_base).await;
+        let resp = server
+            .get(&format!(
+                "/api/v1/auth/oauth/MockIdP/callback?code=goodcode&state={st}"
+            ))
+            .await;
+        let loc = resp
+            .headers()
+            .get("location")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(loc.starts_with("/login/?oauth_totp="), "{loc}");
+        assert!(
+            !resp.headers().contains_key("set-cookie"),
+            "no session before TOTP"
+        );
+        let ticket = loc
+            .trim_start_matches("/login/?oauth_totp=")
+            .split('&')
+            .next()
+            .unwrap()
+            .to_string();
+        // Wrong code refused, ticket burnt.
+        let resp = server
+            .post("/api/v1/auth/oauth/totp")
+            .json(&json!({"ticket": &ticket, "totp_code": "000000"}))
+            .await;
+        resp.assert_status(StatusCode::UNAUTHORIZED);
+        let code = crate::auth::totp::generate_current(&secret).unwrap();
+        let resp = server
+            .post("/api/v1/auth/oauth/totp")
+            .json(&json!({"ticket": &ticket, "totp_code": &code}))
+            .await;
+        resp.assert_status(StatusCode::UNAUTHORIZED); // single-use ticket
+        // Fresh ticket + right code → session.
+        let st = start(&server, &idp_base).await;
+        let resp = server
+            .get(&format!(
+                "/api/v1/auth/oauth/MockIdP/callback?code=goodcode&state={st}"
+            ))
+            .await;
+        let loc = resp
+            .headers()
+            .get("location")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        let ticket = loc
+            .trim_start_matches("/login/?oauth_totp=")
+            .split('&')
+            .next()
+            .unwrap()
+            .to_string();
+        let code = crate::auth::totp::generate_current(&secret).unwrap();
+        let resp = server
+            .post("/api/v1/auth/oauth/totp")
+            .json(&json!({"ticket": &ticket, "totp_code": &code}))
+            .await;
+        resp.assert_status_ok();
+        assert!(resp.json::<Value>()["access_token"].is_string());
+        assert!(resp.headers().contains_key("set-cookie"));
     }
 }

--- a/aifw-ui/src/app/login/page.tsx
+++ b/aifw-ui/src/app/login/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import { api, setAuthed } from "@/lib/api";
 import { hardNavigate } from "@/lib/navigation";
+import { fetchOAuthLoginOptions, startOAuthLogin, oauthErrorMessage, type OAuthLoginOption } from "@/lib/api/oauth";
 
 export default function LoginPage() {
   const [username, setUsername] = useState("");
@@ -12,6 +13,50 @@ export default function LoginPage() {
   const [totpRequired, setTotpRequired] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  // OAuth / SSO (#170)
+  const [oauthOptions, setOauthOptions] = useState<OAuthLoginOption[]>([]);
+  const [oauthTicket, setOauthTicket] = useState<string | null>(null);
+  const [oauthUser, setOauthUser] = useState("");
+
+  useEffect(() => {
+    // The provider callback bounces the browser back here with the outcome
+    // in the query string (static UI, no server-side rendering). State
+    // updates run from an async continuation so the effect body itself
+    // stays side-effect free for the linter.
+    const params = new URLSearchParams(window.location.search);
+    (async () => {
+      if (params.get("oauth") === "ok") {
+        setAuthed(true);
+        hardNavigate("/");
+        return;
+      }
+      const oauthError = params.get("oauth_error");
+      if (oauthError) setError(oauthErrorMessage(oauthError));
+      const ticket = params.get("oauth_totp");
+      if (ticket) {
+        setOauthTicket(ticket);
+        setOauthUser(params.get("user") || "");
+        setTotpRequired(true);
+        window.history.replaceState(null, "", window.location.pathname);
+      }
+      try {
+        setOauthOptions(await fetchOAuthLoginOptions());
+      } catch {
+        /* no SSO configured or API unreachable — password form still works */
+      }
+    })();
+  }, []);
+
+  const handleOAuthStart = async (name: string) => {
+    setError("");
+    setLoading(true);
+    try {
+      await startOAuthLogin(name);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not start single sign-on");
+      setLoading(false);
+    }
+  };
 
   const inputClass = "w-full px-3 py-2 text-sm bg-[var(--bg-primary)] border border-[var(--border)] rounded-md text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent)]";
 
@@ -47,17 +92,28 @@ export default function LoginPage() {
     setError("");
     setLoading(true);
     try {
-      const data = await api.post<{ access_token?: string }>(
-        "/api/v1/auth/totp/login",
-        { username, password, totp_code: totpCode },
-        { noAuthRedirect: true },
-      );
+      // Two TOTP entry points: after a password login (username+password
+      // re-sent) or after an OAuth callback (single-use ticket, #170).
+      const data = oauthTicket
+        ? await api.post<{ access_token?: string }>(
+            "/api/v1/auth/oauth/totp",
+            { ticket: oauthTicket, totp_code: totpCode },
+            { noAuthRedirect: true },
+          )
+        : await api.post<{ access_token?: string }>(
+            "/api/v1/auth/totp/login",
+            { username, password, totp_code: totpCode },
+            { noAuthRedirect: true },
+          );
       if (data.access_token) {
         setAuthed(true);
         hardNavigate("/");
       }
     } catch {
-      setError("Invalid TOTP code or recovery code");
+      setError(oauthTicket
+        ? "Invalid code — or the sign-in ticket expired. Start single sign-on again."
+        : "Invalid TOTP code or recovery code");
+      if (oauthTicket) { setOauthTicket(null); setTotpRequired(false); }
     } finally {
       setLoading(false);
     }
@@ -94,6 +150,22 @@ export default function LoginPage() {
               className="w-full py-2.5 bg-[var(--accent)] hover:bg-[var(--accent-hover)] text-white rounded-md text-sm font-medium transition-colors disabled:opacity-50">
               {loading ? "Signing in..." : "Sign In"}
             </button>
+
+            {oauthOptions.length > 0 && (
+              <div className="pt-2 space-y-2">
+                <div className="flex items-center gap-3 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
+                  <span className="flex-1 border-t border-[var(--border)]" />
+                  or continue with
+                  <span className="flex-1 border-t border-[var(--border)]" />
+                </div>
+                {oauthOptions.map((o) => (
+                  <button key={o.name} type="button" disabled={loading} onClick={() => handleOAuthStart(o.name)}
+                    className="w-full py-2 border border-[var(--border)] hover:border-[var(--accent)] rounded-md text-sm text-[var(--text-primary)] transition-colors disabled:opacity-50">
+                    {o.name}
+                  </button>
+                ))}
+              </div>
+            )}
           </form>
         ) : (
           <form onSubmit={handleTotpLogin} className="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-6 space-y-4">
@@ -104,6 +176,7 @@ export default function LoginPage() {
             )}
 
             <div className="text-center text-sm text-[var(--text-secondary)] mb-2">
+              {oauthTicket && oauthUser ? <span className="block text-xs text-[var(--text-muted)] mb-1">Signed in as {oauthUser} — second factor required.</span> : null}
               Enter the 6-digit code from your authenticator app, or a recovery code.
             </div>
 
@@ -119,7 +192,7 @@ export default function LoginPage() {
               {loading ? "Verifying..." : "Verify"}
             </button>
 
-            <button type="button" onClick={() => { setTotpRequired(false); setTotpCode(""); setError(""); }}
+            <button type="button" onClick={() => { setTotpRequired(false); setTotpCode(""); setError(""); setOauthTicket(null); }}
               className="w-full py-2 text-[var(--text-muted)] hover:text-[var(--text-primary)] text-sm transition-colors">
               Back to login
             </button>

--- a/aifw-ui/src/app/settings/components/SsoSection.tsx
+++ b/aifw-ui/src/app/settings/components/SsoSection.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { Feedback } from "@/hooks/useFeedback";
+import type { OAuthProvider } from "@/lib/api/oauth";
+import type { ProviderForm } from "@/hooks/useSsoSettings";
+import { FeedbackBanner } from "./FeedbackBanner";
+import { inputCls, labelCls, saveBtnCls, sectionCls } from "./sectionStyles";
+
+export interface SsoSectionProps {
+  visible: boolean;
+  providers: OAuthProvider[];
+  publicUrl: string;
+  setPublicUrl: (v: string) => void;
+  requireTotpForOauth: boolean;
+  setRequireTotpForOauth: (v: boolean) => void;
+  autoCreateUsers: boolean;
+  setAutoCreateUsers: (v: boolean) => void;
+  form: ProviderForm;
+  setForm: (f: ProviderForm) => void;
+  showForm: boolean;
+  setShowForm: (v: boolean) => void;
+  loading: boolean;
+  saving: boolean;
+  deleting: string | null;
+  feedback: Feedback | null;
+  savePolicy: () => void;
+  addProvider: () => void;
+  removeProvider: (p: OAuthProvider) => void;
+  redirectUriFor: (name: string) => string;
+}
+
+const TYPE_LABEL: Record<string, string> = { google: "Google", github: "GitHub", oidc: "Generic OIDC" };
+
+export function SsoSection({
+  visible, providers, publicUrl, setPublicUrl, requireTotpForOauth, setRequireTotpForOauth,
+  autoCreateUsers, setAutoCreateUsers, form, setForm, showForm, setShowForm, loading, saving,
+  deleting, feedback, savePolicy, addProvider, removeProvider, redirectUriFor,
+}: SsoSectionProps) {
+  const set = <K extends keyof ProviderForm>(k: K, v: ProviderForm[K]) => setForm({ ...form, [k]: v });
+  const formValid =
+    form.name.trim() && form.client_id.trim() && form.client_secret &&
+    (form.provider_type !== "oidc" || (form.auth_url.trim() && form.token_url.trim() && form.userinfo_url.trim()));
+
+  return (
+    <section className={`${sectionCls} ${visible ? "" : "hidden"}`}>
+      <div className="flex items-center justify-between mb-1">
+        <h2 className="font-medium">Single Sign-On (OAuth / OIDC)</h2>
+      </div>
+      <p className="text-xs text-[var(--text-muted)] mb-4">
+        Let users sign in with Google, GitHub or any OpenID Connect provider (Okta, Auth0, Keycloak, Entra ID…).
+        The first sign-in links the provider identity to a local account: a <em>verified</em> email that matches an
+        existing username links that account; otherwise, if enabled below, a new <strong>viewer</strong> account is
+        created — promote it under Users. Register the redirect URI shown for each provider at the identity provider.
+      </p>
+      <FeedbackBanner feedback={feedback} />
+      {loading ? (
+        <p className="text-sm text-[var(--text-muted)]">Loading…</p>
+      ) : (
+        <div className="space-y-5">
+          {/* Providers */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <h3 className="text-sm font-medium">Providers</h3>
+              <button type="button" onClick={() => setShowForm(!showForm)}
+                className="px-3 py-1.5 text-xs rounded border border-[var(--border)] hover:border-[var(--accent)]">
+                {showForm ? "Cancel" : "Add provider"}
+              </button>
+            </div>
+            {providers.length === 0 && !showForm && (
+              <p className="text-sm text-[var(--text-muted)]">No providers configured — the sign-in page shows only the password form.</p>
+            )}
+            {providers.length > 0 && (
+              <div className="overflow-x-auto rounded-md border border-[var(--border)]">
+                <table className="w-full text-sm">
+                  <thead className="bg-[var(--bg-primary)] text-xs uppercase tracking-wider text-[var(--text-muted)]">
+                    <tr>
+                      <th className="text-left px-3 py-2">Name</th>
+                      <th className="text-left px-3 py-2">Type</th>
+                      <th className="text-left px-3 py-2">Client ID</th>
+                      <th className="text-left px-3 py-2">Redirect URI (register at provider)</th>
+                      <th className="px-3 py-2" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {providers.map((p) => (
+                      <tr key={p.id} className="border-t border-[var(--border)]">
+                        <td className="px-3 py-2 font-medium">{p.name}</td>
+                        <td className="px-3 py-2 text-[var(--text-secondary)]">{TYPE_LABEL[p.provider_type] ?? p.provider_type}</td>
+                        <td className="px-3 py-2 font-mono text-xs truncate max-w-[14rem]" title={p.client_id}>{p.client_id}</td>
+                        <td className="px-3 py-2 font-mono text-[11px] break-all">{redirectUriFor(p.name)}</td>
+                        <td className="px-3 py-2 text-right">
+                          <button type="button" onClick={() => removeProvider(p)} disabled={deleting === p.id}
+                            className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50">
+                            {deleting === p.id ? "Removing…" : "Remove"}
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            {showForm && (
+              <div className="mt-3 rounded-md border border-[var(--border)] bg-[var(--bg-primary)] p-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className={labelCls}>Display name</label>
+                  <input type="text" value={form.name} onChange={(e) => set("name", e.target.value)} className={inputCls} placeholder="e.g. Google Workspace" />
+                  <p className="mt-1 text-[11px] text-[var(--text-muted)]">Shown on the sign-in button and used in the redirect URI.</p>
+                </div>
+                <div>
+                  <label className={labelCls}>Type</label>
+                  <select value={form.provider_type} onChange={(e) => set("provider_type", e.target.value as ProviderForm["provider_type"])} className={inputCls}>
+                    <option value="google">Google</option>
+                    <option value="github">GitHub</option>
+                    <option value="oidc">Generic OIDC</option>
+                  </select>
+                </div>
+                <div>
+                  <label className={labelCls}>Client ID</label>
+                  <input type="text" value={form.client_id} onChange={(e) => set("client_id", e.target.value)} className={inputCls} />
+                </div>
+                <div>
+                  <label className={labelCls}>Client secret</label>
+                  <input type="password" autoComplete="new-password" value={form.client_secret} onChange={(e) => set("client_secret", e.target.value)} className={inputCls} />
+                </div>
+                {form.provider_type === "oidc" && (
+                  <>
+                    <div className="md:col-span-2">
+                      <label className={labelCls}>Authorization endpoint</label>
+                      <input type="url" value={form.auth_url} onChange={(e) => set("auth_url", e.target.value)} className={inputCls} placeholder="https://idp.example.com/oauth2/v1/authorize" />
+                    </div>
+                    <div>
+                      <label className={labelCls}>Token endpoint</label>
+                      <input type="url" value={form.token_url} onChange={(e) => set("token_url", e.target.value)} className={inputCls} placeholder="https://idp.example.com/oauth2/v1/token" />
+                    </div>
+                    <div>
+                      <label className={labelCls}>Userinfo endpoint</label>
+                      <input type="url" value={form.userinfo_url} onChange={(e) => set("userinfo_url", e.target.value)} className={inputCls} placeholder="https://idp.example.com/oauth2/v1/userinfo" />
+                    </div>
+                  </>
+                )}
+                <div className="md:col-span-2">
+                  <label className={labelCls}>Scopes <span className="normal-case">(optional)</span></label>
+                  <input type="text" value={form.scopes} onChange={(e) => set("scopes", e.target.value)} className={inputCls}
+                    placeholder={form.provider_type === "github" ? "read:user user:email" : "openid email profile"} />
+                </div>
+                <div className="md:col-span-2 flex items-center gap-3">
+                  <button type="button" onClick={addProvider} disabled={saving || !formValid} className={saveBtnCls}>
+                    {saving ? "Adding…" : "Add provider"}
+                  </button>
+                  {form.name.trim() && (
+                    <span className="text-[11px] text-[var(--text-muted)] font-mono break-all">Redirect URI: {redirectUriFor(form.name.trim())}</span>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Policy */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-2 border-t border-[var(--border)]">
+            <div className="md:col-span-2">
+              <label className={labelCls}>Public URL (for the redirect URI)</label>
+              <input type="url" value={publicUrl} onChange={(e) => setPublicUrl(e.target.value)} className={inputCls}
+                placeholder="https://firewall.example.com:8080 — leave empty to use the address in the browser" />
+              <p className="mt-1 text-[11px] text-[var(--text-muted)]">
+                Set this when the appliance sits behind a reverse proxy or is reached under a name different from the request Host.
+              </p>
+            </div>
+            <label className="flex items-start gap-2 text-sm cursor-pointer">
+              <input type="checkbox" checked={autoCreateUsers} onChange={(e) => setAutoCreateUsers(e.target.checked)} className="mt-0.5" />
+              <span>
+                Auto-create accounts on first sign-in
+                <span className="block text-[11px] text-[var(--text-muted)]">New identities become <strong>viewer</strong> accounts. Off ⇒ only pre-linked accounts (or a verified email matching an existing username) can sign in.</span>
+              </span>
+            </label>
+            <label className="flex items-start gap-2 text-sm cursor-pointer">
+              <input type="checkbox" checked={requireTotpForOauth} onChange={(e) => setRequireTotpForOauth(e.target.checked)} className="mt-0.5" />
+              <span>
+                Require TOTP after single sign-on
+                <span className="block text-[11px] text-[var(--text-muted)]">Accounts with TOTP enrolled must also enter their code. Off ⇒ the identity provider is trusted for MFA.</span>
+              </span>
+            </label>
+            <div className="md:col-span-2">
+              <button type="button" onClick={savePolicy} disabled={saving} className={saveBtnCls}>
+                {saving ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/aifw-ui/src/app/settings/page.tsx
+++ b/aifw-ui/src/app/settings/page.tsx
@@ -26,6 +26,8 @@ import {
 import { AiProvidersSection } from "./components/AiProvidersSection";
 import { ApiServerSection } from "./components/ApiServerSection";
 import { AuthSection } from "./components/AuthSection";
+import { SsoSection } from "./components/SsoSection";
+import { useSsoSettings } from "@/hooks/useSsoSettings";
 import { BannerSection } from "./components/BannerSection";
 import { ConfigHistorySection } from "./components/ConfigHistorySection";
 import { ConsoleSection } from "./components/ConsoleSection";
@@ -52,7 +54,7 @@ import { ValkeySection } from "./components/ValkeySection";
 // system config) but the category tabs make the long scroll navigable.
 const CATEGORIES: { key: string; label: string; sections: string[] }[] = [
   { key: "system",  label: "System",          sections: ["General", "Login Banner & MOTD", "SSH Access", "Console", "System Actions", "pf State Table"] },
-  { key: "api",     label: "API & Auth",      sections: ["API Server", "TLS Policy", "Authentication"] },
+  { key: "api",     label: "API & Auth",      sections: ["API Server", "TLS Policy", "Authentication", "Single Sign-On (OAuth / OIDC)"] },
   { key: "dns",     label: "DNS",             sections: ["DNS Configuration"] },
   { key: "storage", label: "Storage & Metrics", sections: ["Metrics Storage", "Dashboard History", "Metrics Persistence (Valkey)", "IDS Alert Storage"] },
   { key: "backup",  label: "Backup & History", sections: ["Config History", "S3 Backup Sync", "Email Notifications (SMTP)"] },
@@ -72,6 +74,7 @@ export default function SettingsPage() {
   const apiServer = useApiServerSettings();
   const tls = useTlsPolicy();
   const auth = useAuthSettings();
+  const sso = useSsoSettings();
   const valkey = useValkeySettings();
   const ids = useIdsAlertSettings();
   const ai = useAiProviders();
@@ -150,6 +153,7 @@ export default function SettingsPage() {
       <ApiServerSection visible={inCategory("API Server")} {...apiServer} />
       <TlsPolicySection visible={inCategory("TLS Policy")} {...tls} />
       <AuthSection visible={inCategory("Authentication")} {...auth} />
+      <SsoSection visible={inCategory("Single Sign-On (OAuth / OIDC)")} {...sso} />
       <ValkeySection visible={inCategory("Metrics Persistence (Valkey)")} {...valkey} />
       <IdsAlertSection visible={inCategory("IDS Alert Storage")} {...ids} />
       <AiProvidersSection visible={inCategory("AI / LLM Providers")} {...ai} />

--- a/aifw-ui/src/hooks/useSsoSettings.ts
+++ b/aifw-ui/src/hooks/useSsoSettings.ts
@@ -1,0 +1,158 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useFeedback } from "@/hooks/useFeedback";
+import { api } from "@/lib/api";
+import {
+  CreateOAuthProviderRequest,
+  OAuthProvider,
+  OAuthProviderType,
+  createOAuthProvider,
+  deleteOAuthProvider,
+  getOAuthSettings,
+  listOAuthProviders,
+  saveOAuthSettings,
+} from "@/lib/api/oauth";
+
+export interface ProviderForm {
+  name: string;
+  provider_type: OAuthProviderType;
+  client_id: string;
+  client_secret: string;
+  auth_url: string;
+  token_url: string;
+  userinfo_url: string;
+  scopes: string;
+}
+
+export const emptyProviderForm: ProviderForm = {
+  name: "",
+  provider_type: "google",
+  client_id: "",
+  client_secret: "",
+  auth_url: "",
+  token_url: "",
+  userinfo_url: "",
+  scopes: "",
+};
+
+/** State + actions for Settings → API & Auth → Single Sign-On (#170). */
+export function useSsoSettings() {
+  const [providers, setProviders] = useState<OAuthProvider[]>([]);
+  const [publicUrl, setPublicUrl] = useState("");
+  const [requireTotpForOauth, setRequireTotpForOauth] = useState(false);
+  const [autoCreateUsers, setAutoCreateUsers] = useState(true);
+  const [form, setForm] = useState<ProviderForm>(emptyProviderForm);
+  const [showForm, setShowForm] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const { feedback, showFeedback, clearFeedback } = useFeedback(6000);
+
+  const refresh = useCallback(async () => {
+    try {
+      const [list, settings, auth] = await Promise.all([
+        listOAuthProviders(),
+        getOAuthSettings(),
+        api.get<{ require_totp_for_oauth?: boolean; auto_create_oauth_users?: boolean }>("/api/v1/auth/settings"),
+      ]);
+      setProviders(list);
+      setPublicUrl(settings.public_url || "");
+      setRequireTotpForOauth(!!auth.require_totp_for_oauth);
+      setAutoCreateUsers(auth.auto_create_oauth_users !== false);
+    } catch {
+      /* older API or not admin — section stays empty */
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { queueMicrotask(refresh); }, [refresh]);
+
+  const savePolicy = async () => {
+    setSaving(true);
+    clearFeedback();
+    try {
+      await saveOAuthSettings({ public_url: publicUrl.trim() });
+      await api.put("/api/v1/auth/settings", {
+        require_totp_for_oauth: requireTotpForOauth,
+        auto_create_oauth_users: autoCreateUsers,
+      });
+      showFeedback("success", "Single sign-on settings saved.");
+    } catch (err) {
+      showFeedback("error", err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const addProvider = async () => {
+    setSaving(true);
+    clearFeedback();
+    try {
+      const req: CreateOAuthProviderRequest = {
+        name: form.name.trim(),
+        provider_type: form.provider_type,
+        client_id: form.client_id.trim(),
+        client_secret: form.client_secret,
+      };
+      if (form.provider_type === "oidc") {
+        req.auth_url = form.auth_url.trim();
+        req.token_url = form.token_url.trim();
+        req.userinfo_url = form.userinfo_url.trim();
+      }
+      if (form.scopes.trim()) req.scopes = form.scopes.trim();
+      await createOAuthProvider(req);
+      setForm(emptyProviderForm);
+      setShowForm(false);
+      showFeedback("success", `Provider "${req.name}" added.`);
+      await refresh();
+    } catch (err) {
+      showFeedback("error", err instanceof Error ? err.message : "Could not add provider");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const removeProvider = async (p: OAuthProvider) => {
+    if (!window.confirm(`Remove sign-in provider "${p.name}"? Users linked to it can no longer sign in with it.`)) return;
+    setDeleting(p.id);
+    try {
+      await deleteOAuthProvider(p.id);
+      showFeedback("success", `Provider "${p.name}" removed.`);
+      await refresh();
+    } catch (err) {
+      showFeedback("error", err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  /// Redirect URI the operator must register at the provider.
+  const redirectUriFor = (name: string): string => {
+    const base = publicUrl.trim().replace(/\/+$/, "") || (typeof window !== "undefined" ? window.location.origin : "");
+    return `${base}/api/v1/auth/oauth/${encodeURIComponent(name)}/callback`;
+  };
+
+  return {
+    providers,
+    publicUrl,
+    setPublicUrl,
+    requireTotpForOauth,
+    setRequireTotpForOauth,
+    autoCreateUsers,
+    setAutoCreateUsers,
+    form,
+    setForm,
+    showForm,
+    setShowForm,
+    loading,
+    saving,
+    deleting,
+    feedback,
+    savePolicy,
+    addProvider,
+    removeProvider,
+    redirectUriFor,
+  };
+}

--- a/aifw-ui/src/lib/api/oauth.ts
+++ b/aifw-ui/src/lib/api/oauth.ts
@@ -1,0 +1,87 @@
+import { api } from "@/lib/api";
+
+/// OAuth / SSO (#170) — types + typed API calls. Provider management is
+/// admin-only; login options / authorize are public.
+
+export type OAuthProviderType = "google" | "github" | "oidc";
+
+export interface OAuthLoginOption {
+  name: string;
+  provider_type: OAuthProviderType;
+}
+
+export interface OAuthProvider {
+  id: string;
+  name: string;
+  provider_type: OAuthProviderType;
+  client_id: string;
+  auth_url: string;
+  token_url: string;
+  userinfo_url: string;
+  scopes: string;
+  enabled: boolean;
+  created_at: string;
+}
+
+export interface CreateOAuthProviderRequest {
+  name: string;
+  provider_type: OAuthProviderType;
+  client_id: string;
+  client_secret: string;
+  auth_url?: string;
+  token_url?: string;
+  userinfo_url?: string;
+  scopes?: string;
+}
+
+export interface OAuthSettings {
+  public_url: string;
+}
+
+export async function fetchOAuthLoginOptions(): Promise<OAuthLoginOption[]> {
+  const body = await api.get<{ data: OAuthLoginOption[] }>("/api/v1/auth/oauth/login-options");
+  return body.data ?? [];
+}
+
+/// Ask the API for the provider's authorization URL and send the browser there.
+export async function startOAuthLogin(name: string): Promise<void> {
+  const body = await api.get<{ authorize_url: string }>(
+    `/api/v1/auth/oauth/${encodeURIComponent(name)}/authorize`,
+  );
+  window.location.assign(body.authorize_url);
+}
+
+/// Human text for the `?oauth_error=` codes the callback redirects with.
+export function oauthErrorMessage(code: string): string {
+  switch (code) {
+    case "denied": return "Sign-in was cancelled at the identity provider.";
+    case "state": return "The sign-in request expired or was already used. Please try again.";
+    case "exchange": return "The identity provider rejected the sign-in (token exchange failed). Check the client ID / secret and redirect URI.";
+    case "userinfo": return "Could not read your profile from the identity provider.";
+    case "no_account": return "No AiFw account is linked to that identity, and automatic account creation is off. Ask an administrator.";
+    case "disabled": return "This account is disabled.";
+    case "provider": return "That sign-in provider is not available.";
+    default: return "Single sign-on failed. Please try again.";
+  }
+}
+
+export async function listOAuthProviders(): Promise<OAuthProvider[]> {
+  const body = await api.get<{ data: OAuthProvider[] }>("/api/v1/auth/oauth/providers");
+  return body.data ?? [];
+}
+
+export function createOAuthProvider(req: CreateOAuthProviderRequest): Promise<{ data: OAuthProvider }> {
+  return api.post<{ data: OAuthProvider }>("/api/v1/auth/oauth/providers", req);
+}
+
+export function deleteOAuthProvider(id: string): Promise<unknown> {
+  return api.delete<unknown>(`/api/v1/auth/oauth/providers/${id}`);
+}
+
+export function getOAuthSettings(): Promise<OAuthSettings> {
+  return api.get<OAuthSettings>("/api/v1/auth/oauth/settings");
+}
+
+export function saveOAuthSettings(s: OAuthSettings): Promise<OAuthSettings> {
+  return api.put<OAuthSettings>("/api/v1/auth/oauth/settings", s);
+}

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -144,9 +144,12 @@ Sensible defaults are applied when omitted; check the relevant subsystem doc for
 | `POST` | `/api/v1/auth/api-keys` | Create an API key |
 | `GET`,&nbsp;`PUT` | `/api/v1/auth/settings` | Auth settings (lockout, refresh TTL, &hellip;) |
 | `GET`,&nbsp;`POST` | `/api/v1/auth/oauth/providers` | List / create OAuth providers |
-| `PUT`,&nbsp;`DELETE` | `/api/v1/auth/oauth/providers/{id}` | Manage one provider |
-| `GET` | `/api/v1/auth/oauth/{provider}/authorize` | Begin OAuth login |
-| `GET` | `/api/v1/auth/oauth/{provider}/callback` | OAuth provider callback |
+| `DELETE` | `/api/v1/auth/oauth/providers/{id}` | Remove a provider |
+| `GET`,&nbsp;`PUT` | `/api/v1/auth/oauth/settings` | SSO public URL used for the redirect URI |
+| `GET` | `/api/v1/auth/oauth/login-options` | Enabled providers for the sign-in page (public) |
+| `GET` | `/api/v1/auth/oauth/{provider}/authorize` | Begin OAuth login (state + PKCE) |
+| `GET` | `/api/v1/auth/oauth/{provider}/callback` | OAuth provider callback — installs the session cookies |
+| `POST` | `/api/v1/auth/oauth/totp` | Finish a TOTP-gated OAuth login |
 
 ## Status, metrics, logs
 

--- a/docs/docs/auth.md
+++ b/docs/docs/auth.md
@@ -81,15 +81,13 @@ Disable from `POST /api/v1/auth/totp/disable` (requires a fresh password challen
 
 ## OAuth / SSO
 
-Three provider types are built in:
+Sign in with Google, GitHub or any OpenID Connect provider (Okta, Auth0, Keycloak, Entra ID, &hellip;). Configure providers under **Settings &rarr; API &amp; Auth &rarr; Single Sign-On**, or via the API:
 
 | Provider | `provider_type` | Notes |
 |---|---|---|
-| Google | `google` | Pre-configured auth + token URLs |
-| GitHub | `github` | Pre-configured auth + token URLs |
-| Generic OIDC | `oidc` | Supply your own auth / token / userinfo URLs (Okta, Auth0, Keycloak, Azure AD, &hellip;) |
-
-Add a provider:
+| Google | `google` | Pre-configured auth / token / userinfo URLs |
+| GitHub | `github` | Pre-configured; the verified primary email is read from `/user/emails` |
+| Generic OIDC | `oidc` | Supply your own `auth_url`, `token_url`, `userinfo_url` (must be `https`) |
 
 ```bash
 curl -X POST https://aifw.local/api/v1/auth/oauth/providers \
@@ -100,18 +98,25 @@ curl -X POST https://aifw.local/api/v1/auth/oauth/providers \
     "provider_type": "google",
     "client_id": "...apps.googleusercontent.com",
     "client_secret": "...",
-    "scopes": "openid email profile",
-    "enabled": true
+    "scopes": "openid email profile"
   }'
 ```
 
-Redirect URI to register with the provider:
+Register this redirect URI at the provider (the settings page shows it per provider):
 
 ```
-https://aifw.local/api/v1/auth/oauth/{provider}/callback
+https://aifw.local/api/v1/auth/oauth/{provider name}/callback
 ```
 
-Login flow uses `/api/v1/auth/oauth/{provider}/authorize` &rarr; provider consent &rarr; callback &rarr; AiFw mints a JWT for the matched (or auto-provisioned) local user.
+The host part comes from the request `Host` (with the API's own TLS mode) unless you pin it &mdash; `PUT /api/v1/auth/oauth/settings {"public_url": "https://fw.example.com:8080"}` &mdash; which you need behind a reverse proxy or when the box is reached under several names.
+
+**Flow.** The sign-in page lists enabled providers (`GET /api/v1/auth/oauth/login-options`). Clicking one calls `GET /api/v1/auth/oauth/{provider}/authorize`, which mints a single-use `state` nonce plus a PKCE (S256) verifier and returns the provider's authorization URL. After consent the provider redirects to the callback, which checks the `state` (10-minute TTL, replay-proof), exchanges the code at the token endpoint (client secret + PKCE verifier), reads the userinfo endpoint and resolves a local account:
+
+1. an existing link in `oauth_identities` (provider + subject) wins;
+2. otherwise a **verified** email that equals an existing local username links that account (unverified emails never link &mdash; a hostile IdP claim can't take over an admin);
+3. otherwise, when **Auto-create accounts** is on (default), a new `viewer` account is provisioned with an unusable password &mdash; promote it under Users; when off, the login is refused (`no_account`).
+
+The session is then installed as the usual `HttpOnly` cookies and the browser lands on the UI. With **Require TOTP after single sign-on** on, an account that has TOTP enrolled is sent to the TOTP prompt first (single-use 5-minute ticket, `POST /api/v1/auth/oauth/totp {"ticket","totp_code"}`); off means the identity provider is trusted for MFA. Failures come back to the sign-in page as `?oauth_error=state|exchange|userinfo|no_account|disabled|denied` and are logged server-side with detail. Provider client secrets are sealed at rest and never returned by the API.
 
 ## API keys
 
@@ -255,6 +260,11 @@ The canonical list lives in [`aifw-common/src/permission.rs`](https://github.com
 | `POST` | `/api/v1/auth/refresh` | Exchange a refresh token for a new JWT |
 | `POST` | `/api/v1/auth/logout` | Revoke the current session |
 | `POST` | `/api/v1/auth/register` | Bootstrap the first admin — unauthenticated, only succeeds while no user account exists |
+| `GET` | `/api/v1/auth/oauth/login-options` | Enabled SSO providers for the sign-in page (public) |
+| `GET` | `/api/v1/auth/oauth/{provider}/authorize` | Start SSO: returns the provider authorization URL (state + PKCE) |
+| `GET` | `/api/v1/auth/oauth/{provider}/callback` | Provider redirect target — installs the session or hands off to TOTP |
+| `POST` | `/api/v1/auth/oauth/totp` | Finish a TOTP-gated SSO login with the callback's ticket |
+| `GET` `/` `PUT` | `/api/v1/auth/oauth/settings` | SSO public URL (admin) |
 | `GET` | `/api/v1/auth/me` | Current user identity, role, perms |
 | `POST` | `/api/v1/auth/totp/setup` | Begin TOTP enrolment |
 | `POST` | `/api/v1/auth/totp/verify` | Verify and activate TOTP |


### PR DESCRIPTION
Closes #170.

`/api/v1/auth/oauth/{provider}/callback` stopped at the state check and returned 501; SSO was advertised but never completed a login, and there was no UI for it at all.

**Backend** (`aifw-api/src/auth/oauth_flow.rs`, routes)
- `authorize` mints `state` + a PKCE S256 verifier (both stored with the state row, 10-min TTL, single-use) and returns a properly percent-encoded authorization URL. Redirect URI = `<public base>/api/v1/auth/oauth/<name>/callback`; the base is the new `oauth_public_url` setting (`GET/PUT /auth/oauth/settings`) or, if unset, the request `Host` + the API's TLS mode.
- `callback`: consume state → POST token endpoint (client secret + `code_verifier`, `Accept: application/json` for GitHub) → userinfo (`sub`/`email`/`email_verified`; GitHub `id`/`login` + `/user/emails` verified primary) → resolve account → session cookies → `302 /login/?oauth=ok`. Failures redirect with `?oauth_error=state|exchange|userinfo|no_account|disabled|denied|provider` and log detail server-side.
- Account resolution: existing `oauth_identities` link wins; else a **verified** email equal to a local username links that account (unverified never links); else `auto_create_oauth_users` provisions a `viewer` with an unusable random password (`auth_provider` = provider name) and audits it; else `no_account`.
- `require_totp_for_oauth`: on ⇒ accounts with TOTP enrolled get a single-use 5-min ticket and finish via `POST /auth/oauth/totp {ticket, totp_code}` (TOTP or recovery code); off ⇒ IdP trusted for MFA. Both policy flags read live, no restart.
- `GET /auth/oauth/login-options` (public: names + types only). Provider create validates the name, honours custom names for Google/GitHub, requires https endpoints for generic OIDC.
- Migration adds `oauth_states.code_verifier/redirect_uri` and `oauth_pending_logins`.

**UI**
- Sign-in page: "or continue with …" buttons for enabled providers, handles `?oauth=ok`, `?oauth_error=`, and the `?oauth_totp=<ticket>` second step.
- Settings → API & Auth → **Single Sign-On**: provider table with the exact redirect URI to register, add/remove (Google / GitHub / generic OIDC form), public URL, auto-create and require-TOTP toggles.

**Tests**: unit tests for PKCE (RFC 7636 vector), URL encoding, userinfo normalisation; integration test spins up an in-process mock IdP (axum on 127.0.0.1) and drives: happy path + cookies + `/auth/me`, PKCE verifier/redirect URI in the exchange, state replay refusal, bad code, same-subject re-login (no dup user), auto-create off, verified-email linking vs unverified refusal, and the TOTP ticket step (wrong code burns ticket, right code issues session). Existing state-binding test updated for the redirecting callback. Docs: auth.md, api.md.