### PR TITLE
ui: accessible modals and toggles, class-based state styling (#451 #449)

### DIFF
--- a/aifw-ui/src/app/acme/page.tsx
+++ b/aifw-ui/src/app/acme/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { api } from "@/lib/api";
 import Help, { HelpBanner } from "./Help";
+import { ModalOverlay } from "@/components/ui/ModalOverlay";
 
 /* ---------- Types ---------- */
 
@@ -274,8 +275,9 @@ function AddCertModal({ providers, onClose, onCreated }:
   }
 
   return (
-    <div className="fixed inset-0 bg-black/60 z-40 flex items-center justify-center p-4" onClick={onClose}>
-      <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-5 w-full max-w-md space-y-3" onClick={(e) => e.stopPropagation()}>
+    <ModalOverlay onClose={onClose} ariaLabel="Request certificate"
+      className="fixed inset-0 bg-black/60 z-40 flex items-center justify-center p-4"
+      panelClassName="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-5 w-full max-w-md space-y-3">
         <h2 className="text-lg font-semibold text-white">Request certificate</h2>
 
         <Field label="Common Name (CN)" error={cn ? cnErr : null}>
@@ -321,8 +323,7 @@ function AddCertModal({ providers, onClose, onCreated }:
             {busy ? "Creating…" : "Save (issue happens on Renew)"}
           </button>
         </div>
-      </div>
-    </div>
+    </ModalOverlay>
   );
 }
 
@@ -406,8 +407,9 @@ function AddExportTargetModal({ certId, onClose, onCreated }: { certId: number; 
   }
 
   return (
-    <div className="fixed inset-0 bg-black/60 z-40 flex items-center justify-center p-4" onClick={onClose}>
-      <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-5 w-full max-w-lg space-y-3" onClick={(e) => e.stopPropagation()}>
+    <ModalOverlay onClose={onClose} ariaLabel="Add export target"
+      className="fixed inset-0 bg-black/60 z-40 flex items-center justify-center p-4"
+      panelClassName="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-5 w-full max-w-lg space-y-3">
         <h2 className="text-lg font-semibold text-white">Add export target</h2>
         <Field label="Kind">
           <select value={kind} onChange={(e) => setKind(e.target.value as "file" | "webhook" | "local-tls-store")} className="form-input">
@@ -427,8 +429,7 @@ function AddExportTargetModal({ certId, onClose, onCreated }: { certId: number; 
             {busy ? "Saving…" : "Save"}
           </button>
         </div>
-      </div>
-    </div>
+    </ModalOverlay>
   );
 }
 
@@ -687,8 +688,9 @@ function ProviderModal({ initial, onClose, onSaved }: { initial: DnsProvider | n
   }
 
   return (
-    <div className="fixed inset-0 bg-black/60 z-40 flex items-center justify-center p-4" onClick={onClose}>
-      <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto space-y-4" onClick={(e) => e.stopPropagation()}>
+    <ModalOverlay onClose={onClose} ariaLabel={`${isNew ? "Add" : "Edit"} DNS provider`}
+      className="fixed inset-0 bg-black/60 z-40 flex items-center justify-center p-4"
+      panelClassName="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto space-y-4">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold text-white">{isNew ? "Add" : "Edit"} DNS provider</h2>
           <button onClick={onClose} className="text-[var(--text-muted)] hover:text-white text-xl leading-none">✕</button>
@@ -796,8 +798,7 @@ function ProviderModal({ initial, onClose, onSaved }: { initial: DnsProvider | n
             </button>
           </div>
         </div>
-      </div>
-    </div>
+    </ModalOverlay>
   );
 }
 

--- a/aifw-ui/src/app/aliases/page.tsx
+++ b/aifw-ui/src/app/aliases/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { api } from "@/lib/api";
 import { isValidAliasName, isValidIP, isValidCIDR, isValidPortRange, isValidURL } from "@/lib/validate";
+import { Toggle } from "@/components/ui/Toggle";
 
 interface Alias {
   id: string;
@@ -278,13 +279,7 @@ export default function AliasesPage() {
                         <span className="text-xs text-gray-400">{alias.description || "-"}</span>
                       </td>
                       <td className="py-2.5 px-4" onClick={(e) => e.stopPropagation()}>
-                        <button onClick={() => handleToggle(alias)}
-                          className="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200"
-                          style={{ backgroundColor: alias.enabled ? "#22c55e" : "#4b5563" }}
-                          title={alias.enabled ? "Disable" : "Enable"}>
-                          <span className="pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow transition duration-200"
-                            style={{ transform: alias.enabled ? "translateX(16px)" : "translateX(0)" }} />
-                        </button>
+                        <Toggle checked={alias.enabled} onChange={() => handleToggle(alias)} title={alias.enabled ? "Disable" : "Enable"} />
                       </td>
                       <td className="py-2.5 px-2" onClick={(e) => e.stopPropagation()}>
                         <div className="flex items-center gap-1">

--- a/aifw-ui/src/app/blocked/page.tsx
+++ b/aifw-ui/src/app/blocked/page.tsx
@@ -222,7 +222,7 @@ export default function BlockedTrafficPage() {
           ) : (
             <div className="divide-y divide-gray-700/50">
               {stats.topSources.map((s, i) => (
-                <div key={s.ip} className="px-4 py-2 hover:bg-gray-700/30 cursor-pointer" onClick={() => setFilterSrcAddr(s.ip)}>
+                <button type="button" key={s.ip} className="w-full text-left px-4 py-2 hover:bg-gray-700/30 cursor-pointer focus:outline-none focus-visible:bg-gray-700/40" onClick={() => setFilterSrcAddr(s.ip)} title={`Filter by ${s.ip}`}>
                   <div className="flex items-center justify-between mb-1">
                     <div className="flex items-center gap-2">
                       <span className="text-[10px] text-gray-600 w-4">{i + 1}.</span>
@@ -233,7 +233,7 @@ export default function BlockedTrafficPage() {
                   <div className="w-full h-1.5 bg-gray-700 rounded-full overflow-hidden">
                     <div className="h-full rounded-full bg-gradient-to-r from-red-500 to-orange-500 transition-all" style={{ width: `${(s.count / maxSourceCount) * 100}%` }} />
                   </div>
-                </div>
+                </button>
               ))}
             </div>
           )}
@@ -251,14 +251,14 @@ export default function BlockedTrafficPage() {
               {stats.topPorts.map(p => {
                 const [port, proto] = p.port.split('/');
                 return (
-                  <div key={p.port} className="px-4 py-1.5 hover:bg-gray-700/30 cursor-pointer flex items-center gap-3" onClick={() => { setFilterDstPort(port); if (proto) setFilterProto(proto); }}>
+                  <button type="button" key={p.port} className="w-full text-left px-4 py-1.5 hover:bg-gray-700/30 cursor-pointer flex items-center gap-3 focus:outline-none focus-visible:bg-gray-700/40" onClick={() => { setFilterDstPort(port); if (proto) setFilterProto(proto); }} title={`Filter by port ${p.port}`}>
                     <span className={`uppercase text-[10px] font-bold w-7 ${proto === "tcp" ? "text-blue-400" : proto === "udp" ? "text-purple-400" : "text-gray-400"}`}>{proto}</span>
                     <span className="font-mono text-xs text-amber-400 w-14 text-right">{port}</span>
                     <div className="flex-1 h-1.5 bg-gray-700 rounded-full overflow-hidden">
                       <div className="h-full rounded-full bg-amber-500 transition-all" style={{ width: `${(p.count / (stats.topPorts[0]?.count || 1)) * 100}%` }} />
                     </div>
                     <span className="text-[10px] text-gray-400 w-8 text-right">{p.count}</span>
-                  </div>
+                  </button>
                 );
               })}
             </div>

--- a/aifw-ui/src/app/ddns/page.tsx
+++ b/aifw-ui/src/app/ddns/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { api } from "@/lib/api";
 import Help, { HelpBanner } from "./Help";
+import { ModalOverlay } from "@/components/ui/ModalOverlay";
 
 interface DdnsRecord {
   id: number;
@@ -295,8 +296,9 @@ function RecordModal({ initial, providers, onClose, onSaved }:
   }
 
   return (
-    <div className="fixed inset-0 bg-black/60 z-40 flex items-center justify-center p-4" onClick={onClose}>
-      <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-5 w-full max-w-md space-y-3" onClick={(e) => e.stopPropagation()}>
+    <ModalOverlay onClose={onClose} ariaLabel={`${isNew ? "Add" : "Edit"} DDNS record`}
+      className="fixed inset-0 bg-black/60 z-40 flex items-center justify-center p-4"
+      panelClassName="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-5 w-full max-w-md space-y-3">
         <h2 className="text-lg font-semibold text-white">{isNew ? "Add" : "Edit"} DDNS record</h2>
 
         <Field label="DNS provider">
@@ -366,8 +368,7 @@ function RecordModal({ initial, providers, onClose, onSaved }:
             {busy ? "Saving…" : "Save"}
           </button>
         </div>
-      </div>
-    </div>
+    </ModalOverlay>
   );
 }
 

--- a/aifw-ui/src/app/dns/blocklists/page.tsx
+++ b/aifw-ui/src/app/dns/blocklists/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState, useCallback } from "react";
 import Help, { HelpBanner } from "../Help";
 import { api } from "@/lib/api";
+import { ModalOverlay } from "@/components/ui/ModalOverlay";
 
 /* ---------- Types ---------- */
 
@@ -458,8 +459,9 @@ function AddSourceModal({ onClose, onCreated }: { onClose: () => void; onCreated
   }
 
   return (
-    <div className="fixed inset-0 bg-black/60 z-40 flex items-center justify-center p-4" onClick={onClose}>
-      <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-5 w-full max-w-md space-y-3" onClick={(e) => e.stopPropagation()}>
+    <ModalOverlay onClose={onClose} ariaLabel="Add custom blocklist"
+      className="fixed inset-0 bg-black/60 z-40 flex items-center justify-center p-4"
+      panelClassName="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-5 w-full max-w-md space-y-3">
         <h2 className="text-lg font-semibold text-white flex items-center gap-2">
           Add custom blocklist
           <Help title="Custom blocklists" size="sm">
@@ -528,8 +530,7 @@ function AddSourceModal({ onClose, onCreated }: { onClose: () => void; onCreated
             {busy ? "Saving…" : "Save"}
           </button>
         </div>
-      </div>
-    </div>
+    </ModalOverlay>
   );
 }
 

--- a/aifw-ui/src/app/ids/alerts/page.tsx
+++ b/aifw-ui/src/app/ids/alerts/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { api } from "@/lib/api";
+import { ModalOverlay } from "@/components/ui/ModalOverlay";
 
 interface IdsAlert {
   id: string;
@@ -235,8 +236,9 @@ export default function IdsAlertsPage() {
 
       {/* Clear-all confirmation */}
       {purgeConfirm && (
-        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50" onClick={() => setPurgeConfirm(false)}>
-          <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-6 max-w-md w-full mx-4 space-y-3" onClick={(e) => e.stopPropagation()}>
+        <ModalOverlay onClose={() => setPurgeConfirm(false)} ariaLabel="Clear all IDS alerts"
+          className="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
+          panelClassName="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg p-6 max-w-md w-full mx-4 space-y-3">
             <h3 className="text-lg font-semibold text-[var(--text-primary)]">Clear all IDS alerts?</h3>
             <p className="text-sm text-[var(--text-muted)]">
               This permanently deletes all {total.toLocaleString()} stored alerts and reclaims the
@@ -253,8 +255,7 @@ export default function IdsAlertsPage() {
                 {purging ? "Clearing..." : "Delete All"}
               </button>
             </div>
-          </div>
-        </div>
+        </ModalOverlay>
       )}
 
       {/* Alerts Table */}

--- a/aifw-ui/src/app/nat/outbound/page.tsx
+++ b/aifw-ui/src/app/nat/outbound/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { api, NatRule, InterfaceInfo, CreateNatRequest, UpdateNatRequest } from "@/lib/api";
 import { parsePortField } from "@/lib/ports";
 import { validateAddress, validatePort, validateIP } from "@/lib/validate";
+import { Toggle } from "@/components/ui/Toggle";
 
 type AddrMode = "any" | "network";
 type TransMode = "interface" | "address" | "nonat";
@@ -539,18 +540,7 @@ export default function OutboundNatPage() {
                         <span className="text-xs text-gray-400">{rule.label || "-"}</span>
                       </td>
                       <td className="py-2.5 px-3" onClick={(e) => e.stopPropagation()}>
-                        <button
-                          onClick={() => handleToggleStatus(rule)}
-                          disabled={togglingId === rule.id}
-                          className="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none disabled:opacity-50"
-                          style={{ backgroundColor: rule.status === "active" ? "#22c55e" : "#4b5563" }}
-                          title={rule.status === "active" ? "Disable" : "Enable"}
-                        >
-                          <span
-                            className="pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                            style={{ transform: rule.status === "active" ? "translateX(16px)" : "translateX(0)" }}
-                          />
-                        </button>
+                        <Toggle checked={rule.status === "active"} onChange={() => handleToggleStatus(rule)} disabled={togglingId === rule.id} title={rule.status === "active" ? "Disable" : "Enable"} />
                       </td>
                       <td className="py-2.5 px-2" onClick={(e) => e.stopPropagation()}>
                         <div className="flex items-center gap-1">

--- a/aifw-ui/src/app/nat/page.tsx
+++ b/aifw-ui/src/app/nat/page.tsx
@@ -10,6 +10,7 @@ import {
   isCrossFamily,
   validateCrossFamily,
 } from "./components/crossFamily";
+import { Toggle } from "@/components/ui/Toggle";
 
 const defaultForm = {
   nat_type: "dnat",
@@ -590,21 +591,7 @@ export default function NatPage() {
                       </td>
                       {/* Status toggle */}
                       <td className="py-2.5 px-3" onClick={(e) => e.stopPropagation()}>
-                        <button
-                          onClick={() => handleToggleStatus(rule)}
-                          disabled={togglingId === rule.id}
-                          className="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none disabled:opacity-50"
-                          style={{
-                            backgroundColor: rule.status === "active" ? "#22c55e" : "#4b5563",
-                          }}
-                          title={rule.status === "active" ? "Disable" : "Enable"}
-                        >
-                          <span
-                            className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
-                              rule.status === "active" ? "translate-x-[18px]" : "translate-x-[3px]"
-                            }`}
-                          />
-                        </button>
+                        <Toggle checked={rule.status === "active"} onChange={() => handleToggleStatus(rule)} disabled={togglingId === rule.id} title={rule.status === "active" ? "Disable" : "Enable"} />
                       </td>
                       {/* Actions */}
                       <td className="py-2.5 px-2" onClick={(e) => e.stopPropagation()}>

--- a/aifw-ui/src/app/nat/port-forward/page.tsx
+++ b/aifw-ui/src/app/nat/port-forward/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { api, NatRule, InterfaceInfo, CreateNatRequest, UpdateNatRequest } from "@/lib/api";
 import { parsePortField } from "@/lib/ports";
 import { validateAddress, validatePort, validateIP } from "@/lib/validate";
+import { Toggle } from "@/components/ui/Toggle";
 
 const defaultForm = {
   interface: "",
@@ -476,22 +477,7 @@ export default function PortForwardPage() {
                         <span className="text-xs text-gray-400">{rule.label || "-"}</span>
                       </td>
                       <td className="py-2.5 px-3" onClick={(e) => e.stopPropagation()}>
-                        <button
-                          onClick={() => handleToggleStatus(rule)}
-                          disabled={togglingId === rule.id}
-                          className="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none disabled:opacity-50"
-                          style={{
-                            backgroundColor: rule.status === "active" ? "#22c55e" : "#4b5563",
-                          }}
-                          title={rule.status === "active" ? "Disable" : "Enable"}
-                        >
-                          <span
-                            className="pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                            style={{
-                              transform: rule.status === "active" ? "translateX(16px)" : "translateX(0)",
-                            }}
-                          />
-                        </button>
+                        <Toggle checked={rule.status === "active"} onChange={() => handleToggleStatus(rule)} disabled={togglingId === rule.id} title={rule.status === "active" ? "Disable" : "Enable"} />
                       </td>
                       <td className="py-2.5 px-2" onClick={(e) => e.stopPropagation()}>
                         <div className="flex items-center gap-1">

--- a/aifw-ui/src/app/page.tsx
+++ b/aifw-ui/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useRef, useMemo, useCallback } from "react";
 import { useWs } from "@/context/WsContext";
 import { api, isAuthed } from "@/lib/api";
 import { usePolling } from "@/lib/usePolling";
+import { ModalOverlay } from "@/components/ui/ModalOverlay";
 
 interface StatusData {
   pf_running: boolean; pf_states: number; pf_rules: number;
@@ -571,11 +572,11 @@ export default function Dashboard() {
             <svg className="w-3.5 h-3.5 text-[var(--text-muted)]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" /></svg>
           </div>
           <div className="flex items-center gap-2 text-xs">
-            <span style={{ color: cpu > 80 ? "#ef4444" : "#3b82f6" }}>{cpu.toFixed(0)}% CPU</span>
+            <span className={cpu > 80 ? "text-red-500" : "text-blue-500"}>{cpu.toFixed(0)}% CPU</span>
             <span className="text-[var(--border)]">|</span>
-            <span style={{ color: mem > 80 ? "#ef4444" : "#8b5cf6" }}>{mem.toFixed(0)}% Mem</span>
+            <span className={mem > 80 ? "text-red-500" : "text-violet-500"}>{mem.toFixed(0)}% Mem</span>
             <span className="text-[var(--border)]">|</span>
-            <span style={{ color: disk > 90 ? "#ef4444" : "#06b6d4" }}>{disk.toFixed(0)}% Disk</span>
+            <span className={disk > 90 ? "text-red-500" : "text-cyan-500"}>{disk.toFixed(0)}% Disk</span>
           </div>
         </button>
 
@@ -705,8 +706,9 @@ export default function Dashboard() {
 
       {/* Modals */}
       {modal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setModal(null)}>
-          <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl shadow-2xl max-w-lg w-full mx-4 max-h-[80vh] overflow-hidden" onClick={e => e.stopPropagation()}>
+        <ModalOverlay onClose={() => setModal(null)} ariaLabel={modal === "system" ? "System Details" : modal === "talkers" ? "Top Talkers" : "Recent Blocked"}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          panelClassName="bg-[var(--bg-card)] border border-[var(--border)] rounded-xl shadow-2xl max-w-lg w-full mx-4 max-h-[80vh] overflow-hidden">
             <div className="flex items-center justify-between px-5 py-3 border-b border-[var(--border)]">
               <h2 className="text-sm font-bold">
                 {modal === "system" ? "System Details" : modal === "talkers" ? "Top Talkers" : "Recent Blocked"}
@@ -740,7 +742,7 @@ export default function Dashboard() {
                 return (
                 <div className="space-y-3 text-xs">
                   <div className="flex justify-between"><span className="text-[var(--text-muted)]">Memory</span><span>{formatBytes(system?.memory_used ?? 0)} / {formatBytes(system?.memory_total ?? 0)} ({mem.toFixed(0)}%)</span></div>
-                  <div className="w-full h-1.5 bg-gray-700 rounded-full"><div className="h-full rounded-full transition-all" style={{ width: `${mem}%`, backgroundColor: mem > 80 ? "#ef4444" : "#8b5cf6" }} /></div>
+                  <div className="w-full h-1.5 bg-gray-700 rounded-full"><div className={`h-full rounded-full transition-all ${mem > 80 ? "bg-red-500" : "bg-violet-500"}`} style={{ width: `${mem}%` }} /></div>
 
                   {mb && (
                     <div className="pt-2 border-t border-[var(--border)]">
@@ -778,7 +780,7 @@ export default function Dashboard() {
                   {system?.disks?.map(d => (
                     <div key={d.mount}>
                       <div className="flex justify-between"><span className="text-[var(--text-muted)] font-mono">{d.mount}</span><span>{d.pct.toFixed(0)}% ({formatBytes(d.used)} / {formatBytes(d.total)})</span></div>
-                      <div className="w-full h-1.5 bg-gray-700 rounded-full mt-1"><div className="h-full rounded-full transition-all" style={{ width: `${d.pct}%`, backgroundColor: d.pct > 80 ? "#ef4444" : "#06b6d4" }} /></div>
+                      <div className="w-full h-1.5 bg-gray-700 rounded-full mt-1"><div className={`h-full rounded-full transition-all ${d.pct > 80 ? "bg-red-500" : "bg-cyan-500"}`} style={{ width: `${d.pct}%` }} /></div>
                     </div>
                   ))}
                   <div className="pt-2 border-t border-[var(--border)] space-y-2">
@@ -847,8 +849,7 @@ export default function Dashboard() {
                 </>
               )}
             </div>
-          </div>
-        </div>
+        </ModalOverlay>
       )}
     </div>
   );

--- a/aifw-ui/src/app/plugins/page.tsx
+++ b/aifw-ui/src/app/plugins/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { api } from "@/lib/api";
+import { ModalOverlay } from "@/components/ui/ModalOverlay";
 
 interface PluginEntry {
   name: string;
@@ -139,7 +140,7 @@ export default function PluginsPage() {
                   <span className={`text-[10px] px-2 py-0.5 rounded-full border ${stateColor(p.state)}`}>
                     {p.state}
                   </span>
-                  <div onClick={(e) => e.stopPropagation()}>
+                  <div role="presentation" onClick={(e) => e.stopPropagation()}>
                     <button
                       onClick={() => togglePlugin(p.name, p.state !== "running")}
                       className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${p.state === "running" ? "bg-green-500" : "bg-gray-600"}`}
@@ -157,8 +158,9 @@ export default function PluginsPage() {
 
       {/* Config Editor Modal */}
       {selectedPlugin && pluginConfig && (
-        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50" onClick={() => setSelectedPlugin(null)}>
-          <div className="bg-gray-800 border border-gray-700 rounded-lg p-6 max-w-lg w-full mx-4 space-y-4" onClick={(e) => e.stopPropagation()}>
+        <ModalOverlay onClose={() => setSelectedPlugin(null)} ariaLabel={`${selectedPlugin} configuration`}
+          className="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
+          panelClassName="bg-gray-800 border border-gray-700 rounded-lg p-6 max-w-lg w-full mx-4 space-y-4">
             <div className="flex items-center justify-between">
               <h3 className="text-lg font-semibold text-white">{selectedPlugin} Configuration</h3>
               <button onClick={() => setSelectedPlugin(null)} className="text-gray-400 hover:text-white">
@@ -196,8 +198,7 @@ export default function PluginsPage() {
                 {savingConfig ? "Saving..." : "Save Config"}
               </button>
             </div>
-          </div>
-        </div>
+        </ModalOverlay>
       )}
 
       {/* Hook Reference */}

--- a/aifw-ui/src/app/reverse-proxy/http/middlewares/components/MiddlewaresTable.tsx
+++ b/aifw-ui/src/app/reverse-proxy/http/middlewares/components/MiddlewaresTable.tsx
@@ -2,6 +2,7 @@
 
 import { HttpMiddleware, fmtDate } from "@/lib/api/reverse-proxy/middlewares";
 import { TypeBadge } from "./TypeBadge";
+import { Toggle } from "@/components/ui/Toggle";
 
 /* ── Middlewares table ────────────────────────────────────────── */
 
@@ -62,20 +63,7 @@ export function MiddlewaresTable({
                     <TypeBadge mtype={mw.middleware_type} />
                   </td>
                   <td className="py-2.5 px-3" onClick={(e) => e.stopPropagation()}>
-                    <button
-                      onClick={() => onToggleEnabled(mw)}
-                      className="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none"
-                      style={{
-                        backgroundColor: mw.enabled ? "#22c55e" : "#4b5563",
-                      }}
-                      title={mw.enabled ? "Disable" : "Enable"}
-                    >
-                      <span
-                        className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
-                          mw.enabled ? "translate-x-[18px]" : "translate-x-[3px]"
-                        }`}
-                      />
-                    </button>
+                    <Toggle checked={mw.enabled} onChange={() => onToggleEnabled(mw)} title={mw.enabled ? "Disable" : "Enable"} />
                   </td>
                   <td className="py-2.5 px-3 text-xs text-[var(--text-muted)]">
                     {fmtDate(mw.created_at)}

--- a/aifw-ui/src/app/reverse-proxy/http/routers/components/RoutersTable.tsx
+++ b/aifw-ui/src/app/reverse-proxy/http/routers/components/RoutersTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type HttpRouter, parseJsonArray } from "@/lib/api/reverse-proxy/routers";
+import { Toggle } from "@/components/ui/Toggle";
 
 const chipCls =
   "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-500/15 text-blue-400 border border-blue-500/30";
@@ -106,20 +107,7 @@ export function RoutersTable({ routers, deletingId, onEdit, onDelete, onToggleEn
                     </td>
                     {/* Enabled toggle */}
                     <td className="py-2.5 px-3" onClick={(e) => e.stopPropagation()}>
-                      <button
-                        onClick={() => onToggleEnabled(router)}
-                        className="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none"
-                        style={{
-                          backgroundColor: router.enabled ? "#2563eb" : "#4b5563",
-                        }}
-                        title={router.enabled ? "Disable" : "Enable"}
-                      >
-                        <span
-                          className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
-                            router.enabled ? "translate-x-[18px]" : "translate-x-[3px]"
-                          }`}
-                        />
-                      </button>
+                      <Toggle checked={router.enabled} onChange={() => onToggleEnabled(router)} title={router.enabled ? "Disable" : "Enable"} color="blue" />
                     </td>
                     {/* Actions */}
                     <td className="py-2.5 px-2" onClick={(e) => e.stopPropagation()}>

--- a/aifw-ui/src/app/reverse-proxy/http/services/page.tsx
+++ b/aifw-ui/src/app/reverse-proxy/http/services/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { api } from "@/lib/api";
+import { Toggle as Switch } from "@/components/ui/Toggle";
 
 /* ────────────────────────── Types ────────────────────────── */
 
@@ -210,6 +211,9 @@ function Toggle({ value, onChange, label }: { value: boolean; onChange: (v: bool
       <span className="text-sm text-gray-300">{label}</span>
       <button
         type="button"
+        role="switch"
+        aria-checked={value}
+        aria-label={label}
         onClick={() => onChange(!value)}
         className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
           value ? "bg-blue-600" : "bg-gray-600"
@@ -828,18 +832,7 @@ export default function HttpServicesPage() {
                       <span className="text-xs text-gray-400 font-mono">{describeHealthCheck(svc)}</span>
                     </td>
                     <td className="py-2.5 px-4" onClick={(e) => e.stopPropagation()}>
-                      <button
-                        onClick={() => handleToggleEnabled(svc)}
-                        className="relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none"
-                        style={{ backgroundColor: svc.enabled ? "#22c55e" : "#4b5563" }}
-                        title={svc.enabled ? "Disable" : "Enable"}
-                      >
-                        <span
-                          className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
-                            svc.enabled ? "translate-x-[18px]" : "translate-x-[3px]"
-                          }`}
-                        />
-                      </button>
+                      <Switch checked={svc.enabled} onChange={() => handleToggleEnabled(svc)} title={svc.enabled ? "Disable" : "Enable"} />
                     </td>
                     <td className="py-2.5 px-2" onClick={(e) => e.stopPropagation()}>
                       <div className="flex items-center gap-1">

--- a/aifw-ui/src/app/rules/components/RulesTable.tsx
+++ b/aifw-ui/src/app/rules/components/RulesTable.tsx
@@ -3,6 +3,7 @@
 import type { Rule } from "@/lib/api/rules";
 import { actionLabel, formatAddrPort, ipVersionLabel } from "@/lib/api/rules";
 import StatusBadge from "@/components/StatusBadge";
+import { Toggle } from "@/components/ui/Toggle";
 
 /* ─── Reusable rules table section ──────────────────────────────── */
 
@@ -82,17 +83,7 @@ export function RulesTable({
                       </div>
                     </td>
                     <td className="py-2.5 px-3" onClick={e => e.stopPropagation()}>
-                      <button
-                        onClick={() => onToggleStatus(rule)}
-                        className="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
-                        style={{ backgroundColor: rule.status === "active" ? "#22c55e" : "#4b5563" }}
-                        title={rule.status === "active" ? "Disable rule" : "Enable rule"}
-                      >
-                        <span
-                          className="pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                          style={{ transform: rule.status === "active" ? "translateX(16px)" : "translateX(0)" }}
-                        />
-                      </button>
+                      <Toggle checked={rule.status === "active"} onChange={() => onToggleStatus(rule)} title={rule.status === "active" ? "Disable rule" : "Enable rule"} />
                     </td>
                     <td className="py-2.5 px-3">
                       <span className="font-mono text-gray-300">{rule.priority}</span>

--- a/aifw-ui/src/app/rules/schedules/page.tsx
+++ b/aifw-ui/src/app/rules/schedules/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { api } from "@/lib/api";
+import { Toggle } from "@/components/ui/Toggle";
 
 interface Schedule {
   id: string;
@@ -275,17 +276,7 @@ export default function SchedulesPage() {
                       </div>
                     </td>
                     <td className="py-3 px-4">
-                      <button
-                        onClick={() => handleToggleEnabled(schedule)}
-                        className="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
-                        style={{ backgroundColor: schedule.enabled ? "#22c55e" : "#4b5563" }}
-                        title={schedule.enabled ? "Disable schedule" : "Enable schedule"}
-                      >
-                        <span
-                          className="pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                          style={{ transform: schedule.enabled ? "translateX(16px)" : "translateX(0)" }}
-                        />
-                      </button>
+                      <Toggle checked={schedule.enabled} onChange={() => handleToggleEnabled(schedule)} title={schedule.enabled ? "Disable schedule" : "Enable schedule"} />
                     </td>
                     <td className="py-3 px-4">
                       <div className="flex items-center justify-end gap-1">
@@ -430,16 +421,7 @@ export default function SchedulesPage() {
 
               {/* Enabled */}
               <div className="flex items-center gap-3">
-                <button
-                  onClick={() => setForm((f) => ({ ...f, enabled: !f.enabled }))}
-                  className="relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
-                  style={{ backgroundColor: form.enabled ? "#22c55e" : "#4b5563" }}
-                >
-                  <span
-                    className="pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                    style={{ transform: form.enabled ? "translateX(16px)" : "translateX(0)" }}
-                  />
-                </button>
+                <Toggle checked={form.enabled} onChange={() => setForm((f) => ({ ...f, enabled: !f.enabled }))} label="Enabled" title={form.enabled ? "Disable schedule" : "Enable schedule"} />
                 <span className="text-sm text-gray-300">Enabled</span>
               </div>
             </div>

--- a/aifw-ui/src/app/settings/components/IdsAlertSection.tsx
+++ b/aifw-ui/src/app/settings/components/IdsAlertSection.tsx
@@ -64,11 +64,11 @@ export function IdsAlertSection({
           </div>
           <div className="bg-[var(--bg-primary)] rounded-lg p-3">
             <div className="text-[10px] text-[var(--text-muted)] uppercase">Usage</div>
-            <div className="text-lg font-bold" style={{ color: stats.usage_pct > 80 ? "#ef4444" : "#22c55e" }}>
+            <div className={`text-lg font-bold ${stats.usage_pct > 80 ? "text-red-500" : "text-green-500"}`}>
               {stats.usage_pct.toFixed(0)}%
             </div>
             <div className="w-full h-1 bg-gray-700 rounded-full mt-1">
-              <div className="h-full rounded-full transition-all" style={{ width: `${stats.usage_pct}%`, backgroundColor: stats.usage_pct > 80 ? "#ef4444" : "#22c55e" }} />
+              <div className={`h-full rounded-full transition-all ${stats.usage_pct > 80 ? "bg-red-500" : "bg-green-500"}`} style={{ width: `${stats.usage_pct}%` }} />
             </div>
           </div>
           <div className="bg-[var(--bg-primary)] rounded-lg p-3">

--- a/aifw-ui/src/app/vpn/components/ConfigModal.tsx
+++ b/aifw-ui/src/app/vpn/components/ConfigModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import type { ConfigModalData } from "@/lib/api/vpn";
+import { ModalOverlay } from "@/components/ui/ModalOverlay";
 
 interface ConfigModalProps {
   config: ConfigModalData;
@@ -22,9 +23,9 @@ export function ConfigModal({ config, onClose }: ConfigModalProps) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative w-full max-w-2xl bg-gray-800 border border-gray-700 rounded-xl shadow-2xl m-4">
+    <ModalOverlay onClose={onClose} ariaLabel="WireGuard client configuration"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
+      panelClassName="relative w-full max-w-2xl bg-gray-800 border border-gray-700 rounded-xl shadow-2xl m-4">
         <div className="px-6 py-4 border-b border-gray-700 flex items-center justify-between">
           <h3 className="text-lg font-semibold text-white">
             Client Config — {config.peerName}
@@ -93,7 +94,6 @@ export function ConfigModal({ config, onClose }: ConfigModalProps) {
             until it is.
           </p>
         </div>
-      </div>
-    </div>
+    </ModalOverlay>
   );
 }

--- a/aifw-ui/src/components/AppShell.tsx
+++ b/aifw-ui/src/components/AppShell.tsx
@@ -90,7 +90,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           <div className="flex min-h-screen">
             {/* Mobile overlay */}
             {sidebarOpen && (
-              <div className="fixed inset-0 bg-black/50 z-30 lg:hidden" onClick={() => setSidebarOpen(false)} />
+              <div role="presentation" aria-hidden="true" className="fixed inset-0 bg-black/50 z-30 lg:hidden" onClick={() => setSidebarOpen(false)} />
             )}
 
             {/* Sidebar — fixed on desktop, slide-in on mobile */}

--- a/aifw-ui/src/components/ui/ModalOverlay.tsx
+++ b/aifw-ui/src/components/ui/ModalOverlay.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+
+/**
+ * Accessible modal chrome (QUAL-M16 #451). Renders the dimmed backdrop and
+ * the dialog panel:
+ * - Escape closes (keyboard users had no way to dismiss click-only overlays);
+ * - clicking the backdrop itself closes, clicks inside the panel don't
+ *   (no `stopPropagation` handlers on non-interactive elements);
+ * - the panel is announced as a modal dialog.
+ *
+ * `className` styles the backdrop (position/z-index/color), `panelClassName`
+ * the dialog box. Put a visible close button in the panel as well.
+ */
+export function ModalOverlay({
+  onClose,
+  children,
+  className = "fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4",
+  panelClassName = "",
+  ariaLabel,
+}: {
+  onClose: () => void;
+  children: ReactNode;
+  className?: string;
+  panelClassName?: string;
+  /** Accessible name for the dialog when the title isn't linked by id. */
+  ariaLabel?: string;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      role="presentation"
+      className={className}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div role="dialog" aria-modal="true" aria-label={ariaLabel} className={panelClassName}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/aifw-ui/src/components/ui/Toggle.tsx
+++ b/aifw-ui/src/components/ui/Toggle.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * Accessible on/off switch (QUAL-M14/M16 #449 #451). Replaces the
+ * hand-rolled `<button style={{backgroundColor…}}>` toggles: `role="switch"`
+ * + `aria-checked` for screen readers, keyboard-operable like any button,
+ * state expressed with classes instead of inline styles.
+ */
+export function Toggle({
+  checked,
+  onChange,
+  disabled = false,
+  title,
+  label,
+  color = "green",
+  className = "",
+}: {
+  checked: boolean;
+  onChange: () => void;
+  disabled?: boolean;
+  /** Tooltip; defaults to Enable/Disable. */
+  title?: string;
+  /** Accessible name when there is no visible label next to the switch. */
+  label?: string;
+  color?: "green" | "blue";
+  className?: string;
+}) {
+  const on = color === "blue" ? "bg-blue-600" : "bg-green-500";
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={onChange}
+      disabled={disabled}
+      title={title ?? (checked ? "Disable" : "Enable")}
+      className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] disabled:opacity-50 disabled:cursor-not-allowed ${checked ? on : "bg-gray-600"} ${className}`}
+    >
+      <span
+        className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${checked ? "translate-x-4" : "translate-x-0"}`}
+      />
+    </button>
+  );
+}


### PR DESCRIPTION
Closes #451, closes #449.

**#451 (a11y — `<div onClick>` patterns)**
- New `components/ui/ModalOverlay`: Escape closes, clicking the backdrop itself closes (`e.target === e.currentTarget`, so no `stopPropagation` handlers on non-interactive elements), the panel is `role="dialog" aria-modal="true"` with an accessible name. Replaced the 9 click-only backdrops: plugins config editor, VPN client-config modal, DDNS record modal, dashboard detail modals, ACME (request cert / add export / DNS provider), DNS custom blocklist, IDS clear-all confirm.
- Blocked page: "top sources" / "targeted ports" rows that filter on click are now real `<button>`s (keyboard-reachable, focus style).
- Sidebar mobile scrim marked `role="presentation" aria-hidden` (the sidebar has its own close control).
- Result: zero interactive `<div onClick>` left; the two remaining `div onClick`s are a presentation-role scrim and an event-plumbing wrapper around a toggle.

**#449 (inline styles)**
- New `components/ui/Toggle` (`role="switch"`, `aria-checked`, focus ring, green/blue variants) replaces 10 hand-rolled switches that expressed state via `style={{backgroundColor, transform}}` (rules table, schedules ×2, NAT ×3, aliases, reverse-proxy routers/middlewares/services). The services page's own labelled toggle got `role="switch"` too.
- Threshold colours (dashboard CPU/Mem/Disk, IDS storage usage) are conditional Tailwind classes instead of hex colours in `style`.
- 88 → 69 `style={{…}}` occurrences; everything left is a genuinely dynamic value Tailwind can't express at build time — computed widths/heights (progress bars, NAT flow diagram, chart containers), data-driven colours (chart legends), virtualizer transforms, and `global-error.tsx` (renders without the app CSS by design).

`npm run lint`, `tsc --noEmit`, `npm run build` clean.