### PR TITLE
setup: no-panic console prompts on terminal loss; repo secret audit documented (#446 #455)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,10 @@ freebsd/ui-export/
 
 # CLAUDE.md is project policy and is tracked in the repo — do not ignore it.
 Cargo.lock
+
+# Never track key material or local environment files (#455)
+.env
+.env.*
+*.pem
+*.key
+!freebsd/overlay/usr/local/etc/aifw/update-signing.pub

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,3 +52,13 @@ This policy covers the AiFw firewall software, including:
 - `aifw-ui` (web interface)
 - `aifw-setup` (setup wizard)
 - FreeBSD ISO/IMG build artifacts
+
+## Secrets in the repository
+
+Nothing in this repository is a live credential. Verified 2026-08-17 (#455) against every tracked file and the full history (`git log --all -S` for private-key headers and AWS / GitHub / Slack / Google token prefixes; every file ever added, filtered for key/env/credential names):
+
+- **Intentionally checked in:** `freebsd/overlay/usr/local/etc/aifw/update-signing.pub` — the minisign *public* key the in-app updater verifies release tarballs with. Its private half lives outside the repo.
+- **Fixtures only:** the strings `-----BEGIN PRIVATE KEY-----\nabc\n…` in `aifw-common`/`aifw-core` IPsec tests, `TestPass123`-style passwords in API tests, and `AKIA...` / `CHANGE-ME` placeholders in docs and the setup seed template. None are usable.
+- **Ignored, never tracked:** `.env`, `*.pem`, `*.key`, key material and any local `status.md` (see `.gitignore`).
+
+Runtime secrets live outside the tree: `/var/db/aifw/secrets.key` (AES-256-GCM master key for values in the database), `/var/db/aifw/jwt.key`, and the appliance TLS key under `/usr/local/etc/aifw/tls/`. If you find anything that looks like a real credential in the repo, report it through the channel above.

--- a/aifw-setup/src/console.rs
+++ b/aifw-setup/src/console.rs
@@ -1,4 +1,23 @@
+//! Console prompts for the setup wizard. Every prompt returns
+//! `io::Result` so a lost terminal (stdin closed mid-wizard on an
+//! unattended SSH run, stdout gone) propagates as an error the caller can
+//! report instead of a panic (#446 / QUAL-M11).
+
 use std::io::{self, BufRead, Write};
+
+/// Read one line from stdin; a closed stdin (EOF) is an error too — the
+/// wizard cannot continue without an operator.
+fn read_line() -> io::Result<String> {
+    let mut input = String::new();
+    let n = io::stdin().lock().read_line(&mut input)?;
+    if n == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "stdin closed — terminal lost",
+        ));
+    }
+    Ok(input)
+}
 
 /// Print a section header
 pub fn header(title: &str) {
@@ -30,36 +49,28 @@ pub fn error(msg: &str) {
 }
 
 /// Prompt for text input with a default value
-pub fn prompt(label: &str, default: &str) -> String {
+pub fn prompt(label: &str, default: &str) -> io::Result<String> {
     if default.is_empty() {
         print!("  {label}: ");
     } else {
         print!("  {label} [{default}]: ");
     }
-    io::stdout()
-        .flush()
-        .expect("stdout flush failed — terminal lost");
+    io::stdout().flush()?;
 
-    let mut input = String::new();
-    io::stdin()
-        .lock()
-        .read_line(&mut input)
-        .expect("stdin read failed — terminal lost");
-    let input = input.trim().to_string();
-
-    if input.is_empty() {
+    let input = read_line()?.trim().to_string();
+    Ok(if input.is_empty() {
         default.to_string()
     } else {
         input
-    }
+    })
 }
 
 /// Prompt for a required field (no default, keeps asking until non-empty)
-pub fn prompt_required(label: &str) -> String {
+pub fn prompt_required(label: &str) -> io::Result<String> {
     loop {
-        let val = prompt(label, "");
+        let val = prompt(label, "")?;
         if !val.is_empty() {
-            return val;
+            return Ok(val);
         }
         warn("This field is required.");
     }
@@ -67,11 +78,9 @@ pub fn prompt_required(label: &str) -> String {
 
 /// Prompt for a password (no echo)
 /// Falls back to regular prompt if terminal doesn't support no-echo
-pub fn prompt_password(label: &str) -> String {
+pub fn prompt_password(label: &str) -> io::Result<String> {
     print!("  {label}: ");
-    io::stdout()
-        .flush()
-        .expect("stdout flush failed — terminal lost");
+    io::stdout().flush()?;
 
     // Try to disable echo on Unix
     #[cfg(unix)]
@@ -83,72 +92,50 @@ pub fn prompt_password(label: &str) -> String {
             term.local_flags.remove(LocalFlags::ECHO);
             let _ = tcsetattr(&stdin, SetArg::TCSANOW, &term);
 
-            let mut input = String::new();
-            stdin
-                .lock()
-                .read_line(&mut input)
-                .expect("stdin read failed — terminal lost");
+            let read = read_line();
             println!(); // newline after hidden input
-
+            // Always restore echo, even when the read failed.
             let _ = tcsetattr(&stdin, SetArg::TCSANOW, &old_term);
-            return input.trim().to_string();
+            return Ok(read?.trim().to_string());
         }
         // tcgetattr failed (not a tty) — fall through to echoed read.
-        let mut input = String::new();
-        stdin
-            .lock()
-            .read_line(&mut input)
-            .expect("stdin read failed — terminal lost");
-        input.trim().to_string()
+        Ok(read_line()?.trim().to_string())
     }
 
     #[cfg(not(unix))]
     {
-        let mut input = String::new();
-        io::stdin()
-            .lock()
-            .read_line(&mut input)
-            .expect("stdin read failed — terminal lost");
-        input.trim().to_string()
+        Ok(read_line()?.trim().to_string())
     }
 }
 
 /// Prompt for password with confirmation
-pub fn prompt_password_confirm(label: &str) -> String {
+pub fn prompt_password_confirm(label: &str) -> io::Result<String> {
     loop {
-        let pw1 = prompt_password(label);
-        let pw2 = prompt_password("Confirm password");
+        let pw1 = prompt_password(label)?;
+        let pw2 = prompt_password("Confirm password")?;
 
         if pw1 == pw2 {
-            return pw1;
+            return Ok(pw1);
         }
         warn("Passwords do not match. Try again.");
     }
 }
 
 /// Prompt for a yes/no confirmation
-pub fn confirm(label: &str, default: bool) -> bool {
+pub fn confirm(label: &str, default: bool) -> io::Result<bool> {
     let hint = if default { "Y/n" } else { "y/N" };
     print!("  {label} [{hint}]: ");
-    io::stdout()
-        .flush()
-        .expect("stdout flush failed — terminal lost");
+    io::stdout().flush()?;
 
-    let mut input = String::new();
-    io::stdin()
-        .lock()
-        .read_line(&mut input)
-        .expect("stdin read failed — terminal lost");
-    let input = input.trim().to_lowercase();
-
+    let input = read_line()?.trim().to_lowercase();
     if input.is_empty() {
-        return default;
+        return Ok(default);
     }
-    matches!(input.as_str(), "y" | "yes")
+    Ok(matches!(input.as_str(), "y" | "yes"))
 }
 
 /// Prompt to select from a numbered list. Returns the 0-based index.
-pub fn select(label: &str, options: &[&str], default: usize) -> usize {
+pub fn select(label: &str, options: &[&str], default: usize) -> io::Result<usize> {
     println!("  {label}:");
     for (i, opt) in options.iter().enumerate() {
         let marker = if i == default { " *" } else { "" };
@@ -156,12 +143,12 @@ pub fn select(label: &str, options: &[&str], default: usize) -> usize {
     }
 
     loop {
-        let input = prompt("Choice", &(default + 1).to_string());
+        let input = prompt("Choice", &(default + 1).to_string())?;
         if let Ok(n) = input.parse::<usize>()
             && n >= 1
             && n <= options.len()
         {
-            return n - 1;
+            return Ok(n - 1);
         }
         warn(&format!("Please enter 1-{}", options.len()));
     }

--- a/aifw-setup/src/main.rs
+++ b/aifw-setup/src/main.rs
@@ -106,7 +106,11 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Run interactive wizard
-    let Some(result) = wizard::run_wizard(args.reconfigure) else {
+    // A lost terminal (stdin closed on an unattended SSH run) surfaces as an
+    // error here instead of a panic (#446).
+    let Some(result) = wizard::run_wizard(args.reconfigure)
+        .map_err(|e| anyhow::anyhow!("setup wizard aborted: {e}"))?
+    else {
         std::process::exit(0);
     };
 

--- a/aifw-setup/src/tests.rs
+++ b/aifw-setup/src/tests.rs
@@ -475,6 +475,40 @@ mod let_underscore_tests {
         );
     }
 
+    /// QUAL-M11 (#446): the interactive console layer must never panic on
+    /// a lost terminal — every prompt returns `io::Result` and the wizard
+    /// propagates it. Keep `.expect(` / `.unwrap(` out of the non-test code
+    /// of these files.
+    #[test]
+    fn console_and_wizard_do_not_panic_on_terminal_loss() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        let mut violations = Vec::new();
+        for rel in [
+            "aifw-setup/src/console.rs",
+            "aifw-setup/src/wizard.rs",
+            "aifw-setup/src/tuning.rs",
+        ] {
+            let content = std::fs::read_to_string(root.join(rel))
+                .unwrap_or_else(|e| panic!("failed to read {rel}: {e}"));
+            // Only the non-test part of the file.
+            let prod = content.split("#[cfg(test)]").next().unwrap_or("");
+            for (idx, line) in prod.lines().enumerate() {
+                let t = line.trim_start();
+                if t.starts_with("//") {
+                    continue;
+                }
+                if t.contains(".expect(") || t.contains(".unwrap()") {
+                    violations.push(format!("{rel}:{}: {t}", idx + 1));
+                }
+            }
+        }
+        assert!(
+            violations.is_empty(),
+            "panicking call in setup console/wizard code (QUAL-M11 #446) — return io::Result instead:\n{}",
+            violations.join("\n")
+        );
+    }
+
     // --- Unattended seed (#533 Phase 2) ---
 
     #[test]

--- a/aifw-setup/src/tuning.rs
+++ b/aifw-setup/src/tuning.rs
@@ -294,7 +294,7 @@ pub fn generate_recommendations(profile: &SystemProfile) -> Vec<TuningItem> {
 
 /// Interactive tuning wizard step. Shows recommendations and lets user
 /// accept defaults or customize each one.
-pub fn run_tuning_wizard(profile: &SystemProfile) -> Vec<TuningItem> {
+pub fn run_tuning_wizard(profile: &SystemProfile) -> std::io::Result<Vec<TuningItem>> {
     let mut items = generate_recommendations(profile);
 
     console::header("Step 4/11 — System Detection & Performance Tuning");
@@ -339,7 +339,7 @@ pub fn run_tuning_wizard(profile: &SystemProfile) -> Vec<TuningItem> {
             "Skip tuning entirely",
         ],
         0,
-    );
+    )?;
 
     match choice {
         0 => {
@@ -350,7 +350,7 @@ pub fn run_tuning_wizard(profile: &SystemProfile) -> Vec<TuningItem> {
             println!();
             console::info("Enter item numbers to toggle (space-separated), or 'done' to finish:");
             loop {
-                let input = console::prompt("Toggle items", "done");
+                let input = console::prompt("Toggle items", "done")?;
                 if input == "done" || input.is_empty() {
                     break;
                 }
@@ -377,7 +377,7 @@ pub fn run_tuning_wizard(profile: &SystemProfile) -> Vec<TuningItem> {
         }
     }
 
-    items
+    Ok(items)
 }
 
 /// Generate sysctl.conf content from enabled tuning items

--- a/aifw-setup/src/wizard.rs
+++ b/aifw-setup/src/wizard.rs
@@ -37,26 +37,26 @@ fn detect_interfaces() -> Vec<String> {
 }
 
 /// Set the system root password via pw (FreeBSD)
-fn set_root_password() {
+fn set_root_password() -> std::io::Result<()> {
     let max_attempts = 5;
     for attempt in 1..=max_attempts {
-        let pass1 = console::prompt_password("New root password");
+        let pass1 = console::prompt_password("New root password")?;
         if pass1.len() < 8 {
             console::error("Password must be at least 8 characters.");
             if attempt == max_attempts {
                 console::warn(
                     "Max attempts reached. Skipping root password — set it manually later.",
                 );
-                return;
+                return Ok(());
             }
             continue;
         }
-        let pass2 = console::prompt_password("Confirm root password");
+        let pass2 = console::prompt_password("Confirm root password")?;
         if pass1 != pass2 {
             console::error("Passwords do not match. Try again.");
             if attempt == max_attempts {
                 console::warn("Max attempts reached. Skipping root password.");
-                return;
+                return Ok(());
             }
             continue;
         }
@@ -77,7 +77,7 @@ fn set_root_password() {
                 Ok(c) => c,
                 Err(e) => {
                     console::error(&format!("Failed to spawn pw: {}", e));
-                    return;
+                    return Ok(());
                 }
             };
 
@@ -89,7 +89,7 @@ fn set_root_password() {
                 None => {
                     console::error("pw stdin was not piped (internal error)");
                     let _ = child.wait();
-                    return;
+                    return Ok(());
                 }
             };
             let write_res = writeln!(stdin, "{}", pass1);
@@ -98,13 +98,13 @@ fn set_root_password() {
             if let Err(e) = write_res {
                 console::error(&format!("Failed to write password to pw stdin: {}", e));
                 let _ = child.wait();
-                return;
+                return Ok(());
             }
 
             match child.wait_with_output() {
                 Ok(out) if out.status.success() => {
                     console::success("Root password set.");
-                    return;
+                    return Ok(());
                 }
                 Ok(out) => {
                     let stderr = String::from_utf8_lossy(&out.stderr);
@@ -113,11 +113,11 @@ fn set_root_password() {
                         out.status.code(),
                         stderr.trim()
                     ));
-                    return;
+                    return Ok(());
                 }
                 Err(e) => {
                     console::error(&format!("Failed to wait for pw: {}", e));
-                    return;
+                    return Ok(());
                 }
             }
         }
@@ -125,9 +125,10 @@ fn set_root_password() {
         #[cfg(not(target_os = "freebsd"))]
         {
             console::success("Root password set (simulated).");
-            return;
+            return Ok(());
         }
     }
+    Ok(())
 }
 
 /// Result of the setup wizard
@@ -187,7 +188,7 @@ fn step(n: u32, title: &str) {
 }
 
 /// Run the full setup wizard
-pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
+pub fn run_wizard(reconfigure: bool) -> std::io::Result<Option<WizardResult>> {
     let mut config = SetupConfig::default();
 
     // ── Splash Screen ───────────────────────────────────────
@@ -199,15 +200,15 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
 
     if reconfigure {
         console::warn("Running in reconfigure mode. Existing config will be overwritten.");
-        if !console::confirm("Continue?", true) {
-            return None;
+        if !console::confirm("Continue?", true)? {
+            return Ok(None);
         }
     }
 
     // ── Step 1: Root Password ────────────────────────────────
     step(1, "Root Password");
     console::info("Set the system root password for console access.");
-    set_root_password();
+    set_root_password()?;
 
     // ── Step 2: SSH Access ───────────────────────────────────
     step(2, "SSH Access");
@@ -221,7 +222,7 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
             "Password authentication (not recommended)",
         ],
         0,
-    );
+    )?;
     config.ssh_auth_method = if ssh_method_idx == 1 {
         SshAuthMethod::Password
     } else {
@@ -230,7 +231,7 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
 
     if config.ssh_auth_method == SshAuthMethod::KeyOnly {
         console::info("You can import SSH keys from your GitHub account.");
-        let github_user = console::prompt("GitHub username (leave empty to skip)", "");
+        let github_user = console::prompt("GitHub username (leave empty to skip)", "")?;
         if !github_user.is_empty() {
             console::info(&format!("Fetching keys from github.com/{github_user}..."));
             match fetch_github_keys(&github_user) {
@@ -257,7 +258,7 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
 
         if config.ssh_authorized_keys.is_empty() {
             console::info("You can paste an SSH public key now (or press Enter to skip).");
-            let key = console::prompt("SSH public key", "");
+            let key = console::prompt("SSH public key", "")?;
             if !key.is_empty()
                 && (key.starts_with("ssh-") || key.starts_with("ecdsa-") || key.starts_with("sk-"))
             {
@@ -277,7 +278,7 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
     // ── Step 3: Hostname ─────────────────────────────────────
     step(3, "Hostname");
     loop {
-        config.hostname = console::prompt("Hostname", &config.hostname);
+        config.hostname = console::prompt("Hostname", &config.hostname)?;
         // Basic RFC 1123 validation
         if config.hostname.is_empty()
             || config.hostname.len() > 63
@@ -299,7 +300,7 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
     // ── Step 4: System Tuning (auto-detected) ────────────────
     let profile = SystemProfile::detect();
     config.ram_mb = profile.memory.total_mb;
-    let tuning_items = tuning::run_tuning_wizard(&profile);
+    let tuning_items = tuning::run_tuning_wizard(&profile)?;
 
     // ── Step 5: Network Interfaces ───────────────────────────
     step(5, "Network Interfaces");
@@ -308,7 +309,7 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
     if interfaces.is_empty() {
         console::error("No network interfaces detected!");
         console::info("Continuing with manual configuration...");
-        config.wan_interface = console::prompt_required("WAN interface name");
+        config.wan_interface = console::prompt_required("WAN interface name")?;
     } else {
         console::info("Detected interfaces:");
         for iface in &interfaces {
@@ -329,7 +330,7 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
             config.nat_enabled = false;
         } else {
             let iface_refs: Vec<&str> = interfaces.iter().map(|s| s.as_str()).collect();
-            let wan_idx = console::select("Select WAN interface", &iface_refs, 0);
+            let wan_idx = console::select("Select WAN interface", &iface_refs, 0)?;
             config.wan_interface = interfaces[wan_idx].clone();
 
             let remaining: Vec<&str> = interfaces
@@ -338,8 +339,8 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
                 .map(|s| s.as_str())
                 .collect();
 
-            if !remaining.is_empty() && console::confirm("Configure a LAN interface?", true) {
-                let lan_idx = console::select("Select LAN interface", &remaining, 0);
+            if !remaining.is_empty() && console::confirm("Configure a LAN interface?", true)? {
+                let lan_idx = console::select("Select LAN interface", &remaining, 0)?;
                 config.lan_interface = Some(remaining[lan_idx].to_string());
                 config.nat_enabled = true;
                 console::success("NAT will be enabled between WAN and LAN.");
@@ -356,7 +357,7 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
         "WAN IP configuration",
         &["DHCP (automatic)", "Static IP"],
         0,
-    );
+    )?;
     config.wan_mode = match wan_mode_idx {
         1 => WanMode::Static,
         _ => WanMode::Dhcp,
@@ -364,7 +365,7 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
 
     if config.wan_mode == WanMode::Static {
         loop {
-            let ip = console::prompt_required("WAN IP address (e.g., 203.0.113.1/24)");
+            let ip = console::prompt_required("WAN IP address (e.g., 203.0.113.1/24)")?;
             if console::validate_cidr(&ip) {
                 config.wan_ip = Some(ip);
                 break;
@@ -372,7 +373,7 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
             console::warn("Invalid IP/prefix format. Use format: x.x.x.x/xx");
         }
         loop {
-            let gw = console::prompt_required("Default gateway");
+            let gw = console::prompt_required("Default gateway")?;
             if console::validate_ip(&gw) {
                 config.wan_gateway = Some(gw);
                 break;
@@ -385,14 +386,14 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
     if config.lan_interface.is_some() {
         step(7, "LAN Configuration");
         loop {
-            let ip = console::prompt("LAN IP address", "192.168.1.1/24");
+            let ip = console::prompt("LAN IP address", "192.168.1.1/24")?;
             if console::validate_cidr(&ip) {
                 config.lan_ip = Some(ip);
                 break;
             }
             console::warn("Invalid IP/prefix format.");
         }
-        if console::confirm("Enable DHCP server on the LAN interface?", true) {
+        if console::confirm("Enable DHCP server on the LAN interface?", true)? {
             config.dhcp_enabled = true;
             console::success("DHCP server will be enabled on LAN.");
         }
@@ -405,7 +406,7 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
     println!();
 
     loop {
-        config.admin_username = console::prompt("Admin username", "admin");
+        config.admin_username = console::prompt("Admin username", "admin")?;
         if config.admin_username.is_empty()
             || config.admin_username.contains(' ')
             || config.admin_username.len() > 32
@@ -417,7 +418,7 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
     }
 
     loop {
-        let password = console::prompt_password_confirm("Password");
+        let password = console::prompt_password_confirm("Password")?;
         match console::validate_password(&password) {
             Ok(()) => {
                 match hash_password(&password) {
@@ -438,9 +439,9 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
 
     // ── Step 9: API & Web UI ─────────────────────────────────
     step(9, "API & Web UI");
-    config.api_listen = console::prompt("API listen address", &config.api_listen);
+    config.api_listen = console::prompt("API listen address", &config.api_listen)?;
     loop {
-        let port_str = console::prompt("API port", &config.api_port.to_string());
+        let port_str = console::prompt("API port", &config.api_port.to_string())?;
         match port_str.parse::<u16>() {
             Ok(p) if p > 0 => {
                 config.api_port = p;
@@ -451,12 +452,12 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
             }
         }
     }
-    config.ui_enabled = console::confirm("Enable web UI?", true);
+    config.ui_enabled = console::confirm("Enable web UI?", true)?;
 
     // ── Step 10: DNS Servers ─────────────────────────────────
     step(10, "DNS Servers");
     loop {
-        let dns = console::prompt("DNS servers (comma-separated)", "1.1.1.1,8.8.8.8");
+        let dns = console::prompt("DNS servers (comma-separated)", "1.1.1.1,8.8.8.8")?;
         let servers: Vec<String> = dns
             .split(',')
             .map(|s| s.trim().to_string())
@@ -481,7 +482,7 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
             "Permissive — allow all (testing only!)",
         ],
         0,
-    );
+    )?;
     config.default_policy = match policy_idx {
         1 => DefaultPolicy::Strict,
         2 => DefaultPolicy::Permissive,
@@ -489,7 +490,7 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
     };
 
     // ── Optional HA step ────────────────────────────────────
-    config.cluster = ask_cluster(&config);
+    config.cluster = ask_cluster(&config)?;
 
     // ── Summary ──────────────────────────────────────────────
     console::header("Configuration Summary");
@@ -572,32 +573,32 @@ pub fn run_wizard(reconfigure: bool) -> Option<WizardResult> {
     }
     println!();
 
-    if console::confirm("Apply this configuration?", true) {
-        Some(WizardResult {
+    if console::confirm("Apply this configuration?", true)? {
+        Ok(Some(WizardResult {
             config,
             tuning: tuning_items,
-        })
+        }))
     } else {
         console::info("Setup cancelled.");
-        None
+        Ok(None)
     }
 }
 
 /// Ask whether this node is part of an HA pair and collect cluster settings.
 /// Returns `None` if the operator declines or enters invalid data.
-fn ask_cluster(config: &SetupConfig) -> Option<WizardClusterConfig> {
+fn ask_cluster(config: &SetupConfig) -> std::io::Result<Option<WizardClusterConfig>> {
     if !console::confirm(
         "Configure this node as part of an HA pair? (Two AiFw boxes sharing a virtual IP via CARP + pfsync)",
         false,
-    ) {
-        return None;
+    )? {
+        return Ok(None);
     }
 
     let role_idx = console::select(
         "Is this the PRIMARY (master under normal load) or SECONDARY node?",
         &["primary", "secondary"],
         0,
-    );
+    )?;
     let role = match role_idx {
         0 => aifw_common::ClusterRole::Primary,
         _ => aifw_common::ClusterRole::Secondary,
@@ -606,7 +607,7 @@ fn ask_cluster(config: &SetupConfig) -> Option<WizardClusterConfig> {
     let pfsync_iface = loop {
         let s = console::prompt_required(
             "Which interface carries pfsync traffic? (a dedicated NIC is strongly recommended)",
-        );
+        )?;
         let s = s.trim().to_string();
         // FreeBSD interface names: ASCII letters, digits, and dots only.
         // Reject anything else to prevent newline injection into rc.conf.
@@ -619,7 +620,7 @@ fn ask_cluster(config: &SetupConfig) -> Option<WizardClusterConfig> {
     };
 
     let peer_address = loop {
-        let s = console::prompt_required("Peer node IP on the pfsync link:");
+        let s = console::prompt_required("Peer node IP on the pfsync link:")?;
         match s.parse::<std::net::IpAddr>() {
             Ok(addr) => break addr,
             Err(_) => console::error("Not a valid IP address."),
@@ -631,7 +632,8 @@ fn ask_cluster(config: &SetupConfig) -> Option<WizardClusterConfig> {
     // rc.conf is sourced by /bin/sh at boot; these chars would corrupt the
     // value or execute arbitrary code as root.
     let password = loop {
-        let pw = console::prompt_password("CARP password (will be shared with peer; min 8 chars):");
+        let pw =
+            console::prompt_password("CARP password (will be shared with peer; min 8 chars):")?;
         if pw.len() < 8 {
             console::error("Password must be at least 8 characters.");
             continue;
@@ -653,7 +655,7 @@ fn ask_cluster(config: &SetupConfig) -> Option<WizardClusterConfig> {
         if !console::confirm(
             &format!("Add a CARP VIP on the {iface_label} interface?"),
             true,
-        ) {
+        )? {
             continue;
         }
         let default_iface = if *iface_label == "WAN" {
@@ -664,7 +666,7 @@ fn ask_cluster(config: &SetupConfig) -> Option<WizardClusterConfig> {
         // Validate interface name: ASCII letters, digits, and dots only.
         // Prevents newline injection into rc.conf values.
         let interface = loop {
-            let s = console::prompt(&format!("{iface_label} interface name:"), default_iface);
+            let s = console::prompt(&format!("{iface_label} interface name:"), default_iface)?;
             let s = s.trim().to_string();
             if s.is_empty() {
                 console::warn("Interface name required — skipping this VIP.");
@@ -681,7 +683,7 @@ fn ask_cluster(config: &SetupConfig) -> Option<WizardClusterConfig> {
             continue;
         }
         let vip_str =
-            console::prompt_required(&format!("Virtual IP on {interface} (e.g. 192.0.2.1):"));
+            console::prompt_required(&format!("Virtual IP on {interface} (e.g. 192.0.2.1):"))?;
         let virtual_ip = match vip_str.parse::<std::net::IpAddr>() {
             Ok(ip) => ip,
             Err(_) => {
@@ -690,14 +692,14 @@ fn ask_cluster(config: &SetupConfig) -> Option<WizardClusterConfig> {
             }
         };
         let prefix: u8 = loop {
-            let s = console::prompt("Prefix length (e.g. 24):", "24");
+            let s = console::prompt("Prefix length (e.g. 24):", "24")?;
             match s.parse::<u8>() {
                 Ok(p) if p <= 128 => break p,
                 _ => console::warn("Enter a valid prefix length (0-32 for IPv4, 0-128 for IPv6)."),
             }
         };
         let vhid: u8 = loop {
-            let s = console::prompt_required("CARP VHID (1-255, must match peer):");
+            let s = console::prompt_required("CARP VHID (1-255, must match peer):")?;
             match s.parse::<u8>() {
                 Ok(v) if v >= 1 => break v,
                 _ => console::warn("VHID must be 1-255."),
@@ -711,13 +713,13 @@ fn ask_cluster(config: &SetupConfig) -> Option<WizardClusterConfig> {
         });
     }
 
-    Some(WizardClusterConfig {
+    Ok(Some(WizardClusterConfig {
         role,
         pfsync_iface,
         peer_address,
         vips,
         password,
-    })
+    }))
 }
 
 /// Fetch SSH public keys from a GitHub user's profile.


### PR DESCRIPTION
Closes #446, closes #455.

**#446 (QUAL-M11)** — `aifw-setup/src/console.rs` used `.expect("… terminal lost")` on every stdout flush / stdin read, so a wizard run over SSH whose stdin closed mid-way died with a panic. All prompt helpers now return `io::Result` (a stdin EOF is reported as `UnexpectedEof: stdin closed — terminal lost` — the wizard cannot proceed without an operator; the no-echo password prompt restores terminal echo before returning the error). `wizard::run_wizard` → `io::Result<Option<WizardResult>>`, `ask_cluster`, `set_root_password`, `tuning::run_tuning_wizard` propagate with `?`, and `main` reports `setup wizard aborted: <cause>` with a non-zero exit. A guard test in `aifw-setup::tests` fails if `.expect(`/`.unwrap()` reappears in the non-test code of console/wizard/tuning.

**#455 (QUAL-M20)** — audited the working tree and the whole history: `git ls-files` regex scan for private-key headers and AWS/GitHub/Slack/OpenAI/Google token shapes; `git log --all -S` pickaxe for the same markers (only hit: the `AKIA...` placeholder in the backup docs); every file ever added, filtered for key/env/credential names (none). Findings written up in a new **Secrets in the repository** section of `SECURITY.md`: the minisign *public* key is the only key material intentionally tracked, the rest are test fixtures / placeholders, runtime secrets live outside the tree. `.gitignore` now excludes `.env*`, `*.pem`, `*.key` (with the public key whitelisted).