### PR TITLE
test: coverage for aifw-daemon / aifw-cli / aifw-tui and untested API resources (#172 #173 #174 #442)

### DIFF
--- a/aifw-api/src/dhcp.rs
+++ b/aifw-api/src/dhcp.rs
@@ -814,6 +814,71 @@ fn validate_option_overrides(options: &[DhcpOptionOverride]) -> Result<(), Strin
     Ok(())
 }
 
+/// Address-family and range sanity for an IPv4 subnet definition (#442):
+/// `network` must be a v4 CIDR, the pool bounds and gateway must be v4
+/// addresses inside it, and the pool must not be inverted. The import path
+/// (`backup::validate_dhcp`) already enforced this; the create/update
+/// handlers accepted anything.
+fn validate_v4_subnet_shape(
+    network: &str,
+    pool_start: &str,
+    pool_end: &str,
+    gateway: &str,
+) -> Result<(), String> {
+    use std::net::Ipv4Addr;
+    let (net_s, prefix_s) = network
+        .split_once('/')
+        .ok_or_else(|| format!("network '{network}' must be IPv4 CIDR (a.b.c.d/nn)"))?;
+    let net: Ipv4Addr = net_s
+        .parse()
+        .map_err(|_| format!("network '{network}' is not a valid IPv4 CIDR"))?;
+    let prefix: u8 = prefix_s
+        .parse()
+        .ok()
+        .filter(|p| *p <= 32)
+        .ok_or_else(|| format!("network '{network}' has an invalid prefix length"))?;
+    let mask: u32 = if prefix == 0 {
+        0
+    } else {
+        u32::MAX << (32 - prefix)
+    };
+    let in_net = |ip: Ipv4Addr| (u32::from(ip) & mask) == (u32::from(net) & mask);
+    let parse = |label: &str, v: &str| -> Result<Ipv4Addr, String> {
+        v.parse()
+            .map_err(|_| format!("{label} '{v}' is not a valid IPv4 address"))
+    };
+    let start = parse("pool_start", pool_start)?;
+    let end = parse("pool_end", pool_end)?;
+    let gw = parse("gateway", gateway)?;
+    for (label, ip) in [("pool_start", start), ("pool_end", end), ("gateway", gw)] {
+        if !in_net(ip) {
+            return Err(format!("{label} {ip} is outside network {network}"));
+        }
+    }
+    if u32::from(start) > u32::from(end) {
+        return Err(format!("pool_start {start} is after pool_end {end}"));
+    }
+    Ok(())
+}
+
+/// A reservation needs a real MAC (six hex octets, `:`/`-` separated) and a
+/// v4 address; rDHCP would otherwise render an unusable host entry (#442).
+fn validate_reservation_shape(mac: &str, ip: &str) -> Result<(), String> {
+    let octets: Vec<&str> = mac.split([':', '-']).collect();
+    let mac_ok = octets.len() == 6
+        && octets
+            .iter()
+            .all(|o| o.len() == 2 && o.chars().all(|c| c.is_ascii_hexdigit()));
+    if !mac_ok {
+        return Err(format!(
+            "mac_address '{mac}' is not a valid MAC (aa:bb:cc:dd:ee:ff)"
+        ));
+    }
+    ip.parse::<std::net::Ipv4Addr>()
+        .map(|_| ())
+        .map_err(|_| format!("ip_address '{ip}' is not a valid IPv4 address"))
+}
+
 /// Validate a list of trusted relay agent IPs. IPv4-only; loopback (127.0.0.0/8) rejected.
 fn validate_trusted_relays(relays: &[String]) -> Result<(), String> {
     use std::net::Ipv4Addr;
@@ -1643,6 +1708,13 @@ pub async fn create_subnet(
     let now = Utc::now().to_rfc3339();
     let enabled = req.enabled.unwrap_or(true);
     let subnet_type = req.subnet_type.as_deref().unwrap_or("address");
+    if subnet_type == "address"
+        && let Err(e) =
+            validate_v4_subnet_shape(&req.network, &req.pool_start, &req.pool_end, &req.gateway)
+    {
+        tracing::warn!(error = %e, "dhcp: create subnet rejected");
+        return Err(bad_request());
+    }
     let dns_str = req.dns_servers.as_ref().map(|v| v.join(","));
     let ntp_str = req.ntp_servers.as_ref().and_then(|v| {
         let s = v
@@ -1719,6 +1791,13 @@ pub async fn update_subnet(
 ) -> Result<Json<ApiResponse<DhcpSubnet>>, StatusCode> {
     let enabled = req.enabled.unwrap_or(true);
     let subnet_type = req.subnet_type.as_deref().unwrap_or("address");
+    if subnet_type == "address"
+        && let Err(e) =
+            validate_v4_subnet_shape(&req.network, &req.pool_start, &req.pool_end, &req.gateway)
+    {
+        tracing::warn!(error = %e, "dhcp: update subnet rejected");
+        return Err(bad_request());
+    }
     let dns_str = req.dns_servers.as_ref().map(|v| v.join(","));
     let ntp_str = req.ntp_servers.as_ref().and_then(|v| {
         let s = v
@@ -1846,6 +1925,10 @@ pub async fn create_reservation(
     State(state): State<AppState>,
     Json(req): Json<CreateReservationRequest>,
 ) -> Result<(StatusCode, Json<ApiResponse<DhcpReservation>>), StatusCode> {
+    if let Err(e) = validate_reservation_shape(&req.mac_address, &req.ip_address) {
+        tracing::warn!(error = %e, "dhcp: create reservation rejected");
+        return Err(bad_request());
+    }
     let id = Uuid::new_v4().to_string();
     let now = Utc::now().to_rfc3339();
     sqlx::query("INSERT INTO dhcp_reservations (id, subnet_id, mac_address, ip_address, hostname, client_id, description, created_at) VALUES (?1,?2,?3,?4,?5,?6,?7,?8)")
@@ -1875,6 +1958,10 @@ pub async fn update_reservation(
     Path(id): Path<String>,
     Json(req): Json<CreateReservationRequest>,
 ) -> Result<Json<ApiResponse<DhcpReservation>>, StatusCode> {
+    if let Err(e) = validate_reservation_shape(&req.mac_address, &req.ip_address) {
+        tracing::warn!(error = %e, "dhcp: update reservation rejected");
+        return Err(bad_request());
+    }
     let result = sqlx::query("UPDATE dhcp_reservations SET subnet_id=?2, mac_address=?3, ip_address=?4, hostname=?5, client_id=?6, description=?7 WHERE id=?1")
         .bind(&id).bind(req.subnet_id.as_deref()).bind(&req.mac_address).bind(&req.ip_address)
         .bind(req.hostname.as_deref()).bind(req.client_id.as_deref()).bind(req.description.as_deref())

--- a/aifw-api/src/tests/mod.rs
+++ b/aifw-api/src/tests/mod.rs
@@ -199,6 +199,7 @@ mod backup;
 mod cluster;
 mod cookies;
 mod rbac;
+mod resources;
 mod rules;
 mod system;
 mod vpn_pki;

--- a/aifw-api/src/tests/resources.rs
+++ b/aifw-api/src/tests/resources.rs
@@ -1,0 +1,309 @@
+//! Round-trip coverage for API resources that had no integration tests
+//! (#442): geo-IP, WireGuard tunnels/peers, IDS endpoints without the IDS process,
+//! DHCP subnets/reservations, DNS resolver host overrides. Each test drives
+//! create → list → get/update → delete and one validation rejection.
+
+use super::*;
+
+#[tokio::test]
+async fn geoip_rules_round_trip_and_reject_bad_country() {
+    let (server, _) = test_app().await;
+    let token = create_user_and_login(&server).await;
+
+    let resp = server
+        .post("/api/v1/geoip")
+        .authorization_bearer(&token)
+        .json(&json!({"country_code": "CN", "action": "block"}))
+        .await;
+    assert!(resp.status_code().is_success(), "{}", resp.text());
+    let created: Value = resp.json();
+    let id = created["data"]["id"].as_str().unwrap().to_string();
+
+    let resp = server
+        .get("/api/v1/geoip")
+        .authorization_bearer(&token)
+        .await;
+    resp.assert_status_ok();
+    let list: Value = resp.json();
+    assert_eq!(list["data"].as_array().unwrap().len(), 1);
+    assert_eq!(list["data"][0]["country"], "CN");
+
+    // Not a real ISO code → 400, list unchanged.
+    let resp = server
+        .post("/api/v1/geoip")
+        .authorization_bearer(&token)
+        .json(&json!({"country_code": "XYZ", "action": "block"}))
+        .await;
+    assert!(resp.status_code().is_client_error(), "{}", resp.text());
+    let resp = server
+        .post("/api/v1/geoip")
+        .authorization_bearer(&token)
+        .json(&json!({"country_code": "US", "action": "nuke"}))
+        .await;
+    assert!(
+        resp.status_code().is_client_error(),
+        "bad action: {}",
+        resp.text()
+    );
+
+    server
+        .delete(&format!("/api/v1/geoip/{id}"))
+        .authorization_bearer(&token)
+        .await
+        .assert_status_ok();
+    let list: Value = server
+        .get("/api/v1/geoip")
+        .authorization_bearer(&token)
+        .await
+        .json();
+    assert!(list["data"].as_array().unwrap().is_empty());
+
+    // Unauthenticated read is refused.
+    server
+        .get("/api/v1/geoip")
+        .await
+        .assert_status(StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn wireguard_tunnel_and_peer_round_trip() {
+    let (server, _) = test_app().await;
+    let token = create_user_and_login(&server).await;
+
+    let resp = server
+        .post("/api/v1/vpn/wg")
+        .authorization_bearer(&token)
+        .json(&json!({"name": "wg-office", "listen_port": 51820, "address": "10.66.0.1/24"}))
+        .await;
+    assert!(resp.status_code().is_success(), "{}", resp.text());
+    let t: Value = resp.json();
+    let tid = t["data"]["id"].as_str().unwrap().to_string();
+    // Key pair generated server-side.
+    assert!(
+        t["data"]["public_key"]
+            .as_str()
+            .map(|k| !k.is_empty())
+            .unwrap_or(false)
+    );
+
+    let resp = server
+        .post(&format!("/api/v1/vpn/wg/{tid}/peers"))
+        .authorization_bearer(&token)
+        .json(&json!({"name": "laptop", "auto_generate_key": true, "allowed_ips": "10.66.0.2/32"}))
+        .await;
+    assert!(resp.status_code().is_success(), "{}", resp.text());
+    let p: Value = resp.json();
+    let pid = p["data"]["id"].as_str().unwrap().to_string();
+
+    // next-ip skips the address the peer just took.
+    let resp = server
+        .get(&format!("/api/v1/vpn/wg/{tid}/peers/next-ip"))
+        .authorization_bearer(&token)
+        .await;
+    resp.assert_status_ok();
+    let next = resp.text();
+    assert!(
+        !next.contains("10.66.0.2/32"),
+        "next-ip must skip the used address: {next}"
+    );
+
+    let resp = server
+        .get(&format!("/api/v1/vpn/wg/{tid}/peers"))
+        .authorization_bearer(&token)
+        .await;
+    resp.assert_status_ok();
+    assert_eq!(resp.json::<Value>()["data"].as_array().unwrap().len(), 1);
+
+    // Client config export renders a [Peer] section pointing at our public key.
+    let resp = server
+        .get(&format!("/api/v1/vpn/wg/{tid}/peers/{pid}/config"))
+        .authorization_bearer(&token)
+        .await;
+    resp.assert_status_ok();
+    let cfg = resp.text();
+    assert!(
+        cfg.contains("[Interface]") && cfg.contains("[Peer]"),
+        "{cfg}"
+    );
+
+    // Bad address is rejected.
+    let resp = server
+        .post("/api/v1/vpn/wg")
+        .authorization_bearer(&token)
+        .json(&json!({"name": "bad", "listen_port": 51821, "address": "not-an-address"}))
+        .await;
+    assert!(resp.status_code().is_client_error(), "{}", resp.text());
+
+    server
+        .delete(&format!("/api/v1/vpn/wg/{tid}/peers/{pid}"))
+        .authorization_bearer(&token)
+        .await
+        .assert_status_ok();
+    server
+        .delete(&format!("/api/v1/vpn/wg/{tid}"))
+        .authorization_bearer(&token)
+        .await
+        .assert_status_ok();
+    let list: Value = server
+        .get("/api/v1/vpn/wg")
+        .authorization_bearer(&token)
+        .await
+        .json();
+    assert!(list["data"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn ids_endpoints_degrade_cleanly_without_the_ids_process() {
+    // The IDS config and alert/suppression tables belong to the aifw-ids
+    // process (IPC + its own schema). Without it the API must answer 503
+    // for the config, never 500, and auth still gates everything.
+    let (server, _) = test_app().await;
+    let token = create_user_and_login(&server).await;
+    let resp = server
+        .get("/api/v1/ids/config")
+        .authorization_bearer(&token)
+        .await;
+    assert!(
+        resp.status_code() == StatusCode::OK
+            || resp.status_code() == StatusCode::SERVICE_UNAVAILABLE,
+        "{}",
+        resp.text()
+    );
+    server
+        .get("/api/v1/ids/config")
+        .await
+        .assert_status(StatusCode::UNAUTHORIZED);
+    // Unknown suppress_type is a client error regardless of IDS state.
+    let resp = server
+        .post("/api/v1/ids/suppressions")
+        .authorization_bearer(&token)
+        .json(&json!({"sid": 1, "suppress_type": "by_magic", "ip_cidr": "10.0.0.0/8"}))
+        .await;
+    assert!(resp.status_code().is_client_error(), "{}", resp.text());
+}
+
+#[tokio::test]
+async fn dhcp_subnets_and_reservations_round_trip() {
+    let (server, _) = test_app().await;
+    let token = create_user_and_login(&server).await;
+
+    let resp = server
+        .post("/api/v1/dhcp/v4/subnets")
+        .authorization_bearer(&token)
+        .json(&json!({
+            "network": "192.168.50.0/24", "pool_start": "192.168.50.100",
+            "pool_end": "192.168.50.200", "gateway": "192.168.50.1",
+            "dns_servers": ["192.168.50.1"], "lease_time": 3600
+        }))
+        .await;
+    assert!(resp.status_code().is_success(), "{}", resp.text());
+    let sub: Value = resp.json();
+    let sub_id = sub["data"]["id"].as_str().unwrap().to_string();
+    assert_eq!(sub["data"]["network"], "192.168.50.0/24");
+
+    let list: Value = server
+        .get("/api/v1/dhcp/v4/subnets")
+        .authorization_bearer(&token)
+        .await
+        .json();
+    assert_eq!(list["data"].as_array().unwrap().len(), 1);
+
+    // Pool outside the network is rejected.
+    let resp = server
+        .post("/api/v1/dhcp/v4/subnets")
+        .authorization_bearer(&token)
+        .json(&json!({
+            "network": "192.168.60.0/24", "pool_start": "10.0.0.5",
+            "pool_end": "10.0.0.9", "gateway": "192.168.60.1"
+        }))
+        .await;
+    assert!(resp.status_code().is_client_error(), "{}", resp.text());
+
+    let resp = server
+        .post("/api/v1/dhcp/v4/reservations")
+        .authorization_bearer(&token)
+        .json(&json!({
+            "subnet_id": sub_id, "mac_address": "aa:bb:cc:dd:ee:ff",
+            "ip_address": "192.168.50.10", "hostname": "printer"
+        }))
+        .await;
+    assert!(resp.status_code().is_success(), "{}", resp.text());
+    let res: Value = resp.json();
+    let res_id = res["data"]["id"].as_str().unwrap().to_string();
+
+    // Malformed MAC rejected.
+    let resp = server
+        .post("/api/v1/dhcp/v4/reservations")
+        .authorization_bearer(&token)
+        .json(&json!({"mac_address": "not-a-mac", "ip_address": "192.168.50.11"}))
+        .await;
+    assert!(resp.status_code().is_client_error(), "{}", resp.text());
+
+    let list: Value = server
+        .get("/api/v1/dhcp/v4/reservations")
+        .authorization_bearer(&token)
+        .await
+        .json();
+    assert_eq!(list["data"].as_array().unwrap().len(), 1);
+    assert_eq!(list["data"][0]["hostname"], "printer");
+
+    server
+        .delete(&format!("/api/v1/dhcp/v4/reservations/{res_id}"))
+        .authorization_bearer(&token)
+        .await
+        .assert_status_ok();
+    server
+        .delete(&format!("/api/v1/dhcp/v4/subnets/{sub_id}"))
+        .authorization_bearer(&token)
+        .await
+        .assert_status_ok();
+    let list: Value = server
+        .get("/api/v1/dhcp/v4/subnets")
+        .authorization_bearer(&token)
+        .await
+        .json();
+    assert!(list["data"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn dns_resolver_host_overrides_round_trip() {
+    let (server, _) = test_app().await;
+    let token = create_user_and_login(&server).await;
+
+    let resp = server
+        .post("/api/v1/dns/resolver/hosts")
+        .authorization_bearer(&token)
+        .json(&json!({"hostname": "nas", "domain": "home.arpa", "value": "192.168.1.20"}))
+        .await;
+    assert!(resp.status_code().is_success(), "{}", resp.text());
+    let h: Value = resp.json();
+    let hid = h["data"]["id"].as_str().unwrap().to_string();
+    assert_eq!(h["data"]["record_type"], "A", "record type defaults to A");
+
+    // AAAA with a v4 value is inconsistent → rejected.
+    let resp = server
+        .post("/api/v1/dns/resolver/hosts")
+        .authorization_bearer(&token)
+        .json(&json!({"hostname": "bad", "domain": "home.arpa", "record_type": "AAAA", "value": "192.168.1.21"}))
+        .await;
+    assert!(resp.status_code().is_client_error(), "{}", resp.text());
+
+    let list: Value = server
+        .get("/api/v1/dns/resolver/hosts")
+        .authorization_bearer(&token)
+        .await
+        .json();
+    assert_eq!(list["data"].as_array().unwrap().len(), 1);
+
+    server
+        .delete(&format!("/api/v1/dns/resolver/hosts/{hid}"))
+        .authorization_bearer(&token)
+        .await
+        .assert_status_ok();
+    let list: Value = server
+        .get("/api/v1/dns/resolver/hosts")
+        .authorization_bearer(&token)
+        .await
+        .json();
+    assert!(list["data"].as_array().unwrap().is_empty());
+}

--- a/aifw-cli/src/commands/common.rs
+++ b/aifw-cli/src/commands/common.rs
@@ -52,3 +52,37 @@ pub(super) async fn create_nat_engine(db_path: &Path) -> anyhow::Result<NatEngin
     // rule class in their anchor since #531.
     Ok(NatEngine::new(db.pool().clone(), pf).with_anchor("aifw-nat".to_string()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_port_single_and_range() {
+        assert_eq!(parse_port("22").unwrap(), PortRange { start: 22, end: 22 });
+        assert_eq!(
+            parse_port("8000:8080").unwrap(),
+            PortRange {
+                start: 8000,
+                end: 8080
+            }
+        );
+        assert!(parse_port("x").is_err());
+        assert!(parse_port("70000").is_err(), "u16 overflow rejected");
+        assert!(parse_port("1:2:3").is_err());
+    }
+
+    #[test]
+    fn parse_action_and_direction_vocabulary() {
+        assert_eq!(parse_action("pass").unwrap(), Action::Pass);
+        assert_eq!(parse_action("block").unwrap(), Action::Block);
+        assert_eq!(parse_action("block-drop").unwrap(), Action::BlockDrop);
+        assert_eq!(parse_action("block-return").unwrap(), Action::BlockReturn);
+        let e = parse_action("deny").unwrap_err().to_string();
+        assert!(e.contains("pass, block, block-drop, block-return"), "{e}");
+        assert_eq!(parse_direction("in").unwrap(), Direction::In);
+        assert_eq!(parse_direction("out").unwrap(), Direction::Out);
+        assert_eq!(parse_direction("any").unwrap(), Direction::Any);
+        assert!(parse_direction("inbound").is_err());
+    }
+}

--- a/aifw-cli/src/commands/config.rs
+++ b/aifw-cli/src/commands/config.rs
@@ -238,3 +238,29 @@ pub async fn config_diff(db_path: &Path, v1: i64, v2: i64) -> anyhow::Result<()>
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::backup_passphrase;
+
+    #[test]
+    fn passphrase_file_first_line_wins_and_empty_is_error() {
+        let dir = std::env::temp_dir().join(format!("aifw-cli-pw-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let f = dir.join("pw");
+        std::fs::write(&f, "hunter2\r\nsecond line\n").unwrap();
+        assert_eq!(
+            backup_passphrase(Some(f.to_str().unwrap()))
+                .unwrap()
+                .as_deref(),
+            Some("hunter2")
+        );
+        std::fs::write(&f, "\n").unwrap();
+        assert!(
+            backup_passphrase(Some(f.to_str().unwrap())).is_err(),
+            "empty file is an error"
+        );
+        assert!(backup_passphrase(Some(dir.join("missing").to_str().unwrap())).is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/aifw-cli/src/commands/logging.rs
+++ b/aifw-cli/src/commands/logging.rs
@@ -394,3 +394,17 @@ mod syslog_cli_tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 }
+
+#[cfg(test)]
+mod human_bytes_tests {
+    use super::human_bytes;
+
+    #[test]
+    fn scales_with_binary_units() {
+        assert_eq!(human_bytes(0), "0 B");
+        assert_eq!(human_bytes(1023), "1023 B");
+        assert_eq!(human_bytes(1024), "1 KB");
+        assert_eq!(human_bytes(5 * 1024 * 1024), "5.0 MB");
+        assert_eq!(human_bytes(3 * 1024 * 1024 * 1024 / 2), "1.5 GB");
+    }
+}

--- a/aifw-cli/src/commands/nat.rs
+++ b/aifw-cli/src/commands/nat.rs
@@ -192,3 +192,44 @@ pub async fn nat_list(db_path: &Path, json: bool) -> anyhow::Result<()> {
     println!("\n{} NAT rule(s) total", rules.len());
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flag_hints_map_engine_errors_to_cli_flags() {
+        assert!(
+            nat_flag_hint("static_port is only valid for SNAT")
+                .unwrap()
+                .contains("--static-port")
+        );
+        assert!(
+            nat_flag_hint("af_to_dst (translated destination) is only valid for nat46")
+                .unwrap()
+                .contains("--af-to-dst")
+        );
+        assert!(
+            nat_flag_hint("nat46 translated destination must be a single IPv6")
+                .unwrap()
+                .contains("--af-to-dst")
+        );
+        assert!(
+            nat_flag_hint("rules do not support a redirect port")
+                .unwrap()
+                .contains("--redirect-port")
+        );
+        assert!(nat_flag_hint("something unrelated").is_none());
+    }
+
+    #[test]
+    fn nat_embed_validates_inputs() {
+        assert!(nat_embed("64:ff9b::/96", "10.1.2.3").is_ok());
+        assert!(
+            nat_embed("64:ff9b::", "10.1.2.3").is_ok(),
+            "bare address accepted"
+        );
+        assert!(nat_embed("not-v6", "10.1.2.3").is_err());
+        assert!(nat_embed("64:ff9b::/96", "300.1.1.1").is_err());
+    }
+}

--- a/aifw-cli/src/commands/vpn.rs
+++ b/aifw-cli/src/commands/vpn.rs
@@ -307,3 +307,18 @@ pub async fn vpn_list(db_path: &Path, json: bool) -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::split_ts;
+
+    #[test]
+    fn split_ts_trims_and_drops_empties() {
+        assert_eq!(
+            split_ts("10.0.0.0/24, 10.1.0.0/24 ,,"),
+            vec!["10.0.0.0/24", "10.1.0.0/24"]
+        );
+        assert!(split_ts("").is_empty());
+        assert!(split_ts(" , ").is_empty());
+    }
+}

--- a/aifw-daemon/src/cluster_replicator.rs
+++ b/aifw-daemon/src/cluster_replicator.rs
@@ -90,10 +90,7 @@ impl ClusterReplicator {
         let local_hash = aifw_core::sha256_hex(&local_data);
 
         let nodes = self.engine.list_nodes().await?;
-        for peer in nodes
-            .iter()
-            .filter(|n| !matches!(n.role, ClusterRole::Primary | ClusterRole::Standalone))
-        {
+        for peer in replication_targets(&nodes) {
             let key = match self.engine.peer_api_key(peer.id).await? {
                 Some(k) => k,
                 None => continue,
@@ -171,5 +168,46 @@ impl ClusterReplicator {
             }
         }
         Ok(())
+    }
+}
+
+/// Nodes the primary pushes snapshots to: every secondary. Primaries (this
+/// node, or a stale duplicate) and standalone entries are never targets.
+pub(crate) fn replication_targets(
+    nodes: &[aifw_common::ClusterNode],
+) -> Vec<&aifw_common::ClusterNode> {
+    nodes
+        .iter()
+        .filter(|n| !matches!(n.role, ClusterRole::Primary | ClusterRole::Standalone))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aifw_common::ClusterNode;
+
+    fn node(name: &str, role: ClusterRole) -> ClusterNode {
+        ClusterNode::new(
+            name.to_string(),
+            format!("10.0.0.{}", name.len()).parse().unwrap(),
+            role,
+        )
+    }
+
+    #[test]
+    fn only_secondaries_receive_snapshots() {
+        let nodes = vec![
+            node("me", ClusterRole::Primary),
+            node("standby", ClusterRole::Secondary),
+            node("lonely", ClusterRole::Standalone),
+            node("standby2", ClusterRole::Secondary),
+        ];
+        let targets: Vec<&str> = replication_targets(&nodes)
+            .iter()
+            .map(|n| n.name.as_str())
+            .collect();
+        assert_eq!(targets, vec!["standby", "standby2"]);
+        assert!(replication_targets(&[]).is_empty());
     }
 }

--- a/aifw-daemon/src/role_watcher.rs
+++ b/aifw-daemon/src/role_watcher.rs
@@ -36,12 +36,8 @@ impl RoleWatcher {
                     // Convert raw ifconfig role strings ("master"/"backup") to
                     // canonical ClusterRole vocabulary ("primary"/"secondary") so
                     // audit history and WS event consumers see one vocabulary.
-                    let from_canon = aifw_common::ClusterRole::parse(prev)
-                        .map(|r| r.to_string())
-                        .unwrap_or_else(|_| prev.clone());
-                    let to_canon = aifw_common::ClusterRole::parse(&role)
-                        .map(|r| r.to_string())
-                        .unwrap_or_else(|_| role.clone());
+                    let from_canon = canonical_role(prev);
+                    let to_canon = canonical_role(&role);
                     let body = serde_json::json!({"from": from_canon, "to": to_canon, "vhid": 0u8});
                     let url = format!("{}/api/v1/cluster/internal/role-changed", self.api_base);
                     let client = match loopback.get() {
@@ -89,16 +85,64 @@ impl RoleWatcher {
 /// or "unknown" if neither is observed (e.g. on Linux, or before pfsync
 /// initializes).
 pub(crate) async fn current_carp_role() -> String {
-    let out = tokio::process::Command::new("sh")
-        .arg("-c")
-        .arg("ifconfig 2>/dev/null | awk '/carp:/ {print tolower($2); exit}'")
-        .output()
-        .await;
+    let out = tokio::process::Command::new("ifconfig").output().await;
     match out {
-        Ok(o) if o.status.success() => {
-            let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
-            if s.is_empty() { "unknown".into() } else { s }
-        }
+        Ok(o) if o.status.success() => carp_role_from_ifconfig(&String::from_utf8_lossy(&o.stdout)),
         _ => "unknown".into(),
+    }
+}
+
+/// Pure parse of `ifconfig` output: the state of the first `carp:` line
+/// (`carp: MASTER vhid 1 advbase 1 advskew 0`), lower-cased; "unknown"
+/// when no CARP interface is present.
+pub(crate) fn carp_role_from_ifconfig(out: &str) -> String {
+    out.lines()
+        .find_map(|l| {
+            let t = l.trim_start();
+            t.strip_prefix("carp:")
+                .and_then(|rest| rest.split_whitespace().next())
+                .map(|s| s.to_ascii_lowercase())
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Canonical (`primary`/`secondary`) form of a raw ifconfig role, falling
+/// back to the raw string when it isn't a known CARP state — this is what
+/// the role-changed event carries so audit history uses one vocabulary.
+pub(crate) fn canonical_role(raw: &str) -> String {
+    aifw_common::ClusterRole::parse(raw)
+        .map(|r| r.to_string())
+        .unwrap_or_else(|_| raw.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_first_carp_state_from_ifconfig() {
+        let out = "em0: flags=8863<UP> metric 0 mtu 1500\n\
+                   \tinet 192.0.2.2 netmask 0xffffff00\n\
+                   \tinet 192.0.2.1 netmask 0xffffffff vhid 1\n\
+                   \tcarp: MASTER vhid 1 advbase 1 advskew 0\n\
+                   em1: flags=8863<UP>\n\
+                   \tcarp: BACKUP vhid 2 advbase 1 advskew 100\n";
+        assert_eq!(carp_role_from_ifconfig(out), "master");
+        assert_eq!(
+            carp_role_from_ifconfig("lo0: flags=8049<UP,LOOPBACK>\n"),
+            "unknown"
+        );
+        assert_eq!(carp_role_from_ifconfig(""), "unknown");
+        assert_eq!(carp_role_from_ifconfig("\tcarp: INIT vhid 3\n"), "init");
+    }
+
+    #[test]
+    fn role_change_events_use_canonical_vocabulary() {
+        assert_eq!(canonical_role("master"), "primary");
+        assert_eq!(canonical_role("backup"), "secondary");
+        // Unknown states pass through untouched rather than being guessed.
+        assert_eq!(canonical_role("init"), "init");
+        assert_eq!(canonical_role("unknown"), "unknown");
     }
 }

--- a/aifw-tui/src/app.rs
+++ b/aifw-tui/src/app.rs
@@ -85,8 +85,14 @@ pub struct App {
 impl App {
     pub async fn new(db_path: &std::path::Path) -> anyhow::Result<Self> {
         let db = Database::new(db_path).await?;
-        let pool = db.pool().clone();
         let pf: Arc<dyn PfBackend> = Arc::from(aifw_pf::create_backend());
+        Self::with_backend(db, pf).await
+    }
+
+    /// Build the app on an existing database + pf backend (tests use an
+    /// in-memory DB and the mock backend).
+    pub async fn with_backend(db: Database, pf: Arc<dyn PfBackend>) -> anyhow::Result<Self> {
+        let pool = db.pool().clone();
 
         let rule_engine = Arc::new(RuleEngine::new(pool.clone(), pf.clone()));
         // "aifw-nat" — must match the API/daemon anchor (#531).
@@ -207,5 +213,112 @@ impl App {
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aifw_common::{Action, Address, Direction, Protocol, RuleMatch};
+
+    async fn app() -> App {
+        let db = Database::new_in_memory().await.unwrap();
+        let pf: Arc<dyn PfBackend> = Arc::new(aifw_pf::PfMock::new());
+        App::with_backend(db, pf).await.unwrap()
+    }
+
+    fn rule(port: u16) -> Rule {
+        Rule::new(
+            Action::Pass,
+            Direction::In,
+            Protocol::Tcp,
+            RuleMatch {
+                src_addr: Address::Any,
+                src_port: None,
+                dst_addr: Address::Any,
+                dst_port: Some(aifw_common::PortRange {
+                    start: port,
+                    end: port,
+                }),
+            },
+        )
+    }
+
+    #[test]
+    fn tabs_cycle_in_both_directions() {
+        let mut t = Tab::Dashboard;
+        for expected in Tab::ALL.iter().skip(1) {
+            t = t.next();
+            assert_eq!(t.title(), expected.title());
+        }
+        assert_eq!(t.next().title(), Tab::Dashboard.title(), "wraps forward");
+        let mut t = Tab::Dashboard;
+        assert_eq!(t.prev().title(), Tab::Logs.title(), "wraps backward");
+        for _ in 0..Tab::ALL.len() {
+            t = t.prev();
+        }
+        assert_eq!(t.title(), Tab::Dashboard.title(), "full backward cycle");
+        // Every title is distinct — the tab bar relies on it.
+        let mut titles: Vec<&str> = Tab::ALL.iter().map(Tab::title).collect();
+        titles.sort();
+        titles.dedup();
+        assert_eq!(titles.len(), Tab::ALL.len());
+    }
+
+    #[tokio::test]
+    async fn fresh_app_starts_on_dashboard_with_empty_caches() {
+        let a = app().await;
+        assert!(a.running);
+        assert_eq!(a.tab.title(), "Dashboard");
+        assert!(a.rules.is_empty() && a.nat_rules.is_empty() && a.connections.is_empty());
+        assert_eq!(a.rules_selected, 0);
+    }
+
+    #[tokio::test]
+    async fn selection_is_clamped_per_tab_and_no_op_on_empty_lists() {
+        let mut a = app().await;
+        a.tab = Tab::Rules;
+        // Empty list: down does nothing, up saturates at 0.
+        a.select_down();
+        a.select_up();
+        assert_eq!(a.rules_selected, 0);
+
+        a.rule_engine.add_rule(rule(22)).await.unwrap();
+        a.rule_engine.add_rule(rule(80)).await.unwrap();
+        a.rule_engine.add_rule(rule(443)).await.unwrap();
+        a.refresh().await;
+        assert_eq!(a.rules.len(), 3);
+        for _ in 0..10 {
+            a.select_down();
+        }
+        assert_eq!(a.rules_selected, 2, "clamped to last row");
+        a.select_up();
+        assert_eq!(a.rules_selected, 1);
+        // Selection state is per tab — moving on Rules must not touch NAT.
+        assert_eq!(a.nat_selected, 0);
+        a.tab = Tab::Dashboard;
+        a.select_down();
+        assert_eq!(a.rules_selected, 1, "dashboard has no selection");
+    }
+
+    #[tokio::test]
+    async fn delete_selected_rule_removes_it_and_keeps_selection_in_range() {
+        let mut a = app().await;
+        a.rule_engine.add_rule(rule(22)).await.unwrap();
+        a.rule_engine.add_rule(rule(80)).await.unwrap();
+        a.refresh().await;
+        a.tab = Tab::Rules;
+        a.select_down();
+        assert_eq!(a.rules_selected, 1);
+        a.delete_selected_rule().await;
+        assert_eq!(a.rules.len(), 1);
+        assert!(
+            a.rules_selected < a.rules.len(),
+            "selection stays in range after delete"
+        );
+        a.delete_selected_rule().await;
+        assert!(a.rules.is_empty());
+        // Deleting with nothing selected is a no-op, not a panic.
+        a.delete_selected_rule().await;
     }
 }

--- a/aifw-tui/src/ui.rs
+++ b/aifw-tui/src/ui.rs
@@ -459,7 +459,7 @@ fn draw_logs(f: &mut Frame, app: &App, area: Rect) {
     f.render_stateful_widget(table, area, &mut state);
 }
 
-fn format_bytes(bytes: u64) -> String {
+pub(crate) fn format_bytes(bytes: u64) -> String {
     if bytes >= 1_000_000_000 {
         format!("{:.1} GB", bytes as f64 / 1_000_000_000.0)
     } else if bytes >= 1_000_000 {
@@ -471,12 +471,64 @@ fn format_bytes(bytes: u64) -> String {
     }
 }
 
-fn format_duration(secs: u64) -> String {
+pub(crate) fn format_duration(secs: u64) -> String {
     if secs >= 3600 {
         format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
     } else if secs >= 60 {
         format!("{}m{}s", secs / 60, secs % 60)
     } else {
         format!("{secs}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    #[test]
+    fn format_helpers() {
+        assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(999), "999 B");
+        assert_eq!(format_bytes(1_000), "1.0 KB");
+        assert_eq!(format_bytes(1_536_000), "1.5 MB");
+        assert_eq!(format_bytes(2_000_000_000), "2.0 GB");
+        assert_eq!(format_duration(5), "5s");
+        assert_eq!(format_duration(65), "1m5s");
+        assert_eq!(format_duration(3_600), "1h0m");
+        assert_eq!(format_duration(3_725), "1h2m");
+    }
+
+    /// Every tab renders on a small terminal without panicking (index
+    /// arithmetic on empty lists, layout splits on tiny areas) and the tab
+    /// bar shows the active tab's title.
+    #[tokio::test]
+    async fn every_tab_renders_on_a_small_terminal() {
+        let db = aifw_core::Database::new_in_memory().await.unwrap();
+        let pf: std::sync::Arc<dyn aifw_pf::PfBackend> =
+            std::sync::Arc::new(aifw_pf::PfMock::new());
+        let mut app = crate::app::App::with_backend(db, pf).await.unwrap();
+        for tab in crate::app::Tab::ALL {
+            app.tab = tab;
+            for (w, h) in [(80u16, 24u16), (40, 12), (20, 6)] {
+                let backend = TestBackend::new(w, h);
+                let mut term = Terminal::new(backend).unwrap();
+                term.draw(|f| draw(f, &app)).unwrap();
+                if w >= 80 {
+                    let text: String = term
+                        .backend()
+                        .buffer()
+                        .content()
+                        .iter()
+                        .map(|c| c.symbol())
+                        .collect();
+                    assert!(
+                        text.contains(tab.title()),
+                        "{} missing from tab bar",
+                        tab.title()
+                    );
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #172, closes #173, closes #174, closes #442. Stacked on #681 (test-file split) so the CLI tests land in the new `commands/*.rs` files.

**aifw-daemon** — the pure pieces of the HA loops are now functions with tests: `carp_role_from_ifconfig` (parses `ifconfig` output in Rust; replaces the `sh -c "ifconfig | awk …"` pipeline), `canonical_role` (master/backup → primary/secondary for the role-changed event), `replication_targets` (only secondaries get snapshots). Sits alongside the existing prober/pf-reconcile tests.

**aifw-tui** — `App::with_backend(db, pf)` lets the app run on an in-memory DB + `PfMock`. Tests: tab cycling both directions, per-tab selection clamping and no-op on empty lists, delete-selected keeps the selection in range, `format_bytes`/`format_duration`, and a `TestBackend` render smoke test over every tab at 80×24 / 40×12 / 20×6 asserting the active tab title is drawn.

**aifw-cli** — unit tests for `parse_port` (single/range/overflow), `parse_action`/`parse_direction` vocabularies + error hints, `split_ts`, `human_bytes`, `nat_flag_hint`, `nat_embed` input validation, `backup_passphrase` (first line, CRLF, empty file → error).

**aifw-api** — new `tests/resources.rs`: geo-IP CRUD + bad country/action, WireGuard tunnel + peer (auto key, next-ip skips used address, client config export, bad address), DHCP subnets + reservations, DNS resolver host overrides (default record type, AAAA/v4 mismatch), and IDS endpoints degrading to 503/401 without the IDS process.

Two gaps those tests exposed and fixed in `aifw-api/src/dhcp.rs`: subnet create/update accepted a pool/gateway outside the network (the import path already validated this) — now `validate_v4_subnet_shape`; reservations accepted any string as a MAC/IP — now `validate_reservation_shape`.

One observation left as-is for a decision: `POST/GET /api/v1/vpn/wg` return the tunnel's `private_key` in the response body (the UI's edit form binds it). I didn't change the API shape here.

Test totals: daemon 12, tui 6, cli 8, api 237.