### PR TITLE
refactor(db): one probe-then-alter helper for inline column migrations (#193)

### DIFF
--- a/aifw-api/src/auth/migrate.rs
+++ b/aifw-api/src/auth/migrate.rs
@@ -41,9 +41,8 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     // rows (pre-upgrade) have NULL prefix and simply won't match a lookup —
     // those refresh tokens become invalid on upgrade (services restart anyway),
     // forcing a harmless re-login.
-    let _ = sqlx::query("ALTER TABLE refresh_tokens ADD COLUMN token_prefix TEXT")
-        .execute(pool)
-        .await;
+    aifw_core::schema::add_column_if_missing(pool, "refresh_tokens", "token_prefix", "TEXT")
+        .await?;
     sqlx::query(
         "CREATE INDEX IF NOT EXISTS idx_refresh_tokens_prefix ON refresh_tokens(token_prefix)",
     )
@@ -108,12 +107,20 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     super::oauth_flow::migrate(pool).await?;
 
     // Add role and enabled columns if they don't exist
-    let _ = sqlx::query("ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'admin'")
-        .execute(pool)
-        .await;
-    let _ = sqlx::query("ALTER TABLE users ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1")
-        .execute(pool)
-        .await;
+    aifw_core::schema::add_column_if_missing(
+        pool,
+        "users",
+        "role",
+        "TEXT NOT NULL DEFAULT 'admin'",
+    )
+    .await?;
+    aifw_core::schema::add_column_if_missing(
+        pool,
+        "users",
+        "enabled",
+        "INTEGER NOT NULL DEFAULT 1",
+    )
+    .await?;
 
     // Static routes — shared schema
     sqlx::query(aifw_common::schemas::STATIC_ROUTES_CREATE)
@@ -122,9 +129,13 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
 
     // Add fib column (0 = main FIB). Multi-WAN (#132) routes can target
     // additional FIBs created via routing instances.
-    let _ = sqlx::query("ALTER TABLE static_routes ADD COLUMN fib INTEGER NOT NULL DEFAULT 0")
-        .execute(pool)
-        .await;
+    aifw_core::schema::add_column_if_missing(
+        pool,
+        "static_routes",
+        "fib",
+        "INTEGER NOT NULL DEFAULT 0",
+    )
+    .await?;
 
     // Schedules
     sqlx::query(
@@ -142,9 +153,7 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     .await?;
 
     // Add schedule_id column to rules if not exists
-    let _ = sqlx::query("ALTER TABLE rules ADD COLUMN schedule_id TEXT")
-        .execute(pool)
-        .await;
+    aifw_core::schema::add_column_if_missing(pool, "rules", "schedule_id", "TEXT").await?;
 
     // User audit log
     sqlx::query(
@@ -244,9 +253,7 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     }
 
     // Add role_id column to users (references roles table)
-    let _ = sqlx::query("ALTER TABLE users ADD COLUMN role_id TEXT")
-        .execute(pool)
-        .await;
+    aifw_core::schema::add_column_if_missing(pool, "users", "role_id", "TEXT").await?;
 
     // Backfill role_id from legacy role string
     sqlx::query(

--- a/aifw-api/src/auth/oauth_flow.rs
+++ b/aifw-api/src/auth/oauth_flow.rs
@@ -552,15 +552,8 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     )
     .execute(pool)
     .await?;
-    for stmt in [
-        "ALTER TABLE oauth_states ADD COLUMN code_verifier TEXT",
-        "ALTER TABLE oauth_states ADD COLUMN redirect_uri TEXT",
-    ] {
-        if let Err(e) = sqlx::query(stmt).execute(pool).await
-            && !e.to_string().contains("duplicate column")
-        {
-            return Err(e);
-        }
+    for column in ["code_verifier", "redirect_uri"] {
+        aifw_core::schema::add_column_if_missing(pool, "oauth_states", column, "TEXT").await?;
     }
     Ok(())
 }

--- a/aifw-api/src/dhcp.rs
+++ b/aifw-api/src/dhcp.rs
@@ -382,37 +382,20 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
         .execute(pool)
         .await?;
 
-    // Add new columns if they don't exist (migration from old schema)
-    for col in [
-        "preferred_time INTEGER",
-        "subnet_type TEXT DEFAULT 'address'",
-        "delegated_length INTEGER",
-        "max_lease_time INTEGER",
-        "renewal_time INTEGER",
-        "rebinding_time INTEGER",
-        "accept_relayed INTEGER NOT NULL DEFAULT 1",
-        "trusted_relays TEXT NOT NULL DEFAULT '[]'",
-        "ntp_servers TEXT",
-        "options TEXT NOT NULL DEFAULT '[]'",
+    // Columns added after the table shipped (#193: probe, then alter).
+    for (column, definition) in [
+        ("preferred_time", "INTEGER"),
+        ("subnet_type", "TEXT DEFAULT 'address'"),
+        ("delegated_length", "INTEGER"),
+        ("max_lease_time", "INTEGER"),
+        ("renewal_time", "INTEGER"),
+        ("rebinding_time", "INTEGER"),
+        ("accept_relayed", "INTEGER NOT NULL DEFAULT 1"),
+        ("trusted_relays", "TEXT NOT NULL DEFAULT '[]'"),
+        ("ntp_servers", "TEXT"),
+        ("options", "TEXT NOT NULL DEFAULT '[]'"),
     ] {
-        let col_name = col.split_whitespace().next().unwrap_or("");
-        let check = sqlx::query_scalar::<_, i32>(sqlx::AssertSqlSafe(format!(
-            "SELECT COUNT(*) FROM pragma_table_info('dhcp_subnets') WHERE name='{}'",
-            col_name
-        )))
-        .fetch_one(pool)
-        .await
-        .unwrap_or(0);
-        if check == 0
-            && let Err(e) = sqlx::query(sqlx::AssertSqlSafe(format!(
-                "ALTER TABLE dhcp_subnets ADD COLUMN {}",
-                col
-            )))
-            .execute(pool)
-            .await
-        {
-            tracing::warn!(error = %e, column = col_name, "dhcp: dhcp_subnets column migration failed");
-        }
+        aifw_core::schema::add_column_if_missing(pool, "dhcp_subnets", column, definition).await?;
     }
 
     sqlx::query(
@@ -432,20 +415,8 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     .execute(pool)
     .await?;
 
-    // Add client_id column if missing
-    let check = sqlx::query_scalar::<_, i32>(
-        "SELECT COUNT(*) FROM pragma_table_info('dhcp_reservations') WHERE name='client_id'",
-    )
-    .fetch_one(pool)
-    .await
-    .unwrap_or(0);
-    if check == 0
-        && let Err(e) = sqlx::query("ALTER TABLE dhcp_reservations ADD COLUMN client_id TEXT")
-            .execute(pool)
-            .await
-    {
-        tracing::warn!(error = %e, "dhcp: dhcp_reservations client_id column migration failed");
-    }
+    aifw_core::schema::add_column_if_missing(pool, "dhcp_reservations", "client_id", "TEXT")
+        .await?;
 
     sqlx::query(
         r#"

--- a/aifw-api/src/dns_resolver.rs
+++ b/aifw-api/src/dns_resolver.rs
@@ -349,10 +349,13 @@ pub async fn migrate(pool: &SqlitePool) -> Result<(), sqlx::Error> {
     sqlx::query(aifw_common::schemas::DNS_ACCESS_LISTS_CREATE)
         .execute(pool)
         .await?;
-    let _ =
-        sqlx::query("ALTER TABLE dns_access_lists ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1")
-            .execute(pool)
-            .await;
+    aifw_core::schema::add_column_if_missing(
+        pool,
+        "dns_access_lists",
+        "enabled",
+        "INTEGER NOT NULL DEFAULT 1",
+    )
+    .await?;
 
     // Upgrade heal (v5.57.5): if forwarding is disabled but forwarding_servers
     // is populated, flip forwarding on. rDNS 1.12.8 has broken iterative

--- a/aifw-core/src/db.rs
+++ b/aifw-core/src/db.rs
@@ -134,16 +134,15 @@ impl Database {
         .execute(&self.pool)
         .await?;
 
-        // Idempotent ALTERs for pre-existing tables. SQLite has no IF NOT
-        // EXISTS for ADD COLUMN; ignore the duplicate-column error.
-        for stmt in [
-            "ALTER TABLE rules ADD COLUMN ip_version TEXT NOT NULL DEFAULT 'both'",
-            "ALTER TABLE rules ADD COLUMN src_invert INTEGER NOT NULL DEFAULT 0",
-            "ALTER TABLE rules ADD COLUMN dst_invert INTEGER NOT NULL DEFAULT 0",
+        // Columns added after the table shipped (#193: probe, then alter).
+        for (column, definition) in [
+            ("ip_version", "TEXT NOT NULL DEFAULT 'both'"),
+            ("src_invert", "INTEGER NOT NULL DEFAULT 0"),
+            ("dst_invert", "INTEGER NOT NULL DEFAULT 0"),
             // Policy-routing gateway reference (#540)
-            "ALTER TABLE rules ADD COLUMN gateway TEXT",
+            ("gateway", "TEXT"),
         ] {
-            let _ = sqlx::query(stmt).execute(&self.pool).await;
+            crate::schema::add_column_if_missing(&self.pool, "rules", column, definition).await?;
         }
 
         sqlx::query("CREATE INDEX IF NOT EXISTS idx_rules_priority ON rules(priority);")

--- a/aifw-core/src/dns_blocklists.rs
+++ b/aifw-core/src/dns_blocklists.rs
@@ -224,12 +224,14 @@ pub async fn migrate(pool: &SqlitePool) -> aifw_common::Result<()> {
     )
     .execute(pool)
     .await?;
-    // Idempotent column add for existing deployments that predate the `enabled` flag.
-    let _ = sqlx::query(
-        "ALTER TABLE dns_blocklist_schedule ADD COLUMN enabled INTEGER NOT NULL DEFAULT 0",
+    // Deployments that predate the `enabled` flag (#193: probe, then alter).
+    crate::schema::add_column_if_missing(
+        pool,
+        "dns_blocklist_schedule",
+        "enabled",
+        "INTEGER NOT NULL DEFAULT 0",
     )
-    .execute(pool)
-    .await;
+    .await?;
     sqlx::query(
         r#"
         INSERT OR IGNORE INTO dns_blocklist_schedule (id, cron, on_boot, concurrency, enabled)

--- a/aifw-core/src/ha.rs
+++ b/aifw-core/src/ha.rs
@@ -50,13 +50,15 @@ impl ClusterEngine {
         .await?;
 
         // Drop legacy per-VIP timer columns — profile on pfsync_config is now
-        // the source of truth (SQLite 3.35+; fails silently on older versions
-        // which is acceptable since the columns are simply unused on those nodes).
-        for stmt in [
-            "ALTER TABLE carp_vips DROP COLUMN advskew",
-            "ALTER TABLE carp_vips DROP COLUMN advbase",
-        ] {
-            let _ = sqlx::query(stmt).execute(&self.pool).await;
+        // the source of truth. Needs SQLite 3.35+ (DROP COLUMN); on older
+        // libraries the columns simply stay unused, so that failure is the
+        // one we tolerate — logged, not silent.
+        for column in ["advskew", "advbase"] {
+            if let Err(e) =
+                crate::schema::drop_column_if_present(&self.pool, "carp_vips", column).await
+            {
+                tracing::warn!(error = %e, column, "ha: could not drop legacy carp_vips column");
+            }
         }
 
         sqlx::query(
@@ -77,14 +79,15 @@ impl ClusterEngine {
         .await?;
 
         // New columns on cluster_nodes for peer auth + drift tracking
-        for stmt in [
-            "ALTER TABLE cluster_nodes ADD COLUMN peer_api_key TEXT",
-            "ALTER TABLE cluster_nodes ADD COLUMN peer_api_key_hash TEXT",
-            "ALTER TABLE cluster_nodes ADD COLUMN software_version TEXT",
-            "ALTER TABLE cluster_nodes ADD COLUMN last_pushed_cert_at TEXT",
-            "ALTER TABLE cluster_nodes ADD COLUMN cert_fingerprint TEXT",
+        for column in [
+            "peer_api_key",
+            "peer_api_key_hash",
+            "software_version",
+            "last_pushed_cert_at",
+            "cert_fingerprint",
         ] {
-            let _ = sqlx::query(stmt).execute(&self.pool).await;
+            crate::schema::add_column_if_missing(&self.pool, "cluster_nodes", column, "TEXT")
+                .await?;
         }
 
         sqlx::query(
@@ -151,14 +154,15 @@ impl ClusterEngine {
         .execute(&self.pool)
         .await?;
 
-        // New columns added in the HA epic — IDEMPOTENT (will fail silently on re-run)
-        for stmt in [
-            "ALTER TABLE pfsync_config ADD COLUMN latency_profile TEXT NOT NULL DEFAULT 'conservative'",
-            "ALTER TABLE pfsync_config ADD COLUMN heartbeat_iface TEXT",
-            "ALTER TABLE pfsync_config ADD COLUMN heartbeat_interval_ms INTEGER",
-            "ALTER TABLE pfsync_config ADD COLUMN dhcp_link INTEGER NOT NULL DEFAULT 0",
+        // Columns added in the HA epic (#193: probe, then alter).
+        for (column, definition) in [
+            ("latency_profile", "TEXT NOT NULL DEFAULT 'conservative'"),
+            ("heartbeat_iface", "TEXT"),
+            ("heartbeat_interval_ms", "INTEGER"),
+            ("dhcp_link", "INTEGER NOT NULL DEFAULT 0"),
         ] {
-            let _ = sqlx::query(stmt).execute(&self.pool).await;
+            crate::schema::add_column_if_missing(&self.pool, "pfsync_config", column, definition)
+                .await?;
         }
 
         Ok(())

--- a/aifw-core/src/lib.rs
+++ b/aifw-core/src/lib.rs
@@ -49,6 +49,7 @@ pub mod path_safety;
 pub mod peer_tls;
 pub mod pf_tuning;
 pub mod s3_backup;
+pub mod schema;
 pub mod secrets;
 /// [`ShapingEngine`] — traffic-shaping queues and connection rate limits
 pub mod shaping;

--- a/aifw-core/src/nat.rs
+++ b/aifw-core/src/nat.rs
@@ -77,31 +77,16 @@ impl NatEngine {
             .execute(&self.pool)
             .await?;
 
-        // #253: `static_port` column added after the table shipped. SQLite
-        // has no ADD COLUMN IF NOT EXISTS, so probe the schema first.
-        let has_static_port: bool = sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*) FROM pragma_table_info('nat_rules') WHERE name = 'static_port'",
+        // Columns added after the table shipped: static_port (#253),
+        // af_to_dst — explicit af-to translated destination (#596).
+        crate::schema::add_column_if_missing(
+            &self.pool,
+            "nat_rules",
+            "static_port",
+            "INTEGER NOT NULL DEFAULT 0",
         )
-        .fetch_one(&self.pool)
-        .await?
-            > 0;
-        if !has_static_port {
-            sqlx::query("ALTER TABLE nat_rules ADD COLUMN static_port INTEGER NOT NULL DEFAULT 0")
-                .execute(&self.pool)
-                .await?;
-        }
-        // #596: explicit af-to translated destination (NAT46/NAT64).
-        let has_af_to_dst: bool = sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*) FROM pragma_table_info('nat_rules') WHERE name = 'af_to_dst'",
-        )
-        .fetch_one(&self.pool)
-        .await?
-            > 0;
-        if !has_af_to_dst {
-            sqlx::query("ALTER TABLE nat_rules ADD COLUMN af_to_dst TEXT")
-                .execute(&self.pool)
-                .await?;
-        }
+        .await?;
+        crate::schema::add_column_if_missing(&self.pool, "nat_rules", "af_to_dst", "TEXT").await?;
 
         Ok(())
     }

--- a/aifw-core/src/s3_backup.rs
+++ b/aifw-core/src/s3_backup.rs
@@ -115,14 +115,9 @@ pub async fn migrate(pool: &SqlitePool) -> aifw_common::Result<()> {
     sqlx::query("INSERT OR IGNORE INTO s3_backup_config (id) VALUES (1)")
         .execute(pool)
         .await?;
-    // #313: added after the table existed; ignore "duplicate column".
-    if let Err(e) = sqlx::query("ALTER TABLE s3_backup_config ADD COLUMN secrets_passphrase TEXT")
-        .execute(pool)
-        .await
-        && !e.to_string().contains("duplicate column")
-    {
-        return Err(e.into());
-    }
+    // #313: added after the table existed.
+    crate::schema::add_column_if_missing(pool, "s3_backup_config", "secrets_passphrase", "TEXT")
+        .await?;
     Ok(())
 }
 

--- a/aifw-core/src/schema.rs
+++ b/aifw-core/src/schema.rs
@@ -1,0 +1,188 @@
+//! Idempotent schema helpers for engine `migrate()` functions (#193).
+//!
+//! SQLite has no `ALTER TABLE … ADD COLUMN IF NOT EXISTS`, so engines used to
+//! run the `ALTER` blind and swallow *every* error (`let _ =` / `.ok()`), which
+//! also hid real failures (locked DB, disk full, typo in the DDL). These
+//! helpers probe `pragma_table_info` first and only then alter, so the only
+//! errors left are real ones — and those propagate.
+//!
+//! Versioning of new schema lives in `aifw-core/migrations/` (sqlx tracks
+//! applied versions in `_sqlx_migrations`); these helpers exist for the
+//! historical inline `CREATE TABLE IF NOT EXISTS` engines that still add
+//! columns to tables they created themselves.
+
+use sqlx::SqlitePool;
+
+/// All helpers return the raw `sqlx::Error` so they slot into engines that
+/// use either `CoreError` or `aifw_common::AifwError` (both convert from it).
+type Result<T> = std::result::Result<T, sqlx::Error>;
+
+/// True when `table` has a column named `column`.
+pub async fn column_exists(pool: &SqlitePool, table: &str, column: &str) -> Result<bool> {
+    let n: i64 = sqlx::query_scalar(sqlx::AssertSqlSafe(format!(
+        "SELECT COUNT(*) FROM pragma_table_info('{}') WHERE name = ?1",
+        table.replace('\'', "''")
+    )))
+    .bind(column)
+    .fetch_one(pool)
+    .await?;
+    Ok(n > 0)
+}
+
+/// `ALTER TABLE <table> ADD COLUMN <column> <definition>` unless the column
+/// already exists. Returns `true` when the column was added. Errors other
+/// than "already there" propagate. `table`/`column`/`definition` are
+/// compile-time DDL fragments, never user input.
+pub async fn add_column_if_missing(
+    pool: &SqlitePool,
+    table: &str,
+    column: &str,
+    definition: &str,
+) -> Result<bool> {
+    if column_exists(pool, table, column).await? {
+        return Ok(false);
+    }
+    match sqlx::query(sqlx::AssertSqlSafe(format!(
+        "ALTER TABLE {table} ADD COLUMN {column} {definition}"
+    )))
+    .execute(pool)
+    .await
+    {
+        Ok(_) => Ok(true),
+        // Two processes migrating the same DB can race between probe and
+        // ALTER; the loser sees "duplicate column", which is fine.
+        Err(e) if e.to_string().contains("duplicate column") => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+/// `ALTER TABLE <table> DROP COLUMN <column>` if present (SQLite ≥ 3.35).
+/// Returns `true` when dropped.
+pub async fn drop_column_if_present(pool: &SqlitePool, table: &str, column: &str) -> Result<bool> {
+    if !column_exists(pool, table, column).await? {
+        return Ok(false);
+    }
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "ALTER TABLE {table} DROP COLUMN {column}"
+    )))
+    .execute(pool)
+    .await?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn add_and_drop_are_idempotent_and_report_changes() {
+        let db = crate::db::Database::new_in_memory().await.unwrap();
+        let pool = db.pool();
+        sqlx::query("CREATE TABLE t (id TEXT PRIMARY KEY)")
+            .execute(pool)
+            .await
+            .unwrap();
+        assert!(!column_exists(pool, "t", "extra").await.unwrap());
+        assert!(
+            add_column_if_missing(pool, "t", "extra", "TEXT NOT NULL DEFAULT 'x'")
+                .await
+                .unwrap()
+        );
+        assert!(
+            !add_column_if_missing(pool, "t", "extra", "TEXT")
+                .await
+                .unwrap(),
+            "second call is a no-op"
+        );
+        assert!(column_exists(pool, "t", "extra").await.unwrap());
+        // The column is really there and its default applies.
+        sqlx::query("INSERT INTO t (id) VALUES ('a')")
+            .execute(pool)
+            .await
+            .unwrap();
+        let v: String = sqlx::query_scalar("SELECT extra FROM t WHERE id = 'a'")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+        assert_eq!(v, "x");
+        assert!(drop_column_if_present(pool, "t", "extra").await.unwrap());
+        assert!(!drop_column_if_present(pool, "t", "extra").await.unwrap());
+        // Real errors are not swallowed: bad DDL surfaces.
+        assert!(
+            add_column_if_missing(pool, "t", "bad", "NOTATYPE (((")
+                .await
+                .is_err()
+        );
+        // Missing table: probe says absent, ALTER fails loudly.
+        assert!(
+            add_column_if_missing(pool, "nope", "c", "TEXT")
+                .await
+                .is_err()
+        );
+    }
+
+    /// Discipline gate (#193): every inline schema change goes through the
+    /// helpers above (or a versioned file in `aifw-core/migrations/`), so no
+    /// engine can reintroduce a blind, error-swallowing `ALTER TABLE`.
+    #[test]
+    fn no_raw_alter_table_in_engine_sources() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+        fn walk(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+            if let Ok(rd) = std::fs::read_dir(dir) {
+                for e in rd.flatten() {
+                    let p = e.path();
+                    if p.is_dir() {
+                        if p.file_name()
+                            .is_some_and(|n| n == "target" || n == "node_modules")
+                        {
+                            continue;
+                        }
+                        walk(&p, out);
+                    } else if p.extension().is_some_and(|x| x == "rs") {
+                        out.push(p);
+                    }
+                }
+            }
+        }
+        let mut files = Vec::new();
+        for crate_dir in [
+            "aifw-core",
+            "aifw-api",
+            "aifw-common",
+            "aifw-daemon",
+            "aifw-setup",
+            "aifw-cli",
+        ] {
+            walk(&root.join(crate_dir).join("src"), &mut files);
+        }
+        let this = std::path::Path::new(file!()).file_name().unwrap();
+        let mut hits = Vec::new();
+        for f in files {
+            if f.file_name() == Some(this) {
+                continue;
+            }
+            let Ok(text) = std::fs::read_to_string(&f) else {
+                continue;
+            };
+            for (i, line) in text.lines().enumerate() {
+                let t = line.trim_start();
+                if t.starts_with("//") {
+                    continue;
+                }
+                if t.contains("ALTER TABLE") && t.contains("ADD COLUMN") {
+                    hits.push(format!(
+                        "{}:{}: {t}",
+                        f.strip_prefix(&root).unwrap().display(),
+                        i + 1
+                    ));
+                }
+            }
+        }
+        assert!(
+            hits.is_empty(),
+            "raw ALTER TABLE … ADD COLUMN outside aifw_core::schema — use \
+             schema::add_column_if_missing (or a versioned migration):\n{}",
+            hits.join("\n")
+        );
+    }
+}

--- a/aifw-core/src/shaping.rs
+++ b/aifw-core/src/shaping.rs
@@ -70,19 +70,8 @@ impl ShapingEngine {
             ("fq_codel_flows", "INTEGER NOT NULL DEFAULT 1024"),
             ("fq_codel_ecn", "INTEGER NOT NULL DEFAULT 1"),
         ] {
-            let present = sqlx::query_scalar::<_, i64>(
-                "SELECT count(*) FROM pragma_table_info('queue_configs') WHERE name = ?1",
-            )
-            .bind(column)
-            .fetch_one(&self.pool)
-            .await?;
-            if present == 0 {
-                let statement =
-                    format!("ALTER TABLE queue_configs ADD COLUMN {column} {definition}");
-                sqlx::query(sqlx::AssertSqlSafe(statement))
-                    .execute(&self.pool)
-                    .await?;
-            }
+            crate::schema::add_column_if_missing(&self.pool, "queue_configs", column, definition)
+                .await?;
         }
 
         sqlx::query(

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -73,27 +73,15 @@ impl VpnEngine {
         .execute(&self.pool)
         .await?;
 
-        // Add client_private_key column if missing (idempotent migration)
-        let _ = sqlx::query("ALTER TABLE wg_peers ADD COLUMN client_private_key TEXT")
-            .execute(&self.pool)
-            .await;
-
-        // Add listen_interface column to tunnels if missing
-        let _ = sqlx::query("ALTER TABLE wg_tunnels ADD COLUMN listen_interface TEXT")
-            .execute(&self.pool)
-            .await;
-
-        // Add split_routes column: comma-separated CIDRs used for split-tunnel
-        // AllowedIPs. NULL means fall back to tunnel's own network CIDR.
-        let _ = sqlx::query("ALTER TABLE wg_tunnels ADD COLUMN split_routes TEXT")
-            .execute(&self.pool)
-            .await;
-
-        // Add address6 column: the server's IPv6 tunnel address for
-        // dual-stack tunnels (#471). NULL means no inner IPv6.
-        let _ = sqlx::query("ALTER TABLE wg_tunnels ADD COLUMN address6 TEXT")
-            .execute(&self.pool)
-            .await;
+        // Columns added after the tables shipped (#193: probe, then alter):
+        // wg_peers.client_private_key; wg_tunnels.listen_interface,
+        // split_routes (comma-separated split-tunnel AllowedIPs, NULL = the
+        // tunnel's own CIDR), address6 (server IPv6 tunnel address, #471).
+        crate::schema::add_column_if_missing(&self.pool, "wg_peers", "client_private_key", "TEXT")
+            .await?;
+        for column in ["listen_interface", "split_routes", "address6"] {
+            crate::schema::add_column_if_missing(&self.pool, "wg_tunnels", column, "TEXT").await?;
+        }
 
         // Shared with aifw-setup / aifw-api (QUAL-C5) — wan_interface() below
         // reads it to build the WireGuard outbound NAT rule.


### PR DESCRIPTION
Closes #193.

Schema *versioning* already lives in `aifw-core/migrations/` + sqlx's `_sqlx_migrations` (QUAL-C6). What was left of #193 was the inline `ALTER TABLE … ADD COLUMN` sites in the historical engine `migrate()` functions: ~30 of them across core/api, in four different styles — `let _ = sqlx::query(...)` swallowing every error, `.ok()`, `if let Err(e) … && !e.to_string().contains("duplicate column")`, and hand-rolled `pragma_table_info` probes (nat, shaping, dhcp).

- New `aifw_core::schema` module: `column_exists`, `add_column_if_missing(pool, table, column, definition) -> Result<bool>`, `drop_column_if_present`. Probe first, alter only when needed, so the only errors left are real ones (locked DB, disk full, bad DDL) — and those propagate instead of being silenced. The probe→ALTER race between two processes is the one tolerated case (`duplicate column` → `Ok(false)`). Returns `sqlx::Error` so it fits engines on `CoreError` and on `AifwError` alike.
- Every site converted: `db.rs` (rules), `ha.rs` (cluster_nodes, pfsync_config, carp_vips DROP COLUMN — now logged if unsupported instead of silent), `shaping.rs`, `vpn.rs`, `nat.rs`, `dns_blocklists.rs`, `s3_backup.rs`, `auth/migrate.rs`, `auth/oauth_flow.rs`, `dhcp.rs`, `dns_resolver.rs`.
- Tests: helper round-trip (add/no-op/default applied/drop/bad DDL surfaces/missing table errors) and a guard test that fails if a raw `ALTER TABLE … ADD COLUMN` reappears in engine sources.

Behaviour on a healthy DB is identical; on a broken one, migrate now fails loudly at startup instead of running with a half-migrated table. Core 252 / API 232 tests green, clippy clean.