### PR TITLE
chore(api): explicit re-export lists in routes/mod.rs (#462)

### DIFF
--- a/aifw-api/src/routes/mod.rs
+++ b/aifw-api/src/routes/mod.rs
@@ -40,23 +40,62 @@ pub mod status;
 pub mod users;
 pub mod vpn;
 
-pub use ai::*;
-pub use auth::*;
-pub use config_io::*;
-pub use dns::*;
-pub use geoip::*;
-pub use interfaces::*;
-pub use nat::*;
-pub use rbac::*;
-pub use response::*;
-pub use rules::*;
-pub use schedules::*;
-pub use settings::*;
-pub use shaper::*;
-pub use static_routes::*;
-pub use status::*;
-pub use users::*;
-pub use vpn::*;
+// Explicit re-export lists (#462): renaming an item inside a submodule is a
+// visible change here instead of silently reshaping `routes::*`.
+pub use ai::{get_ai_settings, list_ai_models, test_ai_provider, update_ai_settings};
+pub use auth::{
+    create_api_key, create_oauth_provider, delete_oauth_provider, get_auth_settings,
+    get_oauth_settings, list_oauth_providers, login, logout, oauth_authorize, oauth_callback,
+    oauth_login_options, oauth_totp, put_oauth_settings, refresh_token, register, totp_disable,
+    totp_login, totp_setup, totp_verify, update_auth_settings,
+};
+pub use config_io::{export_config, export_config_with_passphrase, import_config};
+pub use dns::{get_dns, update_dns};
+pub use geoip::{
+    create_geoip_rule, delete_geoip_rule, geoip_lookup, list_geoip_rules, update_geoip_rule,
+};
+pub use interfaces::{get_interface_stats, get_system_routes, list_interfaces};
+pub use nat::{
+    create_nat_rule, delete_nat_rule, get_nat_pf_output, list_nat_rules, reorder_nat_rules,
+    update_nat_rule,
+};
+pub use rbac::{
+    create_role, delete_role, get_current_user, list_permissions, list_roles, update_role,
+};
+pub use response::{ApiResponse, MessageResponse};
+pub use rules::{
+    create_rule, delete_rule, get_rule, list_rules, list_system_rules, reorder_rules,
+    toggle_block_logging, update_rule,
+};
+pub use schedules::{create_schedule, delete_schedule, list_schedules, update_schedule};
+pub use settings::{
+    HISTORY_SECONDS_HARD_MAX, get_dashboard_history_settings, get_generic_settings,
+    get_ids_alert_settings, get_tls_settings, get_valkey_settings,
+    update_dashboard_history_settings, update_generic_settings, update_ids_alert_settings,
+    update_tls_settings, update_valkey_settings,
+};
+pub use shaper::{
+    apply_shaper, create_shaper_queue, delete_shaper_queue, list_shaper_queues, shaper_status,
+    update_shaper_queue,
+};
+pub use static_routes::{
+    SystemRoute, apply_all_routes, create_static_route, delete_static_route, list_static_routes,
+    update_static_route,
+};
+pub use status::{
+    about_info, get_pending, get_pf_tuning, issue_ws_ticket, list_blocked_traffic,
+    list_connections, list_logs, metrics, pending_stream, put_pf_tuning, reload, status,
+};
+pub use users::{
+    create_user, delete_user_handler, get_user, list_user_audit, list_users, update_user,
+};
+pub use vpn::{
+    create_ipsec_sa_gone, create_ipsec_tunnel, create_wg_peer, create_wg_tunnel, delete_ipsec_sa,
+    delete_ipsec_tunnel, delete_wg_peer, delete_wg_tunnel, get_ipsec_tunnel, get_peer_config,
+    ipsec_status_all, ipsec_tunnel_status, list_ipsec_sas, list_ipsec_tunnels, list_wg_peers,
+    list_wg_tunnels, next_wg_peer_ip, start_ipsec_tunnel, start_wg_tunnel, stop_ipsec_tunnel,
+    stop_wg_tunnel, update_ipsec_tunnel, update_wg_peer, update_wg_tunnel, wg_tunnel_status,
+};
 
 // Crate-internal helpers (validate_route_target, apply_route_to_system,
 // remove_route_from_system) are re-exported with their original


### PR DESCRIPTION
Closes #462 (QUAL-L7).

`aifw-api/src/routes/mod.rs` re-exported every submodule with `pub use <module>::*;`. Those 17 globs are now explicit item lists of the handlers and types the crate actually consumes through `routes::`, so a rename or removal inside a submodule is a visible change to the public surface of `routes` instead of a silent one (and request/response types used only inside their own module are no longer re-exported at all). No callers or handlers changed; `cargo clippy --all-targets -D warnings` clean.