### PR TITLE
build: one shared freebsd/lib-build.sh behind build-local.sh, build-update.sh and the CI ISO workflow (#203)

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -46,6 +46,15 @@ jobs:
         working-directory: aifw-ui
         run: npm run build
 
+      # Same pre-compression build-local.sh does (#203): tower_http serves
+      # .br/.gz siblings; without this CI-built appliances shipped raw JS.
+      - name: Pre-compress UI assets
+        run: |
+          sudo apt-get install -y brotli
+          PROJECT_ROOT="$GITHUB_WORKSPACE"
+          . freebsd/lib-build.sh
+          aifw_precompress_ui aifw-ui/out
+
       - name: Upload UI artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -81,7 +90,8 @@ jobs:
           usesh: true
           copyback: true
           prepare: |
-            # Install build tools
+            # Install build tools (same set build-local.sh installs, minus
+            # node — the UI is built on the Linux job)
             pkg install -y curl gmake jq
 
             # Install Rust via rustup
@@ -92,9 +102,16 @@ jobs:
             set -e
             . "$HOME/.cargo/env"
 
-            echo "=== Building AiFw binaries ==="
             cd /home/runner/work/AiFw/AiFw
+            # Shared build steps — the same functions build-local.sh /
+            # build-update.sh run, so CI cannot drift from a local build (#203).
+            PROJECT_ROOT="$(pwd)"
+            . freebsd/lib-build.sh
+            VERSION="${{ steps.version.outputs.version }}"
+
+            echo "=== Building AiFw binaries ==="
             cargo build --release
+            aifw_verify_binary_version "$VERSION"
 
             echo "=== Validating sudoers content (visudo -cf, #204) ==="
             # Pipe the same content aifw-setup writes to
@@ -105,81 +122,20 @@ jobs:
             visudo -cf /tmp/aifw-sudoers
             echo "sudoers OK"
 
-            # Install companion services from crates.io at the versions
-            # pinned in the manifest (#651, replacing the #538 git SHA
-            # pins). A missing pin or an unpublished version fails the
-            # build — never fall back to branch HEAD.
-            MANIFEST="freebsd/manifest.json"
+            echo "=== Installing companion services from crates.io (#651) ==="
             COMPANIONS_ROOT="/tmp/companions"
-            COMPANIONS_BIN="$COMPANIONS_ROOT/bin"
-            for NAME in $(jq -r '.external_repos[].name' "$MANIFEST"); do
-              CRATE=$(jq -r --arg n "$NAME" '.external_repos[] | select(.name == $n) | .crate // empty' "$MANIFEST")
-              VER=$(jq -r --arg n "$NAME" '.external_repos[] | select(.name == $n) | .version // empty' "$MANIFEST")
-              if [ -z "$CRATE" ] || [ -z "$VER" ]; then
-                echo "ERROR: ${NAME} has no crate/version pin in ${MANIFEST} (#651)" >&2
-                exit 1
-              fi
-              echo "=== Installing $NAME ($CRATE $VER from crates.io) ==="
-              cargo install --locked --version "$VER" --root "$COMPANIONS_ROOT" "$CRATE"
-            done
+            aifw_install_companions "$COMPANIONS_ROOT"
 
             echo "=== Preparing build inputs ==="
-            mkdir -p freebsd/release
-            # Copy local binaries
-            for bin in $(jq -r '.binaries.local[]' "$MANIFEST"); do
-              cp "target/release/${bin}" "freebsd/release/${bin}"
-            done
-            # Copy companion binaries — installed from crates.io above, so
-            # a missing one is a bug; refuse to ship a partial artifact set.
-            for bin in $(jq -r '.external_repos[].binaries[]' "$MANIFEST"); do
-              if [ ! -f "$COMPANIONS_BIN/$bin" ]; then
-                echo "ERROR: companion binary $bin missing from $COMPANIONS_BIN" >&2
-                exit 1
-              fi
-              cp "$COMPANIONS_BIN/$bin" "freebsd/release/$bin"
-            done
+            aifw_stage_binaries freebsd/release "$COMPANIONS_ROOT/bin"
 
             echo "=== Recording component versions (#538/#651) ==="
-            # Machine-readable record of the exact source that produced this
-            # artifact set: AiFw commit + every pinned companion crate version.
-            # Ships as a release asset and inside the update tarball.
-            VERSION="${{ steps.version.outputs.version }}"
-            jq -n \
-              --arg version "$VERSION" \
-              --arg aifw_commit "${{ github.sha }}" \
-              --slurpfile manifest "$MANIFEST" \
-              '{version: $version, aifw_commit: $aifw_commit,
-                components: [$manifest[0].external_repos[] | {name, repo, crate, version}]}' \
-              > /tmp/aifw-components.json
-            cat /tmp/aifw-components.json
             mkdir -p /usr/obj/aifw-iso/output
-            cp /tmp/aifw-components.json "/usr/obj/aifw-iso/output/aifw-components-${VERSION}.json"
+            aifw_write_components_json "$VERSION" "/usr/obj/aifw-iso/output/aifw-components-${VERSION}.json"
+            cat "/usr/obj/aifw-iso/output/aifw-components-${VERSION}.json"
 
             echo "=== Building update tarball ==="
-            TARBALL_DIR="/tmp/aifw-update-${VERSION}-amd64"
-            mkdir -p "$TARBALL_DIR/bin" "$TARBALL_DIR/ui" "$TARBALL_DIR/rc.d" "$TARBALL_DIR/sbin" "$TARBALL_DIR/libexec"
-            # Copy all binaries from freebsd/release/ into tarball
-            for bin in freebsd/release/*; do
-              [ -f "$bin" ] && cp "$bin" "$TARBALL_DIR/bin/"
-            done
-            cp -a freebsd/ui-export/* "$TARBALL_DIR/ui/"
-            cp -a freebsd/overlay/usr/local/etc/rc.d/* "$TARBALL_DIR/rc.d/"
-            cp -a freebsd/overlay/usr/local/sbin/* "$TARBALL_DIR/sbin/"
-            # libexec scripts (restart driver, watchdog, narrow-grant sudo
-            # helpers). The updater iterates <tarball>/libexec/ on install —
-            # without this, CI-built tarballs never ship helper updates (#469).
-            cp -a freebsd/overlay/usr/local/libexec/* "$TARBALL_DIR/libexec/"
-            chmod 755 "$TARBALL_DIR"/rc.d/* "$TARBALL_DIR"/sbin/* "$TARBALL_DIR"/libexec/*
-            echo "$VERSION" > "$TARBALL_DIR/version"
-            # OS floor stamp (#612): the updater refuses this tarball on a
-            # FreeBSD older than the VM it was built in.
-            freebsd-version -u | sed 's/-.*//' > "$TARBALL_DIR/required-os"
-            cp /tmp/aifw-components.json "$TARBALL_DIR/components.json"
-            tar -C /tmp -cJf "/usr/obj/aifw-iso/output/aifw-update-${VERSION}-amd64.tar.xz" "aifw-update-${VERSION}-amd64"
-            cd /usr/obj/aifw-iso/output
-            sha256 "aifw-update-${VERSION}-amd64.tar.xz" > "aifw-update-${VERSION}-amd64.tar.xz.sha256"
-            rm -rf "$TARBALL_DIR"
-            cd /home/runner/work/AiFw/AiFw
+            aifw_build_update_tarball "$VERSION" "$COMPANIONS_ROOT/bin" freebsd/ui-export /usr/obj/aifw-iso/output
 
             echo "=== Building ISO + IMG ==="
             cd freebsd

--- a/aifw-core/src/updater/tests.rs
+++ b/aifw-core/src/updater/tests.rs
@@ -442,6 +442,17 @@ fn test_external_repos_pin_crates_io_versions() {
             repo.name
         );
     }
+    // #203: the pin-consuming install lives once, in lib-build.sh; every
+    // release path must source it rather than carry its own copy.
+    let lib = include_str!("../../../freebsd/lib-build.sh");
+    assert!(
+        lib.contains("cargo install --locked --version"),
+        "freebsd/lib-build.sh no longer installs companions from crates.io at the manifest pin"
+    );
+    assert!(
+        !lib.contains(".commit"),
+        "lib-build.sh references the retired .commit field"
+    );
     for (path, content) in [
         (
             "freebsd/build-local.sh",
@@ -457,8 +468,16 @@ fn test_external_repos_pin_crates_io_versions() {
         ),
     ] {
         assert!(
-            content.contains("cargo install --locked --version"),
-            "{path} no longer installs companions from crates.io at the manifest pin"
+            content.contains("lib-build.sh") && content.contains("aifw_install_companions"),
+            "{path} must source freebsd/lib-build.sh and call aifw_install_companions (#203)"
+        );
+        assert!(
+            content.contains("aifw_build_update_tarball"),
+            "{path} must build the update tarball through lib-build.sh (#203)"
+        );
+        assert!(
+            !content.contains("cargo install --locked --version"),
+            "{path} carries its own companion install — use lib-build.sh (#203)"
         );
         assert!(
             !content.contains(".commit"),

--- a/freebsd/build-local.sh
+++ b/freebsd/build-local.sh
@@ -8,43 +8,24 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-die() {
-    echo "ERROR: $1" >&2
-    exit 1
-}
-
-# --- Must be FreeBSD ---
+# --- Must be FreeBSD, as root ---
 if [ "$(uname -s)" != "FreeBSD" ]; then
-    die "This script must be run on FreeBSD"
+    echo "ERROR: This script must be run on FreeBSD" >&2
+    exit 1
+fi
+if [ "$(id -u)" -ne 0 ]; then
+    echo "ERROR: Must be run as root (try: sudo sh $0)" >&2
+    exit 1
 fi
 
-# --- Must be root ---
-if [ "$(id -u)" -ne 0 ]; then
-    die "Must be run as root (try: sudo sh $0)"
-fi
+# All shared build steps come from lib-build.sh (#203) — the same code CI
+# and build-update.sh run, so the three release paths cannot drift.
+. "$SCRIPT_DIR/lib-build.sh"
 
 # --- Install dependencies ---
-echo "=== [1/6] Installing dependencies ==="
+echo "=== [1/8] Installing dependencies ==="
 pkg install -y curl git gmake node24 npm-node24 brotli jq
-
-# `sudo` clears PATH, so even if rust is already installed under root's home
-# we won't see `cargo` on PATH unless we source cargo's env first. Skipping
-# this check caused v5.47 builds on a working toolchain to attempt a full
-# rustup re-sync against static.rust-lang.org and fail on networks where
-# IPv6/IPv4 resolution for that host is broken.
-if [ -f "$HOME/.cargo/env" ]; then
-    . "$HOME/.cargo/env"
-fi
-
-# Only bootstrap rustup when cargo really isn't installed.
-if ! command -v cargo >/dev/null 2>&1; then
-    echo "Installing Rust via rustup..."
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    . "$HOME/.cargo/env"
-fi
-
-echo "--- Using cargo: $(command -v cargo) ---"
-cargo --version
+aifw_ensure_cargo
 
 # --- Clone or update repo ---
 if [ ! -f "$PROJECT_ROOT/Cargo.toml" ]; then
@@ -61,113 +42,29 @@ echo "  Building AiFw v${VERSION}"
 echo ""
 
 # --- Build Web UI static export ---
-echo "=== [2/6] Building Web UI static export ==="
+echo "=== [2/8] Building Web UI static export ==="
 cd "$PROJECT_ROOT/aifw-ui"
 npm config delete python 2>/dev/null || true
 npm ci
 npm run build
-
-# Pre-compress every text asset alongside the originals. tower_http's
-# ServeDir picks up .br / .gz siblings automatically when the request
-# advertises the matching Accept-Encoding. Skipping images / fonts —
-# they're already compressed.
-if [ -d out ]; then
-    echo "  Pre-compressing UI text assets (br + gz)..."
-    has_brotli=0
-    command -v brotli >/dev/null 2>&1 && has_brotli=1
-    find out -type f \( -name '*.html' -o -name '*.js' -o -name '*.css' \
-        -o -name '*.svg' -o -name '*.json' -o -name '*.txt' \
-        -o -name '*.map' -o -name '*.xml' \) | while read -r f; do
-        if [ "$has_brotli" -eq 1 ] && [ ! -f "${f}.br" ]; then
-            brotli -q 11 -k "$f" 2>/dev/null || true
-        fi
-        if [ ! -f "${f}.gz" ]; then
-            gzip -k -9 "$f" 2>/dev/null || true
-        fi
-    done
-    # Quick stats so the build log shows the win.
-    js_orig=$(find out -name '*.js' -not -name '*.gz' -not -name '*.br' -exec stat -f%z {} + 2>/dev/null | awk '{s+=$1} END {print s}')
-    js_br=$(find out -name '*.js.br' -exec stat -f%z {} + 2>/dev/null | awk '{s+=$1} END {print s}')
-    if [ -n "$js_orig" ] && [ -n "$js_br" ] && [ "$js_orig" -gt 0 ]; then
-        printf "  JS size: %d KB raw  ->  %d KB brotli (%d%% smaller)\n" \
-            "$((js_orig / 1024))" "$((js_br / 1024))" \
-            "$(( (js_orig - js_br) * 100 / js_orig ))"
-    fi
-fi
+aifw_precompress_ui "$PROJECT_ROOT/aifw-ui/out"
 cd "$PROJECT_ROOT"
 
 # --- Build Rust binaries ---
-echo "=== [3/6] Building Rust binaries (release) ==="
-# Ensure cargo is in PATH (rustup installs to $HOME/.cargo/bin)
-[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+echo "=== [3/8] Building Rust binaries (release) ==="
 echo "--- AiFw commit: $(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown) ---"
 cargo build --release
+aifw_verify_binary_version "$VERSION"
 
-# --- Guard: the compiled binary version MUST match the release version ---
-# The version label, tarball name and version file all come from $VERSION,
-# but the binaries' version is baked in from Cargo.toml at compile time. If
-# those diverge — a stale cargo artifact that wasn't recompiled after a
-# version bump, or a $VERSION arg that doesn't match the checked-out
-# Cargo.toml — we'd ship a tarball whose binaries install as the WRONG
-# version. That shipped a "5.96.10" tarball containing 5.96.8 binaries,
-# making every appliance's in-app update a silent no-op. Fail loudly instead.
-BIN_VER="$("$PROJECT_ROOT/target/release/aifw" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
-[ "$BIN_VER" = "$VERSION" ] || die "version mismatch: building v${VERSION} but target/release/aifw reports v${BIN_VER:-unknown}. Bump Cargo.toml and rebuild (try 'cargo clean -p aifw') before releasing."
-echo "--- Verified compiled aifw binary is v${VERSION} ---"
-
-# Install companion services (reverse proxy, DHCP, DNS, NTP) from
-# crates.io at the versions pinned in manifest.json (#651, replacing the
-# #538 git SHA pins — the published crates track the companion repo
-# releases, so there are no sibling checkouts to clone or branch-juggle).
-# cargo install is a no-op when the pinned version is already in
-# COMPANIONS_ROOT and fails loudly on a missing or unpublished pin.
+# --- Companion services from crates.io (#651) ---
+echo "=== [4/8] Installing companion services from crates.io ==="
 COMPANIONS_ROOT="$PROJECT_ROOT/target/companions"
 COMPANIONS_BIN="$COMPANIONS_ROOT/bin"
-for name in $(jq -r '.external_repos[].name' "$PROJECT_ROOT/freebsd/manifest.json"); do
-    crate=$(jq -r --arg n "$name" \
-        '.external_repos[] | select(.name == $n) | .crate // empty' \
-        "$PROJECT_ROOT/freebsd/manifest.json")
-    ver=$(jq -r --arg n "$name" \
-        '.external_repos[] | select(.name == $n) | .version // empty' \
-        "$PROJECT_ROOT/freebsd/manifest.json")
-    [ -n "$crate" ] || die "no crate name for $name in manifest.json (#651)"
-    [ -n "$ver" ] || die "no pinned version for $name in manifest.json (#651)"
-    echo "--- Installing $name ($crate $ver from crates.io) ---"
-    cargo install --locked --version "$ver" --root "$COMPANIONS_ROOT" "$crate" \
-        || die "cargo install of $crate $ver failed"
-    for bin in $(jq -r --arg n "$name" \
-        '.external_repos[] | select(.name == $n) | .binaries[]' \
-        "$PROJECT_ROOT/freebsd/manifest.json"); do
-        [ -f "$COMPANIONS_BIN/$bin" ] || die "$crate $ver did not produce binary $bin"
-    done
-done
-cd "$PROJECT_ROOT"
+aifw_install_companions "$COMPANIONS_ROOT"
 
-# --- Stage build inputs ---
-echo "=== [4/6] Staging build inputs ==="
-mkdir -p "$SCRIPT_DIR/release"
-
-# Pull the binary list from manifest.json so adding a new crate to the
-# workspace (e.g. aifw-ids in 5.76) requires only a manifest edit, not a
-# build-script edit. Hardcoding the list here was the bug that shipped a
-# 5.76.1 release missing aifw-ids.
-LOCAL_BINS=$(jq -r '.binaries.local[]' "$PROJECT_ROOT/freebsd/manifest.json" | tr '\n' ' ')
-[ -n "$LOCAL_BINS" ] || die "Could not parse binaries.local from manifest.json (jq failed)"
-for bin in $LOCAL_BINS; do
-    if [ ! -f "$PROJECT_ROOT/target/release/${bin}" ]; then
-        echo "ERROR: ${bin} listed in manifest but not built — refusing to ship a partial release" >&2
-        exit 1
-    fi
-    cp "$PROJECT_ROOT/target/release/${bin}" "$SCRIPT_DIR/release/${bin}"
-done
-# Stage companion binaries — installed from crates.io above, so a missing
-# one is a bug; refuse to ship a partial artifact set.
-EXT_BINS=$(jq -r '.external_repos[].binaries[]' "$PROJECT_ROOT/freebsd/manifest.json" | tr '\n' ' ')
-for bin in $EXT_BINS; do
-    [ -f "$COMPANIONS_BIN/$bin" ] || die "companion binary $bin missing from $COMPANIONS_BIN"
-    cp "$COMPANIONS_BIN/$bin" "$SCRIPT_DIR/release/$bin"
-done
-
+# --- Stage build inputs for build-iso.sh ---
+echo "=== [5/8] Staging build inputs ==="
+aifw_stage_binaries "$SCRIPT_DIR/release" "$COMPANIONS_BIN"
 rm -rf "$SCRIPT_DIR/ui-export"
 cp -a "$PROJECT_ROOT/aifw-ui/out" "$SCRIPT_DIR/ui-export"
 
@@ -179,93 +76,9 @@ cp -a "$PROJECT_ROOT/aifw-ui/out" "$SCRIPT_DIR/ui-export"
 # on the build host) doesn't block a release. We stage to a separate
 # directory that build-iso.sh will not wipe, then copy into the release
 # OUTPUTDIR at the end.
-echo "=== [5/9] Building update tarball ==="
-TARBALL_DIR="/tmp/aifw-update-${VERSION}-amd64"
-rm -rf "$TARBALL_DIR"
-mkdir -p "$TARBALL_DIR/bin" "$TARBALL_DIR/ui"
-# Same source-of-truth as the staging step above.
-for bin in $LOCAL_BINS; do
-    cp "$PROJECT_ROOT/target/release/${bin}" "$TARBALL_DIR/bin/"
-done
-# Companion binaries from the crates.io install — same missing-binary
-# refusal as the staging step above.
-for bin in $EXT_BINS; do
-    [ -f "$COMPANIONS_BIN/$bin" ] || die "companion binary $bin missing from $COMPANIONS_BIN"
-    cp "$COMPANIONS_BIN/$bin" "$TARBALL_DIR/bin/"
-done
-cp -a "$PROJECT_ROOT/aifw-ui/out/"* "$TARBALL_DIR/ui/"
-
-# rc.d service scripts — the updater (aifw-core/src/updater/) iterates
-# every file found under <tarball>/rc.d/ and installs it; it does not consult
-# manifest.json's rc_scripts list. Skipping this ships stale service files.
-mkdir -p "$TARBALL_DIR/rc.d"
-if [ -d "$PROJECT_ROOT/freebsd/overlay/usr/local/etc/rc.d" ]; then
-    cp -a "$PROJECT_ROOT/freebsd/overlay/usr/local/etc/rc.d/"* "$TARBALL_DIR/rc.d/" 2>/dev/null || true
-fi
-
-# sbin scripts — aifw-console, aifw-installer, etc.
-mkdir -p "$TARBALL_DIR/sbin"
-if [ -d "$PROJECT_ROOT/freebsd/overlay/usr/local/sbin" ]; then
-    cp -a "$PROJECT_ROOT/freebsd/overlay/usr/local/sbin/"* "$TARBALL_DIR/sbin/" 2>/dev/null || true
-fi
-
-# libexec scripts — aifw-restart.sh (detached bouncer), aifw-watchdog.sh
-# (self-heal loop), aifw-motd-cleanup.sh, aifw-login-migrate.sh. The
-# updater (aifw-core/src/updater/) iterates <tarball>/libexec/ on
-# install. Skipping this means the new bouncer never reaches the
-# appliance and restart_services() falls back to the in-process loop.
-mkdir -p "$TARBALL_DIR/libexec"
-if [ -d "$PROJECT_ROOT/freebsd/overlay/usr/local/libexec" ]; then
-    cp -a "$PROJECT_ROOT/freebsd/overlay/usr/local/libexec/"* "$TARBALL_DIR/libexec/" 2>/dev/null || true
-fi
-
-# Everything the appliance executes must carry the x bit regardless of
-# checkout modes — sudo reports a 644 helper as "command not found" (#469).
-chmod 755 "$TARBALL_DIR"/rc.d/* "$TARBALL_DIR"/sbin/* "$TARBALL_DIR"/libexec/* 2>/dev/null || true
-
-echo "$VERSION" > "$TARBALL_DIR/version"
-# OS floor stamp (#612): the updater refuses this tarball on a FreeBSD
-# older than the build host — its binaries wouldn't link.
-freebsd-version -u | sed 's/-.*//' > "$TARBALL_DIR/required-os"
-
-# Write a manifest of what made it into the tarball — the crates.io
-# version of every component plus a quick sanity check on rDNS features.
-# Makes a stale or mispinned companion (which has burned us before —
-# rdns 1.5.1 shipping in a v5.45.0 tarball) visible at build time.
-{
-    echo "AiFw             $(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
-    # Companion versions come from the manifest crates.io pins — the
-    # install step verified each pinned version produced its binaries.
-    jq -r '.external_repos[] | "\(.name) \(.version) \(.crate)"' \
-        "$PROJECT_ROOT/freebsd/manifest.json" | \
-    while read -r n v c; do
-        printf '%-16s %s (crates.io %s)\n' "$n" "$v" "$c"
-    done
-    if [ -f "$TARBALL_DIR/bin/rdns" ]; then
-        rver=$(grep -ao 'rDNS [0-9][0-9.]*' "$TARBALL_DIR/bin/rdns" | head -1 || true)
-        echo "rdns binary      ${rver:-unknown}"
-    fi
-} | tee "$TARBALL_DIR/BUILD_MANIFEST"
-
-# Refuse to release an obviously-stale rDNS. Any rdns earlier than 1.10 is
-# missing per-zone counters and the streaming control commands that the
-# dashboard depends on.
-if [ -f "$TARBALL_DIR/bin/rdns" ]; then
-    if ! grep -q 'stats-json' "$TARBALL_DIR/bin/rdns"; then
-        echo "ERROR: rDNS binary does not contain 'stats-json' — this is a stale build (pre-v1.10)." >&2
-        echo "       Check the rdns-server version pin in freebsd/manifest.json." >&2
-        exit 1
-    fi
-fi
-# Stage the tarball outside /usr/obj/aifw-iso/ — build-iso.sh wipes that
-# tree, so anything we put under it before the ISO step would vanish.
+echo "=== [6/8] Building update tarball ==="
 STAGE_OUT="/usr/obj/aifw-release-stage"
-mkdir -p "$STAGE_OUT"
-XZ_OPT='-9 -T0' tar -C /tmp -cJf "${STAGE_OUT}/aifw-update-${VERSION}-amd64.tar.xz" "aifw-update-${VERSION}-amd64"
-( cd "$STAGE_OUT" && sha256 "aifw-update-${VERSION}-amd64.tar.xz" > "aifw-update-${VERSION}-amd64.tar.xz.sha256" )
-rm -rf "$TARBALL_DIR"
-echo "  Update tarball staged: ${STAGE_OUT}/aifw-update-${VERSION}-amd64.tar.xz"
-ls -lh "${STAGE_OUT}/aifw-update-${VERSION}-amd64.tar.xz"
+aifw_build_update_tarball "$VERSION" "$COMPANIONS_BIN" "$PROJECT_ROOT/aifw-ui/out" "$STAGE_OUT"
 cd "$PROJECT_ROOT"
 
 # --- Build ISO + IMG (best-effort) ---
@@ -275,7 +88,7 @@ cd "$PROJECT_ROOT"
 # don't want one bad ISO build to block a release — every appliance gets
 # new code through the update tarball, not the ISO. So: failures here
 # are noted but non-fatal.
-echo "=== [6/9] Building ISO + IMG (best-effort) ==="
+echo "=== [7/8] Building ISO + IMG (best-effort) ==="
 ISO_BUILD_OK=1
 sh "$SCRIPT_DIR/build-iso.sh" "$VERSION" amd64 || ISO_BUILD_OK=0
 if [ "$ISO_BUILD_OK" -eq 0 ]; then
@@ -292,7 +105,7 @@ mv "${STAGE_OUT}/aifw-update-${VERSION}-amd64.tar.xz.sha256" "$OUTPUTDIR/"
 rmdir "$STAGE_OUT" 2>/dev/null || true
 
 # --- Compress ISO + IMG ---
-echo "=== [7/9] Compressing ISO + IMG ==="
+echo "=== [8/8] Compressing ISO + IMG ==="
 for f in "${OUTPUTDIR}"/aifw-*.iso "${OUTPUTDIR}"/aifw-*.img; do
     if [ -f "$f" ] && [ ! -f "${f}.xz" ]; then
         echo "  Compressing $(basename $f)..."
@@ -302,7 +115,7 @@ for f in "${OUTPUTDIR}"/aifw-*.iso "${OUTPUTDIR}"/aifw-*.img; do
 done
 
 # --- Cleanup intermediate files ---
-echo "=== [8/8] Cleaning up ==="
+echo "=== Cleaning up ==="
 rm -rf "$SCRIPT_DIR/release"
 rm -rf "$SCRIPT_DIR/ui-export"
 # Remove staging dirs but keep output with the final artifacts

--- a/freebsd/build-update.sh
+++ b/freebsd/build-update.sh
@@ -5,245 +5,61 @@
 #   sh freebsd/build-update.sh [version]
 #
 # Output:
-#   ${AIFW_STAGE_OUT}/aifw-update-${VERSION}-amd64.tar.xz
-#   ${AIFW_STAGE_OUT}/aifw-update-${VERSION}-amd64.tar.xz.sha256
+#   ${AIFW_STAGE_OUT}/aifw-update-${VERSION}-amd64.tar.xz (+ .sha256)
 #
-# AIFW_STAGE_OUT defaults to /usr/obj/aifw-release-stage (same as build-local.sh)
-# but can be overridden via the env var for non-FreeBSD test iteration that
-# targets a different path (e.g. AIFW_STAGE_OUT=/tmp/aifw-out sh build-update.sh).
+# AIFW_STAGE_OUT defaults to /usr/obj/aifw-release-stage and is then moved
+# into /usr/obj/aifw-iso/output (what release.sh reads); set it explicitly for
+# test iteration that should land somewhere else.
 #
-# This script must be run as root on FreeBSD.  It performs the same sanity
-# checks as build-local.sh (rust toolchain, jq, manifest.json, rDNS staleness)
-# and produces a tarball that is byte-identical in content and layout to the
-# one build-local.sh produces — just without the ISO/IMG steps.
-#
-# NOTE: build-update.sh and build-local.sh share a common code path for
-# the tarball-pack step.  If you modify tarball staging logic here, mirror
-# the change in build-local.sh (steps [5/9]) so the two outputs stay in
-# sync.  A future refactor could extract freebsd/lib-build.sh to avoid the
-# duplication; for now keeping them parallel is simpler.
+# All build steps live in freebsd/lib-build.sh and are shared with
+# build-local.sh and the CI ISO workflow (#203) — the tarball this produces
+# is byte-for-byte the same layout as theirs.
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+. "$SCRIPT_DIR/lib-build.sh"
 
-die() {
-    echo "ERROR: $1" >&2
-    exit 1
-}
+[ "$(uname -s)" = "FreeBSD" ] || aifw_die "This script must be run on FreeBSD (it invokes pkg, sha256, etc.)"
+[ "$(id -u)" -eq 0 ] || aifw_die "Must be run as root (try: sudo sh $0)"
 
-# --- Must be FreeBSD ---
-if [ "$(uname -s)" != "FreeBSD" ]; then
-    die "This script must be run on FreeBSD (it invokes pkg, sha256, etc.)"
-fi
-
-# --- Must be root ---
-if [ "$(id -u)" -ne 0 ]; then
-    die "Must be run as root (try: sudo sh $0)"
-fi
-
-# --- Output directory ---
-# Allow operator to override so test iteration can land the tarball
-# in a convenient location (e.g. AIFW_STAGE_OUT=/tmp/out sh build-update.sh).
 STAGE_OUT="${AIFW_STAGE_OUT:-/usr/obj/aifw-release-stage}"
 
-# --- Install dependencies ---
-echo "=== [1/6] Installing dependencies ==="
+echo "=== [1/5] Installing dependencies ==="
 pkg install -y curl git gmake node24 npm-node24 brotli jq
+aifw_ensure_cargo
 
-# Source cargo env before checking — sudo clears PATH so even an installed
-# toolchain won't be visible without this.  Same reasoning as build-local.sh.
-if [ -f "$HOME/.cargo/env" ]; then
-    . "$HOME/.cargo/env"
-fi
-
-if ! command -v cargo >/dev/null 2>&1; then
-    echo "Installing Rust via rustup..."
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    . "$HOME/.cargo/env"
-fi
-
-echo "--- Using cargo: $(command -v cargo) ---"
-cargo --version
-
-# --- Clone or update repo ---
 if [ ! -f "$PROJECT_ROOT/Cargo.toml" ]; then
     echo "=== Cloning repository ==="
     git clone https://github.com/ZerosAndOnesLLC/AiFw.git "$PROJECT_ROOT"
 fi
-
 cd "$PROJECT_ROOT"
 
-# --- Extract version ---
 VERSION="${1:-$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')}"
 echo ""
-echo "  Building AiFw update tarball v${VERSION}"
+echo "  Building AiFw v${VERSION} (update tarball only)"
 echo ""
 
-# --- Build Web UI static export ---
-echo "=== [2/6] Building Web UI static export ==="
+echo "=== [2/5] Building Web UI static export ==="
 cd "$PROJECT_ROOT/aifw-ui"
 npm config delete python 2>/dev/null || true
 npm ci
 npm run build
-
-if [ -d out ]; then
-    echo "  Pre-compressing UI text assets (br + gz)..."
-    has_brotli=0
-    command -v brotli >/dev/null 2>&1 && has_brotli=1
-    find out -type f \( -name '*.html' -o -name '*.js' -o -name '*.css' \
-        -o -name '*.svg' -o -name '*.json' -o -name '*.txt' \
-        -o -name '*.map' -o -name '*.xml' \) | while read -r f; do
-        if [ "$has_brotli" -eq 1 ] && [ ! -f "${f}.br" ]; then
-            brotli -q 11 -k "$f" 2>/dev/null || true
-        fi
-        if [ ! -f "${f}.gz" ]; then
-            gzip -k -9 "$f" 2>/dev/null || true
-        fi
-    done
-    js_orig=$(find out -name '*.js' -not -name '*.gz' -not -name '*.br' -exec stat -f%z {} + 2>/dev/null | awk '{s+=$1} END {print s}')
-    js_br=$(find out -name '*.js.br' -exec stat -f%z {} + 2>/dev/null | awk '{s+=$1} END {print s}')
-    if [ -n "$js_orig" ] && [ -n "$js_br" ] && [ "$js_orig" -gt 0 ]; then
-        printf "  JS size: %d KB raw  ->  %d KB brotli (%d%% smaller)\n" \
-            "$((js_orig / 1024))" "$((js_br / 1024))" \
-            "$(( (js_orig - js_br) * 100 / js_orig ))"
-    fi
-fi
+aifw_precompress_ui "$PROJECT_ROOT/aifw-ui/out"
 cd "$PROJECT_ROOT"
 
-# --- Build Rust binaries ---
-echo "=== [3/6] Building Rust binaries (release) ==="
-[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+echo "=== [3/5] Building Rust binaries (release) ==="
 echo "--- AiFw commit: $(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown) ---"
 cargo build --release
+aifw_verify_binary_version "$VERSION"
 
-# --- Guard: the compiled binary version MUST match the release version ---
-# $VERSION drives the tarball name + version file, but the binaries' version
-# is baked in from Cargo.toml at compile time. A divergence (stale cargo
-# artifact not recompiled after a bump, or a $VERSION arg that doesn't match
-# the checked-out Cargo.toml) ships binaries that install as the wrong
-# version — the silent no-op upgrade that stranded appliances on 5.96.8.
-BIN_VER="$("$PROJECT_ROOT/target/release/aifw" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
-[ "$BIN_VER" = "$VERSION" ] || die "version mismatch: building v${VERSION} but target/release/aifw reports v${BIN_VER:-unknown}. Bump Cargo.toml and rebuild (try 'cargo clean -p aifw') before releasing."
-echo "--- Verified compiled aifw binary is v${VERSION} ---"
-
-echo "=== [4/6] Installing companion services from crates.io ==="
-# Companions come from crates.io at the versions pinned in manifest.json
-# (#651, replacing the #538 git SHA pins — the published crates track the
-# companion repo releases, so there are no sibling checkouts to clone or
-# branch-juggle). Same loop as build-local.sh — keep them in sync.
-# cargo install is a no-op when the pinned version is already in
-# COMPANIONS_ROOT and fails loudly on a missing or unpublished pin.
+echo "=== [4/5] Installing companion services from crates.io ==="
 COMPANIONS_ROOT="$PROJECT_ROOT/target/companions"
-COMPANIONS_BIN="$COMPANIONS_ROOT/bin"
-for name in $(jq -r '.external_repos[].name' "$PROJECT_ROOT/freebsd/manifest.json"); do
-    crate=$(jq -r --arg n "$name" \
-        '.external_repos[] | select(.name == $n) | .crate // empty' \
-        "$PROJECT_ROOT/freebsd/manifest.json")
-    ver=$(jq -r --arg n "$name" \
-        '.external_repos[] | select(.name == $n) | .version // empty' \
-        "$PROJECT_ROOT/freebsd/manifest.json")
-    [ -n "$crate" ] || die "no crate name for $name in manifest.json (#651)"
-    [ -n "$ver" ] || die "no pinned version for $name in manifest.json (#651)"
-    echo "--- Installing $name ($crate $ver from crates.io) ---"
-    cargo install --locked --version "$ver" --root "$COMPANIONS_ROOT" "$crate" \
-        || die "cargo install of $crate $ver failed"
-    for bin in $(jq -r --arg n "$name" \
-        '.external_repos[] | select(.name == $n) | .binaries[]' \
-        "$PROJECT_ROOT/freebsd/manifest.json"); do
-        [ -f "$COMPANIONS_BIN/$bin" ] || die "$crate $ver did not produce binary $bin"
-    done
-done
-cd "$PROJECT_ROOT"
+aifw_install_companions "$COMPANIONS_ROOT"
 
-# Pull the binary list from manifest.json (same source-of-truth as build-local.sh).
-LOCAL_BINS=$(jq -r '.binaries.local[]' "$PROJECT_ROOT/freebsd/manifest.json" | tr '\n' ' ')
-[ -n "$LOCAL_BINS" ] || die "Could not parse binaries.local from manifest.json (jq failed)"
-for bin in $LOCAL_BINS; do
-    if [ ! -f "$PROJECT_ROOT/target/release/${bin}" ]; then
-        echo "ERROR: ${bin} listed in manifest but not built — refusing to ship a partial release" >&2
-        exit 1
-    fi
-done
-
-# --- Stage tarball contents ---
-echo "=== [5/6] Staging tarball contents ==="
-TARBALL_DIR="/tmp/aifw-update-${VERSION}-amd64"
-rm -rf "$TARBALL_DIR"
-mkdir -p "$TARBALL_DIR/bin" "$TARBALL_DIR/ui"
-
-for bin in $LOCAL_BINS; do
-    cp "$PROJECT_ROOT/target/release/${bin}" "$TARBALL_DIR/bin/"
-done
-# Companion binaries — installed from crates.io above, so a missing one
-# is a bug; refuse to ship a partial artifact set.
-EXT_BINS=$(jq -r '.external_repos[].binaries[]' "$PROJECT_ROOT/freebsd/manifest.json" | tr '\n' ' ')
-for bin in $EXT_BINS; do
-    [ -f "$COMPANIONS_BIN/$bin" ] || die "companion binary $bin missing from $COMPANIONS_BIN"
-    cp "$COMPANIONS_BIN/$bin" "$TARBALL_DIR/bin/"
-done
-cp -a "$PROJECT_ROOT/aifw-ui/out/"* "$TARBALL_DIR/ui/"
-
-mkdir -p "$TARBALL_DIR/rc.d"
-if [ -d "$PROJECT_ROOT/freebsd/overlay/usr/local/etc/rc.d" ]; then
-    cp -a "$PROJECT_ROOT/freebsd/overlay/usr/local/etc/rc.d/"* "$TARBALL_DIR/rc.d/" 2>/dev/null || true
-fi
-
-mkdir -p "$TARBALL_DIR/sbin"
-if [ -d "$PROJECT_ROOT/freebsd/overlay/usr/local/sbin" ]; then
-    cp -a "$PROJECT_ROOT/freebsd/overlay/usr/local/sbin/"* "$TARBALL_DIR/sbin/" 2>/dev/null || true
-fi
-
-mkdir -p "$TARBALL_DIR/libexec"
-if [ -d "$PROJECT_ROOT/freebsd/overlay/usr/local/libexec" ]; then
-    cp -a "$PROJECT_ROOT/freebsd/overlay/usr/local/libexec/"* "$TARBALL_DIR/libexec/" 2>/dev/null || true
-fi
-
-# Everything the appliance executes must carry the x bit regardless of
-# checkout modes — sudo reports a 644 helper as "command not found" (#469).
-chmod 755 "$TARBALL_DIR"/rc.d/* "$TARBALL_DIR"/sbin/* "$TARBALL_DIR"/libexec/* 2>/dev/null || true
-
-echo "$VERSION" > "$TARBALL_DIR/version"
-
-# Stamp the FreeBSD release these binaries link against (#612). The
-# updater refuses to install the tarball on an older OS — binaries built
-# on 15.1 need libc symbols a 15.0 box doesn't have and would crash-loop
-# every service. The build host's userland IS the compatibility floor.
-freebsd-version -u | sed 's/-.*//' > "$TARBALL_DIR/required-os"
-
-# Write a BUILD_MANIFEST so a stale or mispinned companion is visible at
-# build time.
-{
-    echo "AiFw             $(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
-    # Companion versions come from the manifest crates.io pins — the
-    # install step verified each pinned version produced its binaries.
-    jq -r '.external_repos[] | "\(.name) \(.version) \(.crate)"' \
-        "$PROJECT_ROOT/freebsd/manifest.json" | \
-    while read -r n v c; do
-        printf '%-16s %s (crates.io %s)\n' "$n" "$v" "$c"
-    done
-    if [ -f "$TARBALL_DIR/bin/rdns" ]; then
-        rver=$(grep -ao 'rDNS [0-9][0-9.]*' "$TARBALL_DIR/bin/rdns" | head -1 || true)
-        echo "rdns binary      ${rver:-unknown}"
-    fi
-} | tee "$TARBALL_DIR/BUILD_MANIFEST"
-
-# Refuse to release a stale rDNS (pre-v1.10 is missing stats-json / streaming control).
-if [ -f "$TARBALL_DIR/bin/rdns" ]; then
-    if ! grep -q 'stats-json' "$TARBALL_DIR/bin/rdns"; then
-        echo "ERROR: rDNS binary does not contain 'stats-json' — this is a stale build (pre-v1.10)." >&2
-        echo "       Check the rdns-server version pin in freebsd/manifest.json." >&2
-        exit 1
-    fi
-fi
-
-# --- Pack tarball + sha256 ---
-echo "=== [6/6] Packing tarball ==="
-mkdir -p "$STAGE_OUT"
-XZ_OPT='-9 -T0' tar -C /tmp -cJf "${STAGE_OUT}/aifw-update-${VERSION}-amd64.tar.xz" "aifw-update-${VERSION}-amd64"
-( cd "$STAGE_OUT" && sha256 "aifw-update-${VERSION}-amd64.tar.xz" > "aifw-update-${VERSION}-amd64.tar.xz.sha256" )
-rm -rf "$TARBALL_DIR"
+echo "=== [5/5] Building update tarball ==="
+aifw_build_update_tarball "$VERSION" "$COMPANIONS_ROOT/bin" "$PROJECT_ROOT/aifw-ui/out" "$STAGE_OUT"
 
 # Unless the operator overrode the output path for test iteration, land the
 # artifacts in the release output dir that release.sh actually reads. Without

--- a/freebsd/lib-build.sh
+++ b/freebsd/lib-build.sh
@@ -1,0 +1,193 @@
+#!/bin/sh
+# AiFw shared build steps (#203).
+#
+# Sourced — not executed — by freebsd/build-local.sh, freebsd/build-update.sh
+# and the FreeBSD VM step of .github/workflows/build-iso.yml, so the three
+# release paths run the *same* code for: UI pre-compression, the compiled-
+# version guard, companion installs from crates.io, staging, and packing the
+# update tarball. Change a step here and every path picks it up; there is
+# nothing left to mirror by hand.
+#
+# Requirements of the sourcing script: POSIX sh, `set -e`, `PROJECT_ROOT`
+# set to the repo checkout, `jq` and `cargo` on PATH (`aifw_ensure_cargo`
+# sources rustup's env), running on FreeBSD for the tarball steps
+# (`freebsd-version`, `sha256`).
+
+aifw_die() {
+    echo "ERROR: $1" >&2
+    exit 1
+}
+
+# Source rustup's env (sudo/CI shells lose PATH) and bootstrap rustup only
+# when cargo is really missing — a re-sync against static.rust-lang.org on a
+# working toolchain has broken builds on hosts with flaky DNS.
+aifw_ensure_cargo() {
+    if [ -f "$HOME/.cargo/env" ]; then
+        . "$HOME/.cargo/env"
+    fi
+    if ! command -v cargo >/dev/null 2>&1; then
+        echo "Installing Rust via rustup..."
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "$HOME/.cargo/env"
+    fi
+    echo "--- Using cargo: $(command -v cargo) ($(cargo --version)) ---"
+}
+
+# Pre-compress every text asset in a static UI export alongside the
+# originals. tower_http's ServeDir picks up .br / .gz siblings when the
+# request advertises the matching Accept-Encoding. Images/fonts are skipped
+# (already compressed).
+#   $1 = UI export directory (e.g. aifw-ui/out)
+aifw_precompress_ui() {
+    _dir="$1"
+    [ -d "$_dir" ] || return 0
+    echo "  Pre-compressing UI text assets in $_dir (br + gz)..."
+    _has_brotli=0
+    command -v brotli >/dev/null 2>&1 && _has_brotli=1
+    find "$_dir" -type f \( -name '*.html' -o -name '*.js' -o -name '*.css' \
+        -o -name '*.svg' -o -name '*.json' -o -name '*.txt' \
+        -o -name '*.map' -o -name '*.xml' \) | while read -r f; do
+        if [ "$_has_brotli" -eq 1 ] && [ ! -f "${f}.br" ]; then
+            brotli -q 11 -k "$f" 2>/dev/null || true
+        fi
+        if [ ! -f "${f}.gz" ]; then
+            gzip -k -9 "$f" 2>/dev/null || true
+        fi
+    done
+    # stat -f%z is BSD; on Linux fall back to wc -c so CI's ubuntu job can
+    # print the same summary.
+    if stat -f%z / >/dev/null 2>&1; then
+        _sz='stat -f%z'
+    else
+        _sz='stat -c%s'
+    fi
+    _js_orig=$(find "$_dir" -name '*.js' -not -name '*.gz' -not -name '*.br' -exec $_sz {} + 2>/dev/null | awk '{s+=$1} END {print s}')
+    _js_br=$(find "$_dir" -name '*.js.br' -exec $_sz {} + 2>/dev/null | awk '{s+=$1} END {print s}')
+    if [ -n "$_js_orig" ] && [ -n "$_js_br" ] && [ "$_js_orig" -gt 0 ]; then
+        printf "  JS size: %d KB raw  ->  %d KB brotli (%d%% smaller)\n" \
+            "$((_js_orig / 1024))" "$((_js_br / 1024))" \
+            "$(( (_js_orig - _js_br) * 100 / _js_orig ))"
+    fi
+}
+
+# The version label, tarball name and version file all come from $VERSION,
+# but the binaries' version is baked in from Cargo.toml at compile time. A
+# divergence (stale cargo artifact after a bump, or a VERSION arg that
+# doesn't match the checkout) ships binaries that install as the WRONG
+# version — the silent no-op upgrade that stranded appliances on 5.96.8.
+#   $1 = expected version
+aifw_verify_binary_version() {
+    _bin_ver="$("$PROJECT_ROOT/target/release/aifw" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+    [ "$_bin_ver" = "$1" ] || aifw_die "version mismatch: building v$1 but target/release/aifw reports v${_bin_ver:-unknown}. Bump Cargo.toml and rebuild (try 'cargo clean -p aifw') before releasing."
+    echo "--- Verified compiled aifw binary is v$1 ---"
+}
+
+# Install companion services (reverse proxy, DHCP, DNS, NTP) from crates.io
+# at the versions pinned in freebsd/manifest.json (#651). A missing pin or an
+# unpublished version fails the build — never fall back to branch HEAD.
+# cargo install is a no-op when the pin is already present in the root.
+#   $1 = install root (binaries land in $1/bin)
+aifw_install_companions() {
+    _root="$1"
+    _manifest="$PROJECT_ROOT/freebsd/manifest.json"
+    for _name in $(jq -r '.external_repos[].name' "$_manifest"); do
+        _crate=$(jq -r --arg n "$_name" '.external_repos[] | select(.name == $n) | .crate // empty' "$_manifest")
+        _ver=$(jq -r --arg n "$_name" '.external_repos[] | select(.name == $n) | .version // empty' "$_manifest")
+        [ -n "$_crate" ] || aifw_die "no crate name for $_name in manifest.json (#651)"
+        [ -n "$_ver" ] || aifw_die "no pinned version for $_name in manifest.json (#651)"
+        echo "--- Installing $_name ($_crate $_ver from crates.io) ---"
+        cargo install --locked --version "$_ver" --root "$_root" "$_crate" \
+            || aifw_die "cargo install of $_crate $_ver failed"
+        for _bin in $(jq -r --arg n "$_name" '.external_repos[] | select(.name == $n) | .binaries[]' "$_manifest"); do
+            [ -f "$_root/bin/$_bin" ] || aifw_die "$_crate $_ver did not produce binary $_bin"
+        done
+    done
+}
+
+# Copy every binary the manifest lists (local + companion) into a staging
+# directory. Refuses to ship a partial set — hardcoding the list here was the
+# bug that shipped a 5.76.1 release missing aifw-ids.
+#   $1 = destination dir, $2 = companion bin dir
+aifw_stage_binaries() {
+    _dest="$1"; _cbin="$2"
+    _manifest="$PROJECT_ROOT/freebsd/manifest.json"
+    mkdir -p "$_dest"
+    _local=$(jq -r '.binaries.local[]' "$_manifest" | tr '\n' ' ')
+    [ -n "$_local" ] || aifw_die "Could not parse binaries.local from manifest.json (jq failed)"
+    for _bin in $_local; do
+        [ -f "$PROJECT_ROOT/target/release/$_bin" ] || aifw_die "$_bin listed in manifest but not built — refusing to ship a partial release"
+        cp "$PROJECT_ROOT/target/release/$_bin" "$_dest/$_bin"
+    done
+    for _bin in $(jq -r '.external_repos[].binaries[]' "$_manifest"); do
+        [ -f "$_cbin/$_bin" ] || aifw_die "companion binary $_bin missing from $_cbin"
+        cp "$_cbin/$_bin" "$_dest/$_bin"
+    done
+}
+
+# Machine-readable record of the exact source that produced an artifact
+# set: AiFw commit + every pinned companion crate version. Ships as a
+# release asset and inside the update tarball.
+#   $1 = version, $2 = output file
+aifw_write_components_json() {
+    _commit="$(git -C "$PROJECT_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
+    jq -n \
+        --arg version "$1" \
+        --arg aifw_commit "$_commit" \
+        --slurpfile manifest "$PROJECT_ROOT/freebsd/manifest.json" \
+        '{version: $version, aifw_commit: $aifw_commit,
+          components: [$manifest[0].external_repos[] | {name, repo, crate, version}]}' \
+        > "$2"
+}
+
+# Build the update tarball — the critical artifact: every appliance gets
+# new code through the in-app updater, which only needs this file.
+#   $1 = version, $2 = companion bin dir, $3 = UI export dir, $4 = output dir
+# Produces $4/aifw-update-$1-amd64.tar.xz (+ .sha256).
+aifw_build_update_tarball() {
+    _ver="$1"; _cbin="$2"; _ui="$3"; _out="$4"
+    _tdir="/tmp/aifw-update-${_ver}-amd64"
+    rm -rf "$_tdir"
+    mkdir -p "$_tdir/bin" "$_tdir/ui" "$_tdir/rc.d" "$_tdir/sbin" "$_tdir/libexec"
+    aifw_stage_binaries "$_tdir/bin" "$_cbin"
+    cp -a "$_ui/"* "$_tdir/ui/"
+    # rc.d service scripts — the updater iterates every file under
+    # <tarball>/rc.d/ (it does not consult manifest rc_scripts); sbin
+    # (aifw-console, aifw-installer, …); libexec (restart driver, watchdog,
+    # narrow-grant sudo helpers — #469: without these the appliance never
+    # gets helper updates).
+    _ov="$PROJECT_ROOT/freebsd/overlay/usr/local"
+    [ -d "$_ov/etc/rc.d" ] && cp -a "$_ov/etc/rc.d/"* "$_tdir/rc.d/"
+    [ -d "$_ov/sbin" ] && cp -a "$_ov/sbin/"* "$_tdir/sbin/"
+    [ -d "$_ov/libexec" ] && cp -a "$_ov/libexec/"* "$_tdir/libexec/"
+    # Everything the appliance executes must carry the x bit regardless of
+    # checkout modes — sudo reports a 644 helper as "command not found".
+    chmod 755 "$_tdir"/rc.d/* "$_tdir"/sbin/* "$_tdir"/libexec/* 2>/dev/null || true
+    echo "$_ver" > "$_tdir/version"
+    # OS floor stamp (#612): the updater refuses this tarball on a FreeBSD
+    # older than the build host — its binaries wouldn't link.
+    freebsd-version -u | sed 's/-.*//' > "$_tdir/required-os"
+    aifw_write_components_json "$_ver" "$_tdir/components.json"
+    # Human-readable manifest so a stale or mispinned companion is visible
+    # at build time (rdns 1.5.1 once shipped in a v5.45.0 tarball).
+    {
+        echo "AiFw             $(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+        jq -r '.external_repos[] | "\(.name) \(.version) \(.crate)"' "$PROJECT_ROOT/freebsd/manifest.json" | \
+        while read -r n v c; do
+            printf '%-16s %s (crates.io %s)\n' "$n" "$v" "$c"
+        done
+        if [ -f "$_tdir/bin/rdns" ]; then
+            _rver=$(grep -ao 'rDNS [0-9][0-9.]*' "$_tdir/bin/rdns" | head -1 || true)
+            echo "rdns binary      ${_rver:-unknown}"
+        fi
+    } | tee "$_tdir/BUILD_MANIFEST"
+    # Refuse a stale rDNS: pre-1.10 lacks per-zone counters and the
+    # streaming control commands the dashboard depends on.
+    if [ -f "$_tdir/bin/rdns" ] && ! grep -q 'stats-json' "$_tdir/bin/rdns"; then
+        aifw_die "rDNS binary does not contain 'stats-json' — stale build (pre-v1.10). Check the rdns-server pin in freebsd/manifest.json."
+    fi
+    mkdir -p "$_out"
+    XZ_OPT='-9 -T0' tar -C /tmp -cJf "$_out/aifw-update-${_ver}-amd64.tar.xz" "aifw-update-${_ver}-amd64"
+    ( cd "$_out" && sha256 "aifw-update-${_ver}-amd64.tar.xz" > "aifw-update-${_ver}-amd64.tar.xz.sha256" )
+    rm -rf "$_tdir"
+    echo "  Update tarball: $_out/aifw-update-${_ver}-amd64.tar.xz"
+}


### PR DESCRIPTION
Closes #203. Stacked on #681 (its guard test lives in the split `updater/tests.rs`).

The stage-and-pack logic existed **three** times — `.github/workflows/build-iso.yml` (inline in the FreeBSD VM step), `freebsd/build-local.sh`, `freebsd/build-update.sh` — with a comment asking people to "mirror changes by hand". They had drifted:

| step | CI | build-local | build-update |
|---|---|---|---|
| UI `.br`/`.gz` pre-compression | ✗ | ✓ | ✓ |
| compiled-binary version == release version guard | ✗ | ✓ | ✓ |
| `BUILD_MANIFEST` + stale-rDNS refusal | ✗ | ✓ | ✓ |
| `components.json` inside the tarball | ✓ | ✗ | ✗ |

New `freebsd/lib-build.sh` (POSIX sh, sourced) owns: `aifw_ensure_cargo`, `aifw_precompress_ui` (BSD/GNU `stat` aware so the Linux UI job can use it), `aifw_verify_binary_version`, `aifw_install_companions` (manifest crates.io pins, #651), `aifw_stage_binaries`, `aifw_write_components_json`, `aifw_build_update_tarball` (bins + ui + rc.d/sbin/libexec + `version` + `required-os` + `components.json` + `BUILD_MANIFEST` + rDNS guard + tar/sha256). All three paths now source it and call the same functions; every row above is ✓ everywhere. `build-update.sh` and `build-local.sh` shrink to orchestration; the CI VM step is ~40 lines.

Guard test (`updater::tests::test_external_repos_pin_crates_io_versions`) now requires each of the three files to source `lib-build.sh`, call `aifw_install_companions` and `aifw_build_update_tarball`, and forbids a private `cargo install --locked --version` copy — so the next drift is a red test.

Behaviour notes: CI's `workflow_dispatch` `version` input must now equal `Cargo.toml`'s version (the same guard local builds already had — the mislabeled tarball that caused a silent no-op upgrade can't be produced from CI either). CI-built tarballs now ship pre-compressed UI assets and `BUILD_MANIFEST`; local tarballs now ship `components.json`.

Validation: `sh -n` on all three scripts, YAML parses, `cargo test -p aifw-core updater` green. I could not run a real `build-update.sh` — both FreeBSD VMs (172.29.50.220, 172.29.69.159) were unreachable from here at the time; the first tag build / next local `build-update.sh` run exercises it end-to-end.