### PR TITLE
perf: explicit tokio runtime sizing, mimalloc, runtime metrics + opt-in tokio-console (#409 #412 #413 #185)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,8 @@ argon2 = { version = "0.5", features = ["std"] }
 # minimal set in isolation with `cargo check -p <crate>`; binaries are covered
 # by the workspace union build + test suite.
 tokio = { version = "1" }
+mimalloc = { version = "0.1", default-features = false }
+console-subscriber = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.9", features = ["runtime-tokio", "sqlite", "migrate"] }

--- a/README.md
+++ b/README.md
@@ -230,6 +230,25 @@ sh scripts/install-hooks.sh   # pre-commit runs fmt --check + clippy -D warnings
 
 The hook mirrors CI's fast gates; skip a single run with `git commit --no-verify`.
 
+### Runtime tuning & diagnostics
+
+The long-running binaries (`aifw-api`, `aifw-daemon`, `aifw-ids`) build their
+tokio runtime explicitly with a floor of 4 worker threads (`max(4, cores)`,
+capped at 32) so a 2-vCPU appliance's periodic tasks don't fully subscribe the
+scheduler; override with `AIFW_WORKER_THREADS=<n>`. They use
+[mimalloc](https://github.com/microsoft/mimalloc) as the process allocator
+(cargo feature `mimalloc`, on by default; `--no-default-features` builds with
+the system malloc). `GET /api/v1/metrics` reports the API runtime's
+`worker_threads`, `alive_tasks` and `global_queue_depth` — a queue depth that
+stays above zero means the workers can't keep up. For task-level diagnostics
+build with tokio-console support and pass `--tokio-console`
+(serves on 127.0.0.1:6669):
+
+```bash
+RUSTFLAGS="--cfg tokio_unstable" cargo build --release -p aifw-api --features tokio-console
+aifw-api --tokio-console ...   # then: tokio-console http://127.0.0.1:6669
+```
+
 ## Target Environment
 
 - **OS**: FreeBSD 15.x

--- a/aifw-api/Cargo.toml
+++ b/aifw-api/Cargo.toml
@@ -9,6 +9,8 @@ name = "aifw-api"
 path = "src/main.rs"
 
 [dependencies]
+mimalloc = { workspace = true, optional = true }
+console-subscriber = { workspace = true, optional = true }
 aifw-common = { workspace = true }
 aifw-pf = { workspace = true }
 aifw-core = { workspace = true }
@@ -63,3 +65,8 @@ async-trait = { workspace = true }
 
 [lints]
 workspace = true
+
+[features]
+default = ["mimalloc"]
+# tokio-console needs `RUSTFLAGS="--cfg tokio_unstable"` at build time (#413).
+tokio-console = ["dep:console-subscriber"]

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -310,6 +310,14 @@ impl AppState {
     }
 }
 
+/// mimalloc as the process allocator (#412): the API/daemon/IDS workloads
+/// are dominated by many small short-lived allocations (JSON frames, pf
+/// state snapshots, alert records) where the default libc malloc on the
+/// appliance is measurably slower. `--no-default-features` builds without it.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[derive(Parser)]
 #[command(name = "aifw-api", about = "AiFw REST API server")]
 struct Args {
@@ -380,6 +388,13 @@ struct Args {
     /// Log level
     #[arg(long, default_value = "info")]
     log_level: String,
+
+    /// Serve tokio-console task diagnostics on 127.0.0.1:6669 (#413). Only
+    /// available in a build made with
+    /// `RUSTFLAGS="--cfg tokio_unstable" cargo build --features tokio-console`;
+    /// otherwise the flag is accepted and warns.
+    #[arg(long)]
+    tokio_console: bool,
 }
 
 /// SEC-H10: is this `Origin` allowed to open a WebSocket / SSE stream?
@@ -1511,8 +1526,15 @@ async fn ensure_rdr_anchor() {
     let _ = tokio::fs::remove_file(tmp_path).await;
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
+    // Explicit runtime (#409): worker floor of 4 so a 2-vCPU appliance's
+    // periodic tasks don't fully subscribe the scheduler; override with
+    // AIFW_WORKER_THREADS.
+    let rt = aifw_common::runtime::build("aifw-api")?;
+    rt.block_on(async_main())
+}
+
+async fn async_main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     // Fail closed on FreeBSD — anything that prevents the lock (another
@@ -1568,7 +1590,14 @@ async fn main() -> anyhow::Result<()> {
         use tracing_subscriber::util::SubscriberInitExt;
         let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| args.log_level.parse().unwrap_or_default());
+        // tokio-console layer (#413): only compiled in with the feature;
+        // otherwise `--tokio-console` is a no-op with a warning below.
+        #[cfg(feature = "tokio-console")]
+        let console_layer = args.tokio_console.then(console_subscriber::spawn);
+        #[cfg(not(feature = "tokio-console"))]
+        let console_layer: Option<tracing_subscriber::layer::Identity> = None;
         tracing_subscriber::registry()
+            .with(console_layer)
             .with(
                 tracing_subscriber::fmt::layer()
                     .with_filter(env_filter)
@@ -1581,6 +1610,20 @@ async fn main() -> anyhow::Result<()> {
                 "aifw-api",
             ))
             .init();
+    }
+    #[cfg(not(feature = "tokio-console"))]
+    if args.tokio_console {
+        tracing::warn!(
+            "--tokio-console ignored: this build lacks the tokio-console feature \
+             (build with RUSTFLAGS=\"--cfg tokio_unstable\" --features tokio-console)"
+        );
+    }
+    {
+        let rt = aifw_common::runtime::snapshot();
+        tracing::info!(
+            worker_threads = rt.worker_threads,
+            "aifw-api: tokio runtime ready"
+        );
     }
 
     // Temporary AuthSettings so create_app_state has a DB pool. The real

--- a/aifw-api/src/routes/status.rs
+++ b/aifw-api/src/routes/status.rs
@@ -30,6 +30,10 @@ pub struct MetricsResponse {
     pub aifw_rules_total: usize,
     pub aifw_rules_active: usize,
     pub aifw_nat_rules_total: usize,
+    /// Tokio runtime health of the API process (#413): configured workers,
+    /// live tasks, and the global queue depth (sustained > 0 ⇒ the workers
+    /// can't keep up — the first sign of a stalled dashboard).
+    pub runtime: aifw_common::runtime::RuntimeSnapshot,
 }
 
 pub async fn status(State(state): State<AppState>) -> Result<Json<StatusResponse>, StatusCode> {
@@ -414,6 +418,7 @@ pub async fn metrics(State(state): State<AppState>) -> Result<Json<MetricsRespon
         aifw_rules_total: rules.len(),
         aifw_rules_active: active,
         aifw_nat_rules_total: nat_rules.len(),
+        runtime: aifw_common::runtime::snapshot(),
     }))
 }
 

--- a/aifw-common/Cargo.toml
+++ b/aifw-common/Cargo.toml
@@ -11,7 +11,7 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 sqlx = { workspace = true }
-tokio = { workspace = true, features = ["sync", "net", "rt", "macros", "time", "io-util", "fs"] }
+tokio = { workspace = true, features = ["sync", "net", "rt", "rt-multi-thread", "macros", "time", "io-util", "fs"] }
 arc-swap = "1"
 tracing = { workspace = true }
 argon2 = { workspace = true }

--- a/aifw-common/src/lib.rs
+++ b/aifw-common/src/lib.rs
@@ -39,6 +39,7 @@ pub mod permission;
 pub mod ratelimit;
 /// Core firewall rule model and pf rule rendering
 pub mod rule;
+pub mod runtime;
 pub mod schedule;
 pub mod schemas;
 pub mod secure_fs;

--- a/aifw-common/src/runtime.rs
+++ b/aifw-common/src/runtime.rs
@@ -1,0 +1,107 @@
+//! Tokio runtime sizing shared by the long-running binaries (#409).
+//!
+//! `#[tokio::main]` sizes the worker pool to `available_parallelism()`. On a
+//! 2-vCPU appliance that leaves two workers for the API's dozen periodic
+//! tasks (dashboard producer, memstats, retention, WAL checkpoint, SLA
+//! aggregation, cluster replication, …) plus every request — a single
+//! slow-but-not-blocking task visibly stalls the dashboard. A small floor
+//! keeps the scheduler from being fully subscribed on tiny boxes without
+//! over-provisioning large ones.
+
+/// Fewest workers a long-running AiFw binary runs with.
+pub const MIN_WORKER_THREADS: usize = 4;
+/// Most workers we ever start regardless of core count (`AIFW_WORKER_THREADS`
+/// can still go higher explicitly).
+pub const MAX_WORKER_THREADS: usize = 32;
+/// Environment override, e.g. `AIFW_WORKER_THREADS=8`.
+pub const WORKER_THREADS_ENV: &str = "AIFW_WORKER_THREADS";
+
+/// Worker count for the given core count and optional env override: the
+/// override wins when it parses to ≥ 1; otherwise `cores` clamped to
+/// [`MIN_WORKER_THREADS`]..=[`MAX_WORKER_THREADS`].
+pub fn worker_threads_for(cores: usize, env_override: Option<&str>) -> usize {
+    if let Some(v) = env_override
+        && let Ok(n) = v.trim().parse::<usize>()
+        && n >= 1
+    {
+        return n;
+    }
+    cores.clamp(MIN_WORKER_THREADS, MAX_WORKER_THREADS)
+}
+
+/// Worker count for this host (see [`worker_threads_for`]).
+pub fn worker_threads() -> usize {
+    let cores = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(MIN_WORKER_THREADS);
+    worker_threads_for(cores, std::env::var(WORKER_THREADS_ENV).ok().as_deref())
+}
+
+/// Build the multi-thread runtime every long-running AiFw binary uses:
+/// explicit worker count, named threads (visible in `top -H`/`procstat`),
+/// all drivers enabled.
+pub fn build(name: &'static str) -> std::io::Result<tokio::runtime::Runtime> {
+    let workers = worker_threads();
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(workers)
+        .thread_name(name)
+        .enable_all()
+        .build()
+}
+
+/// Snapshot of the stable tokio runtime metrics, for `/api/v1/metrics` and
+/// logs (#413). Only counters tokio exposes without `tokio_unstable` — the
+/// full task-level view needs a `--features tokio-console` build.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RuntimeSnapshot {
+    /// Configured worker threads.
+    pub worker_threads: usize,
+    /// Tasks currently alive (spawned and not yet completed).
+    pub alive_tasks: usize,
+    /// Tasks waiting in the global (injection) queue — sustained > 0 means
+    /// the workers can't keep up.
+    pub global_queue_depth: usize,
+}
+
+/// Read the runtime metrics of the current runtime.
+pub fn snapshot() -> RuntimeSnapshot {
+    let m = tokio::runtime::Handle::current().metrics();
+    RuntimeSnapshot {
+        worker_threads: m.num_workers(),
+        alive_tasks: m.num_alive_tasks(),
+        global_queue_depth: m.global_queue_depth(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worker_threads_floor_ceiling_and_override() {
+        assert_eq!(worker_threads_for(1, None), MIN_WORKER_THREADS);
+        assert_eq!(worker_threads_for(2, None), MIN_WORKER_THREADS);
+        assert_eq!(worker_threads_for(8, None), 8);
+        assert_eq!(worker_threads_for(128, None), MAX_WORKER_THREADS);
+        assert_eq!(worker_threads_for(2, Some("6")), 6);
+        assert_eq!(
+            worker_threads_for(2, Some(" 48 ")),
+            48,
+            "explicit override may exceed the cap"
+        );
+        assert_eq!(
+            worker_threads_for(2, Some("0")),
+            MIN_WORKER_THREADS,
+            "0 is not a valid count"
+        );
+        assert_eq!(worker_threads_for(2, Some("lots")), MIN_WORKER_THREADS);
+    }
+
+    #[test]
+    fn build_creates_a_runtime_and_snapshot_reads_it() {
+        let rt = build("aifw-test").unwrap();
+        let snap = rt.block_on(async { snapshot() });
+        assert!(snap.worker_threads >= 1);
+        assert!(snap.alive_tasks <= 1);
+    }
+}

--- a/aifw-daemon/Cargo.toml
+++ b/aifw-daemon/Cargo.toml
@@ -9,6 +9,8 @@ name = "aifw-daemon"
 path = "src/main.rs"
 
 [dependencies]
+mimalloc = { workspace = true, optional = true }
+console-subscriber = { workspace = true, optional = true }
 aifw-common = { workspace = true }
 aifw-pf = { workspace = true }
 aifw-core = { workspace = true }
@@ -28,3 +30,8 @@ uuid = { workspace = true }
 
 [lints]
 workspace = true
+
+[features]
+default = ["mimalloc"]
+# tokio-console needs `RUSTFLAGS="--cfg tokio_unstable"` at build time (#413).
+tokio-console = ["dep:console-subscriber"]

--- a/aifw-daemon/src/main.rs
+++ b/aifw-daemon/src/main.rs
@@ -13,6 +13,14 @@ use std::sync::Arc;
 use tokio::signal;
 use tracing::{error, info};
 
+/// mimalloc as the process allocator (#412): the API/daemon/IDS workloads
+/// are dominated by many small short-lived allocations (JSON frames, pf
+/// state snapshots, alert records) where the default libc malloc on the
+/// appliance is measurably slower. `--no-default-features` builds without it.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[derive(Parser)]
 #[command(name = "aifw-daemon", about = "AiFw firewall daemon")]
 struct Args {
@@ -31,10 +39,24 @@ struct Args {
     /// Log level (trace, debug, info, warn, error)
     #[arg(long, default_value = "info")]
     log_level: String,
+
+    /// Serve tokio-console task diagnostics on 127.0.0.1:6669 (#413). Only
+    /// available in a build made with
+    /// `RUSTFLAGS="--cfg tokio_unstable" cargo build --features tokio-console`;
+    /// otherwise the flag is accepted and warns.
+    #[arg(long)]
+    tokio_console: bool,
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
+    // Explicit runtime (#409): worker floor of 4 so a 2-vCPU appliance's
+    // periodic tasks don't fully subscribe the scheduler; override with
+    // AIFW_WORKER_THREADS.
+    let rt = aifw_common::runtime::build("aifw-daemon")?;
+    rt.block_on(async_main())
+}
+
+async fn async_main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     // Fail closed when another instance actually holds the lock; fail open
@@ -67,7 +89,14 @@ async fn main() -> anyhow::Result<()> {
         use tracing_subscriber::util::SubscriberInitExt;
         let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| args.log_level.parse().unwrap_or_default());
+        // tokio-console layer (#413): only compiled in with the feature;
+        // otherwise `--tokio-console` is a no-op with a warning below.
+        #[cfg(feature = "tokio-console")]
+        let console_layer = args.tokio_console.then(console_subscriber::spawn);
+        #[cfg(not(feature = "tokio-console"))]
+        let console_layer: Option<tracing_subscriber::layer::Identity> = None;
         tracing_subscriber::registry()
+            .with(console_layer)
             .with(
                 tracing_subscriber::fmt::layer()
                     .with_filter(env_filter)
@@ -80,6 +109,20 @@ async fn main() -> anyhow::Result<()> {
                 "aifw-daemon",
             ))
             .init();
+    }
+    #[cfg(not(feature = "tokio-console"))]
+    if args.tokio_console {
+        tracing::warn!(
+            "--tokio-console ignored: this build lacks the tokio-console feature \
+             (build with RUSTFLAGS=\"--cfg tokio_unstable\" --features tokio-console)"
+        );
+    }
+    {
+        let rt = aifw_common::runtime::snapshot();
+        tracing::info!(
+            worker_threads = rt.worker_threads,
+            "aifw-daemon: tokio runtime ready"
+        );
     }
 
     info!("AiFw daemon starting");

--- a/aifw-ids-bin/Cargo.toml
+++ b/aifw-ids-bin/Cargo.toml
@@ -9,6 +9,8 @@ name = "aifw-ids"
 path = "src/main.rs"
 
 [dependencies]
+mimalloc = { workspace = true, optional = true }
+console-subscriber = { workspace = true, optional = true }
 aifw-common = { workspace = true }
 aifw-ids = { workspace = true }
 aifw-ids-ipc = { workspace = true }
@@ -24,3 +26,8 @@ anyhow = { workspace = true }
 
 [lints]
 workspace = true
+
+[features]
+default = ["mimalloc"]
+# tokio-console needs `RUSTFLAGS="--cfg tokio_unstable"` at build time (#413).
+tokio-console = ["dep:console-subscriber"]

--- a/aifw-ids-bin/src/main.rs
+++ b/aifw-ids-bin/src/main.rs
@@ -17,6 +17,14 @@ use std::time::Duration;
 use tokio::net::UnixListener;
 use tokio::signal::unix::{SignalKind, signal};
 
+/// mimalloc as the process allocator (#412): the API/daemon/IDS workloads
+/// are dominated by many small short-lived allocations (JSON frames, pf
+/// state snapshots, alert records) where the default libc malloc on the
+/// appliance is measurably slower. `--no-default-features` builds without it.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[derive(Parser)]
 #[command(name = "aifw-ids", about = "AiFw IDS daemon")]
 struct Args {
@@ -28,10 +36,24 @@ struct Args {
 
     #[arg(long, default_value = "info")]
     log_level: String,
+
+    /// Serve tokio-console task diagnostics on 127.0.0.1:6669 (#413). Only
+    /// available in a build made with
+    /// `RUSTFLAGS="--cfg tokio_unstable" cargo build --features tokio-console`;
+    /// otherwise the flag is accepted and warns.
+    #[arg(long)]
+    tokio_console: bool,
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
+    // Explicit runtime (#409): worker floor of 4 so a 2-vCPU appliance's
+    // periodic tasks don't fully subscribe the scheduler; override with
+    // AIFW_WORKER_THREADS.
+    let rt = aifw_common::runtime::build("aifw-ids")?;
+    rt.block_on(async_main())
+}
+
+async fn async_main() -> anyhow::Result<()> {
     let args = Args::parse();
 
     // Fail closed when another instance actually holds the lock; fail open
@@ -62,7 +84,14 @@ async fn main() -> anyhow::Result<()> {
         use tracing_subscriber::util::SubscriberInitExt;
         let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(&args.log_level));
+        // tokio-console layer (#413): only compiled in with the feature;
+        // otherwise `--tokio-console` is a no-op with a warning below.
+        #[cfg(feature = "tokio-console")]
+        let console_layer = args.tokio_console.then(console_subscriber::spawn);
+        #[cfg(not(feature = "tokio-console"))]
+        let console_layer: Option<tracing_subscriber::layer::Identity> = None;
         tracing_subscriber::registry()
+            .with(console_layer)
             .with(
                 tracing_subscriber::fmt::layer()
                     .with_filter(env_filter)
@@ -75,6 +104,20 @@ async fn main() -> anyhow::Result<()> {
                 "aifw-ids",
             ))
             .init();
+    }
+    #[cfg(not(feature = "tokio-console"))]
+    if args.tokio_console {
+        tracing::warn!(
+            "--tokio-console ignored: this build lacks the tokio-console feature \
+             (build with RUSTFLAGS=\"--cfg tokio_unstable\" --features tokio-console)"
+        );
+    }
+    {
+        let rt = aifw_common::runtime::snapshot();
+        tracing::info!(
+            worker_threads = rt.worker_threads,
+            "aifw-ids: tokio runtime ready"
+        );
     }
 
     // aifw-api and aifw-ids share aifw.db. Without WAL + busy_timeout we

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -159,7 +159,7 @@ Sensible defaults are applied when omitted; check the relevant subsystem doc for
 |---|---|---|
 | `GET` | `/api/v1/status` | Daemon + pf health snapshot |
 | `GET` | `/api/v1/about` | Build / version / feature flags |
-| `GET` | `/api/v1/metrics` | Current metrics snapshot |
+| `GET` | `/api/v1/metrics` | Current metrics snapshot (pf counters, rule counts, API tokio runtime: workers / alive tasks / global queue depth) |
 | `GET` | `/api/v1/metrics/list` | Available metric series names |
 | `GET` | `/api/v1/metrics/series` | Time-series data for one or more metrics |
 | `GET` | `/api/v1/connections` | Live pf state table (paginated) |


### PR DESCRIPTION
Closes #409, closes #412, closes #413, closes #185. Together with the already-closed PERF items this finishes epic #282.

- **#409 runtime sizing** — `aifw_common::runtime`: `worker_threads()` = `AIFW_WORKER_THREADS` if set, else `cores.clamp(4, 32)`; `build(name)` creates the named multi-thread runtime. `aifw-api`, `aifw-daemon`, `aifw-ids` now have a sync `main` that builds it and `block_on`s `async_main` instead of `#[tokio::main]`, so a 2-vCPU appliance gets 4 workers for its dozen periodic tasks. Unit tests for floor/ceiling/override.
- **#412 allocator** — `mimalloc` (MIT) as `#[global_allocator]` in the three long-running binaries behind a default-on `mimalloc` cargo feature (`--no-default-features` = system malloc). Builds via `cc`, no cmake; the FreeBSD functional job builds api+daemon and will exercise it.
- **#413 visibility** — `GET /api/v1/metrics` now includes `runtime: {worker_threads, alive_tasks, global_queue_depth}` (the stable tokio metrics; sustained queue depth > 0 = workers can't keep up); each binary logs its worker count at start. Opt-in `tokio-console` feature + `--tokio-console` flag on all three binaries (`console-subscriber` on 127.0.0.1:6669; requires `RUSTFLAGS="--cfg tokio_unstable"` at build time — verified to compile). Release builds are unaffected; the flag warns when the feature isn't compiled in.
- **#185 lock contention** — audited every `plugin_manager` / `metrics_history` lock site: `plugin_manager` reads are a `dispatch_set()` snapshot under a short read lock (per tick, per audit event) and writes happen only on plugin register/enable/reload; `metrics_history` writes are one O(1) push per tick or a trim on retention change, reads a `len()`, a size sum, or a clone on WS connect. Nothing holds across `.await` beyond those. With `global_queue_depth` exposed a real stall is now observable; no sharding/arc-swap warranted today.

README gets a *Runtime tuning & diagnostics* section (env var, feature flags, metrics fields, tokio-console recipe). Clippy clean; common 182 / daemon 12 / api tests green.