### PR TITLE
refactor: engine verb convention (add/get/list/update/delete) and one anchor-name source (#199 #198)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,11 @@ pub struct XEngine {
 
 Engines: `RuleEngine` (engine.rs), `NatEngine` (nat.rs), `AliasEngine` (alias.rs), `GeoIpEngine` (geoip.rs), `VpnEngine` (vpn.rs), `ShapingEngine` (shaping.rs), `HaEngine` / `ClusterEngine` (ha.rs), plus the multiwan family (`InstanceEngine`, `GatewayEngine`, `GroupEngine`, `PolicyEngine`, `LeakEngine`, `PreflightEngine`, `SlaEngine`) under `multiwan/`.
 
-Each engine has its own `migrate()` method that creates its SQLite tables. Migrations are **inline SQL** in Rust code (no separate migration files).
+Each engine has its own `migrate()` method that creates its SQLite tables. Migrations are **inline SQL** in Rust code (no separate migration files); columns added after a table shipped go through `aifw_core::schema::add_column_if_missing` (never a raw `ALTER TABLE` — a guard test refuses it), and brand-new schema goes in `aifw-core/migrations/`.
+
+**Verb convention (#199).** An engine that manages one resource uses bare verbs: `add` / `get` / `list` / `update` / `delete` (`RuleEngine`, `NatEngine`, `GeoIpEngine`, `AliasEngine`, the multiwan engines). An engine that manages several resources uses `verb_<noun>`: `add_wg_tunnel`, `list_carp_vips`, `update_queue`. Applying to pf is `apply`/`apply_rules`; clearing is `flush`/`flush_rules`.
+
+**Anchor convention (#198).** All pf anchor names live in `aifw_common::anchors` (`FILTER = "aifw"`, `NAT = "aifw-nat"`, `VPN`, `GEOIP`, `TLS`, `HA`, `PBR`, `MWAN_LEAK`, `MWAN_REPLY`, `RATELIMIT`; `FILTER_HOOKS` is the pf.conf hook list in evaluation order). Engines default to their constant in `new()`; `with_anchor()` exists for tests, callers don't pass anchors. A new engine adds its `aifw-<domain>` constant there and to `FILTER_HOOKS` so setup writes the hook and the daemon heals it.
 
 ### Secrets at Rest (#298)
 

--- a/aifw-api/src/backup.rs
+++ b/aifw-api/src/backup.rs
@@ -226,11 +226,7 @@ pub async fn check_config(
     let mut info = Vec::new();
 
     // Check rules
-    let rules = state
-        .rule_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
+    let rules = state.rule_engine.list().await.map_err(|_| internal())?;
     info.push(format!("{} firewall rules configured", rules.len()));
 
     // Check for rules with Any/Any (too permissive)
@@ -248,11 +244,7 @@ pub async fn check_config(
     }
 
     // Check NAT
-    let nat_rules = state
-        .nat_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
+    let nat_rules = state.nat_engine.list().await.map_err(|_| internal())?;
     info.push(format!("{} NAT rules configured", nat_rules.len()));
 
     // Check for duplicate NAT port forwards
@@ -270,11 +262,7 @@ pub async fn check_config(
     }
 
     // Check GeoIP
-    let geoip_rules = state
-        .geoip_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
+    let geoip_rules = state.geoip_engine.list().await.map_err(|_| internal())?;
     if !geoip_rules.is_empty() {
         info.push(format!("{} Geo-IP rules configured", geoip_rules.len()));
     }
@@ -392,16 +380,8 @@ pub async fn commit_confirm_start(
 pub(crate) async fn capture_runtime_snapshot(state: &AppState) -> Result<String, StatusCode> {
     use aifw_core::config::*;
 
-    let rules = state
-        .rule_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
-    let nat_rules = state
-        .nat_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
+    let rules = state.rule_engine.list().await.map_err(|_| internal())?;
+    let nat_rules = state.nat_engine.list().await.map_err(|_| internal())?;
     let aliases = build_aliases_section(state).await;
     let static_routes = build_static_routes_section(&state.pool).await;
 
@@ -596,21 +576,9 @@ pub async fn commit_confirm_status() -> Result<Json<CommitConfirmState>, StatusC
 pub(crate) async fn build_current_config(state: &AppState) -> Result<FirewallConfig, StatusCode> {
     use aifw_core::config::*;
 
-    let rules = state
-        .rule_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
-    let nat_rules = state
-        .nat_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
-    let geoip_rules = state
-        .geoip_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
+    let rules = state.rule_engine.list().await.map_err(|_| internal())?;
+    let nat_rules = state.nat_engine.list().await.map_err(|_| internal())?;
+    let geoip_rules = state.geoip_engine.list().await.map_err(|_| internal())?;
     let wg_tunnels = state
         .vpn_engine
         .list_wg_tunnels()

--- a/aifw-api/src/main.rs
+++ b/aifw-api/src/main.rs
@@ -835,8 +835,7 @@ async fn create_state_from_db(
     auth::migrate(&pool).await?;
 
     let rule_engine = Arc::new(RuleEngine::new(pool.clone(), pf.clone()));
-    let nat_engine =
-        Arc::new(NatEngine::new(pool.clone(), pf.clone()).with_anchor("aifw-nat".to_string()));
+    let nat_engine = Arc::new(NatEngine::new(pool.clone(), pf.clone()));
     let vpn_engine = Arc::new(VpnEngine::new(pool.clone(), pf.clone()));
     let ipsec_engine = Arc::new(aifw_core::IpsecEngine::new(
         pool.clone(),
@@ -1392,7 +1391,11 @@ async fn ensure_rdr_anchor() {
     const ND_RULE: &str =
         "pass quick inet6 proto icmp6 icmp6-type { routersol, routeradv, neighbrsol, neighbradv }";
     let has_nd = lines.iter().any(|l| l.trim() == ND_RULE);
-    let mwan_anchors = ["aifw-pbr", "aifw-mwan-leak", "aifw-mwan-reply"];
+    let mwan_anchors = [
+        aifw_common::anchors::PBR,
+        aifw_common::anchors::MWAN_LEAK,
+        aifw_common::anchors::MWAN_REPLY,
+    ];
     let has_mwan: Vec<bool> = mwan_anchors
         .iter()
         .map(|a| {

--- a/aifw-api/src/opnsense/importer.rs
+++ b/aifw-api/src/opnsense/importer.rs
@@ -815,10 +815,10 @@ struct InsertedRows {
 impl InsertedRows {
     async fn cleanup(&self, state: &AppState) {
         for id in &self.rule_ids {
-            let _ = state.rule_engine.delete_rule(*id).await;
+            let _ = state.rule_engine.delete(*id).await;
         }
         for id in &self.nat_ids {
-            let _ = state.nat_engine.delete_rule(*id).await;
+            let _ = state.nat_engine.delete(*id).await;
         }
         for id in &self.alias_ids {
             let _ = state.alias_engine.delete(*id).await;
@@ -955,7 +955,7 @@ async fn apply_rules(
             match build_rule(r, iface.as_deref(), alias_names, priority) {
                 Ok(rule) => {
                     let rule_id = rule.id;
-                    match state.rule_engine.add_rule(rule).await {
+                    match state.rule_engine.add(rule).await {
                         Ok(_) => {
                             tracker.rule_ids.push(rule_id);
                             summary.rules += 1;
@@ -1136,7 +1136,7 @@ async fn apply_nat(
         match build_port_forward(n, iface_map, &empty) {
             Ok((rule, advisories)) => {
                 let id = rule.id;
-                match state.nat_engine.add_rule(rule).await {
+                match state.nat_engine.add(rule).await {
                     Ok(_) => {
                         tracker.nat_ids.push(id);
                         summary.nat_port_forwards += 1;
@@ -1182,7 +1182,7 @@ async fn apply_nat(
             match build_outbound(n, iface_map, &empty) {
                 Ok(rule) => {
                     let id = rule.id;
-                    match state.nat_engine.add_rule(rule).await {
+                    match state.nat_engine.add(rule).await {
                         Ok(_) => {
                             tracker.nat_ids.push(id);
                             summary.nat_outbound += 1;
@@ -1214,7 +1214,7 @@ async fn apply_nat(
         match build_one_to_one(n, iface_map, &empty) {
             Ok(rule) => {
                 let id = rule.id;
-                match state.nat_engine.add_rule(rule).await {
+                match state.nat_engine.add(rule).await {
                     Ok(_) => {
                         tracker.nat_ids.push(id);
                         summary.nat_one_to_one += 1;

--- a/aifw-api/src/routes/geoip.rs
+++ b/aifw-api/src/routes/geoip.rs
@@ -18,11 +18,7 @@ pub struct CreateGeoIpRuleRequest {
 pub async fn list_geoip_rules(
     State(state): State<AppState>,
 ) -> Result<Json<ApiResponse<Vec<GeoIpRule>>>, StatusCode> {
-    let rules = state
-        .geoip_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
+    let rules = state.geoip_engine.list().await.map_err(|_| internal())?;
     Ok(Json(ApiResponse { data: rules }))
 }
 
@@ -35,7 +31,7 @@ pub async fn create_geoip_rule(
     let rule = GeoIpRule::new(country, action);
     let rule = state
         .geoip_engine
-        .add_rule(rule)
+        .add(rule)
         .await
         .map_err(|_| bad_request())?;
     Ok((StatusCode::CREATED, Json(ApiResponse { data: rule })))
@@ -49,7 +45,7 @@ pub async fn update_geoip_rule(
     let uuid = Uuid::parse_str(&id).map_err(|_| bad_request())?;
     let mut rule = state
         .geoip_engine
-        .get_rule(uuid)
+        .get(uuid)
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
     rule.country = CountryCode::new(&req.country_code).map_err(|_| bad_request())?;
@@ -63,7 +59,7 @@ pub async fn update_geoip_rule(
     }
     state
         .geoip_engine
-        .update_rule(&rule)
+        .update(&rule)
         .await
         .map_err(|_| internal())?;
     Ok(Json(ApiResponse { data: rule }))
@@ -76,7 +72,7 @@ pub async fn delete_geoip_rule(
     let uuid = Uuid::parse_str(&id).map_err(|_| bad_request())?;
     state
         .geoip_engine
-        .delete_rule(uuid)
+        .delete(uuid)
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
     Ok(Json(MessageResponse {

--- a/aifw-api/src/routes/nat.rs
+++ b/aifw-api/src/routes/nat.rs
@@ -36,11 +36,7 @@ pub struct CreateNatRuleRequest {
 pub async fn list_nat_rules(
     State(state): State<AppState>,
 ) -> Result<Json<ApiResponse<Vec<NatRule>>>, StatusCode> {
-    let rules = state
-        .nat_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
+    let rules = state.nat_engine.list().await.map_err(|_| internal())?;
     Ok(Json(ApiResponse { data: rules }))
 }
 
@@ -131,11 +127,7 @@ pub async fn create_nat_rule(
         _ => None,
     };
 
-    let rule = state
-        .nat_engine
-        .add_rule(rule)
-        .await
-        .map_err(nat_engine_error)?;
+    let rule = state.nat_engine.add(rule).await.map_err(nat_engine_error)?;
     state.set_pending(|p| p.nat = true).await;
     Ok((StatusCode::CREATED, Json(ApiResponse { data: rule })))
 }
@@ -146,11 +138,7 @@ pub async fn update_nat_rule(
     Json(req): Json<CreateNatRuleRequest>,
 ) -> Result<Json<ApiResponse<NatRule>>, NatError> {
     let uuid = Uuid::parse_str(&id).map_err(|_| nat_bad_request("invalid rule id"))?;
-    let mut rule = state
-        .nat_engine
-        .get_rule(uuid)
-        .await
-        .map_err(nat_engine_error)?;
+    let mut rule = state.nat_engine.get(uuid).await.map_err(nat_engine_error)?;
 
     rule.nat_type = NatType::parse(&req.nat_type)
         .map_err(|_| nat_bad_request(format!("unknown NAT type '{}'", req.nat_type)))?;
@@ -205,7 +193,7 @@ pub async fn update_nat_rule(
 
     state
         .nat_engine
-        .update_rule(&rule)
+        .update(&rule)
         .await
         .map_err(nat_engine_error)?;
     state.set_pending(|p| p.nat = true).await;
@@ -219,7 +207,7 @@ pub async fn delete_nat_rule(
     let uuid = Uuid::parse_str(&id).map_err(|_| bad_request())?;
     state
         .nat_engine
-        .delete_rule(uuid)
+        .delete(uuid)
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
     state.set_pending(|p| p.nat = true).await;
@@ -234,8 +222,16 @@ pub async fn get_nat_pf_output(
     // The NAT engine loads into "aifw-nat" (this endpoint used to read the
     // "aifw" filter anchor and always came back empty). Cross-family af-to
     // rules are filter-class, so both rulesets of the anchor are shown.
-    let nat_rules = state.pf.get_nat_rules("aifw-nat").await.unwrap_or_default();
-    let filter_rules = state.pf.get_rules("aifw-nat").await.unwrap_or_default();
+    let nat_rules = state
+        .pf
+        .get_nat_rules(aifw_common::anchors::NAT)
+        .await
+        .unwrap_or_default();
+    let filter_rules = state
+        .pf
+        .get_rules(aifw_common::anchors::NAT)
+        .await
+        .unwrap_or_default();
     let mut output = Vec::new();
     if !nat_rules.is_empty() {
         output.push("# NAT rules (anchor: aifw-nat)".to_string());

--- a/aifw-api/src/routes/rules.rs
+++ b/aifw-api/src/routes/rules.rs
@@ -73,7 +73,12 @@ pub async fn list_system_rules() -> Result<Json<ApiResponse<Vec<String>>>, Statu
     }
 
     // AiFw anchor rules
-    for anchor in ["aifw", "aifw-nat", "aifw-vpn", "aifw-geoip"] {
+    for anchor in [
+        aifw_common::anchors::FILTER,
+        aifw_common::anchors::NAT,
+        aifw_common::anchors::VPN,
+        aifw_common::anchors::GEOIP,
+    ] {
         if let Ok(output) = tokio::process::Command::new("/usr/local/bin/sudo")
             .args(["pfctl", "-a", anchor, "-sr"])
             .output()
@@ -98,11 +103,7 @@ pub async fn list_system_rules() -> Result<Json<ApiResponse<Vec<String>>>, Statu
 pub async fn list_rules(
     State(state): State<AppState>,
 ) -> Result<Json<ApiResponse<Vec<Rule>>>, StatusCode> {
-    let rules = state
-        .rule_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
+    let rules = state.rule_engine.list().await.map_err(|_| internal())?;
     Ok(Json(ApiResponse { data: rules }))
 }
 
@@ -113,7 +114,7 @@ pub async fn get_rule(
     let uuid = Uuid::parse_str(&id).map_err(|_| bad_request())?;
     let rule = state
         .rule_engine
-        .get_rule(uuid)
+        .get(uuid)
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
     Ok(Json(ApiResponse { data: rule }))
@@ -202,7 +203,7 @@ pub async fn create_rule(
 
     let rule = state
         .rule_engine
-        .add_rule(rule)
+        .add(rule)
         .await
         .map_err(|_| bad_request())?;
     state.set_pending(|p| p.firewall = true).await;
@@ -217,7 +218,7 @@ pub async fn update_rule(
     let uuid = Uuid::parse_str(&id).map_err(|_| bad_request())?;
     let mut rule = state
         .rule_engine
-        .get_rule(uuid)
+        .get(uuid)
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
 
@@ -295,7 +296,7 @@ pub async fn update_rule(
 
     state
         .rule_engine
-        .update_rule(rule.clone())
+        .update(rule.clone())
         .await
         .map_err(|_| internal())?;
     state.set_pending(|p| p.firewall = true).await;
@@ -309,7 +310,7 @@ pub async fn delete_rule(
     let uuid = Uuid::parse_str(&id).map_err(|_| bad_request())?;
     state
         .rule_engine
-        .delete_rule(uuid)
+        .delete(uuid)
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
     state.set_pending(|p| p.firewall = true).await;
@@ -334,11 +335,7 @@ pub async fn toggle_block_logging(
         .execute(&state.pool).await.map_err(|_| internal())?;
 
     // Reload pf rules
-    let rules = state
-        .rule_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
+    let rules = state.rule_engine.list().await.map_err(|_| internal())?;
     let pf_rules: Vec<String> = rules.iter().map(|r| r.to_pf_rule("aifw")).collect();
     let _ = state.pf.load_rules("aifw", &pf_rules).await;
 
@@ -360,14 +357,14 @@ pub async fn reorder_rules(
         let uuid = Uuid::parse_str(id_str).map_err(|_| bad_request())?;
         let mut rule = state
             .rule_engine
-            .get_rule(uuid)
+            .get(uuid)
             .await
             .map_err(|_| StatusCode::NOT_FOUND)?;
         rule.priority = i as i32;
         rule.updated_at = chrono::Utc::now();
         state
             .rule_engine
-            .update_rule(rule)
+            .update(rule)
             .await
             .map_err(|_| internal())?;
     }

--- a/aifw-api/src/routes/status.rs
+++ b/aifw-api/src/routes/status.rs
@@ -34,20 +34,12 @@ pub struct MetricsResponse {
 
 pub async fn status(State(state): State<AppState>) -> Result<Json<StatusResponse>, StatusCode> {
     let stats = state.pf.get_stats().await.map_err(|_| internal())?;
-    let rules = state
-        .rule_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
+    let rules = state.rule_engine.list().await.map_err(|_| internal())?;
     let active = rules
         .iter()
         .filter(|r| r.status == RuleStatus::Active)
         .count();
-    let nat_rules = state
-        .nat_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
+    let nat_rules = state.nat_engine.list().await.map_err(|_| internal())?;
 
     Ok(Json(StatusResponse {
         pf_running: stats.running,
@@ -388,20 +380,12 @@ pub async fn list_blocked_traffic() -> Result<Json<ApiResponse<Vec<BlockedEntry>
 
 pub async fn metrics(State(state): State<AppState>) -> Result<Json<MetricsResponse>, StatusCode> {
     let stats = state.pf.get_stats().await.map_err(|_| internal())?;
-    let rules = state
-        .rule_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
+    let rules = state.rule_engine.list().await.map_err(|_| internal())?;
     let active = rules
         .iter()
         .filter(|r| r.status == RuleStatus::Active)
         .count();
-    let nat_rules = state
-        .nat_engine
-        .list_rules()
-        .await
-        .map_err(|_| internal())?;
+    let nat_rules = state.nat_engine.list().await.map_err(|_| internal())?;
 
     Ok(Json(MetricsResponse {
         pf_running: stats.running,

--- a/aifw-api/src/tests/backup.rs
+++ b/aifw-api/src/tests/backup.rs
@@ -170,7 +170,7 @@ async fn test_mid_apply_failure_rolls_back_db_transaction() {
             dst_port: None,
         },
     );
-    let rule_id = state.rule_engine.add_rule(rule).await.unwrap().id;
+    let rule_id = state.rule_engine.add(rule).await.unwrap().id;
 
     let config = crate::backup::build_current_config(&state).await.unwrap();
     sqlx::query("DROP TABLE dhcp_subnets")
@@ -180,7 +180,7 @@ async fn test_mid_apply_failure_rolls_back_db_transaction() {
     let res = crate::backup::apply_firewall_config(&state, &config, &Default::default()).await;
     assert!(res.is_err(), "late failure must abort the restore");
 
-    let rules = state.rule_engine.list_rules().await.unwrap();
+    let rules = state.rule_engine.list().await.unwrap();
     assert_eq!(rules.len(), 1, "transaction rollback must keep prior rows");
     assert_eq!(rules[0].id, rule_id);
 }
@@ -224,7 +224,7 @@ async fn test_restore_1k_rules_round_trips() {
         .await
         .expect("bulk restore must succeed");
     let elapsed = started.elapsed();
-    let rules = state.rule_engine.list_rules().await.unwrap();
+    let rules = state.rule_engine.list().await.unwrap();
     assert_eq!(rules.len(), 1000, "every rule must survive the round trip");
     // Generous bound — the point is one transaction, not per-row fsyncs.
     assert!(elapsed.as_secs() < 30, "bulk restore took {elapsed:?}");
@@ -264,7 +264,7 @@ async fn test_restore_failure_injection_every_db_stage() {
         let state = crate::create_app_state_in_memory(plain_auth_settings())
             .await
             .unwrap();
-        state.rule_engine.add_rule(any_tcp_rule()).await.unwrap();
+        state.rule_engine.add(any_tcp_rule()).await.unwrap();
         let config = crate::backup::build_current_config(&state).await.unwrap();
         // Replace the table with a read-only VIEW of the same name: the
         // engine migrates' CREATE TABLE IF NOT EXISTS no-op on it (so
@@ -283,7 +283,7 @@ async fn test_restore_failure_injection_every_db_stage() {
         .unwrap();
         let res = crate::backup::apply_firewall_config(&state, &config, &Default::default()).await;
         assert!(res.is_err(), "failure at {table} must abort the restore");
-        let rules = state.rule_engine.list_rules().await.unwrap();
+        let rules = state.rule_engine.list().await.unwrap();
         assert_eq!(
             rules.len(),
             1,
@@ -300,7 +300,7 @@ async fn test_restore_mid_tx_failure_rolls_back_and_audits() {
     let state = crate::create_app_state_in_memory(plain_auth_settings())
         .await
         .unwrap();
-    state.rule_engine.add_rule(any_tcp_rule()).await.unwrap();
+    state.rule_engine.add(any_tcp_rule()).await.unwrap();
     state
         .alias_engine
         .add(aifw_common::Alias {
@@ -336,7 +336,7 @@ async fn test_restore_mid_tx_failure_rolls_back_and_audits() {
     let aliases = state.alias_engine.list().await.unwrap();
     assert_eq!(aliases.len(), 1, "prior alias set must be restored");
     assert_eq!(aliases[0].name, "keepme");
-    assert_eq!(state.rule_engine.list_rules().await.unwrap().len(), 1);
+    assert_eq!(state.rule_engine.list().await.unwrap().len(), 1);
 
     let (audits,): (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM audit_log WHERE details LIKE '%rolled back to pre-restore state%'",
@@ -355,7 +355,7 @@ async fn test_restore_pf_failure_after_commit_rolls_back_cleanly() {
     let state = crate::create_app_state_in_memory(plain_auth_settings())
         .await
         .unwrap();
-    state.rule_engine.add_rule(any_tcp_rule()).await.unwrap();
+    state.rule_engine.add(any_tcp_rule()).await.unwrap();
     let mock = state
         .pf
         .as_any()
@@ -377,11 +377,11 @@ async fn test_restore_pf_failure_after_commit_rolls_back_cleanly() {
             .await;
     assert!(res.is_err(), "pf failure must abort the restore");
     assert_eq!(
-        state.geoip_engine.list_rules().await.unwrap().len(),
+        state.geoip_engine.list().await.unwrap().len(),
         0,
         "geo-ip rows from the failed target must be rolled back"
     );
-    assert_eq!(state.rule_engine.list_rules().await.unwrap().len(), 1);
+    assert_eq!(state.rule_engine.list().await.unwrap().len(), 1);
 }
 
 #[tokio::test]
@@ -392,7 +392,7 @@ async fn test_restore_rollback_failure_is_audited_high_severity() {
     let state = crate::create_app_state_in_memory(plain_auth_settings())
         .await
         .unwrap();
-    state.rule_engine.add_rule(any_tcp_rule()).await.unwrap();
+    state.rule_engine.add(any_tcp_rule()).await.unwrap();
     let mock = state
         .pf
         .as_any()
@@ -450,7 +450,7 @@ async fn test_post_apply_verification_detects_pf_drift() {
             dst_port: None,
         },
     );
-    state.rule_engine.add_rule(rule).await.unwrap();
+    state.rule_engine.add(rule).await.unwrap();
     state.rule_engine.apply_rules().await.unwrap();
     state
         .rule_engine
@@ -483,7 +483,7 @@ async fn test_prevalidation_rejects_bad_config_without_mutation() {
             dst_port: None,
         },
     );
-    state.rule_engine.add_rule(rule).await.unwrap();
+    state.rule_engine.add(rule).await.unwrap();
 
     let mut config = crate::backup::build_current_config(&state).await.unwrap();
     config.rules[0].priority = 20_000; // validate_rule caps at 10000
@@ -492,7 +492,7 @@ async fn test_prevalidation_rejects_bad_config_without_mutation() {
         crate::backup::apply_firewall_config_or_rollback(&state, &config, &Default::default())
             .await;
     assert_eq!(res, Err(axum::http::StatusCode::BAD_REQUEST));
-    let rules = state.rule_engine.list_rules().await.unwrap();
+    let rules = state.rule_engine.list().await.unwrap();
     assert_eq!(rules.len(), 1, "prevalidation failure must not touch rows");
 }
 

--- a/aifw-api/src/ws.rs
+++ b/aifw-api/src/ws.rs
@@ -620,20 +620,12 @@ struct BuiltUpdate {
 
 async fn build_update(state: &AppState) -> Result<BuiltUpdate, String> {
     let stats = state.pf.get_stats().await.map_err(|e| e.to_string())?;
-    let rules = state
-        .rule_engine
-        .list_rules()
-        .await
-        .map_err(|e| e.to_string())?;
+    let rules = state.rule_engine.list().await.map_err(|e| e.to_string())?;
     let active = rules
         .iter()
         .filter(|r| r.status == RuleStatus::Active)
         .count();
-    let nat_rules = state
-        .nat_engine
-        .list_rules()
-        .await
-        .map_err(|e| e.to_string())?;
+    let nat_rules = state.nat_engine.list().await.map_err(|e| e.to_string())?;
 
     // conntrack snapshot — refreshed by the background polling task started
     // at boot, so this is an atomic ArcSwap load (no syscall, no clone).

--- a/aifw-cli/src/commands/common.rs
+++ b/aifw-cli/src/commands/common.rs
@@ -50,7 +50,7 @@ pub(super) async fn create_nat_engine(db_path: &Path) -> anyhow::Result<NatEngin
     let pf = Arc::from(aifw_pf::create_backend());
     // "aifw-nat" — must match the API/daemon anchor; NAT loads replace every
     // rule class in their anchor since #531.
-    Ok(NatEngine::new(db.pool().clone(), pf).with_anchor("aifw-nat".to_string()))
+    Ok(NatEngine::new(db.pool().clone(), pf))
 }
 
 #[cfg(test)]

--- a/aifw-cli/src/commands/geoip.rs
+++ b/aifw-cli/src/commands/geoip.rs
@@ -25,7 +25,7 @@ pub async fn geoip_add(
     let engine = create_geoip_engine(db_path).await?;
     let mut rule = GeoIpRule::new(CountryCode::new(country)?, GeoIpAction::parse(action)?);
     rule.label = label.map(String::from);
-    let rule = engine.add_rule(rule).await?;
+    let rule = engine.add(rule).await?;
     println!("Added geo-ip rule {}", rule.id);
     println!("  Country: {}", rule.country);
     println!("  Action:  {}", rule.action);
@@ -37,14 +37,14 @@ pub async fn geoip_add(
 pub async fn geoip_remove(db_path: &Path, id: &str) -> anyhow::Result<()> {
     let engine = create_geoip_engine(db_path).await?;
     let uuid = Uuid::parse_str(id)?;
-    engine.delete_rule(uuid).await?;
+    engine.delete(uuid).await?;
     println!("Removed geo-ip rule {id}");
     Ok(())
 }
 
 pub async fn geoip_list(db_path: &Path, json: bool) -> anyhow::Result<()> {
     let engine = create_geoip_engine(db_path).await?;
-    let rules = engine.list_rules().await?;
+    let rules = engine.list().await?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&rules)?);

--- a/aifw-cli/src/commands/nat.rs
+++ b/aifw-cli/src/commands/nat.rs
@@ -44,7 +44,7 @@ pub async fn nat_add(
         .map(Address::parse)
         .transpose()?;
 
-    let rule = nat.add_rule(rule).await.map_err(|e| {
+    let rule = nat.add(rule).await.map_err(|e| {
         let msg = e.to_string();
         match nat_flag_hint(&msg) {
             Some(hint) => anyhow::anyhow!("{msg}\n  hint: {hint}"),
@@ -111,14 +111,14 @@ pub fn nat_embed(prefix: &str, ipv4: &str) -> anyhow::Result<()> {
 pub async fn nat_remove(db_path: &Path, id: &str) -> anyhow::Result<()> {
     let nat = create_nat_engine(db_path).await?;
     let uuid = Uuid::parse_str(id)?;
-    nat.delete_rule(uuid).await?;
+    nat.delete(uuid).await?;
     println!("Removed NAT rule {id}");
     Ok(())
 }
 
 pub async fn nat_list(db_path: &Path, json: bool) -> anyhow::Result<()> {
     let nat = create_nat_engine(db_path).await?;
-    let rules = nat.list_rules().await?;
+    let rules = nat.list().await?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&rules)?);

--- a/aifw-cli/src/commands/rules.rs
+++ b/aifw-cli/src/commands/rules.rs
@@ -51,7 +51,7 @@ pub async fn rules_add(
     rule.label = label.map(String::from);
     rule.interface = interface.map(|s| Interface(s.to_string()));
 
-    let rule = engine.add_rule(rule).await?;
+    let rule = engine.add(rule).await?;
     println!("Added rule {}", rule.id);
     println!("  pf: {}", rule.to_pf_rule("aifw"));
     Ok(())
@@ -60,14 +60,14 @@ pub async fn rules_add(
 pub async fn rules_remove(db_path: &Path, id: &str) -> anyhow::Result<()> {
     let engine = create_engine(db_path).await?;
     let uuid = Uuid::parse_str(id)?;
-    engine.delete_rule(uuid).await?;
+    engine.delete(uuid).await?;
     println!("Removed rule {id}");
     Ok(())
 }
 
 pub async fn rules_list(db_path: &Path, json: bool) -> anyhow::Result<()> {
     let engine = create_engine(db_path).await?;
-    let rules = engine.list_rules().await?;
+    let rules = engine.list().await?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&rules)?);

--- a/aifw-cli/src/commands/system.rs
+++ b/aifw-cli/src/commands/system.rs
@@ -10,7 +10,7 @@ pub async fn status(db_path: &Path) -> anyhow::Result<()> {
 
     let pf = engine.pf();
     let stats = pf.get_stats().await.map_err(|e| anyhow::anyhow!("{e}"))?;
-    let rules = engine.list_rules().await?;
+    let rules = engine.list().await?;
     let active_rules = rules
         .iter()
         .filter(|r| r.status == aifw_common::RuleStatus::Active)
@@ -113,11 +113,11 @@ async fn sysrc_read_local(key: &str) -> Option<String> {
 pub async fn reload(db_path: &Path) -> anyhow::Result<()> {
     let engine = create_engine(db_path).await?;
     engine.apply_rules().await?;
-    let rules = engine.list_rules().await?;
+    let rules = engine.list().await?;
 
     let nat = create_nat_engine(db_path).await?;
     nat.apply_rules().await?;
-    let nat_rules = nat.list_rules().await?;
+    let nat_rules = nat.list().await?;
 
     let shaping = create_shaping_engine(db_path).await?;
     shaping.apply_queues().await?;

--- a/aifw-common/src/anchors.rs
+++ b/aifw-common/src/anchors.rs
@@ -1,0 +1,67 @@
+//! pf anchor names AiFw owns (#198).
+//!
+//! Every engine loads into its own anchor so AiFw never touches the system
+//! ruleset outside these hooks; `aifw-setup` writes the matching `anchor`/
+//! `nat-anchor`/`rdr-anchor` lines into `pf.conf`, and the API/daemon heal
+//! them if missing. Convention: `aifw` for the base filter ruleset,
+//! `aifw-<domain>` for everything else. New engines take their anchor from
+//! here (constructor default) and expose `with_anchor()` only for tests.
+
+/// Base filter ruleset (`RuleEngine`); traffic-shaping queues attach here too.
+pub const FILTER: &str = "aifw";
+/// NAT / rdr / binat / `af-to` rules (`NatEngine`).
+pub const NAT: &str = "aifw-nat";
+/// WireGuard / IPsec pass rules (`VpnEngine`).
+pub const VPN: &str = "aifw-vpn";
+/// Geo-IP allow/block rules + tables (`GeoIpEngine`).
+pub const GEOIP: &str = "aifw-geoip";
+/// CARP / pfsync pass rules (`ClusterEngine`).
+pub const HA: &str = "aifw-ha";
+/// TLS inspection redirect rules (`TlsEngine`).
+pub const TLS: &str = "aifw-tls";
+/// Multi-WAN policy-based routing (`PolicyEngine`).
+pub const PBR: &str = "aifw-pbr";
+/// Multi-WAN reply-to rules (`PolicyEngine`).
+pub const MWAN_REPLY: &str = "aifw-mwan-reply";
+/// Multi-WAN leak-detection block rules (`LeakEngine`).
+pub const MWAN_LEAK: &str = "aifw-mwan-leak";
+/// Suffix appended to the filter anchor for connection rate-limit rules
+/// (`ShapingEngine`): `aifw-ratelimit`.
+pub const RATELIMIT_SUFFIX: &str = "-ratelimit";
+/// Connection rate-limit rules under the default filter anchor.
+pub const RATELIMIT: &str = "aifw-ratelimit";
+
+/// Filter-class anchors `pf.conf` must hook (`anchor "…"`), in evaluation
+/// order: multi-WAN first so route-to / rtable decisions exist before general
+/// filtering, then the base ruleset and the per-domain anchors. `NAT`
+/// additionally needs `nat-anchor`/`rdr-anchor` hooks. `aifw-setup` writes
+/// this list; the API/daemon heal missing hooks from it.
+pub const FILTER_HOOKS: &[&str] = &[
+    PBR, MWAN_LEAK, MWAN_REPLY, FILTER, NAT, RATELIMIT, VPN, GEOIP, TLS, HA,
+];
+
+/// Rate-limit anchor derived from a filter anchor.
+pub fn ratelimit_anchor(filter_anchor: &str) -> String {
+    format!("{filter_anchor}{RATELIMIT_SUFFIX}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn convention_holds() {
+        assert_eq!(FILTER, "aifw");
+        for a in FILTER_HOOKS {
+            assert!(
+                *a == FILTER || a.starts_with("aifw-"),
+                "{a} breaks the aifw-<domain> convention"
+            );
+        }
+        assert_eq!(ratelimit_anchor(FILTER), RATELIMIT);
+        let mut all: Vec<&str> = FILTER_HOOKS.to_vec();
+        all.sort();
+        all.dedup();
+        assert_eq!(all.len(), FILTER_HOOKS.len(), "duplicate anchor names");
+    }
+}

--- a/aifw-common/src/lib.rs
+++ b/aifw-common/src/lib.rs
@@ -17,6 +17,7 @@ pub const DEFAULT_LOOPBACK_API_BASE: &str = "https://127.0.0.1:8080";
 
 /// Named aliases (host/network/port/URL-table) usable in firewall rules
 pub mod alias;
+pub mod anchors;
 pub mod cluster_events;
 /// Crate-wide `AifwError` enum and `Result` alias
 pub mod error;

--- a/aifw-core/src/engine.rs
+++ b/aifw-core/src/engine.rs
@@ -8,7 +8,7 @@ use crate::audit::{AuditAction, AuditLog};
 use crate::db::Database;
 use crate::validation::validate_rule;
 
-const DEFAULT_ANCHOR: &str = "aifw";
+const DEFAULT_ANCHOR: &str = aifw_common::anchors::FILTER;
 
 /// Resolve a rule's policy-routing gateway reference to the `(interface,
 /// next_hop)` pair `route-to` needs (#540). Falls back to default routing
@@ -82,7 +82,7 @@ impl RuleEngine {
     /// Validate and insert a rule; the rule row and its audit entry commit
     /// in one transaction. pf is untouched until [`Self::apply_rules`].
     /// Fails on validation or DB errors.
-    pub async fn add_rule(&self, rule: Rule) -> Result<Rule> {
+    pub async fn add(&self, rule: Rule) -> Result<Rule> {
         validate_rule(&rule)?;
         let pf_syntax = rule.to_pf_rule(&self.anchor);
         // PERF-H6 (#350): mutation + audit row commit together — one fsync
@@ -103,7 +103,7 @@ impl RuleEngine {
     }
 
     /// Fetch a rule by id. Fails with `NotFound` if it doesn't exist
-    pub async fn get_rule(&self, id: Uuid) -> Result<Rule> {
+    pub async fn get(&self, id: Uuid) -> Result<Rule> {
         self.db
             .get_rule(id)
             .await?
@@ -111,14 +111,14 @@ impl RuleEngine {
     }
 
     /// All rules ordered by priority, then creation time
-    pub async fn list_rules(&self) -> Result<Vec<Rule>> {
+    pub async fn list(&self) -> Result<Vec<Rule>> {
         self.db.list_rules().await
     }
 
     /// Validate and update a rule; the update and its audit entry commit in
     /// one transaction. Fails with `NotFound` for an unknown id. pf is
     /// untouched until [`Self::apply_rules`].
-    pub async fn update_rule(&self, rule: Rule) -> Result<()> {
+    pub async fn update(&self, rule: Rule) -> Result<()> {
         validate_rule(&rule)?;
         let mut tx = self.db.pool().begin().await?;
         Database::update_rule_on(&mut *tx, &rule).await?;
@@ -137,7 +137,7 @@ impl RuleEngine {
 
     /// Delete a rule; the delete and its audit entry commit in one
     /// transaction. Fails with `NotFound` for an unknown id
-    pub async fn delete_rule(&self, id: Uuid) -> Result<()> {
+    pub async fn delete(&self, id: Uuid) -> Result<()> {
         let mut tx = self.db.pool().begin().await?;
         Database::delete_rule_on(&mut *tx, id).await?;
         AuditLog::log_on(

--- a/aifw-core/src/geoip.rs
+++ b/aifw-core/src/geoip.rs
@@ -57,7 +57,7 @@ impl GeoIpEngine {
         Self {
             pool,
             pf,
-            anchor: "aifw-geoip".to_string(),
+            anchor: aifw_common::anchors::GEOIP.to_string(),
             index: Arc::new(ArcSwap::from_pointee(GeoIpIndex::empty())),
         }
     }
@@ -98,7 +98,7 @@ impl GeoIpEngine {
 
     /// Insert a per-country block/allow rule row. pf tables aren't touched
     /// until the geo-IP rules are next applied
-    pub async fn add_rule(&self, rule: GeoIpRule) -> Result<GeoIpRule> {
+    pub async fn add(&self, rule: GeoIpRule) -> Result<GeoIpRule> {
         Self::insert_rule_on(&self.pool, &rule).await?;
         tracing::info!(id = %rule.id, country = %rule.country, action = %rule.action, "geo-ip rule added");
         Ok(rule)
@@ -132,7 +132,7 @@ impl GeoIpEngine {
     }
 
     /// All geo-IP rules ordered by country code
-    pub async fn list_rules(&self) -> Result<Vec<GeoIpRule>> {
+    pub async fn list(&self) -> Result<Vec<GeoIpRule>> {
         let rows = sqlx::query_as::<_, GeoIpRuleRow>(sqlx::AssertSqlSafe(format!(
             "SELECT {GEOIP_RULE_COLUMNS} FROM geoip_rules ORDER BY country ASC"
         )))
@@ -142,7 +142,7 @@ impl GeoIpEngine {
     }
 
     /// Fetch a geo-IP rule by id. Fails with `NotFound` if it doesn't exist
-    pub async fn get_rule(&self, id: Uuid) -> Result<GeoIpRule> {
+    pub async fn get(&self, id: Uuid) -> Result<GeoIpRule> {
         let row = sqlx::query_as::<_, GeoIpRuleRow>(sqlx::AssertSqlSafe(format!(
             "SELECT {GEOIP_RULE_COLUMNS} FROM geoip_rules WHERE id = ?1"
         )))
@@ -154,7 +154,7 @@ impl GeoIpEngine {
     }
 
     /// Update a geo-IP rule row. Fails with `NotFound` for an unknown id
-    pub async fn update_rule(&self, rule: &GeoIpRule) -> Result<()> {
+    pub async fn update(&self, rule: &GeoIpRule) -> Result<()> {
         let result = sqlx::query(
             r#"UPDATE geoip_rules SET country = ?2, action = ?3, label = ?4, status = ?5, updated_at = ?6 WHERE id = ?1"#,
         )
@@ -180,7 +180,7 @@ impl GeoIpEngine {
     }
 
     /// Delete a geo-IP rule row. Fails with `NotFound` for an unknown id
-    pub async fn delete_rule(&self, id: Uuid) -> Result<()> {
+    pub async fn delete(&self, id: Uuid) -> Result<()> {
         let result = sqlx::query("DELETE FROM geoip_rules WHERE id = ?1")
             .bind(id.to_string())
             .execute(&self.pool)
@@ -281,7 +281,7 @@ impl GeoIpEngine {
 
     /// Apply geo-ip rules: create pf tables per country and populate them
     pub async fn apply_rules(&self) -> Result<()> {
-        let rules = self.list_rules().await?;
+        let rules = self.list().await?;
         let active: Vec<_> = rules
             .iter()
             .filter(|r| r.status == GeoIpRuleStatus::Active)
@@ -322,7 +322,7 @@ impl GeoIpEngine {
     /// rules; emptiness invariant on real pfctl, which re-renders rules and
     /// omits table definitions from `-sr` (see `RuleEngine::verify_applied`).
     pub async fn verify_applied(&self) -> Result<()> {
-        let rules = self.list_rules().await?;
+        let rules = self.list().await?;
         let expected: Vec<String> = rules
             .iter()
             .filter(|r| r.status == GeoIpRuleStatus::Active)

--- a/aifw-core/src/ha.rs
+++ b/aifw-core/src/ha.rs
@@ -23,7 +23,7 @@ impl ClusterEngine {
         Self {
             pool,
             pf,
-            anchor: "aifw-ha".to_string(),
+            anchor: aifw_common::anchors::HA.to_string(),
         }
     }
 

--- a/aifw-core/src/multiwan/leak.rs
+++ b/aifw-core/src/multiwan/leak.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 /// pf anchor that holds the compiled route-leak rules
-pub const LEAK_ANCHOR: &str = "aifw-mwan-leak";
+pub const LEAK_ANCHOR: &str = aifw_common::anchors::MWAN_LEAK;
 
 /// Route-leak engine: CRUD over `multiwan_leaks` (controlled cross-FIB
 /// traffic exceptions) and compilation of enabled leaks into pf rules in

--- a/aifw-core/src/multiwan/policy.rs
+++ b/aifw-core/src/multiwan/policy.rs
@@ -13,9 +13,9 @@ use uuid::Uuid;
 use super::group::{Selection, select};
 
 /// pf anchor holding the compiled policy-based routing (inbound match) rules
-pub const PBR_ANCHOR: &str = "aifw-pbr";
+pub const PBR_ANCHOR: &str = aifw_common::anchors::PBR;
 /// pf anchor holding the reply-to rules that route return traffic back out the same gateway
-pub const REPLY_ANCHOR: &str = "aifw-mwan-reply";
+pub const REPLY_ANCHOR: &str = aifw_common::anchors::MWAN_REPLY;
 
 /// Policy-based routing engine: CRUD over `multiwan_policies` and compilation
 /// of active policies into pf rules in the PBR and reply anchors

--- a/aifw-core/src/nat.rs
+++ b/aifw-core/src/nat.rs
@@ -35,7 +35,7 @@ impl NatEngine {
             pool,
             pf,
             audit,
-            anchor: "aifw-nat".to_string(),
+            anchor: aifw_common::anchors::NAT.to_string(),
         }
     }
 
@@ -95,7 +95,7 @@ impl NatEngine {
     /// in one transaction. pf is untouched until [`Self::apply_rules`].
     /// Fails validation when the interface is empty or a DNAT/RDR rule has
     /// neither a destination nor a redirect port.
-    pub async fn add_rule(&self, rule: NatRule) -> Result<NatRule> {
+    pub async fn add(&self, rule: NatRule) -> Result<NatRule> {
         validate_nat_rule(&rule)?;
         self.parser_gate_with(&rule).await?;
         let pf_syntax = rule.to_pf_rule();
@@ -117,7 +117,7 @@ impl NatEngine {
     }
 
     /// Fetch a NAT rule by id. Fails with `NotFound` if it doesn't exist
-    pub async fn get_rule(&self, id: Uuid) -> Result<NatRule> {
+    pub async fn get(&self, id: Uuid) -> Result<NatRule> {
         let row = sqlx::query_as::<_, NatRuleRow>(sqlx::AssertSqlSafe(format!(
             "SELECT {NAT_RULE_COLUMNS} FROM nat_rules WHERE id = ?1"
         )))
@@ -131,7 +131,7 @@ impl NatEngine {
     }
 
     /// All NAT rules, oldest first
-    pub async fn list_rules(&self) -> Result<Vec<NatRule>> {
+    pub async fn list(&self) -> Result<Vec<NatRule>> {
         let rows = sqlx::query_as::<_, NatRuleRow>(sqlx::AssertSqlSafe(format!(
             "SELECT {NAT_RULE_COLUMNS} FROM nat_rules ORDER BY created_at ASC"
         )))
@@ -155,7 +155,7 @@ impl NatEngine {
     /// Validate and update a NAT rule; the update and its audit entry
     /// commit in one transaction. Fails with `NotFound` for an unknown id.
     /// pf is untouched until [`Self::apply_rules`].
-    pub async fn update_rule(&self, rule: &NatRule) -> Result<()> {
+    pub async fn update(&self, rule: &NatRule) -> Result<()> {
         validate_nat_rule(rule)?;
         self.parser_gate_with(rule).await?;
         let mut tx = self.pool.begin().await?;
@@ -216,7 +216,7 @@ impl NatEngine {
 
     /// Delete a NAT rule; the delete and its audit entry commit in one
     /// transaction. Fails with `NotFound` for an unknown id
-    pub async fn delete_rule(&self, id: Uuid) -> Result<()> {
+    pub async fn delete(&self, id: Uuid) -> Result<()> {
         let mut tx = self.pool.begin().await?;
         let result = sqlx::query("DELETE FROM nat_rules WHERE id = ?1")
             .bind(id.to_string())

--- a/aifw-core/src/shaping.rs
+++ b/aifw-core/src/shaping.rs
@@ -30,7 +30,7 @@ impl ShapingEngine {
         Self {
             pool,
             pf,
-            anchor: "aifw".to_string(),
+            anchor: aifw_common::anchors::FILTER.to_string(),
         }
     }
 
@@ -253,7 +253,10 @@ impl ShapingEngine {
         tracing::info!(count = active.len(), "applying rate limit rules to pf");
         // Rate limit rules go into the main rules anchor
         self.pf
-            .load_rules(&format!("{}-ratelimit", self.anchor), &pf_lines)
+            .load_rules(
+                &aifw_common::anchors::ratelimit_anchor(&self.anchor),
+                &pf_lines,
+            )
             .await
             .map_err(|e| AifwError::Pf(e.to_string()))?;
 

--- a/aifw-core/src/tests/geoip.rs
+++ b/aifw-core/src/tests/geoip.rs
@@ -16,15 +16,15 @@ async fn test_geoip_rule_crud() {
 
     let rule = GeoIpRule::new(CountryCode::new("CN").unwrap(), GeoIpAction::Block);
     let id = rule.id;
-    engine.add_rule(rule).await.unwrap();
+    engine.add(rule).await.unwrap();
 
-    let rules = engine.list_rules().await.unwrap();
+    let rules = engine.list().await.unwrap();
     assert_eq!(rules.len(), 1);
     assert_eq!(rules[0].country.0, "CN");
     assert_eq!(rules[0].action, GeoIpAction::Block);
 
-    engine.delete_rule(id).await.unwrap();
-    assert!(engine.list_rules().await.unwrap().is_empty());
+    engine.delete(id).await.unwrap();
+    assert!(engine.list().await.unwrap().is_empty());
 }
 
 #[tokio::test]
@@ -83,7 +83,7 @@ async fn test_geoip_apply_rules() {
     engine.migrate().await.unwrap();
 
     engine
-        .add_rule(GeoIpRule::new(
+        .add(GeoIpRule::new(
             CountryCode::new("RU").unwrap(),
             GeoIpAction::Block,
         ))
@@ -91,7 +91,7 @@ async fn test_geoip_apply_rules() {
         .unwrap();
 
     engine
-        .add_rule(GeoIpRule::new(
+        .add(GeoIpRule::new(
             CountryCode::new("US").unwrap(),
             GeoIpAction::Allow,
         ))

--- a/aifw-core/src/tests/nat.rs
+++ b/aifw-core/src/tests/nat.rs
@@ -33,9 +33,9 @@ async fn test_nat_add_list() {
 
     let rule = make_test_nat_rule();
     let id = rule.id;
-    engine.add_rule(rule).await.unwrap();
+    engine.add(rule).await.unwrap();
 
-    let rules = engine.list_rules().await.unwrap();
+    let rules = engine.list().await.unwrap();
     assert_eq!(rules.len(), 1);
     assert_eq!(rules[0].id, id);
     assert_eq!(rules[0].nat_type, NatType::Snat);
@@ -47,17 +47,17 @@ async fn test_nat_delete() {
 
     let rule = make_test_nat_rule();
     let id = rule.id;
-    engine.add_rule(rule).await.unwrap();
-    engine.delete_rule(id).await.unwrap();
+    engine.add(rule).await.unwrap();
+    engine.delete(id).await.unwrap();
 
-    let rules = engine.list_rules().await.unwrap();
+    let rules = engine.list().await.unwrap();
     assert!(rules.is_empty());
 }
 
 #[tokio::test]
 async fn test_nat_delete_nonexistent() {
     let engine = create_nat_engine().await;
-    assert!(engine.delete_rule(uuid::Uuid::new_v4()).await.is_err());
+    assert!(engine.delete(uuid::Uuid::new_v4()).await.is_err());
 }
 
 #[tokio::test]
@@ -86,8 +86,8 @@ async fn test_nat_db_roundtrip() {
     rule.label = Some("web-redirect".to_string());
     let id = rule.id;
 
-    engine.add_rule(rule).await.unwrap();
-    let fetched = engine.get_rule(id).await.unwrap();
+    engine.add(rule).await.unwrap();
+    let fetched = engine.get(id).await.unwrap();
 
     assert_eq!(fetched.nat_type, NatType::Dnat);
     assert_eq!(fetched.protocol, Protocol::Tcp);
@@ -116,16 +116,16 @@ async fn test_nat_static_port_and_nonat_roundtrip() {
     );
     masq.static_port = true;
     let masq_id = masq.id;
-    engine.add_rule(masq).await.unwrap();
-    let fetched = engine.get_rule(masq_id).await.unwrap();
+    engine.add(masq).await.unwrap();
+    let fetched = engine.get(masq_id).await.unwrap();
     assert!(fetched.static_port, "static_port must round-trip");
     assert!(fetched.to_pf_rule().ends_with("static-port"));
 
     // Update can clear it again.
     let mut cleared = fetched.clone();
     cleared.static_port = false;
-    engine.update_rule(&cleared).await.unwrap();
-    assert!(!engine.get_rule(masq_id).await.unwrap().static_port);
+    engine.update(&cleared).await.unwrap();
+    assert!(!engine.get(masq_id).await.unwrap().static_port);
 
     // nonat round-trips and renders `no nat`.
     let nonat = NatRule::new(
@@ -140,8 +140,8 @@ async fn test_nat_static_port_and_nonat_roundtrip() {
         },
     );
     let nonat_id = nonat.id;
-    engine.add_rule(nonat).await.unwrap();
-    let fetched = engine.get_rule(nonat_id).await.unwrap();
+    engine.add(nonat).await.unwrap();
+    let fetched = engine.get(nonat_id).await.unwrap();
     assert_eq!(fetched.nat_type, NatType::NoNat);
     assert!(fetched.to_pf_rule().starts_with("no nat on em0"));
 
@@ -160,7 +160,7 @@ async fn test_nat_static_port_and_nonat_roundtrip() {
         },
     );
     bad.static_port = true;
-    assert!(engine.add_rule(bad).await.is_err());
+    assert!(engine.add(bad).await.is_err());
 
     // nonat with a redirect target is rejected.
     let bad = NatRule::new(
@@ -176,7 +176,7 @@ async fn test_nat_static_port_and_nonat_roundtrip() {
             port: None,
         },
     );
-    assert!(engine.add_rule(bad).await.is_err());
+    assert!(engine.add(bad).await.is_err());
 }
 
 #[tokio::test]
@@ -186,7 +186,7 @@ async fn test_nat_apply_rules() {
     let pf: Arc<dyn PfBackend> = mock.clone();
     let engine = crate::nat::NatEngine::new(db.pool().clone(), pf);
 
-    engine.add_rule(make_test_nat_rule()).await.unwrap();
+    engine.add(make_test_nat_rule()).await.unwrap();
     engine.apply_rules().await.unwrap();
 
     let nat_rules = mock.get_nat_rules("aifw-nat").await.unwrap();
@@ -202,8 +202,8 @@ async fn test_nat_apply_mixed_classes_and_flush() {
     let engine =
         crate::nat::NatEngine::new(db.pool().clone(), pf).with_anchor("aifw-nat".to_string());
 
-    engine.add_rule(make_test_nat_rule()).await.unwrap();
-    engine.add_rule(make_test_nat64_rule()).await.unwrap();
+    engine.add(make_test_nat_rule()).await.unwrap();
+    engine.add(make_test_nat64_rule()).await.unwrap();
     engine.apply_rules().await.unwrap();
 
     // nat-class rule lands in the nat ruleset; the af-to pass rule is
@@ -240,7 +240,7 @@ async fn test_nat_validation_dnat_needs_port() {
         },
     );
     // DNAT without any port should fail validation
-    assert!(engine.add_rule(rule).await.is_err());
+    assert!(engine.add(rule).await.is_err());
 }
 
 #[tokio::test]
@@ -258,7 +258,7 @@ async fn test_nat_validation_needs_interface() {
             port: None,
         },
     );
-    assert!(engine.add_rule(rule).await.is_err());
+    assert!(engine.add(rule).await.is_err());
 }
 
 fn make_test_nat64_rule() -> NatRule {
@@ -280,7 +280,7 @@ fn make_test_nat64_rule() -> NatRule {
 #[tokio::test]
 async fn test_nat64_validation_accepts_well_formed_rule() {
     let engine = create_nat_engine().await;
-    engine.add_rule(make_test_nat64_rule()).await.unwrap();
+    engine.add(make_test_nat64_rule()).await.unwrap();
 
     // NAT46 mirror: v4 match, v6 translation source
     let nat46 = NatRule::new(
@@ -294,7 +294,7 @@ async fn test_nat64_validation_accepts_well_formed_rule() {
             port: None,
         },
     );
-    engine.add_rule(nat46).await.unwrap();
+    engine.add(nat46).await.unwrap();
 }
 
 #[tokio::test]
@@ -304,7 +304,7 @@ async fn test_nat64_validation_rejects_bad_families() {
     // dst not a /96 prefix
     let mut rule = make_test_nat64_rule();
     rule.dst_addr = Address::Network(std::net::IpAddr::V6("64:ff9b::".parse().unwrap()), 64);
-    assert!(engine.add_rule(rule).await.is_err());
+    assert!(engine.add(rule).await.is_err());
 
     // dst IPv4
     let mut rule = make_test_nat64_rule();
@@ -312,17 +312,17 @@ async fn test_nat64_validation_rejects_bad_families() {
         std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 0)),
         8,
     );
-    assert!(engine.add_rule(rule).await.is_err());
+    assert!(engine.add(rule).await.is_err());
 
     // source in the wrong (translated) family
     let mut rule = make_test_nat64_rule();
     rule.src_addr = Address::Single(std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)));
-    assert!(engine.add_rule(rule).await.is_err());
+    assert!(engine.add(rule).await.is_err());
 
     // translation source IPv6 (must be IPv4 for nat64)
     let mut rule = make_test_nat64_rule();
     rule.redirect.address = Address::Single(std::net::IpAddr::V6("2001:db8::1".parse().unwrap()));
-    assert!(engine.add_rule(rule).await.is_err());
+    assert!(engine.add(rule).await.is_err());
 
     // translation source as network (must be a single host)
     let mut rule = make_test_nat64_rule();
@@ -330,17 +330,17 @@ async fn test_nat64_validation_rejects_bad_families() {
         std::net::IpAddr::V4(std::net::Ipv4Addr::new(203, 0, 113, 0)),
         24,
     );
-    assert!(engine.add_rule(rule).await.is_err());
+    assert!(engine.add(rule).await.is_err());
 
     // redirect port unsupported by af-to
     let mut rule = make_test_nat64_rule();
     rule.redirect.port = Some(PortRange { start: 80, end: 80 });
-    assert!(engine.add_rule(rule).await.is_err());
+    assert!(engine.add(rule).await.is_err());
 
     // pf tables can't determine family
     let mut rule = make_test_nat64_rule();
     rule.src_addr = Address::Table("v6clients".to_string());
-    assert!(engine.add_rule(rule).await.is_err());
+    assert!(engine.add(rule).await.is_err());
 }
 
 #[tokio::test]
@@ -364,40 +364,40 @@ async fn test_nat46_validation_rejects_bad_families() {
     // dst IPv6 (must be the concrete IPv4 target)
     let mut rule = make();
     rule.dst_addr = Address::Single(std::net::IpAddr::V6("2001:db8::5".parse().unwrap()));
-    assert!(engine.add_rule(rule).await.is_err());
+    assert!(engine.add(rule).await.is_err());
 
     // dst Any (a concrete IPv4 destination is required)
     let mut rule = make();
     rule.dst_addr = Address::Any;
-    assert!(engine.add_rule(rule).await.is_err());
+    assert!(engine.add(rule).await.is_err());
 
     // translation source IPv4 (must be IPv6 for nat46)
     let mut rule = make();
     rule.redirect.address = Address::Single(std::net::IpAddr::V4(std::net::Ipv4Addr::new(
         203, 0, 113, 1,
     )));
-    assert!(engine.add_rule(rule).await.is_err());
+    assert!(engine.add(rule).await.is_err());
 
     // #596: explicit translated destination must be a single IPv6 host
     let mut rule = make();
     rule.af_to_dst = Some(Address::Single(std::net::IpAddr::V4(
         std::net::Ipv4Addr::new(192, 0, 2, 80),
     )));
-    assert!(engine.add_rule(rule).await.is_err());
+    assert!(engine.add(rule).await.is_err());
     let mut rule = make();
     rule.af_to_dst = Some(Address::Network(
         std::net::IpAddr::V6("2001:db8:2::".parse().unwrap()),
         64,
     ));
-    assert!(engine.add_rule(rule).await.is_err());
+    assert!(engine.add(rule).await.is_err());
     let mut rule = make();
     rule.af_to_dst = Some(Address::Single(std::net::IpAddr::V6(
         "2001:db8:2::80".parse().unwrap(),
     )));
-    let added = engine.add_rule(rule).await.unwrap();
+    let added = engine.add(rule).await.unwrap();
     // round-trips through SQLite
     let stored = engine
-        .list_rules()
+        .list()
         .await
         .unwrap()
         .into_iter()
@@ -432,5 +432,5 @@ async fn test_nat46_validation_rejects_bad_families() {
     snat.af_to_dst = Some(Address::Single(std::net::IpAddr::V6(
         "2001:db8:2::80".parse().unwrap(),
     )));
-    assert!(engine.add_rule(snat).await.is_err());
+    assert!(engine.add(snat).await.is_err());
 }

--- a/aifw-core/src/tests/rules.rs
+++ b/aifw-core/src/tests/rules.rs
@@ -90,9 +90,9 @@ async fn test_engine_add_list_rules() {
 
     let rule = make_test_rule();
     let id = rule.id;
-    engine.add_rule(rule).await.unwrap();
+    engine.add(rule).await.unwrap();
 
-    let rules = engine.list_rules().await.unwrap();
+    let rules = engine.list().await.unwrap();
     assert_eq!(rules.len(), 1);
     assert_eq!(rules[0].id, id);
 }
@@ -105,10 +105,10 @@ async fn test_engine_delete_rule() {
 
     let rule = make_test_rule();
     let id = rule.id;
-    engine.add_rule(rule).await.unwrap();
-    engine.delete_rule(id).await.unwrap();
+    engine.add(rule).await.unwrap();
+    engine.delete(id).await.unwrap();
 
-    let rules = engine.list_rules().await.unwrap();
+    let rules = engine.list().await.unwrap();
     assert!(rules.is_empty());
 }
 
@@ -118,7 +118,7 @@ async fn test_engine_delete_nonexistent() {
     let pf: Arc<dyn PfBackend> = Arc::new(aifw_pf::PfMock::new());
     let engine = RuleEngine::new(db.pool().clone(), pf);
 
-    let result = engine.delete_rule(uuid::Uuid::new_v4()).await;
+    let result = engine.delete(uuid::Uuid::new_v4()).await;
     assert!(result.is_err());
 }
 
@@ -129,7 +129,7 @@ async fn test_engine_apply_rules() {
     let pf: Arc<dyn PfBackend> = mock.clone();
     let engine = RuleEngine::new(db.pool().clone(), pf);
 
-    engine.add_rule(make_test_rule()).await.unwrap();
+    engine.add(make_test_rule()).await.unwrap();
 
     let mut rule2 = Rule::new(
         Action::Pass,
@@ -146,7 +146,7 @@ async fn test_engine_apply_rules() {
         },
     );
     rule2.priority = 50;
-    engine.add_rule(rule2).await.unwrap();
+    engine.add(rule2).await.unwrap();
 
     engine.apply_rules().await.unwrap();
 
@@ -207,7 +207,7 @@ async fn test_engine_schedule_gating() {
     dangling.schedule_id = Some("deleted-schedule".to_string());
     dangling.label = Some("dangling".to_string());
     for r in [gated, open, disabled_sched, dangling] {
-        engine.add_rule(r).await.unwrap();
+        engine.add(r).await.unwrap();
     }
 
     engine.apply_rules().await.unwrap();
@@ -275,16 +275,13 @@ async fn test_engine_gateway_route_to() {
         r.gateway = gw;
         r
     };
+    engine.add(mk("routed", Some(up_id.clone()))).await.unwrap();
     engine
-        .add_rule(mk("routed", Some(up_id.clone())))
+        .add(mk("gw-down", Some(down_id.clone())))
         .await
         .unwrap();
     engine
-        .add_rule(mk("gw-down", Some(down_id.clone())))
-        .await
-        .unwrap();
-    engine
-        .add_rule(mk("gw-dangling", Some(uuid::Uuid::new_v4().to_string())))
+        .add(mk("gw-dangling", Some(uuid::Uuid::new_v4().to_string())))
         .await
         .unwrap();
 
@@ -301,7 +298,7 @@ async fn test_engine_gateway_route_to() {
     assert!(!find("gw-dangling").contains("route-to"));
 
     // Round-trip: the gateway reference survives persistence
-    let rules = engine.list_rules().await.unwrap();
+    let rules = engine.list().await.unwrap();
     let routed = rules
         .iter()
         .find(|r| r.label.as_deref() == Some("routed"))
@@ -316,7 +313,7 @@ async fn test_engine_flush_rules() {
     let pf: Arc<dyn PfBackend> = mock.clone();
     let engine = RuleEngine::new(db.pool().clone(), pf);
 
-    engine.add_rule(make_test_rule()).await.unwrap();
+    engine.add(make_test_rule()).await.unwrap();
     engine.apply_rules().await.unwrap();
 
     let before = mock.get_rules("aifw").await.unwrap();
@@ -402,8 +399,8 @@ async fn test_audit_trail() {
 
     let rule = make_test_rule();
     let id = rule.id;
-    engine.add_rule(rule).await.unwrap();
-    engine.delete_rule(id).await.unwrap();
+    engine.add(rule).await.unwrap();
+    engine.delete(id).await.unwrap();
 
     let entries = engine.audit().list(10).await.unwrap();
     assert_eq!(entries.len(), 2);
@@ -419,7 +416,7 @@ async fn test_audit_for_apply_and_flush() {
     let pf: Arc<dyn PfBackend> = mock.clone();
     let engine = RuleEngine::new(db.pool().clone(), pf);
 
-    engine.add_rule(make_test_rule()).await.unwrap();
+    engine.add(make_test_rule()).await.unwrap();
     engine.apply_rules().await.unwrap();
     engine.flush_rules().await.unwrap();
 

--- a/aifw-core/src/tls.rs
+++ b/aifw-core/src/tls.rs
@@ -26,7 +26,7 @@ impl TlsEngine {
         Self {
             pool,
             pf,
-            anchor: "aifw-tls".to_string(),
+            anchor: aifw_common::anchors::TLS.to_string(),
             policy: TlsPolicy::default(),
             mitm_config: MitmProxyConfig::default(),
         }

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -24,7 +24,7 @@ impl VpnEngine {
         Self {
             pool,
             pf,
-            anchor: "aifw-vpn".to_string(),
+            anchor: aifw_common::anchors::VPN.to_string(),
         }
     }
 

--- a/aifw-daemon/src/main.rs
+++ b/aifw-daemon/src/main.rs
@@ -133,10 +133,10 @@ async fn main() -> anyhow::Result<()> {
     let pf: Arc<dyn aifw_pf::PfBackend> = Arc::from(aifw_pf::create_backend());
     let engine =
         Arc::new(RuleEngine::new(pool.clone(), pf.clone()).with_anchor(args.anchor.clone()));
-    // Same anchor as the API's engine ("aifw-nat", not the default "aifw"):
+    // NAT engine defaults to aifw_common::anchors::NAT ("aifw-nat"):
     // NAT loads replace every rule class in their anchor since #531, so a
     // boot-time apply into "aifw" would wipe the filter rules loaded above.
-    let nat_engine = NatEngine::new(pool.clone(), pf.clone()).with_anchor("aifw-nat".to_string());
+    let nat_engine = NatEngine::new(pool.clone(), pf.clone());
     let alias_engine = AliasEngine::new(pool.clone(), pf.clone());
 
     // Check pf status
@@ -155,7 +155,7 @@ async fn main() -> anyhow::Result<()> {
     // Load and apply filter rules
     match engine.apply_rules().await {
         Ok(()) => {
-            let rules = engine.list_rules().await?;
+            let rules = engine.list().await?;
             info!(count = rules.len(), anchor = %args.anchor, "filter rules applied");
         }
         Err(e) => error!("failed to apply filter rules: {e}"),

--- a/aifw-setup/src/apply/pf_conf.rs
+++ b/aifw-setup/src/apply/pf_conf.rs
@@ -92,18 +92,12 @@ pub fn generate_pf_conf(config: &SetupConfig) -> String {
     lines.push(String::new());
 
     lines.push("# AiFw filter anchors".to_string());
-    // Multi-WAN anchors MUST be evaluated first so policy-routing decisions
-    // (route-to / rtable) are set before general filtering.
-    lines.push("anchor \"aifw-pbr\"".to_string());
-    lines.push("anchor \"aifw-mwan-leak\"".to_string());
-    lines.push("anchor \"aifw-mwan-reply\"".to_string());
-    lines.push("anchor \"aifw\"".to_string());
-    lines.push("anchor \"aifw-nat\"".to_string());
-    lines.push("anchor \"aifw-ratelimit\"".to_string());
-    lines.push("anchor \"aifw-vpn\"".to_string());
-    lines.push("anchor \"aifw-geoip\"".to_string());
-    lines.push("anchor \"aifw-tls\"".to_string());
-    lines.push("anchor \"aifw-ha\"".to_string());
+    // Order comes from aifw_common::anchors::FILTER_HOOKS: multi-WAN anchors
+    // first so policy-routing decisions (route-to / rtable) are set before
+    // general filtering.
+    for anchor in aifw_common::anchors::FILTER_HOOKS {
+        lines.push(format!("anchor \"{anchor}\""));
+    }
     lines.push(String::new());
 
     // Default policy

--- a/aifw-setup/src/apply/run.rs
+++ b/aifw-setup/src/apply/run.rs
@@ -49,18 +49,7 @@ pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<
     let anchors_dir = format!("{}/anchors", config.config_dir);
     std::fs::create_dir_all(&anchors_dir)
         .map_err(|e| format!("failed to create anchors dir: {e}"))?;
-    for anchor in [
-        "aifw",
-        "aifw-nat",
-        "aifw-ratelimit",
-        "aifw-vpn",
-        "aifw-geoip",
-        "aifw-tls",
-        "aifw-ha",
-        "aifw-pbr",
-        "aifw-mwan-leak",
-        "aifw-mwan-reply",
-    ] {
+    for anchor in aifw_common::anchors::FILTER_HOOKS {
         let path = format!("{anchors_dir}/{anchor}");
         if !std::path::Path::new(&path).exists() {
             write_file(&path, "# AiFw managed anchor\n")?;

--- a/aifw-tui/src/app.rs
+++ b/aifw-tui/src/app.rs
@@ -96,8 +96,7 @@ impl App {
 
         let rule_engine = Arc::new(RuleEngine::new(pool.clone(), pf.clone()));
         // "aifw-nat" — must match the API/daemon anchor (#531).
-        let nat_engine =
-            Arc::new(NatEngine::new(pool.clone(), pf.clone()).with_anchor("aifw-nat".to_string()));
+        let nat_engine = Arc::new(NatEngine::new(pool.clone(), pf.clone()));
         nat_engine.migrate().await?;
         let shaping_engine = Arc::new(ShapingEngine::new(pool.clone(), pf.clone()));
         shaping_engine.migrate().await?;
@@ -134,10 +133,10 @@ impl App {
         if let Ok(stats) = self.pf.get_stats().await {
             self.pf_stats = stats;
         }
-        if let Ok(rules) = self.rule_engine.list_rules().await {
+        if let Ok(rules) = self.rule_engine.list().await {
             self.rules = rules;
         }
-        if let Ok(nat) = self.nat_engine.list_rules().await {
+        if let Ok(nat) = self.nat_engine.list().await {
             self.nat_rules = nat;
         }
         let _ = self.conntrack.refresh().await;
@@ -158,7 +157,7 @@ impl App {
     pub async fn delete_selected_rule(&mut self) {
         if let Some(rule) = self.rules.get(self.rules_selected) {
             let id = rule.id;
-            if self.rule_engine.delete_rule(id).await.is_ok() {
+            if self.rule_engine.delete(id).await.is_ok() {
                 self.refresh().await;
                 if self.rules_selected > 0 && self.rules_selected >= self.rules.len() {
                     self.rules_selected = self.rules.len().saturating_sub(1);
@@ -170,7 +169,7 @@ impl App {
     pub async fn delete_selected_nat(&mut self) {
         if let Some(rule) = self.nat_rules.get(self.nat_selected) {
             let id = rule.id;
-            if self.nat_engine.delete_rule(id).await.is_ok() {
+            if self.nat_engine.delete(id).await.is_ok() {
                 self.refresh().await;
                 if self.nat_selected > 0 && self.nat_selected >= self.nat_rules.len() {
                     self.nat_selected = self.nat_rules.len().saturating_sub(1);
@@ -283,9 +282,9 @@ mod tests {
         a.select_up();
         assert_eq!(a.rules_selected, 0);
 
-        a.rule_engine.add_rule(rule(22)).await.unwrap();
-        a.rule_engine.add_rule(rule(80)).await.unwrap();
-        a.rule_engine.add_rule(rule(443)).await.unwrap();
+        a.rule_engine.add(rule(22)).await.unwrap();
+        a.rule_engine.add(rule(80)).await.unwrap();
+        a.rule_engine.add(rule(443)).await.unwrap();
         a.refresh().await;
         assert_eq!(a.rules.len(), 3);
         for _ in 0..10 {
@@ -304,8 +303,8 @@ mod tests {
     #[tokio::test]
     async fn delete_selected_rule_removes_it_and_keeps_selection_in_range() {
         let mut a = app().await;
-        a.rule_engine.add_rule(rule(22)).await.unwrap();
-        a.rule_engine.add_rule(rule(80)).await.unwrap();
+        a.rule_engine.add(rule(22)).await.unwrap();
+        a.rule_engine.add(rule(80)).await.unwrap();
         a.refresh().await;
         a.tab = Tab::Rules;
         a.select_down();


### PR DESCRIPTION
Closes #199, closes #198.

**#199 verbs.** `RuleEngine`, `NatEngine`, `GeoIpEngine` exposed `add_rule / get_rule / list_rules / update_rule / delete_rule` while `AliasEngine` and every multiwan engine used `add / get / list / update / delete`. Convention now (also written into CLAUDE.md's Engine Pattern): single-resource engines use the bare verbs; multi-resource engines (`VpnEngine`, `ClusterEngine`, `ShapingEngine`, `IpsecEngine`…) keep `verb_<noun>` (`add_wg_tunnel`, `list_carp_vips`, …). `apply_rules` / `flush_rules` untouched. The rename was driven by the compiler (~140 call sites across api/cli/daemon/tui/tests); no behaviour change.

**#198 anchors.** New `aifw_common::anchors`: `FILTER="aifw"`, `NAT`, `VPN`, `GEOIP`, `TLS`, `HA`, `PBR`, `MWAN_REPLY`, `MWAN_LEAK`, `RATELIMIT` (+ `ratelimit_anchor()`), and `FILTER_HOOKS` — the pf.conf hook list in evaluation order (multi-WAN first). Every engine's `new()` defaults to its constant (`with_anchor()` stays for tests); `aifw-setup` writes the pf.conf hooks and the anchors directory from `FILTER_HOOKS`; the API's hook-heal list, `/rules` anchor listing, NAT rendered-rules endpoint, and the daemon/CLI use the constants; the redundant `.with_anchor("aifw-nat")` at the four `NatEngine` call sites is gone (its default was already `aifw-nat`; the daemon comment claiming otherwise was stale). Unit test pins the `aifw-<domain>` convention and no duplicates.

Clippy clean; core 253 / api 237 / setup 51 / common 181 tests green (setup's pf.conf ordering guard included).