### PR TITLE
refactor(api): engines own validation; handlers only map engine errors (#194)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,8 @@ Each engine has its own `migrate()` method that creates its SQLite tables. Migra
 
 **Verb convention (#199).** An engine that manages one resource uses bare verbs: `add` / `get` / `list` / `update` / `delete` (`RuleEngine`, `NatEngine`, `GeoIpEngine`, `AliasEngine`, the multiwan engines). An engine that manages several resources uses `verb_<noun>`: `add_wg_tunnel`, `list_carp_vips`, `update_queue`. Applying to pf is `apply`/`apply_rules`; clearing is `flush`/`flush_rules`.
 
+**Validation (#194).** Engines own validation: `add`/`update` re-validate every write (`validate_rule`, `validate_nat_rule`, `GeoIpEngine::validate`, `AliasEngine::validate_name`, `WgTunnel::validate_addresses`…), so API, CLI, restore and cluster snapshots share one set of invariants. Handlers only translate request → domain type and map engine errors with `routes::engine_error` (Validation → 400, NotFound → 404, else 500); a guard test fails if a handler calls `aifw_core::validation::` itself.
+
 **Anchor convention (#198).** All pf anchor names live in `aifw_common::anchors` (`FILTER = "aifw"`, `NAT = "aifw-nat"`, `VPN`, `GEOIP`, `TLS`, `HA`, `PBR`, `MWAN_LEAK`, `MWAN_REPLY`, `RATELIMIT`; `FILTER_HOOKS` is the pf.conf hook list in evaluation order). Engines default to their constant in `new()`; `with_anchor()` exists for tests, callers don't pass anchors. A new engine adds its `aifw-<domain>` constant there and to `FILTER_HOOKS` so setup writes the hook and the daemon heals it.
 
 ### Secrets at Rest (#298)

--- a/aifw-api/src/aliases.rs
+++ b/aifw-api/src/aliases.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::AppState;
+use crate::routes::engine_error;
 use aifw_common::{Alias, AliasType};
 
 #[derive(Debug, Serialize)]
@@ -55,24 +56,10 @@ pub async fn get_alias(
     Ok(Json(ApiResponse { data: alias }))
 }
 
-fn validate_alias_name(name: &str) -> Result<(), StatusCode> {
-    if name.is_empty() || name.len() > 31 {
-        return Err(bad_request());
-    }
-    if !name
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
-    {
-        return Err(bad_request());
-    }
-    Ok(())
-}
-
 pub async fn create_alias(
     State(state): State<AppState>,
     Json(req): Json<CreateAliasRequest>,
 ) -> Result<(StatusCode, Json<ApiResponse<Alias>>), StatusCode> {
-    validate_alias_name(&req.name)?;
     let alias_type = AliasType::parse(&req.alias_type).ok_or(bad_request())?;
     let now = Utc::now();
     let alias = Alias {
@@ -85,11 +72,8 @@ pub async fn create_alias(
         created_at: now,
         updated_at: now,
     };
-    let alias = state
-        .alias_engine
-        .add(alias)
-        .await
-        .map_err(|_| bad_request())?;
+    // Name / reserved-name checks live in AliasEngine::add (`validate_name`).
+    let alias = state.alias_engine.add(alias).await.map_err(engine_error)?;
     state.set_pending(|p| p.firewall = true).await;
     Ok((StatusCode::CREATED, Json(ApiResponse { data: alias })))
 }
@@ -100,7 +84,6 @@ pub async fn update_alias(
     Json(req): Json<CreateAliasRequest>,
 ) -> Result<Json<ApiResponse<Alias>>, StatusCode> {
     let uuid = Uuid::parse_str(&id).map_err(|_| bad_request())?;
-    validate_alias_name(&req.name)?;
     let alias_type = AliasType::parse(&req.alias_type).ok_or(bad_request())?;
     let existing = state
         .alias_engine
@@ -121,7 +104,7 @@ pub async fn update_alias(
         .alias_engine
         .update(alias)
         .await
-        .map_err(|_| bad_request())?;
+        .map_err(engine_error)?;
     state.set_pending(|p| p.firewall = true).await;
     Ok(Json(ApiResponse { data: alias }))
 }

--- a/aifw-api/src/routes/geoip.rs
+++ b/aifw-api/src/routes/geoip.rs
@@ -29,11 +29,7 @@ pub async fn create_geoip_rule(
     let country = CountryCode::new(&req.country_code).map_err(|_| bad_request())?;
     let action = GeoIpAction::parse(&req.action).map_err(|_| bad_request())?;
     let rule = GeoIpRule::new(country, action);
-    let rule = state
-        .geoip_engine
-        .add(rule)
-        .await
-        .map_err(|_| bad_request())?;
+    let rule = state.geoip_engine.add(rule).await.map_err(engine_error)?;
     Ok((StatusCode::CREATED, Json(ApiResponse { data: rule })))
 }
 
@@ -61,7 +57,7 @@ pub async fn update_geoip_rule(
         .geoip_engine
         .update(&rule)
         .await
-        .map_err(|_| internal())?;
+        .map_err(engine_error)?;
     Ok(Json(ApiResponse { data: rule }))
 }
 

--- a/aifw-api/src/routes/mod.rs
+++ b/aifw-api/src/routes/mod.rs
@@ -115,6 +115,24 @@ pub(super) fn bad_request() -> StatusCode {
     StatusCode::BAD_REQUEST
 }
 
+/// Map an engine error to a status (#194): engines own validation, so a
+/// `Validation` error is the caller's fault (400), `NotFound` is 404, and
+/// anything else is a server-side failure — logged, 500. Handlers no longer
+/// pre-validate what the engine's `add`/`update` re-checks anyway.
+pub(crate) fn engine_error(e: aifw_common::AifwError) -> StatusCode {
+    match e {
+        aifw_common::AifwError::Validation(msg) => {
+            tracing::debug!(error = %msg, "request rejected by engine validation");
+            StatusCode::BAD_REQUEST
+        }
+        aifw_common::AifwError::NotFound(_) => StatusCode::NOT_FOUND,
+        other => {
+            tracing::error!(error = %other, "engine call failed");
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    }
+}
+
 pub(super) fn internal() -> StatusCode {
     StatusCode::INTERNAL_SERVER_ERROR
 }

--- a/aifw-api/src/routes/nat.rs
+++ b/aifw-api/src/routes/nat.rs
@@ -97,13 +97,7 @@ pub async fn create_nat_rule(
     let redirect_addr = Address::parse(req.redirect_addr.as_deref().unwrap_or("any"))
         .map_err(|e| nat_bad_request(format!("invalid redirect address: {e}")))?;
 
-    // Validate interface and label to prevent pf rule injection
-    aifw_core::validation::validate_interface_name(&req.interface)
-        .map_err(|e| nat_bad_request(e.to_string()))?;
-    if let Some(ref label) = req.label {
-        aifw_core::validation::validate_label(label).map_err(|e| nat_bad_request(e.to_string()))?;
-    }
-
+    // Interface/label/family checks live in NatEngine::add (`validate_nat_rule`).
     let mut rule = NatRule::new(
         nat_type,
         Interface(req.interface),
@@ -142,13 +136,6 @@ pub async fn update_nat_rule(
 
     rule.nat_type = NatType::parse(&req.nat_type)
         .map_err(|_| nat_bad_request(format!("unknown NAT type '{}'", req.nat_type)))?;
-    // Validate interface and label to prevent pf rule injection
-    aifw_core::validation::validate_interface_name(&req.interface)
-        .map_err(|e| nat_bad_request(e.to_string()))?;
-    if let Some(ref label) = req.label {
-        aifw_core::validation::validate_label(label).map_err(|e| nat_bad_request(e.to_string()))?;
-    }
-
     rule.interface = Interface(req.interface);
     rule.protocol = Protocol::parse(&req.protocol)
         .map_err(|_| nat_bad_request(format!("unknown protocol '{}'", req.protocol)))?;

--- a/aifw-api/src/routes/rules.rs
+++ b/aifw-api/src/routes/rules.rs
@@ -193,19 +193,9 @@ pub async fn create_rule(
     rule.schedule_id = req.schedule_id;
     rule.gateway = validate_gateway_ref(&state, req.gateway).await?;
 
-    // Validate label and interface to prevent pf rule injection
-    if let Some(ref iface) = rule.interface {
-        aifw_core::validation::validate_interface_name(&iface.0).map_err(|_| bad_request())?;
-    }
-    if let Some(ref label) = rule.label {
-        aifw_core::validation::validate_label(label).map_err(|_| bad_request())?;
-    }
-
-    let rule = state
-        .rule_engine
-        .add(rule)
-        .await
-        .map_err(|_| bad_request())?;
+    // Interface/label/port/priority checks live in RuleEngine::add
+    // (`validate_rule`), which every path — API, CLI, restore — goes through.
+    let rule = state.rule_engine.add(rule).await.map_err(engine_error)?;
     state.set_pending(|p| p.firewall = true).await;
     Ok((StatusCode::CREATED, Json(ApiResponse { data: rule })))
 }
@@ -286,19 +276,11 @@ pub async fn update_rule(
     rule.gateway = validate_gateway_ref(&state, req.gateway).await?;
     rule.updated_at = chrono::Utc::now();
 
-    // Validate label and interface to prevent pf rule injection
-    if let Some(ref iface) = rule.interface {
-        aifw_core::validation::validate_interface_name(&iface.0).map_err(|_| bad_request())?;
-    }
-    if let Some(ref label) = rule.label {
-        aifw_core::validation::validate_label(label).map_err(|_| bad_request())?;
-    }
-
     state
         .rule_engine
         .update(rule.clone())
         .await
-        .map_err(|_| internal())?;
+        .map_err(engine_error)?;
     state.set_pending(|p| p.firewall = true).await;
     Ok(Json(ApiResponse { data: rule }))
 }

--- a/aifw-api/src/tests/rules.rs
+++ b/aifw-api/src/tests/rules.rs
@@ -537,3 +537,32 @@ async fn test_rule_gateway_round_trip_and_validation() {
     let body: Value = resp.json();
     assert!(body["data"]["gateway"].is_null());
 }
+
+/// #194: engines own validation. Handlers translate request → domain type
+/// and rely on `add`/`update` re-validating, mapped through
+/// `routes::engine_error`. This keeps a handler from growing its own copy
+/// of a check (which drifts) or skipping one (which weakens an invariant).
+#[test]
+fn handlers_do_not_call_core_validation_directly() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut hits = Vec::new();
+    for rel in [
+        "routes/rules.rs",
+        "routes/nat.rs",
+        "routes/geoip.rs",
+        "routes/vpn.rs",
+        "aliases.rs",
+    ] {
+        let text = std::fs::read_to_string(root.join(rel)).unwrap();
+        for (i, line) in text.lines().enumerate() {
+            if line.contains("aifw_core::validation::") && !line.trim_start().starts_with("//") {
+                hits.push(format!("{rel}:{}: {}", i + 1, line.trim()));
+            }
+        }
+    }
+    assert!(
+        hits.is_empty(),
+        "handler-side validation found — move it into the engine's add/update (#194):\n{}",
+        hits.join("\n")
+    );
+}

--- a/aifw-core/src/geoip.rs
+++ b/aifw-core/src/geoip.rs
@@ -99,6 +99,7 @@ impl GeoIpEngine {
     /// Insert a per-country block/allow rule row. pf tables aren't touched
     /// until the geo-IP rules are next applied
     pub async fn add(&self, rule: GeoIpRule) -> Result<GeoIpRule> {
+        Self::validate(&rule)?;
         Self::insert_rule_on(&self.pool, &rule).await?;
         tracing::info!(id = %rule.id, country = %rule.country, action = %rule.action, "geo-ip rule added");
         Ok(rule)
@@ -153,8 +154,21 @@ impl GeoIpEngine {
         row.into_rule()
     }
 
+    /// Field checks every write path shares (#194): the country code must
+    /// be a real ISO 3166-1 alpha-2 code and the label must be pf-safe.
+    pub fn validate(rule: &GeoIpRule) -> Result<()> {
+        // Re-run the shape check even for values built from the type — a
+        // deserialised snapshot can carry anything.
+        CountryCode::new(&rule.country.0)?;
+        if let Some(label) = rule.label.as_deref() {
+            crate::validation::validate_label(label)?;
+        }
+        Ok(())
+    }
+
     /// Update a geo-IP rule row. Fails with `NotFound` for an unknown id
     pub async fn update(&self, rule: &GeoIpRule) -> Result<()> {
+        Self::validate(rule)?;
         let result = sqlx::query(
             r#"UPDATE geoip_rules SET country = ?2, action = ?3, label = ?4, status = ?5, updated_at = ?6 WHERE id = ?1"#,
         )


### PR DESCRIPTION
Closes #194. Stacked on #687 (uses the renamed engine verbs). With #687 and this, epic #283 is done.

- Rules / NAT / alias handlers dropped their duplicated pre-checks (interface name, pf label, alias name). `RuleEngine::add/update` (`validate_rule`), `NatEngine` (`validate_nat_rule`) and `AliasEngine` (`validate_name`) already re-validate every write, so the API, CLI, config restore and cluster snapshots share one set of invariants and a handler can no longer skip or fork a check.
- `GeoIpEngine` gains `validate()` (country-code shape + pf-safe label) on `add`/`update` — it had none.
- New `routes::engine_error(AifwError) -> StatusCode`: `Validation` → 400 (debug-logged), `NotFound` → 404, anything else → 500 (error-logged). It replaces the `map_err(|_| bad_request())` / `map_err(|_| internal())` pairs that turned a DB failure into a 400 or a validation failure into a 500.
- Guard test (`tests::rules::handlers_do_not_call_core_validation_directly`) fails if `routes/{rules,nat,geoip,vpn}.rs` or `aliases.rs` call `aifw_core::validation::` again. CLAUDE.md documents the rule.

The existing injection tests (`test_pf_label_injection_blocked`, `test_interface_name_injection_blocked`, `test_nat_interface_injection_blocked`, alias name validation) still get their 400s — now from the engine. Clippy clean; api 238 / core tests green.