### PR TITLE
feat(ha): per-node peer API port; optional WireGuard teardown on CARP BACKUP (#487 #486)

### DIFF
--- a/aifw-api/src/cluster.rs
+++ b/aifw-api/src/cluster.rs
@@ -352,6 +352,9 @@ struct PfsyncReq {
     pub heartbeat_iface: Option<String>,
     pub heartbeat_interval_ms: Option<u32>,
     pub dhcp_link: bool,
+    /// #486; omitted ⇒ unchanged (older clients).
+    #[serde(default)]
+    pub wg_deconfigure_on_backup: Option<bool>,
 }
 
 async fn update_pfsync(
@@ -375,6 +378,9 @@ async fn update_pfsync(
     p.heartbeat_iface = r.heartbeat_iface.map(Interface);
     p.heartbeat_interval_ms = r.heartbeat_interval_ms;
     p.dhcp_link = r.dhcp_link;
+    if let Some(v) = r.wg_deconfigure_on_backup {
+        p.wg_deconfigure_on_backup = v;
+    }
     let p = s.cluster_engine.set_pfsync(p).await.map_err(|e| {
         tracing::error!(error = %e, "cluster: failed to set pfsync config");
         StatusCode::INTERNAL_SERVER_ERROR
@@ -398,13 +404,22 @@ struct NodeReq {
     pub name: String,
     pub address: IpAddr,
     pub role: ClusterRole,
+    /// Peer API port (#487); omitted ⇒ 8080.
+    #[serde(default)]
+    pub api_port: Option<u16>,
 }
 
 async fn create_node(
     State(s): State<AppState>,
     Json(r): Json<NodeReq>,
 ) -> Result<Json<ClusterNode>, StatusCode> {
-    let node = ClusterNode::new(r.name, r.address, r.role);
+    let mut node = ClusterNode::new(r.name, r.address, r.role);
+    if let Some(p) = r.api_port {
+        if p == 0 {
+            return Err(StatusCode::BAD_REQUEST);
+        }
+        node.api_port = p;
+    }
     let node = s.cluster_engine.add_node(node).await.map_err(|e| {
         tracing::error!(error = %e, "cluster: failed to add node");
         StatusCode::INTERNAL_SERVER_ERROR
@@ -419,11 +434,15 @@ async fn update_node(
 ) -> Result<Json<ClusterNode>, StatusCode> {
     let mut n = ClusterNode::new(r.name, r.address, r.role);
     n.id = id;
+    if let Some(p) = r.api_port {
+        n.api_port = p;
+    }
     s.cluster_engine
         .update_node(&n)
         .await
         .map_err(|e| match e {
             aifw_common::AifwError::NotFound(_) => StatusCode::NOT_FOUND,
+            aifw_common::AifwError::Validation(_) => StatusCode::BAD_REQUEST,
             _ => {
                 tracing::warn!(?e, "update_node failed");
                 StatusCode::INTERNAL_SERVER_ERROR
@@ -688,7 +707,67 @@ async fn internal_role_changed(
     {
         tracing::warn!(?e, "internal_role_changed: record_failover_event");
     }
+    // #486: WireGuard role-change subscriber. Off unless the operator set
+    // pfsync.wg_deconfigure_on_backup; runs detached so the daemon's
+    // loopback POST returns immediately.
+    match wg_role_action(&r.to, wg_deconfigure_enabled(&s).await) {
+        Some(WgRoleAction::Deconfigure) => {
+            let vpn = s.vpn_engine.clone();
+            tokio::spawn(async move {
+                match vpn.deconfigure_for_backup().await {
+                    Ok(n) => {
+                        tracing::info!(interfaces = n, "ha: WireGuard deconfigured for BACKUP")
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "ha: WireGuard deconfigure on BACKUP failed")
+                    }
+                }
+            });
+        }
+        Some(WgRoleAction::Reconfigure) => {
+            let vpn = s.vpn_engine.clone();
+            tokio::spawn(async move {
+                match vpn.reconfigure_for_master().await {
+                    Ok(n) => tracing::info!(tunnels = n, "ha: WireGuard reconfigured for MASTER"),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "ha: WireGuard reconfigure on MASTER failed")
+                    }
+                }
+            });
+        }
+        None => {}
+    }
     StatusCode::NO_CONTENT
+}
+
+/// What the WireGuard subscriber does on a CARP transition (#486).
+#[derive(Debug, PartialEq, Eq)]
+enum WgRoleAction {
+    /// Went BACKUP: tear the interfaces down.
+    Deconfigure,
+    /// Went MASTER: bring the `up` tunnels back.
+    Reconfigure,
+}
+
+/// Pure decision: only when the flag is on, only for the two canonical
+/// roles (`secondary` = BACKUP, `primary` = MASTER); `init`/`unknown` and
+/// anything else are ignored.
+fn wg_role_action(to_role: &str, enabled: bool) -> Option<WgRoleAction> {
+    if !enabled {
+        return None;
+    }
+    match to_role {
+        "secondary" => Some(WgRoleAction::Deconfigure),
+        "primary" => Some(WgRoleAction::Reconfigure),
+        _ => None,
+    }
+}
+
+async fn wg_deconfigure_enabled(s: &AppState) -> bool {
+    match s.cluster_engine.get_pfsync().await {
+        Ok(Some(p)) => p.wg_deconfigure_on_backup,
+        _ => false,
+    }
 }
 
 /// Maximum allowed byte length for the `detail` field in HealthChangedReq.
@@ -800,11 +879,7 @@ async fn snapshot_force(State(s): State<AppState>) -> StatusCode {
         _ => return StatusCode::PRECONDITION_FAILED,
     };
 
-    let url = format!(
-        "https://{}:{}/api/v1/cluster/snapshot",
-        peer.address,
-        aifw_common::DEFAULT_LOOPBACK_API_PORT
-    );
+    let url = format!("{}/api/v1/cluster/snapshot", peer.api_base());
     // #317: pinned to the master's certificate (learned on first contact).
     let client = match s
         .cluster_engine
@@ -1253,6 +1328,25 @@ async fn generate_loopback_key(
 #[cfg(test)]
 mod tests {
     use super::parse_pfctl_si_state_count;
+    use super::{WgRoleAction, wg_role_action};
+
+    /// #486: the WireGuard subscriber only acts when the flag is on and only
+    /// on the two canonical CARP roles.
+    #[test]
+    fn wg_role_action_gated_by_flag_and_role() {
+        assert_eq!(
+            wg_role_action("secondary", true),
+            Some(WgRoleAction::Deconfigure)
+        );
+        assert_eq!(
+            wg_role_action("primary", true),
+            Some(WgRoleAction::Reconfigure)
+        );
+        assert_eq!(wg_role_action("init", true), None);
+        assert_eq!(wg_role_action("unknown", true), None);
+        assert_eq!(wg_role_action("secondary", false), None);
+        assert_eq!(wg_role_action("primary", false), None);
+    }
 
     #[test]
     fn pfctl_si_parses_normal() {

--- a/aifw-api/src/tests/cluster.rs
+++ b/aifw-api/src/tests/cluster.rs
@@ -245,3 +245,114 @@ async fn derive_ha_peers_standalone_returns_no_peers() {
         "without short-circuit all 3 nodes would appear"
     );
 }
+
+/// #487: a peer's API port is stored per node (default 8080), validated,
+/// and used to build the peer base URL; #486: the WireGuard-on-BACKUP flag
+/// round-trips through the pfsync config (default off).
+#[tokio::test]
+async fn cluster_node_api_port_and_wg_backup_flag_round_trip() {
+    let state = crate::create_app_state_in_memory(plain_auth_settings())
+        .await
+        .unwrap();
+    let engine = state.cluster_engine.clone();
+    let server = TestServer::new(crate::build_router(state, None, "*", false));
+    let token = create_user_and_login(&server).await;
+
+    let resp = server
+        .post("/api/v1/cluster/nodes")
+        .authorization_bearer(&token)
+        .json(&json!({"name": "peer-default", "address": "10.9.9.10", "role": "secondary"}))
+        .await;
+    assert!(resp.status_code().is_success(), "{}", resp.text());
+    assert_eq!(resp.json::<Value>()["api_port"], 8080);
+
+    let resp = server
+        .post("/api/v1/cluster/nodes")
+        .authorization_bearer(&token)
+        .json(&json!({"name": "peer-alt", "address": "10.9.9.11", "role": "secondary", "api_port": 9443}))
+        .await;
+    assert!(resp.status_code().is_success(), "{}", resp.text());
+    let n: Value = resp.json();
+    let id = n["id"].as_str().unwrap().to_string();
+    assert_eq!(n["api_port"], 9443);
+    let stored = engine
+        .list_nodes()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|x| x.id.to_string() == id)
+        .unwrap();
+    assert_eq!(stored.api_port, 9443);
+    assert_eq!(stored.api_base(), "https://10.9.9.11:9443");
+
+    let resp = server
+        .post("/api/v1/cluster/nodes")
+        .authorization_bearer(&token)
+        .json(&json!({"name": "peer-bad", "address": "10.9.9.12", "role": "secondary", "api_port": 0}))
+        .await;
+    resp.assert_status(StatusCode::BAD_REQUEST);
+    let resp = server
+        .put(&format!("/api/v1/cluster/nodes/{id}"))
+        .authorization_bearer(&token)
+        .json(&json!({"name": "peer-alt", "address": "10.9.9.11", "role": "secondary", "api_port": 0}))
+        .await;
+    resp.assert_status(StatusCode::BAD_REQUEST);
+    let resp = server
+        .put(&format!("/api/v1/cluster/nodes/{id}"))
+        .authorization_bearer(&token)
+        .json(&json!({"name": "peer-alt", "address": "10.9.9.11", "role": "secondary", "api_port": 8443}))
+        .await;
+    assert!(resp.status_code().is_success(), "{}", resp.text());
+    let after = engine
+        .list_nodes()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|x| x.id.to_string() == id)
+        .unwrap();
+    assert_eq!(after.api_port, 8443);
+
+    let mut v6 = aifw_common::ClusterNode::new(
+        "v6".into(),
+        "fd00::2".parse().unwrap(),
+        aifw_common::ClusterRole::Secondary,
+    );
+    v6.api_port = 8080;
+    assert_eq!(v6.api_base(), "https://[fd00::2]:8080");
+
+    let body = json!({
+        "sync_interface": "em1", "sync_peer": null, "defer": true, "enabled": true,
+        "latency_profile": "conservative", "heartbeat_iface": null,
+        "heartbeat_interval_ms": null, "dhcp_link": false
+    });
+    let resp = server
+        .put("/api/v1/cluster/pfsync")
+        .authorization_bearer(&token)
+        .json(&body)
+        .await;
+    assert!(resp.status_code().is_success(), "{}", resp.text());
+    assert_eq!(resp.json::<Value>()["wg_deconfigure_on_backup"], false);
+    let mut on = body.clone();
+    on["wg_deconfigure_on_backup"] = json!(true);
+    let resp = server
+        .put("/api/v1/cluster/pfsync")
+        .authorization_bearer(&token)
+        .json(&on)
+        .await;
+    assert_eq!(resp.json::<Value>()["wg_deconfigure_on_backup"], true);
+    let resp = server
+        .put("/api/v1/cluster/pfsync")
+        .authorization_bearer(&token)
+        .json(&body)
+        .await;
+    assert_eq!(
+        resp.json::<Value>()["wg_deconfigure_on_backup"],
+        true,
+        "omitted field leaves the flag alone"
+    );
+    let resp = server
+        .get("/api/v1/cluster/pfsync")
+        .authorization_bearer(&token)
+        .await;
+    assert_eq!(resp.json::<Value>()["wg_deconfigure_on_backup"], true);
+}

--- a/aifw-cli/src/commands/cluster.rs
+++ b/aifw-cli/src/commands/cluster.rs
@@ -196,6 +196,7 @@ pub async fn cluster_pfsync_set(
     defer: bool,
     latency_profile: &str,
     dhcp_link: bool,
+    wg_deconfigure_on_backup: bool,
 ) -> anyhow::Result<()> {
     let body = serde_json::json!({
         "sync_interface": sync_interface,
@@ -206,6 +207,7 @@ pub async fn cluster_pfsync_set(
         "heartbeat_iface": null,
         "heartbeat_interval_ms": null,
         "dhcp_link": dhcp_link,
+        "wg_deconfigure_on_backup": wg_deconfigure_on_backup,
     });
     let v: serde_json::Value = api_put("/api/v1/cluster/pfsync", &body).await?;
     println!("{}", serde_json::to_string_pretty(&v)?);
@@ -226,8 +228,16 @@ pub async fn cluster_nodes_show(id: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn cluster_nodes_add(name: &str, address: &str, role: &str) -> anyhow::Result<()> {
-    let body = serde_json::json!({ "name": name, "address": address, "role": role });
+pub async fn cluster_nodes_add(
+    name: &str,
+    address: &str,
+    role: &str,
+    api_port: Option<u16>,
+) -> anyhow::Result<()> {
+    let mut body = serde_json::json!({ "name": name, "address": address, "role": role });
+    if let Some(p) = api_port {
+        body["api_port"] = serde_json::json!(p);
+    }
     let v: serde_json::Value = api_post("/api/v1/cluster/nodes", &body).await?;
     println!("{}", serde_json::to_string_pretty(&v)?);
     Ok(())

--- a/aifw-cli/src/main.rs
+++ b/aifw-cli/src/main.rs
@@ -240,6 +240,9 @@ enum PfsyncAction {
         latency_profile: String,
         #[arg(long, default_value_t = false)]
         dhcp_link: bool,
+        /// Tear WireGuard interfaces down on CARP BACKUP, back up on MASTER (#486)
+        #[arg(long, default_value_t = false)]
+        wg_deconfigure_on_backup: bool,
     },
 }
 
@@ -258,6 +261,9 @@ enum NodesAction {
         /// Node role: primary, secondary, or standalone
         #[arg(long, default_value = "secondary")]
         role: String,
+        /// Port the peer's API listens on (default 8080)
+        #[arg(long)]
+        api_port: Option<u16>,
     },
     /// Remove a cluster node
     Remove { id: String },
@@ -1659,6 +1665,7 @@ async fn main() -> anyhow::Result<()> {
                     defer,
                     latency_profile,
                     dhcp_link,
+                    wg_deconfigure_on_backup,
                 } => {
                     commands::cluster_pfsync_set(
                         &sync_interface,
@@ -1666,6 +1673,7 @@ async fn main() -> anyhow::Result<()> {
                         defer,
                         &latency_profile,
                         dhcp_link,
+                        wg_deconfigure_on_backup,
                     )
                     .await?
                 }
@@ -1677,7 +1685,8 @@ async fn main() -> anyhow::Result<()> {
                     name,
                     address,
                     role,
-                } => commands::cluster_nodes_add(&name, &address, &role).await?,
+                    api_port,
+                } => commands::cluster_nodes_add(&name, &address, &role, api_port).await?,
                 NodesAction::Remove { id } => commands::cluster_nodes_remove(&id).await?,
                 NodesAction::Repin { id, fingerprint } => {
                     commands::cluster_nodes_repin(&id, fingerprint.as_deref()).await?

--- a/aifw-common/src/ha.rs
+++ b/aifw-common/src/ha.rs
@@ -218,6 +218,13 @@ pub struct PfsyncConfig {
     pub heartbeat_interval_ms: Option<u32>,
     /// Link rDHCP HA state to this pfsync session (consumed in Commit 8 / #221)
     pub dhcp_link: bool,
+    /// Tear down WireGuard interfaces while this node is CARP BACKUP and
+    /// bring them back on MASTER (#486). Off by default: with the tunnels
+    /// bound to floating VIPs, wireguard-go on 0.0.0.0 already stops seeing
+    /// traffic on BACKUP; turn this on when a peer would otherwise keep a
+    /// handshake alive with the standby.
+    #[serde(default)]
+    pub wg_deconfigure_on_backup: bool,
     /// Creation timestamp
     pub created_at: DateTime<Utc>,
 }
@@ -236,6 +243,7 @@ impl PfsyncConfig {
             heartbeat_iface: None,
             heartbeat_interval_ms: None,
             dhcp_link: false,
+            wg_deconfigure_on_backup: false,
             created_at: Utc::now(),
         }
     }
@@ -364,6 +372,15 @@ pub struct ClusterNode {
     /// until first contact learns it (or after an operator re-pin).
     #[serde(default)]
     pub cert_fingerprint: Option<String>,
+    /// TCP port the peer's API listens on (#487). Defaults to
+    /// [`crate::DEFAULT_LOOPBACK_API_PORT`]; set it when a peer runs its
+    /// API on a non-default port.
+    #[serde(default = "default_api_port")]
+    pub api_port: u16,
+}
+
+fn default_api_port() -> u16 {
+    crate::DEFAULT_LOOPBACK_API_PORT
 }
 
 /// Health status of a cluster node (wire values are lowercase)
@@ -408,6 +425,16 @@ impl ClusterNode {
             software_version: None,
             last_pushed_cert_at: None,
             cert_fingerprint: None,
+            api_port: crate::DEFAULT_LOOPBACK_API_PORT,
+        }
+    }
+
+    /// Base URL for calling this peer's API (`https://<address>:<port>`).
+    /// IPv6 addresses are bracketed.
+    pub fn api_base(&self) -> String {
+        match self.address {
+            std::net::IpAddr::V6(v6) => format!("https://[{v6}]:{}", self.api_port),
+            v4 => format!("https://{v4}:{}", self.api_port),
         }
     }
 

--- a/aifw-core/src/acme_engine.rs
+++ b/aifw-core/src/acme_engine.rs
@@ -214,11 +214,7 @@ async fn push_cert_to_peers(
         };
         // Pinned to the peer's current certificate (#317).
         let client = cluster_engine.peer_client(n, std::time::Duration::from_secs(30))?;
-        let url = format!(
-            "https://{}:{}/api/v1/cluster/cert-push",
-            n.address,
-            aifw_common::DEFAULT_LOOPBACK_API_PORT
-        );
+        let url = format!("{}/api/v1/cluster/cert-push", n.api_base());
         let body = serde_json::json!({
             "cert_id": cert_id,
             "fullchain_pem": fullchain,

--- a/aifw-core/src/ha.rs
+++ b/aifw-core/src/ha.rs
@@ -89,6 +89,17 @@ impl ClusterEngine {
             crate::schema::add_column_if_missing(&self.pool, "cluster_nodes", column, "TEXT")
                 .await?;
         }
+        // #487: per-node peer API port.
+        crate::schema::add_column_if_missing(
+            &self.pool,
+            "cluster_nodes",
+            "api_port",
+            &format!(
+                "INTEGER NOT NULL DEFAULT {}",
+                aifw_common::DEFAULT_LOOPBACK_API_PORT
+            ),
+        )
+        .await?;
 
         sqlx::query(
             r#"
@@ -160,6 +171,7 @@ impl ClusterEngine {
             ("heartbeat_iface", "TEXT"),
             ("heartbeat_interval_ms", "INTEGER"),
             ("dhcp_link", "INTEGER NOT NULL DEFAULT 0"),
+            ("wg_deconfigure_on_backup", "INTEGER NOT NULL DEFAULT 0"),
         ] {
             crate::schema::add_column_if_missing(&self.pool, "pfsync_config", column, definition)
                 .await?;
@@ -288,8 +300,8 @@ impl ClusterEngine {
             r#"INSERT INTO pfsync_config
                (id, sync_interface, sync_peer, defer_mode, enabled,
                 latency_profile, heartbeat_iface, heartbeat_interval_ms, dhcp_link,
-                created_at)
-               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)"#,
+                created_at, wg_deconfigure_on_backup)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)"#,
         )
         .bind(config.id.to_string())
         .bind(&config.sync_interface.0)
@@ -301,6 +313,7 @@ impl ClusterEngine {
         .bind(config.heartbeat_interval_ms.map(|n| n as i64))
         .bind(config.dhcp_link)
         .bind(config.created_at.to_rfc3339())
+        .bind(config.wg_deconfigure_on_backup)
         .execute(&mut *conn)
         .await?;
         Ok(())
@@ -339,8 +352,8 @@ impl ClusterEngine {
 
         sqlx::query(
             r#"
-            INSERT INTO cluster_nodes (id, name, address, role, health, last_seen, config_version, created_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+            INSERT INTO cluster_nodes (id, name, address, role, health, last_seen, config_version, created_at, api_port)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
             "#,
         )
         .bind(node.id.to_string())
@@ -351,6 +364,7 @@ impl ClusterEngine {
         .bind(node.last_seen.to_rfc3339())
         .bind(node.config_version as i64)
         .bind(node.created_at.to_rfc3339())
+        .bind(i64::from(node.api_port))
         .execute(exec)
         .await?;
         Ok(())
@@ -377,16 +391,22 @@ impl ClusterEngine {
         Ok(())
     }
 
-    /// Update a node's name, address and role by id. Fails with `NotFound` if
-    /// the id doesn't exist
+    /// Update a node's name, address, role and API port by id. Fails with
+    /// `NotFound` if the id doesn't exist
     pub async fn update_node(&self, n: &ClusterNode) -> Result<()> {
+        if n.api_port == 0 {
+            return Err(AifwError::Validation(
+                "api_port must be 1-65535".to_string(),
+            ));
+        }
         let result = sqlx::query(
-            r#"UPDATE cluster_nodes SET name = ?1, address = ?2, role = ?3 WHERE id = ?4"#,
+            r#"UPDATE cluster_nodes SET name = ?1, address = ?2, role = ?3, api_port = ?5 WHERE id = ?4"#,
         )
         .bind(&n.name)
         .bind(n.address.to_string())
         .bind(n.role.to_string())
         .bind(n.id.to_string())
+        .bind(i64::from(n.api_port))
         .execute(&self.pool)
         .await?;
         if result.rows_affected() == 0 {
@@ -888,7 +908,8 @@ impl CarpVipRow {
 /// sqlx-sqlite column-count panic and blocks column pruning; an explicit list
 /// keeps the count deterministic and matches the `PfsyncRow` fields exactly.
 const PFSYNC_CONFIG_COLUMNS: &str = "id, sync_interface, sync_peer, defer_mode, enabled, \
-    created_at, latency_profile, heartbeat_iface, heartbeat_interval_ms, dhcp_link";
+    created_at, latency_profile, heartbeat_iface, heartbeat_interval_ms, dhcp_link, \
+    wg_deconfigure_on_backup";
 
 #[derive(sqlx::FromRow)]
 struct PfsyncRow {
@@ -902,6 +923,7 @@ struct PfsyncRow {
     heartbeat_interval_ms: Option<i64>,
     dhcp_link: bool,
     created_at: String,
+    wg_deconfigure_on_backup: bool,
 }
 
 impl PfsyncRow {
@@ -922,6 +944,7 @@ impl PfsyncRow {
                 .heartbeat_interval_ms
                 .and_then(|n| u32::try_from(n).ok()),
             dhcp_link: self.dhcp_link,
+            wg_deconfigure_on_backup: self.wg_deconfigure_on_backup,
             created_at: parse_dt(&self.created_at)?,
         })
     }
@@ -933,7 +956,8 @@ impl PfsyncRow {
 /// Note: `peer_api_key`/`peer_api_key_hash` exist on the table but are NOT part
 /// of `ClusterNodeRow`, so they are intentionally omitted here.
 const CLUSTER_NODES_COLUMNS: &str = "id, name, address, role, health, last_seen, \
-    config_version, created_at, software_version, last_pushed_cert_at, cert_fingerprint";
+    config_version, created_at, software_version, last_pushed_cert_at, cert_fingerprint, \
+    api_port";
 
 #[derive(sqlx::FromRow)]
 struct ClusterNodeRow {
@@ -948,6 +972,7 @@ struct ClusterNodeRow {
     software_version: Option<String>,
     last_pushed_cert_at: Option<String>,
     cert_fingerprint: Option<String>,
+    api_port: i64,
 }
 
 impl ClusterNodeRow {
@@ -977,6 +1002,10 @@ impl ClusterNodeRow {
             software_version: self.software_version,
             last_pushed_cert_at,
             cert_fingerprint: self.cert_fingerprint,
+            api_port: u16::try_from(self.api_port)
+                .ok()
+                .filter(|p| *p > 0)
+                .unwrap_or(aifw_common::DEFAULT_LOOPBACK_API_PORT),
         })
     }
 }

--- a/aifw-core/src/vpn.rs
+++ b/aifw-core/src/vpn.rs
@@ -605,9 +605,9 @@ impl VpnEngine {
         // ListenAddress for explicit binding; if AiFw ever migrates to one,
         // this is where the per-iface bind would be wired.
         //
-        // TODO(#486): WG role-change subscriber for explicit wg-quick down on BACKUP
-        // (default-false `wg_deconfigure_on_backup` flag, deferred — out of
-        // scope for Commit 9 #222).
+        // #486: with `wg_deconfigure_on_backup` on, `deconfigure_for_backup`
+        // /`reconfigure_for_master` tear these interfaces down/up on CARP
+        // transitions without touching the DB status.
         let listen_port_s = tunnel.listen_port.to_string();
         let output = crate::sudo::wg(
             "set",
@@ -798,6 +798,45 @@ impl VpnEngine {
             "peer_count": peers.len(),
             "peers": peers,
         }))
+    }
+
+    /// CARP went BACKUP (#486): destroy every WireGuard interface whose
+    /// tunnel is `up` in the DB — but leave the DB status alone, so
+    /// [`Self::reconfigure_for_master`] (and boot recovery) know to bring
+    /// them back. Returns the number of interfaces torn down.
+    pub async fn deconfigure_for_backup(&self) -> Result<u32> {
+        let tunnels = self.list_wg_tunnels().await?;
+        let mut n = 0u32;
+        for t in tunnels.iter().filter(|t| t.status == VpnStatus::Up) {
+            let iface = &t.interface.0;
+            match crate::sudo::ifconfig(iface, "destroy", &[]).await {
+                Ok(o) if o.status.success() => {
+                    n += 1;
+                    tracing::info!(id = %t.id, iface, "WireGuard interface torn down for CARP BACKUP");
+                }
+                Ok(o) => {
+                    tracing::warn!(id = %t.id, iface, stderr = %String::from_utf8_lossy(&o.stderr).trim(),
+                    "ha: wg teardown on BACKUP failed")
+                }
+                Err(e) => {
+                    tracing::warn!(id = %t.id, iface, error = %e, "ha: wg teardown on BACKUP failed to run")
+                }
+            }
+        }
+        // Drop the pass/NAT rules for the interfaces that no longer exist;
+        // reconfigure_for_master re-applies them.
+        if n > 0
+            && let Err(e) = self.pf.flush_rules(&self.anchor).await
+        {
+            tracing::warn!(error = %e, "ha: could not flush aifw-vpn anchor on BACKUP");
+        }
+        Ok(n)
+    }
+
+    /// CARP went MASTER (#486): bring back every tunnel that is `up` in the
+    /// DB. Idempotent — `start_tunnel` recreates the interface from scratch.
+    pub async fn reconfigure_for_master(&self) -> Result<u32> {
+        self.start_active_tunnels().await
     }
 
     /// Start all tunnels that have status "up" in the DB (for boot recovery).

--- a/aifw-daemon/src/cluster_replicator.rs
+++ b/aifw-daemon/src/cluster_replicator.rs
@@ -100,11 +100,7 @@ impl ClusterReplicator {
 
             // Cheap hash probe — we don't need the full snapshot from the peer,
             // only whether it matches what we already have.
-            let peer_hash_url = format!(
-                "https://{}:{}/api/v1/cluster/snapshot/hash",
-                peer.address,
-                aifw_common::DEFAULT_LOOPBACK_API_PORT
-            );
+            let peer_hash_url = format!("{}/api/v1/cluster/snapshot/hash", peer.api_base());
             let peer_hash = match client
                 .get(&peer_hash_url)
                 .header("Authorization", format!("ApiKey {key}"))
@@ -132,11 +128,7 @@ impl ClusterReplicator {
             // Hashes differ — push the snapshot body we already fetched above.
             // No second loopback call, so the pushed body and local_hash are
             // guaranteed to match.
-            let peer_put_url = format!(
-                "https://{}:{}/api/v1/cluster/snapshot",
-                peer.address,
-                aifw_common::DEFAULT_LOOPBACK_API_PORT
-            );
+            let peer_put_url = format!("{}/api/v1/cluster/snapshot", peer.api_base());
             let resp = client
                 .put(&peer_put_url)
                 .header("Authorization", format!("ApiKey {key}"))

--- a/aifw-ui/src/app/cluster/components/NodesSection.tsx
+++ b/aifw-ui/src/app/cluster/components/NodesSection.tsx
@@ -51,7 +51,7 @@ export function NodesSection({
   };
 
   const openEditNode = (n: Node) => {
-    setNodeForm({ name: n.name, address: n.address, role: n.role });
+    setNodeForm({ name: n.name, address: n.address, role: n.role, api_port: String(n.api_port ?? 8080) });
     setEditingNodeId(n.id);
     setShowNodeForm(true);
   };
@@ -122,6 +122,20 @@ export function NodesSection({
                 <option value="standalone">Standalone</option>
               </select>
             </div>
+            <div>
+              <label className={labelCls}>API port</label>
+              <input
+                type="number"
+                min={1}
+                max={65535}
+                value={nodeForm.api_port}
+                onChange={(e) =>
+                  setNodeForm((f) => ({ ...f, api_port: e.target.value }))
+                }
+                className={inputCls}
+              />
+              <p className="mt-1 text-[11px] text-[var(--text-muted)]">Port the peer&apos;s API listens on (default 8080).</p>
+            </div>
           </div>
         </FormCard>
       )}
@@ -166,7 +180,7 @@ export function NodesSection({
                   className="border-b border-gray-700/50 hover:bg-gray-700/30 transition-colors"
                 >
                   <td className="py-2.5 px-4">{n.name}</td>
-                  <td className="py-2.5 px-4 font-mono">{n.address}</td>
+                  <td className="py-2.5 px-4 font-mono">{n.address}{n.api_port && n.api_port !== 8080 ? `:${n.api_port}` : ""}</td>
                   <td className="py-2.5 px-4">{n.role}</td>
                   <td className="py-2.5 px-4">{n.health}</td>
                   <td className="py-2.5 px-4">

--- a/aifw-ui/src/app/cluster/components/PfsyncSection.tsx
+++ b/aifw-ui/src/app/cluster/components/PfsyncSection.tsx
@@ -51,6 +51,7 @@ export function PfsyncSection({
           ? String(pfsync.heartbeat_interval_ms)
           : "",
         dhcp_link: pfsync.dhcp_link,
+        wg_deconfigure_on_backup: pfsync.wg_deconfigure_on_backup ?? false,
       });
     } else {
       setPfsyncForm(defaultPfsyncForm);
@@ -274,6 +275,23 @@ export function PfsyncSection({
                 />
                 <span className="text-sm text-gray-300">DHCP Link</span>
               </label>
+            </div>
+            <div>
+              <label className="flex items-center gap-2 cursor-pointer select-none"
+                title="Tear WireGuard interfaces down while this node is CARP BACKUP and bring them back on MASTER. Leave off unless a peer keeps a handshake alive with the standby.">
+                <input
+                  type="checkbox"
+                  checked={pfsyncForm.wg_deconfigure_on_backup}
+                  onChange={(e) =>
+                    setPfsyncForm((f) => ({
+                      ...f,
+                      wg_deconfigure_on_backup: e.target.checked,
+                    }))
+                  }
+                  className="w-4 h-4 rounded border-gray-600 bg-gray-900 text-blue-500 focus:ring-blue-500 focus:ring-offset-0"
+                />
+                <span className="text-sm text-gray-300">Deconfigure WireGuard on BACKUP</span>
+              </label>
               <p className="text-xs text-gray-500 mt-0.5 ml-6">
                 Auto-derives the rDHCP HA peer list from the cluster nodes —
                 when enabled, you don&apos;t have to enter peer addresses again
@@ -298,6 +316,7 @@ export function PfsyncSection({
           </div>
           <div>Latency profile: {pfsync.latency_profile}</div>
           <div>DHCP link: {pfsync.dhcp_link ? "yes" : "no"}</div>
+          <div>WireGuard down on BACKUP: {pfsync.wg_deconfigure_on_backup ? "yes" : "no"}</div>
           <div>Enabled: {pfsync.enabled ? "yes" : "no"}</div>
           <div className="pt-1">
             <button

--- a/aifw-ui/src/hooks/useCluster.ts
+++ b/aifw-ui/src/hooks/useCluster.ts
@@ -261,6 +261,7 @@ export function useCluster() {
           ? parseInt(form.heartbeat_interval_ms, 10)
           : null,
         dhcp_link: form.dhcp_link,
+        wg_deconfigure_on_backup: form.wg_deconfigure_on_backup,
       };
       await updatePfsync(body);
       onSaved?.();
@@ -298,10 +299,17 @@ export function useCluster() {
     setSavingNode(true);
     setError(null);
     try {
+      const port = parseInt(form.api_port, 10);
+      if (!Number.isFinite(port) || port < 1 || port > 65535) {
+        setError("API port must be 1–65535");
+        setSavingNode(false);
+        return;
+      }
       const body = {
         name: form.name,
         address: form.address,
         role: form.role,
+        api_port: port,
       };
       if (editingNodeId) {
         await updateNode(editingNodeId, body);

--- a/aifw-ui/src/lib/api/cluster.ts
+++ b/aifw-ui/src/lib/api/cluster.ts
@@ -26,6 +26,8 @@ export type Pfsync = {
   heartbeat_iface: string | null;
   heartbeat_interval_ms: number | null;
   dhcp_link: boolean;
+  /** Tear WireGuard down on CARP BACKUP, back up on MASTER (#486). */
+  wg_deconfigure_on_backup?: boolean;
   created_at: string;
 };
 
@@ -38,6 +40,8 @@ export type Node = {
   last_seen: string;
   /** SHA-256 of the peer's API certificate that our calls are pinned to (#317); null until first contact. */
   cert_fingerprint?: string | null;
+  /** Port the peer's API listens on (#487); 8080 unless configured. */
+  api_port?: number;
 };
 
 export type HealthCheck = {
@@ -84,12 +88,14 @@ export type PfsyncRequest = {
   heartbeat_iface: string | null;
   heartbeat_interval_ms: number | null;
   dhcp_link: boolean;
+  wg_deconfigure_on_backup?: boolean;
 };
 
 export type NodeRequest = {
   name: string;
   address: string;
   role: string;
+  api_port?: number;
 };
 
 export type HealthCheckRequest = {
@@ -131,6 +137,7 @@ export type PfsyncFormState = {
   heartbeat_iface: string;
   heartbeat_interval_ms: string;
   dhcp_link: boolean;
+  wg_deconfigure_on_backup: boolean;
 };
 
 export const defaultPfsyncForm: PfsyncFormState = {
@@ -142,18 +149,21 @@ export const defaultPfsyncForm: PfsyncFormState = {
   heartbeat_iface: "",
   heartbeat_interval_ms: "",
   dhcp_link: false,
+  wg_deconfigure_on_backup: false,
 };
 
 export type NodeFormState = {
   name: string;
   address: string;
   role: string;
+  api_port: string;
 };
 
 export const defaultNodeForm: NodeFormState = {
   name: "",
   address: "",
   role: "secondary",
+  api_port: "8080",
 };
 
 export type HcFormState = {

--- a/docs/ha.md
+++ b/docs/ha.md
@@ -72,6 +72,14 @@ If your network does not satisfy "trusted pfsync segment," do not enable HA repl
 4. After both nodes are up: visit `https://<node-A-mgmt-ip>/cluster` and confirm both nodes appear in the table with a green health status.
 5. Verify with `aifw cluster verify` on each node, then run `scripts/ha-verify.sh node-a node-b` over SSH for a pair-wide check.
 
+### Peer API port
+
+Every cluster call to a peer (snapshot replication, health probes, cert push) goes to `https://<peer address>:<api_port>`. The port defaults to 8080 and is stored per node (`api_port` on `POST/PUT /api/v1/cluster/nodes`, the *API port* field on the Cluster → Nodes form, `aifw cluster nodes add --api-port`) — set it when a peer's API listens elsewhere.
+
+### WireGuard on the standby
+
+WireGuard listens on `0.0.0.0`, so a tunnel that terminates on a CARP VIP simply stops seeing traffic when the node goes BACKUP and picks it up again on MASTER — no action needed in the common case. If a remote peer keeps a handshake alive with the standby (a WAN VIP that is *also* reachable through the standby's own address), turn on **Deconfigure WireGuard on BACKUP** (`wg_deconfigure_on_backup` on `PUT /api/v1/cluster/pfsync`, `aifw cluster pfsync set --wg-deconfigure-on-backup`, or the checkbox in Cluster → pfsync). With it on, a transition to BACKUP destroys every `up` WireGuard interface (the DB status stays `up`) and a transition to MASTER recreates them; the flag is off by default.
+
 ## Latency profiles
 
 The `pfsync.latency_profile` setting controls CARP advertisement timing and therefore the detection window for unplanned failures.


### PR DESCRIPTION
Closes #487, closes #486.

**#487 peer API port** — `ClusterNode.api_port` (new `cluster_nodes.api_port INTEGER NOT NULL DEFAULT 8080` via `schema::add_column_if_missing`; validated 1–65535 on create/update) and `ClusterNode::api_base()` (`https://<addr>:<port>`, IPv6 bracketed). Every peer call now uses it: the daemon replicator's hash probe + snapshot push, the API's snapshot pull, and ACME cert-push. `DEFAULT_LOOPBACK_API_PORT` remains only as the default. Exposed on `POST/PUT /api/v1/cluster/nodes` (`api_port`, optional), the Cluster → Nodes form (new *API port* field; the table shows `addr:port` when non-default), and `aifw cluster nodes add --api-port`.

**#486 WireGuard on BACKUP** — `pfsync_config.wg_deconfigure_on_backup` (default **off**; `PUT /cluster/pfsync` accepts it, omitted ⇒ unchanged; UI checkbox on the pfsync form; `aifw cluster pfsync set --wg-deconfigure-on-backup`). `VpnEngine::deconfigure_for_backup()` destroys every WireGuard interface whose tunnel is `up` in the DB — leaving the DB status alone — and flushes the `aifw-vpn` anchor; `reconfigure_for_master()` re-runs `start_active_tunnels`. The daemon's `role-changed` POST dispatches them (`wg_role_action`: only with the flag on, only for `secondary`→teardown / `primary`→bring-up; `init`/`unknown` ignored) on a detached task so the loopback call returns immediately. The inline TODO in `vpn.rs` is gone.

Tests: `wg_role_action` gating; API round-trip for `api_port` (default, explicit, 0 rejected on create+update, update sticks, `api_base` incl. IPv6) and the pfsync flag (default off, set, omitted-leaves-alone, GET). Docs: `docs/ha.md` *Peer API port* + *WireGuard on the standby*.

**Not exercised on real hardware**: the actual `ifconfig destroy` / re-create path needs the two-VM lab (both VMs were unreachable from here) — the flag is off by default precisely so nothing changes until an operator opts in.