### PR TITLE
feat(dhcp): DHCP relay counters on the metrics page (#159)

### DIFF
--- a/aifw-ui/src/app/dhcp/metrics/page.tsx
+++ b/aifw-ui/src/app/dhcp/metrics/page.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { api } from "@/lib/api";
 import { usePolling } from "@/lib/usePolling";
+import {
+  RELAY_ABUSE_REASONS,
+  RELAY_DROP_REASONS,
+  RELAY_REASON_HELP,
+  parseRelayMetrics,
+  relayDelta,
+  type RelayMetrics,
+} from "@/lib/dhcp/relayMetrics";
 
 interface PoolStats {
   subnet: string;
@@ -15,6 +23,11 @@ interface PoolStats {
 export default function DhcpMetricsPage() {
   const [stats, setStats] = useState<PoolStats[]>([]);
   const [rawMetrics, setRawMetrics] = useState("");
+  // Relay counters (#159): current sample plus the delta since the previous
+  // poll so a burst of drops stands out even against a large lifetime total.
+  const [relay, setRelay] = useState<RelayMetrics | null>(null);
+  const [relayDeltaState, setRelayDeltaState] = useState<RelayMetrics | null>(null);
+  const prevRelay = useRef<RelayMetrics | null>(null);
   const [loading, setLoading] = useState(true);
   const [showRaw, setShowRaw] = useState(false);
   const [autoRefresh, setAutoRefresh] = useState(true);
@@ -30,7 +43,12 @@ export default function DhcpMetricsPage() {
 
   const fetchRawMetrics = useCallback(async () => {
     try {
-      setRawMetrics(await api.getText("/api/v1/dhcp/metrics"));
+      const text = await api.getText("/api/v1/dhcp/metrics");
+      setRawMetrics(text);
+      const parsed = parseRelayMetrics(text);
+      setRelayDeltaState(relayDelta(prevRelay.current, parsed));
+      prevRelay.current = parsed;
+      setRelay(parsed);
     } catch {
       setRawMetrics("# rDHCP metrics unavailable (service may not be running)");
     }
@@ -130,6 +148,60 @@ export default function DhcpMetricsPage() {
           ))}
         </div>
       )}
+
+      {/* DHCP relay (#159) — global counters from rDHCP */}
+      {relay?.present && (() => {
+        const abuse = RELAY_ABUSE_REASONS.some((r) => (relayDeltaState?.dropped[r] ?? 0) > 0);
+        return (
+          <div className={`bg-[var(--bg-card)] border rounded-lg p-5 ${abuse ? "border-red-500/50" : "border-[var(--border)]"}`}>
+            <div className="flex items-center justify-between mb-3">
+              <div>
+                <h2 className="text-sm font-medium text-[var(--text-primary)]">DHCP relay</h2>
+                <p className="text-xs text-[var(--text-muted)]">Relayed (giaddr ≠ 0) DHCPv4 traffic across all subnets — lifetime totals, with the change since the last refresh.</p>
+              </div>
+              {abuse && (
+                <span className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full border border-red-500/40 text-red-400 bg-red-500/10">
+                  new untrusted / bad-giaddr drops
+                </span>
+              )}
+            </div>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 text-center text-xs mb-4">
+              <div>
+                <span className="block text-[var(--text-muted)]">Received</span>
+                <span className="text-lg font-bold text-[var(--text-primary)]">{relay.received.toLocaleString()}</span>
+                {relayDeltaState && relayDeltaState.received > 0 && <span className="block text-[10px] text-cyan-400">+{relayDeltaState.received}</span>}
+              </div>
+              <div>
+                <span className="block text-[var(--text-muted)]">Accepted</span>
+                <span className="text-lg font-bold text-green-400">{relay.accepted.toLocaleString()}</span>
+                {relayDeltaState && relayDeltaState.accepted > 0 && <span className="block text-[10px] text-green-400">+{relayDeltaState.accepted}</span>}
+              </div>
+              <div>
+                <span className="block text-[var(--text-muted)]">Dropped</span>
+                <span className={`text-lg font-bold ${relay.droppedTotal > 0 ? "text-red-400" : "text-[var(--text-primary)]"}`}>{relay.droppedTotal.toLocaleString()}</span>
+                {relayDeltaState && relayDeltaState.droppedTotal > 0 && <span className="block text-[10px] text-red-400">+{relayDeltaState.droppedTotal}</span>}
+              </div>
+            </div>
+            <table className="w-full text-xs">
+              <thead className="text-[var(--text-muted)] uppercase tracking-wider text-[10px]">
+                <tr><th className="text-left py-1">Drop reason</th><th className="text-right py-1">Total</th><th className="text-right py-1">Since refresh</th></tr>
+              </thead>
+              <tbody>
+                {RELAY_DROP_REASONS.map((r) => {
+                  const hot = RELAY_ABUSE_REASONS.includes(r) && (relayDeltaState?.dropped[r] ?? 0) > 0;
+                  return (
+                    <tr key={r} className={`border-t border-[var(--border)] ${hot ? "text-red-300" : ""}`} title={RELAY_REASON_HELP[r]}>
+                      <td className="py-1.5 font-mono">{r}<span className="ml-2 font-sans text-[var(--text-muted)] hidden sm:inline">— {RELAY_REASON_HELP[r]}</span></td>
+                      <td className="py-1.5 text-right font-mono">{relay.dropped[r].toLocaleString()}</td>
+                      <td className="py-1.5 text-right font-mono">{(relayDeltaState?.dropped[r] ?? 0) > 0 ? `+${relayDeltaState?.dropped[r]}` : "–"}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        );
+      })()}
 
       {/* Raw Prometheus Metrics */}
       <div className="bg-[var(--bg-card)] border border-[var(--border)] rounded-lg overflow-hidden">

--- a/aifw-ui/src/lib/dhcp/relayMetrics.ts
+++ b/aifw-ui/src/lib/dhcp/relayMetrics.ts
@@ -1,0 +1,78 @@
+/// DHCPv4 relay counters parsed out of rDHCP's Prometheus text (#159).
+///
+/// rDHCP exposes `rdhcpd_dhcpv4_relayed_received_total` and
+/// `rdhcpd_dhcpv4_relayed_dropped_total{reason="…"}` as *global* counters
+/// (no subnet label), so this is a top-level view.
+
+export const RELAY_DROP_REASONS = [
+  "accept_relayed_disabled",
+  "bad_giaddr",
+  "untrusted_relay",
+  "rate_limit",
+] as const;
+export type RelayDropReason = (typeof RELAY_DROP_REASONS)[number];
+
+export interface RelayMetrics {
+  received: number;
+  dropped: Record<RelayDropReason, number>;
+  droppedTotal: number;
+  accepted: number;
+  /** True when the metrics text carried the relay series at all. */
+  present: boolean;
+}
+
+/** Reasons that indicate probing/abuse rather than misconfiguration. */
+export const RELAY_ABUSE_REASONS: RelayDropReason[] = ["untrusted_relay", "bad_giaddr"];
+
+export const RELAY_REASON_HELP: Record<RelayDropReason, string> = {
+  accept_relayed_disabled: "Relayed packets arrived while “Accept relayed requests” is off",
+  bad_giaddr: "giaddr is a bogon or matches no configured subnet — a misconfigured or spoofing relay",
+  untrusted_relay: "Relay source IP not in the subnet’s trusted-relays list",
+  rate_limit: "Per-relay-source rate limiter engaged",
+};
+
+const emptyDropped = (): Record<RelayDropReason, number> => ({
+  accept_relayed_disabled: 0,
+  bad_giaddr: 0,
+  untrusted_relay: 0,
+  rate_limit: 0,
+});
+
+/// Parse the relay series out of a Prometheus exposition body. Tolerates
+/// missing series (older rDHCP) — `present` is false and everything is 0.
+export function parseRelayMetrics(text: string): RelayMetrics {
+  const m: RelayMetrics = { received: 0, dropped: emptyDropped(), droppedTotal: 0, accepted: 0, present: false };
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    let match = /^rdhcpd_dhcpv4_relayed_received_total(?:\{[^}]*\})?\s+([0-9.eE+-]+)/.exec(line);
+    if (match) {
+      m.received = Number(match[1]) || 0;
+      m.present = true;
+      continue;
+    }
+    match = /^rdhcpd_dhcpv4_relayed_dropped_total\{([^}]*)\}\s+([0-9.eE+-]+)/.exec(line);
+    if (match) {
+      const reasonMatch = /reason="([^"]+)"/.exec(match[1]);
+      const reason = reasonMatch?.[1] as RelayDropReason | undefined;
+      if (reason && reason in m.dropped) {
+        m.dropped[reason] = Number(match[2]) || 0;
+        m.present = true;
+      }
+    }
+  }
+  m.droppedTotal = RELAY_DROP_REASONS.reduce((a, r) => a + m.dropped[r], 0);
+  m.accepted = Math.max(0, m.received - m.droppedTotal);
+  return m;
+}
+
+/// Counter deltas between two samples (0 when the counter reset).
+export function relayDelta(prev: RelayMetrics | null, cur: RelayMetrics): RelayMetrics {
+  if (!prev) return { ...cur, received: 0, dropped: emptyDropped(), droppedTotal: 0, accepted: 0 };
+  const d = (a: number, b: number) => (b >= a ? b - a : 0);
+  const dropped = emptyDropped();
+  for (const r of RELAY_DROP_REASONS) dropped[r] = d(prev.dropped[r], cur.dropped[r]);
+  const droppedTotal = RELAY_DROP_REASONS.reduce((a, r) => a + dropped[r], 0);
+  const received = d(prev.received, cur.received);
+  return { received, dropped, droppedTotal, accepted: Math.max(0, received - droppedTotal), present: cur.present };
+}

--- a/docs/docs/dhcp.md
+++ b/docs/docs/dhcp.md
@@ -107,6 +107,19 @@ aifw dhcp restart
 | `GET` | `/api/v1/dhcp/metrics` | Prometheus-style metrics |
 | `GET` | `/api/v1/dhcp/logs` | Recent rDHCP logs |
 
+## Relay metrics
+
+DHCP → Pool Metrics shows a **DHCP relay** card when rDHCP reports relay activity: relayed packets received (`giaddr ≠ 0`), accepted, and dropped by reason, both lifetime totals and the change since the last refresh. Counters are global (rDHCP does not label them per subnet). Drop reasons:
+
+| reason | meaning |
+|---|---|
+| `accept_relayed_disabled` | relayed packets arrived while *Accept relayed requests* is off |
+| `bad_giaddr` | `giaddr` is a bogon or matches no configured subnet — a misconfigured or spoofing relay |
+| `untrusted_relay` | relay source IP is not in the subnet's trusted-relays list |
+| `rate_limit` | the per-relay-source limiter engaged |
+
+New `untrusted_relay` / `bad_giaddr` drops since the previous refresh highlight the card and the row in red — those are the abuse signals; the other two are configuration.
+
 ## HA failover
 
 The DHCP `HaConfig` carries three modes: `standalone`, `active-active`, and `raft`.


### PR DESCRIPTION
Closes #159.

`DHCP → Pool Metrics` gains a **DHCP relay** card built from the rDHCP Prometheus text the page already fetches (`/api/v1/dhcp/metrics`): `rdhcpd_dhcpv4_relayed_received_total` and `rdhcpd_dhcpv4_relayed_dropped_total{reason=…}` → received / accepted / dropped, plus a per-reason table (`accept_relayed_disabled`, `bad_giaddr`, `untrusted_relay`, `rate_limit`) with lifetime totals and the change since the previous refresh. New `untrusted_relay` / `bad_giaddr` drops since the last poll turn the card border and rows red — the abuse signal from the issue. Older rDHCP builds without the series just don't show the card. Parser lives in `src/lib/dhcp/relayMetrics.ts` (tolerant of missing series and counter resets). Reasons documented in `docs/docs/dhcp.md`.

One acceptance item deliberately not done: **per-subnet** breakdown. rDHCP emits these counters without a `subnet` label (`src/api/metrics.rs` in rDHCP), so there's nothing per-subnet to show; that needs an rDHCP-side change first — noted on the issue.