### PR TITLE
release: v5.115.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "5.114.1"
+version = "5.115.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.114.1",
+  "version": "5.115.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.114.1",
+      "version": "5.115.0",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.114.1",
+  "version": "5.115.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Version bump only (`Cargo.toml`, `aifw-ui/package.json` + lock) — 5.114.1 → **5.115.0** (minor: feature release). 43 commits since v5.114.1.

**Gate on this branch:** clippy clean; tests: core 280 / api 240 / everything else 455, all green; UI lint + static export OK; `aifw --version` reports 5.115.0 (build-local/CI guard will match the tag).

### Highlights
- **Sign in with Google / GitHub / OIDC** — the OAuth callback now completes: PKCE, account linking (verified email or auto-provisioned viewer), TOTP second step, SSO settings page (#170).
- **Secrets**: sealed at rest with AES-256-GCM under `/var/db/aifw/secrets.key` (#298); config exports / S3 uploads / history views redact or passphrase-wrap secrets (#313); cluster + loopback HTTPS pinned to certificate fingerprints (#317); `X-Forwarded-For` trusted only from configured proxies (#308); the daemon's service user has a non-admin `system` role (#318); P3 sweep (#306 #319 #324 #325 #446 #455).
- **NAT**: `no nat` bypass + `static-port` (with OPNsense import) (#253); nat46/nat64 explicit translated destination (#596).
- **Ops**: size-based log rotation (#205); OS-upgrade race hardening (#645 #646); IDS `$HOME_NET`/port variables (#485); DHCP relay counters (#159); per-node peer API port + optional WireGuard teardown on CARP BACKUP, off by default (#487 #486); UI error boundaries / real 404 (#452); a11y modals + toggles (#451 #449).
- **Runtime**: explicit tokio sizing + mimalloc + runtime metrics + opt-in tokio-console (#409 #412 #413 #185); WS delta frames / caps (#179).
- **Codebase**: probe-then-alter schema helper (#193), engines own validation (#194), verb + anchor conventions (#199 #198), god-module/test splits (#190 #191 #439 #447), shared `freebsd/lib-build.sh` for CI + local builds (#203), `aifw-ai` gated (#171), broad new test coverage (#172–174 #442).

### Upgrade notes
- First start after upgrade seals legacy plaintext secrets in place (`secrets.key` is created beside `jwt.key`); back up `aifw.db` **and** `secrets.key` together from now on.
- Config exports are redacted by default; use the passphrase (portable) export for a backup restorable on another box.
- CI `workflow_dispatch` version input must equal `Cargo.toml`'s version (5.115.0).
- Two things not yet exercised on FreeBSD hardware: the shared `lib-build.sh` path (`build-update.sh` run) and the WireGuard-on-BACKUP teardown (flag off by default).

After merge: `sudo sh freebsd/build-update.sh 5.115.0` on the build VM, then `release.sh` (signs + publishes; pre-release first per policy). No tag pushed from here.