### PR TITLE
fix(setup): import the FreeBSD-only helpers the apply/ split left unresolved; CI builds every binary on FreeBSD

### DIFF
--- a/.github/workflows/freebsd-functional.yml
+++ b/.github/workflows/freebsd-functional.yml
@@ -12,6 +12,11 @@ on:
       - 'aifw-common/**'
       - 'aifw-api/**'
       - 'aifw-daemon/**'
+      - 'aifw-setup/**'
+      - 'aifw-cli/**'
+      - 'aifw-tui/**'
+      - 'aifw-ids/**'
+      - 'aifw-ids-bin/**'
       - 'freebsd/tests/**'
       - '.github/workflows/freebsd-functional.yml'
   workflow_dispatch:
@@ -41,8 +46,14 @@ jobs:
             set -e
             . "$HOME/.cargo/env"
             cd /home/runner/work/AiFw/AiFw
-            echo "=== Building test binaries (debug) ==="
-            cargo build -p aifw-api -p aifw-daemon
+            echo "=== Building every binary (debug) ==="
+            # All default-member binaries, not just the two the harness
+            # runs: aifw-setup / aifw-cli / aifw-tui / aifw-ids carry
+            # `#[cfg(target_os = "freebsd")]` code that the Linux lint job
+            # never compiles — this is the only place it gets type-checked
+            # before a release build (v5.115.0 shipped a setup split with
+            # imports missing only inside those blocks).
+            cargo build
             echo "=== Running functional harness ==="
             mkdir -p func-artifacts
             # Do NOT let a harness failure fail this step: vmactions only

--- a/aifw-setup/src/apply/database.rs
+++ b/aifw-setup/src/apply/database.rs
@@ -4,7 +4,11 @@ use crate::config::SetupConfig;
 use crate::console;
 use aifw_common::{CarpVip, ClusterNode, ClusterRole, Interface, PfsyncConfig};
 
+// `run_best_effort`/`run_sysrc` are only referenced from the
+// `#[cfg(target_os = "freebsd")]` blocks below (sysrc/chown on a real box).
 use super::system::warn_on_err;
+#[cfg(target_os = "freebsd")]
+use super::system::{run_best_effort, run_sysrc};
 
 /// Initialize the SQLite database and create the admin user
 pub(super) async fn init_database(config: &SetupConfig) -> Result<(), String> {

--- a/aifw-setup/src/apply/run.rs
+++ b/aifw-setup/src/apply/run.rs
@@ -7,6 +7,8 @@ use crate::tuning::{self, TuningItem};
 use super::database::init_database;
 use super::pf_conf::generate_pf_conf;
 use super::rcd::write_rcd_scripts;
+#[cfg(target_os = "freebsd")]
+use super::sudoers::sudoers_content;
 use super::system::*;
 
 pub async fn apply(config: &SetupConfig, tuning_items: &[TuningItem]) -> Result<(), String> {


### PR DESCRIPTION
Follow-up to #692 (the fix landed on the release branch after it was merged) — **blocks the v5.115.0 build**: `sudo sh freebsd/build-update.sh 5.115.0` fails with `cannot find function run_best_effort / run_sysrc / sudoers_content` in `aifw-setup/src/apply/{database,run}.rs`.

Cause: the #191 `apply.rs` split left those three references without imports, but only inside `#[cfg(target_os = "freebsd")]` blocks — the Linux lint/test job never compiles them, and the FreeBSD functional job only built `aifw-api` + `aifw-daemon`, so nothing type-checked `aifw-setup` on FreeBSD before the release build.

- Imports added (cfg-gated so Linux builds don't warn).
- FreeBSD functional job now runs plain `cargo build` (every default-member binary) and also triggers on `aifw-setup/**`, `aifw-cli/**`, `aifw-tui/**`, `aifw-ids*/**`. Verified via workflow_dispatch on the release branch: all binaries built on FreeBSD 15 (6m11s), harness green.

No version change (5.115.0 stays; the tag isn't cut yet). After merge: `git pull` on the VM and re-run `build-update.sh 5.115.0`.