### PR TITLE
chore: bump companion pins — rTIME 0.15.0, TrafficCop 1.4.12

### DIFF
--- a/freebsd/manifest.json
+++ b/freebsd/manifest.json
@@ -15,7 +15,7 @@
       "name": "TrafficCop",
       "repo": "ZerosAndOnesLLC/TrafficCop",
       "crate": "trafficcop",
-      "version": "1.4.11",
+      "version": "1.4.12",
       "binaries": ["trafficcop"]
     },
     {

--- a/freebsd/manifest.json
+++ b/freebsd/manifest.json
@@ -36,7 +36,7 @@
       "name": "rTIME",
       "repo": "ZerosAndOnesLLC/rTIME",
       "crate": "rtimed",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "binaries": ["rtime"]
     }
   ],


### PR DESCRIPTION
Bumps the `rtimed` crates.io pin in `freebsd/manifest.json` from 0.14.1 to 0.15.0 (published 2026-08-19).

Picks up rTime #56/#59 (tracking issue ZerosAndOnesLLC/rTime#57):

- Selection no longer re-applies stale pre-step offsets. Each clock step was being applied once per source and the error doubled every round until the clock crossed the panic threshold and was stranded — the live appliance ended up 19 minutes fast, serving that time to the LAN.
- NTP measurements expire after eight missed polls; a silent source stops voting.
- A clock stranded past the panic threshold now exits for a supervised restart (`daemon -R 5`) so `allow_initial_step` recovers it, instead of logging "Refused implausible offset" forever (`clock.panic_restart_after`, default 8; AiFw's rendered `rtime.toml` doesn't set it, so the default applies).
- Negative sub-second steps no longer fail with EINVAL; `is_adjustable()` probe actually checks CAP_SYS_TIME.

No AiFw code changes; the next AiFw release build will install `rtimed@0.15.0`.

Also bumps **TrafficCop 1.4.11 → 1.4.12** (dependency-only release, no functional changes). With this, all four companions (`trafficcop`, `rdhcpd`, `rdns-server`, `rtimed`) are pinned to the current crates.io latest and release builds install exclusively from crates.io via `lib-build.sh` (`cargo install --locked --version <pin>`).
