### PR TITLE
release: v5.115.1 — rTime clock-step fix, companion pins, setup FreeBSD build fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ resolver = "2"
 
 [workspace.package]
 
-version = "5.115.0"
+version = "5.115.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ZerosAndOnesLLC/AiFw"

--- a/aifw-ui/package-lock.json
+++ b/aifw-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aifw-ui",
-  "version": "5.115.0",
+  "version": "5.115.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aifw-ui",
-      "version": "5.115.0",
+      "version": "5.115.1",
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "lucide-react": "^1.20.0",

--- a/aifw-ui/package.json
+++ b/aifw-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aifw-ui",
-  "version": "5.115.0",
+  "version": "5.115.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Patch release. Bumps `Cargo.toml` + `aifw-ui/package.json` to 5.115.1.

Since v5.115.0:
- #694 — rTIME pin 0.14.1 → **0.15.0**: fixes the clock-step snowball (rTime#57) that left the appliance 19 minutes fast and rtime stranded past its panic threshold; adds measurement expiry and stranded-clock restart. TrafficCop pin 1.4.11 → **1.4.12** (dependency-only).
- #693 — aifw-setup imports the FreeBSD-only helpers the apply/ split left unresolved; CI builds every binary on FreeBSD.

All four companions are pinned to crates.io latest; release builds install them exclusively from crates.io (`lib-build.sh`), verified locally with `cargo install --locked` for each pin.

After merge: build the update tarball + ISO on the FreeBSD build VM (`build-update.sh 5.115.1` / `release.sh 5.115.1`, pre-release by default).